### PR TITLE
Manage camel-servlet and camel-aws-sns in the BOM

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -75,6 +75,17 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
+                <artifactId>camel-aws-sns</artifactId>
+                <version>${camel.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.sun.xml.messaging.saaj</groupId>
+                        <artifactId>saaj-impl</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel</groupId>
                 <artifactId>camel-aws-sqs</artifactId>
                 <version>${camel.version}</version>
                 <exclusions>
@@ -136,6 +147,11 @@
                         <artifactId>saaj-impl</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel</groupId>
+                <artifactId>camel-servlet</artifactId>
+                <version>${camel.version}</version>
             </dependency>
 
             <!-- Quarkus Camel -->


### PR DESCRIPTION
This becomes required when Camel stuff is removed from Quarkus BOM.

In other words, `camel-aws-sns` and `camel-servlet` were missing on our BOM and this fixes issues we would hit when building against Quarkus version where Camel stuff is removed.