### PR TITLE
Fix #97 Inspect routes to detect classes that may require reflection

### DIFF
--- a/extensions/bean/deployment/src/main/java/org/apache/camel/quarkus/component/bean/deployment/BeanProcessor.java
+++ b/extensions/bean/deployment/src/main/java/org/apache/camel/quarkus/component/bean/deployment/BeanProcessor.java
@@ -16,8 +16,24 @@
  */
 package org.apache.camel.quarkus.component.bean.deployment;
 
+import java.util.List;
+
+import org.apache.camel.RoutesBuilder;
+import org.apache.camel.model.BeanDefinition;
+import org.apache.camel.model.ProcessorDefinition;
+import org.apache.camel.model.RouteDefinition;
+import org.apache.camel.quarkus.core.deployment.CamelRegistryBuildItem;
+import org.apache.camel.quarkus.core.deployment.RouteBuilderBuildItem;
+import org.apache.camel.quarkus.core.runtime.support.FastCamelContext;
+import org.apache.camel.quarkus.core.runtime.support.FastModel;
+import org.apache.camel.quarkus.core.runtime.support.RuntimeRegistry;
+
+import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.substrate.ReflectiveClassBuildItem;
 
 class BeanProcessor {
 
@@ -26,6 +42,42 @@ class BeanProcessor {
     @BuildStep
     FeatureBuildItem feature() {
         return new FeatureBuildItem(FEATURE);
+    }
+
+    @Record(ExecutionTime.STATIC_INIT)
+    @BuildStep
+    void registerForReflection(List<RouteBuilderBuildItem> buildTimeRouteBuilderBuildItems, List<CamelRegistryBuildItem> registryItems, BuildProducer<ReflectiveClassBuildItem> reflectiveClassProducer) {
+        if (!buildTimeRouteBuilderBuildItems.isEmpty()) {
+            final RuntimeRegistry registry = new RuntimeRegistry();
+            final FastCamelContext ctx = new FastCamelContext();
+            ctx.setRegistry(registry);
+            final FastModel model = new FastModel(ctx);
+            ctx.setModel(model);
+
+            for (RouteBuilderBuildItem i : buildTimeRouteBuilderBuildItems) {
+                try {
+                    final Class<?> cl = Class.forName(i.getClassName());
+                    final RoutesBuilder rb = (RoutesBuilder) cl.newInstance();
+                    rb.addRoutesToCamelContext(ctx);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }
+            for (RouteDefinition rd : model.getRouteDefinitions()) {
+                for (ProcessorDefinition<?> pd : rd.getOutputs()) {
+                    if (pd instanceof BeanDefinition) {
+                        final BeanDefinition bd = (BeanDefinition) pd;
+                        if (bd.getBean() != null) {
+                            reflectiveClassProducer.produce(new ReflectiveClassBuildItem(true, true, bd.getBean().getClass()));
+                        } else if (bd.getBeanClass() != null) {
+                            reflectiveClassProducer.produce(new ReflectiveClassBuildItem(true, true, bd.getBeanClass()));
+                        } else if (bd.getBeanType() != null) {
+                            reflectiveClassProducer.produce(new ReflectiveClassBuildItem(true, true, bd.getBeanType()));
+                        }
+                    }
+                }
+            }
+        }
     }
 
 }

--- a/extensions/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/RouteBuilderBuildItem.java
+++ b/extensions/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/RouteBuilderBuildItem.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.core.deployment;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+public final class RouteBuilderBuildItem extends MultiBuildItem {
+    private final String className;
+
+    public RouteBuilderBuildItem(String className) {
+        super();
+        this.className = className;
+    }
+
+    public String getClassName() {
+        return className;
+    }
+}

--- a/integration-tests/bean/src/main/java/org/apache/camel/quarkus/component/bean/CamelRoute.java
+++ b/integration-tests/bean/src/main/java/org/apache/camel/quarkus/component/bean/CamelRoute.java
@@ -50,6 +50,10 @@ public class CamelRoute extends RouteBuilder {
             // log out
             .to("log:out");
 
+        from("direct:hello")
+            .bean(HelloBean.class, "hello")
+            .to("log:out");
+
     }
 
     @SuppressWarnings("unchecked")
@@ -100,6 +104,12 @@ public class CamelRoute extends RouteBuilder {
                 return bp;
             }
         };
+    }
+
+    public static class HelloBean {
+        public String hello(String person) {
+            return "Hello " + person;
+        }
     }
 
     @RegisterForReflection


### PR DESCRIPTION
This is currently just a PoC to study the problem.

The PoC works in many simple cases, but I assume it would fail in many more complex cases.

How it works: To get the `org.apache.camel.model.Model` where the `RouteDefinitions` can be inspected for reflective beans, the PoC instantiates a CamelContext and all known RoutesBuilders at build time. See https://github.com/apache/camel-quarkus/pull/178/files#diff-40a8979f4631139bb657ee652820dde7R52 
All these instances are thrown away after the inspection.

The main problem with the above approach is that calling `RoutesBuilder.configure()` may fail due to non-availability of various resources (config values, injected beans, ...) that we simply do not have at build time.

Now I plan to look at options to somehow access the `Model` without needing to instantiate the CamelContext and the RoutesBuilders.
