### PR TITLE
don't start camel context before the container is fully started

### DIFF
--- a/extensions/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/BuildProcessor.java
+++ b/extensions/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/BuildProcessor.java
@@ -40,6 +40,7 @@ import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.ApplicationArchivesBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
+import io.quarkus.deployment.builditem.ServiceStartBuildItem;
 import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
 import io.quarkus.runtime.RuntimeValue;
 import org.apache.camel.RoutesBuilder;
@@ -142,6 +143,9 @@ class BuildProcessor {
             CamelRecorder recorder,
             CamelRuntimeBuildItem runtime,
             ShutdownContextBuildItem shutdown,
+            // TODO: keep this list as placeholder to ensure the ArC container is fully
+            //       started before starting the runtime
+            List<ServiceStartBuildItem> startList,
             CamelConfig.Runtime runtimeConfig)
             throws Exception {
 

--- a/integration-tests/core-cdi/pom.xml
+++ b/integration-tests/core-cdi/pom.xml
@@ -46,6 +46,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vertx</artifactId>
+        </dependency>
 
         <!-- test dependencies -->
         <dependency>

--- a/integration-tests/core-cdi/src/main/java/org/apache/camel/quarkus/component/core/cdi/CamelApplication.java
+++ b/integration-tests/core-cdi/src/main/java/org/apache/camel/quarkus/component/core/cdi/CamelApplication.java
@@ -23,6 +23,8 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
+import io.quarkus.arc.Arc;
+import io.vertx.core.Vertx;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.model.ModelHelper;
 import org.apache.camel.model.RoutesDefinition;
@@ -39,6 +41,13 @@ public class CamelApplication {
 
     public void starting(@Observes StartingEvent event) {
         runtime.addProperty("starting", "true");
+
+        // invoking Arc.::instance(...) before the container is fully
+        // started may result in a null reference being returned
+        Vertx instance = Arc.container().instance(Vertx.class).get();
+        if (instance != null) {
+            runtime.getRegistry().bind("my-vertx", Arc.container().instance(Vertx.class).get());
+        }
 
         addRoute("src/main/resources/hello.xml");
     }

--- a/integration-tests/core-cdi/src/main/java/org/apache/camel/quarkus/component/core/cdi/CamelServlet.java
+++ b/integration-tests/core-cdi/src/main/java/org/apache/camel/quarkus/component/core/cdi/CamelServlet.java
@@ -55,4 +55,12 @@ public class CamelServlet {
     public String sayHello(@PathParam("name") String name) {
         return runtime.getContext().createProducerTemplate().requestBody("direct:hello", name, String.class);
     }
+
+    @Path("/registry/{name}")
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String lookupByName(@PathParam("name") String name) {
+        Object answer = runtime.getContext().getRegistry().lookupByName(name);
+        return answer != null ? answer.getClass().getName() : "";
+    }
 }

--- a/integration-tests/core-cdi/src/test/java/org/apache/camel/quarkus/component/core/cdi/CamelTest.java
+++ b/integration-tests/core-cdi/src/test/java/org/apache/camel/quarkus/component/core/cdi/CamelTest.java
@@ -18,6 +18,7 @@ package org.apache.camel.quarkus.component.core.cdi;
 
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
+import io.vertx.core.impl.VertxImpl;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.Matchers.containsString;
@@ -39,5 +40,10 @@ public class CamelTest {
     @Test
     public void testHello() {
         RestAssured.when().get("/test/hello/quarkus").then().body(is("hello quarkus"));
+    }
+
+    @Test
+    public void restLookupBeanByName() {
+        RestAssured.when().get("/test/registry/my-vertx").then().body(is(VertxImpl.class.getName()));
     }
 }


### PR DESCRIPTION
The camle context is started on runtime init but before there
was no control about starting after the a full initialized ArC 
container and this lead to unpredictable behaviors when the
registry looks up for bean from the container.