### PR TITLE
Fix #112 Make camel-quarkus-bom usable as a parent for user applications

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -323,6 +323,14 @@
                 <artifactId>camel-quarkus-xml-common</artifactId>
                 <version>${project.version}</version>
             </dependency>
+
+            <!-- Other third party dependencies -->
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-client</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -31,6 +31,10 @@
 
     <name>Camel Quarkus :: BOM</name>
 
+    <properties>
+        <camel-quarkus.version>0.1.1-SNAPSHOT</camel-quarkus.version><!-- kept in sync with project.version by the release plugin -->
+    </properties>
+
     <dependencyManagement>
         <dependencies>
 
@@ -229,99 +233,99 @@
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
                 <artifactId>camel-quarkus-jetty-common</artifactId>
-                <version>${project.version}</version>
+                <version>${camel-quarkus.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
                 <artifactId>camel-quarkus-xstream-common</artifactId>
-                <version>${project.version}</version>
+                <version>${camel-quarkus.version}</version>
             </dependency>
 
             <!-- Quarkus Camel -->
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
                 <artifactId>camel-quarkus-bean</artifactId>
-                <version>${project.version}</version>
+                <version>${camel-quarkus.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
                 <artifactId>camel-quarkus-core</artifactId>
-                <version>${project.version}</version>
+                <version>${camel-quarkus.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
                 <artifactId>camel-quarkus-aws-s3</artifactId>
-                <version>${project.version}</version>
+                <version>${camel-quarkus.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
                 <artifactId>camel-quarkus-aws-eks</artifactId>
-                <version>${project.version}</version>
+                <version>${camel-quarkus.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
                 <artifactId>camel-quarkus-aws-sqs</artifactId>
-                <version>${project.version}</version>
+                <version>${camel-quarkus.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
                 <artifactId>camel-quarkus-aws-sns</artifactId>
-                <version>${project.version}</version>
+                <version>${camel-quarkus.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
                 <artifactId>camel-quarkus-direct</artifactId>
-                <version>${project.version}</version>
+                <version>${camel-quarkus.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
                 <artifactId>camel-quarkus-jdbc</artifactId>
-                <version>${project.version}</version>
+                <version>${camel-quarkus.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
                 <artifactId>camel-quarkus-log</artifactId>
-                <version>${project.version}</version>
+                <version>${camel-quarkus.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
                 <artifactId>camel-quarkus-salesforce</artifactId>
-                <version>${project.version}</version>
+                <version>${camel-quarkus.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
                 <artifactId>camel-quarkus-servlet</artifactId>
-                <version>${project.version}</version>
+                <version>${camel-quarkus.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
                 <artifactId>camel-quarkus-rest</artifactId>
-                <version>${project.version}</version>
+                <version>${camel-quarkus.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
                 <artifactId>camel-quarkus-netty4-http</artifactId>
-                <version>${project.version}</version>
+                <version>${camel-quarkus.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
                 <artifactId>camel-quarkus-infinispan</artifactId>
-                <version>${project.version}</version>
+                <version>${camel-quarkus.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
                 <artifactId>camel-quarkus-timer</artifactId>
-                <version>${project.version}</version>
+                <version>${camel-quarkus.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
                 <artifactId>camel-quarkus-twitter</artifactId>
-                <version>${project.version}</version>
+                <version>${camel-quarkus.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
                 <artifactId>camel-quarkus-xml-common</artifactId>
-                <version>${project.version}</version>
+                <version>${camel-quarkus.version}</version>
             </dependency>
 
             <!-- Other third party dependencies -->

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -124,11 +124,6 @@
                     </configuration>
                 </plugin>
                 <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-resources-plugin</artifactId>
-                    <version>${maven-resources-plugin.version}</version>
-                </plugin>
-                <plugin>
                     <groupId>org.codehaus.gmavenplus</groupId>
                     <artifactId>gmavenplus-plugin</artifactId>
                     <version>${gmavenplus-plugin.version}</version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -107,11 +107,6 @@
                 </plugin>
                 <plugin>
                     <groupId>io.quarkus</groupId>
-                    <artifactId>quarkus-maven-plugin</artifactId>
-                    <version>${quarkus.version}</version>
-                </plugin>
-                <plugin>
-                    <groupId>io.quarkus</groupId>
                     <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
                     <version>${quarkus.version}</version>
                     <executions>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -210,23 +210,6 @@
 
     <profiles>
         <profile>
-            <id>jdk-8-classpath</id>
-            <activation>
-                <jdk>[9,</jdk>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <configuration>
-                            <release>8</release>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
             <id>sourcecheck</id>
             <build>
                 <plugins>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -32,10 +32,8 @@
     <name>Camel Quarkus :: Build Parent</name>
 
     <properties>
-        <supported-maven-versions>[3.5.3,)</supported-maven-versions>
 
         <groovy.version>2.5.7</groovy.version>
-        <jetty.version>9.4.18.v20190429</jetty.version>
         <xstream.version>1.4.11</xstream.version>
 
         <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
@@ -122,50 +120,7 @@
                         </execution>
                     </executions>
                 </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-enforcer-plugin</artifactId>
-                    <executions>
-                        <execution>
-                            <id>enforce</id>
-                            <configuration>
-                                <rules>
-                                    <dependencyConvergence />
-                                    <requireMavenVersion>
-                                        <version>${supported-maven-versions}</version>
-                                    </requireMavenVersion>
-                                    <bannedDependencies>
-                                        <excludes>
-                                            <!-- Use javax.annotation-api -->
-                                            <exclude>org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec</exclude>
-                                            <exclude>org.jboss.spec.javax.annotation:jboss-annotations-api_1.3_spec</exclude>
-                                            <!-- use our jboss-logmanager -->
-                                            <exclude>org.jboss.logging:jboss-logmanager</exclude>
-                                            <!-- We don't want all the API's in one jar-->
-                                            <exclude>javax:javaee-api</exclude>
-                                            <!-- Prevent incompatible config from coming in -->
-                                            <exclude>org.wildfly.client:wildfly-client-config</exclude>
-                                            <!-- Use Jakarta Activation -->
-                                            <exclude>javax.activation:javax-activation-api</exclude>
-                                            <exclude>javax.activation:activation</exclude>
-                                            <exclude>org.jboss.marshalling:jboss-marshalling-osgi</exclude>
-                                            <exclude>org.jboss.spec.javax.servlet:jboss-servlet-api_3.1_spec</exclude>
-                                            <!-- The API is packaged by the implementation-->
-                                            <exclude>javax.json:javax.json-api</exclude>
-                                            <!-- Do not use Jakarta APIs for JSON -->
-                                            <exclude>org.glassfish:jakarta.json</exclude>
-                                            <exclude>jakarta.json.bind:jakarta.json.bind-api</exclude>
-                                            <exclude>jakarta.json:jakarta.json-api</exclude>
-                                        </excludes>
-                                    </bannedDependencies>
-                                </rules>
-                            </configuration>
-                            <goals>
-                                <goal>enforce</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                </plugin>
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -36,6 +36,9 @@
         <groovy.version>2.5.7</groovy.version>
         <xstream.version>1.4.11</xstream.version>
 
+        <!-- maven-surefire-plugin -->
+        <failIfNoTests>false</failIfNoTests>
+
         <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
         <maven-checkstyle.version>7.6.1</maven-checkstyle.version>
         <jandex-maven-plugin.version>1.0.6</jandex-maven-plugin.version>
@@ -93,16 +96,6 @@
     <build>
         <pluginManagement>
             <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-surefire-plugin</artifactId>
-                    <configuration>
-                        <failIfNoTests>false</failIfNoTests>
-                        <systemProperties>
-                            <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-                        </systemProperties>
-                    </configuration>
-                </plugin>
                 <plugin>
                     <groupId>io.quarkus</groupId>
                     <artifactId>quarkus-bootstrap-maven-plugin</artifactId>

--- a/extensions/aws-eks/deployment/pom.xml
+++ b/extensions/aws-eks/deployment/pom.xml
@@ -57,13 +57,6 @@
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/extensions/aws-eks/runtime/pom.xml
+++ b/extensions/aws-eks/runtime/pom.xml
@@ -79,13 +79,6 @@
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/extensions/aws-s3/deployment/pom.xml
+++ b/extensions/aws-s3/deployment/pom.xml
@@ -57,13 +57,6 @@
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/extensions/aws-s3/runtime/pom.xml
+++ b/extensions/aws-s3/runtime/pom.xml
@@ -79,13 +79,6 @@
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/extensions/aws-sns/deployment/pom.xml
+++ b/extensions/aws-sns/deployment/pom.xml
@@ -57,13 +57,6 @@
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/extensions/aws-sns/runtime/pom.xml
+++ b/extensions/aws-sns/runtime/pom.xml
@@ -79,13 +79,6 @@
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/extensions/aws-sqs/deployment/pom.xml
+++ b/extensions/aws-sqs/deployment/pom.xml
@@ -57,13 +57,6 @@
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/extensions/aws-sqs/runtime/pom.xml
+++ b/extensions/aws-sqs/runtime/pom.xml
@@ -79,13 +79,6 @@
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/extensions/infinispan/deployment/pom.xml
+++ b/extensions/infinispan/deployment/pom.xml
@@ -65,13 +65,6 @@
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/extensions/infinispan/runtime/pom.xml
+++ b/extensions/infinispan/runtime/pom.xml
@@ -84,13 +84,6 @@
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <configuration>
-                  <skip>true</skip>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/extensions/jetty-common/deployment/pom.xml
+++ b/extensions/jetty-common/deployment/pom.xml
@@ -53,13 +53,6 @@
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/extensions/jetty-common/runtime/pom.xml
+++ b/extensions/jetty-common/runtime/pom.xml
@@ -36,7 +36,6 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-client</artifactId>
-            <version>${jetty.version}</version>
         </dependency>
     </dependencies>
 
@@ -56,13 +55,6 @@
                             <version>${quarkus.version}</version>
                         </path>
                     </annotationProcessorPaths>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <configuration>
-                  <skip>true</skip>
                 </configuration>
             </plugin>
         </plugins>

--- a/extensions/netty4-http/deployment/pom.xml
+++ b/extensions/netty4-http/deployment/pom.xml
@@ -61,13 +61,6 @@
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/extensions/netty4-http/runtime/pom.xml
+++ b/extensions/netty4-http/runtime/pom.xml
@@ -76,13 +76,6 @@
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <configuration>
-                  <skip>true</skip>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -61,7 +61,6 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus.version}</version>
                 <inherited>false</inherited>
                 <!-- Setting for stubbing new extensions via
                        mvn quarkus:create-extension -N -Dquarkus.artifactIdBase=my-new-extension

--- a/extensions/salesforce/deployment/pom.xml
+++ b/extensions/salesforce/deployment/pom.xml
@@ -61,13 +61,6 @@
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/extensions/salesforce/runtime/pom.xml
+++ b/extensions/salesforce/runtime/pom.xml
@@ -71,13 +71,6 @@
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <configuration>
-                  <skip>true</skip>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/extensions/xstream-common/deployment/pom.xml
+++ b/extensions/xstream-common/deployment/pom.xml
@@ -53,13 +53,6 @@
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/extensions/xstream-common/runtime/pom.xml
+++ b/extensions/xstream-common/runtime/pom.xml
@@ -58,13 +58,6 @@
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <configuration>
-                  <skip>true</skip>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/integration-tests/aws/pom.xml
+++ b/integration-tests/aws/pom.xml
@@ -77,18 +77,6 @@
     <build>
         <plugins>
             <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-            <plugin>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
                 <executions>

--- a/integration-tests/bean/pom.xml
+++ b/integration-tests/bean/pom.xml
@@ -68,14 +68,6 @@
             </resource>
         </resources>
         <plugins>
-            <!-- Skip enforcer plugin as we want to use jboss marshalling for test class -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>

--- a/integration-tests/core-cdi/pom.xml
+++ b/integration-tests/core-cdi/pom.xml
@@ -29,11 +29,6 @@
     <name>Camel Quarkus :: Integration Tests :: Core CDI</name>
     <description>The camel integration tests</description>
 
-    <properties>
-        <!-- Skip enforcer plugin as we want to use jboss marshalling for test class -->
-        <enforcer.skip>true</enforcer.skip>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/infinispan/pom.xml
+++ b/integration-tests/infinispan/pom.xml
@@ -29,11 +29,6 @@
     <name>Camel Quarkus :: Integration Tests :: Infinispan</name>
     <description>Integration tests for Camel Infinispan component</description>
 
-    <properties>
-        <!-- Skip enforcer plugin as we want to use jboss marshalling for test class -->
-        <enforcer.skip>true</enforcer.skip>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -59,44 +59,34 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.gmavenplus</groupId>
+                <artifactId>gmavenplus-plugin</artifactId>
+                <inherited>false</inherited>
+                <executions>
+                    <execution>
+                        <id>test-project-sanity-checks</id>
+                        <goals>
+                            <goal>execute</goal>
+                        </goals>
+                        <phase>validate</phase>
+                        <configuration>
+                            <scripts>
+                                <script>file:///${project.basedir}/test-project-sanity-checks.groovy</script>
+                            </scripts>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.codehaus.groovy</groupId>
+                        <artifactId>groovy-xml</artifactId>
+                        <version>${groovy.version}</version>
+                        <scope>runtime</scope>
+                    </dependency>
+                </dependencies>
+            </plugin>
         </plugins>
     </build>
-
-    <profiles>
-        <profile>
-            <id>test-project-sanity-checks</id>
-            <activation>
-                <file>
-                    <!-- Run the script only for the child projects  -->
-                    <exists>../test-project-sanity-checks.groovy</exists>
-                </file>
-            </activation>
-
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.codehaus.gmavenplus</groupId>
-                        <artifactId>gmavenplus-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>test-project-sanity-checks</id>
-                                <goals>
-                                    <goal>execute</goal>
-                                </goals>
-                                <phase>validate</phase>
-                                <configuration>
-                                    <scripts>
-                                        <script>file:///${project.basedir}/../test-project-sanity-checks.groovy</script>
-                                    </scripts>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-
-        </profile>
-    </profiles>
-
 
 </project>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -46,22 +46,6 @@
         <module>twitter</module>
     </modules>
 
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-integration-test-class-transformer-deployment</artifactId>
-                <version>${quarkus.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-integration-test-class-transformer</artifactId>
-                <version>${quarkus.version}</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <build>
         <plugins>
             <plugin>

--- a/integration-tests/salesforce/pom.xml
+++ b/integration-tests/salesforce/pom.xml
@@ -29,14 +29,6 @@
     <name>Camel Quarkus :: Integration Tests :: Salesforce</name>
     <description>The camel integration tests</description>
 
-    <properties>
-        <!--
-            Skip enforcer plugin because of dependency convergence error between
-            camel-salesforce and the version of jetty used by cometd
-        -->
-        <enforcer.skip>true</enforcer.skip>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/salesforce/pom.xml
+++ b/integration-tests/salesforce/pom.xml
@@ -61,18 +61,6 @@
     <build>
         <plugins>
             <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-            <plugin>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
                 <executions>

--- a/integration-tests/servlet/pom.xml
+++ b/integration-tests/servlet/pom.xml
@@ -20,8 +20,10 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <!-- Test that the BOM can serve as parent for user apps, see also https://github.com/apache/camel-quarkus/issues/118 -->
+        <artifactId>camel-quarkus-bom</artifactId>
         <version>0.1.1-SNAPSHOT</version>
+        <relativePath>../../bom/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/twitter/pom.xml
+++ b/integration-tests/twitter/pom.xml
@@ -43,18 +43,6 @@
     <build>
         <plugins>
             <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-            <plugin>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
     <build>
         <pluginManagement>
             <plugins>
-
+                <!-- Only plugins relevant to both end user applications and Camel Quarkus extensions -->
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
@@ -157,12 +157,6 @@
                             <arg>-Xlint:unchecked</arg>
                         </compilerArgs>
                     </configuration>
-                </plugin>
-
-                <plugin>
-                    <groupId>io.quarkus</groupId>
-                    <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
-                    <version>${quarkus.version}</version>
                 </plugin>
 
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -42,12 +42,17 @@
 
         <camel.version>3.0.0-M4</camel.version>
         <quarkus.version>0.20.0</quarkus.version>
+        <jetty.version>9.4.18.v20190429</jetty.version>
 
         <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.testTarget>${maven.compiler.target}</maven.compiler.testTarget>
         <maven.compiler.testSource>${maven.compiler.source}</maven.compiler.testSource>
+
+        <!-- maven-enforcer-plugin -->
+        <supported-maven-versions>[3.5.3,)</supported-maven-versions>
+
 
         <mycila-license.version>3.0</mycila-license.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
@@ -157,6 +162,27 @@
                             <arg>-Xlint:unchecked</arg>
                         </compilerArgs>
                     </configuration>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <executions>
+                        <execution>
+                            <id>enforce-maven-version</id>
+                            <goals>
+                                <goal>enforce</goal>
+                            </goals>
+                            <configuration>
+                                <rules>
+                                    <dependencyConvergence />
+                                    <requireMavenVersion>
+                                        <version>${supported-maven-versions}</version>
+                                    </requireMavenVersion>
+                                </rules>
+                            </configuration>
+                        </execution>
+                    </executions>
                 </plugin>
 
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -186,6 +186,16 @@
                 </plugin>
 
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <configuration>
+                        <systemProperties>
+                            <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                        </systemProperties>
+                    </configuration>
+                </plugin>
+
+                <plugin>
                     <groupId>io.quarkus</groupId>
                     <artifactId>quarkus-maven-plugin</artifactId>
                     <version>${quarkus.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <!-- maven-enforcer-plugin -->
         <supported-maven-versions>[3.5.3,)</supported-maven-versions>
 
-
+        <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
         <mycila-license.version>3.0</mycila-license.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
         <maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
@@ -193,6 +193,12 @@
                             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                         </systemProperties>
                     </configuration>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>exec-maven-plugin</artifactId>
+                    <version>${exec-maven-plugin.version}</version>
                 </plugin>
 
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -43,15 +43,11 @@
         <camel.version>3.0.0-M4</camel.version>
         <quarkus.version>0.20.0</quarkus.version>
 
-        <version.compiler.plugin>3.8.0</version.compiler.plugin>
+        <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.testTarget>${maven.compiler.target}</maven.compiler.testTarget>
         <maven.compiler.testSource>${maven.compiler.source}</maven.compiler.testSource>
-        <maven.compiler.argument.target>${maven.compiler.target}</maven.compiler.argument.target>
-        <maven.compiler.argument.source>${maven.compiler.source}</maven.compiler.argument.source>
-        <maven.compiler.argument.testTarget>${maven.compiler.testTarget}</maven.compiler.argument.testTarget>
-        <maven.compiler.argument.testSource>${maven.compiler.testSource}</maven.compiler.argument.testSource>
 
         <mycila-license.version>3.0</mycila-license.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
@@ -153,14 +149,10 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>${version.compiler.plugin}</version>
+                    <version>${maven-compiler-plugin.version}</version>
                     <configuration>
                         <showDeprecation>true</showDeprecation>
                         <showWarnings>true</showWarnings>
-                        <source>${maven.compiler.argument.source}</source>
-                        <target>${maven.compiler.argument.target}</target>
-                        <testSource>${maven.compiler.argument.testSource}</testSource>
-                        <testTarget>${maven.compiler.argument.testTarget}</testTarget>
                         <compilerArgs>
                             <arg>-Xlint:unchecked</arg>
                         </compilerArgs>
@@ -183,6 +175,23 @@
     </build>
 
     <profiles>
+        <profile>
+            <id>jdk-8-classpath</id>
+            <activation>
+                <jdk>[9,</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <release>8</release>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>license</id>
             <build>


### PR DESCRIPTION
@lburgazzoli this adopts your proposal to fix the BOM so that it can serve as parent for user apps. I moved just a single itest to `examples` making the BOM its parent to make sure that it actually works.