### PR TITLE
Add website build trigger

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,6 +45,17 @@ pipeline {
 
     stages {
 
+        stage('Website update') {
+            when {
+                branch 'master'
+                changeset 'docs/**/*'
+            }
+
+            steps {
+                build job: 'Camel.website', wait: false
+            }
+        }
+
         stage('Build & Deploy') {
             when {
                 branch 'master'


### PR DESCRIPTION
When a change to any files in the `docs/` directory on the master branch the `Camel.website` job is triggered to update the website with those changes.

Fixes #168