### PR TITLE
quarkus-camel-catalog

### DIFF
--- a/catalog/camel-quarkus-catalog/pom.xml
+++ b/catalog/camel-quarkus-catalog/pom.xml
@@ -39,6 +39,33 @@
             <version>${camel.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- logging -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>2.12.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.12.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <version>2.12.1</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/catalog/camel-quarkus-catalog/pom.xml
+++ b/catalog/camel-quarkus-catalog/pom.xml
@@ -76,6 +76,14 @@
                 <groupId>org.apache.camel.quarkus</groupId>
                 <artifactId>camel-quarkus-package-maven-plugin</artifactId>
                 <version>${project.version}</version>
+                <dependencies>
+                    <!-- include camel-catalog on classpath -->
+                    <dependency>
+                        <groupId>org.apache.camel</groupId>
+                        <artifactId>camel-catalog</artifactId>
+                        <version>${camel.version}</version>
+                    </dependency>
+                </dependencies>
                 <executions>
                     <execution>
                         <goals>

--- a/catalog/camel-quarkus-catalog/pom.xml
+++ b/catalog/camel-quarkus-catalog/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.quarkus</groupId>
+        <artifactId>catalog</artifactId>
+        <version>0.2.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>camel-catalog-quarkus</artifactId>
+    <packaging>jar</packaging>
+    <name>Camel Quarkus :: Camel Quarkus Catalog</name>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-catalog</artifactId>
+            <version>${camel.version}</version>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+
+            <!-- generate and include all components in the catalog -->
+            <plugin>
+                <groupId>org.apache.camel.quarkus</groupId>
+                <artifactId>camel-quarkus-package-maven-plugin</artifactId>
+                <version>${project.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-catalog-quarkus</goal>
+                        </goals>
+                        <phase>process-resources</phase>
+                    </execution>
+                </executions>
+            </plugin>
+
+        </plugins>
+
+    </build>
+
+</project>

--- a/catalog/camel-quarkus-catalog/src/main/java/org/apache/camel/catalog/quarkus/QuarkusRuntimeProvider.java
+++ b/catalog/camel-quarkus-catalog/src/main/java/org/apache/camel/catalog/quarkus/QuarkusRuntimeProvider.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.catalog.quarkus;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.camel.catalog.CamelCatalog;
+import org.apache.camel.catalog.CatalogHelper;
+import org.apache.camel.catalog.RuntimeProvider;
+
+/**
+ * A Quarkus based {@link RuntimeProvider} which only includes the supported Camel components, data formats, and languages
+ * which can be installed in Quarkus using the Camel extensions.
+ */
+public class QuarkusRuntimeProvider implements RuntimeProvider {
+
+    private static final String COMPONENT_DIR = "org/apache/camel/catalog/quarkus/components";
+    private static final String DATAFORMAT_DIR = "org/apache/camel/catalog/quarkus/dataformats";
+    private static final String LANGUAGE_DIR = "org/apache/camel/catalog/quarkus/languages";
+    private static final String OTHER_DIR = "org/apache/camel/catalog/quarkus/others";
+    private static final String COMPONENTS_CATALOG = "org/apache/camel/catalog/quarkus/components.properties";
+    private static final String DATA_FORMATS_CATALOG = "org/apache/camel/catalog/quarkus/dataformats.properties";
+    private static final String LANGUAGE_CATALOG = "org/apache/camel/catalog/quarkus/languages.properties";
+    private static final String OTHER_CATALOG = "org/apache/camel/catalog/quarkus/others.properties";
+
+    private CamelCatalog camelCatalog;
+
+    @Override
+    public CamelCatalog getCamelCatalog() {
+        return camelCatalog;
+    }
+
+    @Override
+    public void setCamelCatalog(CamelCatalog camelCatalog) {
+        this.camelCatalog = camelCatalog;
+    }
+
+    @Override
+    public String getProviderName() {
+        return "quarkus";
+    }
+
+    @Override
+    public String getProviderGroupId() {
+        return "org.apache.camel.quarkus";
+    }
+
+    @Override
+    public String getProviderArtifactId() {
+        return "camel-quarkus-catalog";
+    }
+
+    @Override
+    public String getComponentJSonSchemaDirectory() {
+        return COMPONENT_DIR;
+    }
+
+    @Override
+    public String getDataFormatJSonSchemaDirectory() {
+        return DATAFORMAT_DIR;
+    }
+
+    @Override
+    public String getLanguageJSonSchemaDirectory() {
+        return LANGUAGE_DIR;
+    }
+
+    @Override
+    public String getOtherJSonSchemaDirectory() {
+        return OTHER_DIR;
+    }
+
+    @Override
+    public List<String> findComponentNames() {
+        List<String> names = new ArrayList<>();
+        InputStream is = camelCatalog.getVersionManager().getResourceAsStream(COMPONENTS_CATALOG);
+        if (is != null) {
+            try {
+                CatalogHelper.loadLines(is, names);
+            } catch (IOException e) {
+                // ignore
+            }
+        }
+        return names;
+    }
+
+    @Override
+    public List<String> findDataFormatNames() {
+        List<String> names = new ArrayList<>();
+        InputStream is = camelCatalog.getVersionManager().getResourceAsStream(DATA_FORMATS_CATALOG);
+        if (is != null) {
+            try {
+                CatalogHelper.loadLines(is, names);
+            } catch (IOException e) {
+                // ignore
+            }
+        }
+        return names;
+    }
+
+    @Override
+    public List<String> findLanguageNames() {
+        List<String> names = new ArrayList<>();
+        InputStream is = camelCatalog.getVersionManager().getResourceAsStream(LANGUAGE_CATALOG);
+        if (is != null) {
+            try {
+                CatalogHelper.loadLines(is, names);
+            } catch (IOException e) {
+                // ignore
+            }
+        }
+        return names;
+    }
+
+    @Override
+    public List<String> findOtherNames() {
+        List<String> names = new ArrayList<>();
+        InputStream is = camelCatalog.getVersionManager().getResourceAsStream(OTHER_CATALOG);
+        if (is != null) {
+            try {
+                CatalogHelper.loadLines(is, names);
+            } catch (IOException e) {
+                // ignore
+            }
+        }
+        return names;
+    }
+
+}

--- a/catalog/camel-quarkus-catalog/src/main/resources/META-INF/LICENSE.txt
+++ b/catalog/camel-quarkus-catalog/src/main/resources/META-INF/LICENSE.txt
@@ -1,0 +1,203 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/catalog/camel-quarkus-catalog/src/main/resources/META-INF/NOTICE.txt
+++ b/catalog/camel-quarkus-catalog/src/main/resources/META-INF/NOTICE.txt
@@ -1,0 +1,11 @@
+   =========================================================================
+   ==  NOTICE file corresponding to the section 4 d of                    ==
+   ==  the Apache License, Version 2.0,                                   ==
+   ==  in this case for the Apache Camel distribution.                    ==
+   =========================================================================
+
+   This product includes software developed by
+   The Apache Software Foundation (http://www.apache.org/).
+
+   Please read the different LICENSE files present in the licenses directory of
+   this distribution.

--- a/catalog/camel-quarkus-catalog/src/test/java/org/apache/camel/catalog/quarkus/QuarkusRuntimeProviderTest.java
+++ b/catalog/camel-quarkus-catalog/src/test/java/org/apache/camel/catalog/quarkus/QuarkusRuntimeProviderTest.java
@@ -21,7 +21,6 @@ import java.util.List;
 import org.apache.camel.catalog.CamelCatalog;
 import org.apache.camel.catalog.DefaultCamelCatalog;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -29,9 +28,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-// TODO: Update
-
-@Ignore
 public class QuarkusRuntimeProviderTest {
 
     static CamelCatalog catalog;
@@ -64,9 +60,15 @@ public class QuarkusRuntimeProviderTest {
         assertNotNull(names);
         assertFalse(names.isEmpty());
 
-        assertTrue(names.contains("file"));
-        assertTrue(names.contains("ftp"));
-        assertTrue(names.contains("jms"));
+        assertTrue(names.contains("aws-eks"));
+        assertTrue(names.contains("bean"));
+        assertTrue(names.contains("direct"));
+        assertTrue(names.contains("imap"));
+        assertTrue(names.contains("imaps"));
+        assertTrue(names.contains("jdbc"));
+        assertTrue(names.contains("log"));
+        assertTrue(names.contains("servlet"));
+        assertTrue(names.contains("twitter-search"));
         // camel-pax-logging does not work in quarkus
         assertFalse(names.contains("paxlogging"));
     }
@@ -78,8 +80,8 @@ public class QuarkusRuntimeProviderTest {
         assertNotNull(names);
         assertFalse(names.isEmpty());
 
-        assertTrue(names.contains("bindy-csv"));
-        assertTrue(names.contains("zipdeflater"));
+        assertTrue(names.contains("csv"));
+        assertTrue(names.contains("mime-multipart"));
         assertTrue(names.contains("zipfile"));
     }
 
@@ -90,9 +92,15 @@ public class QuarkusRuntimeProviderTest {
         assertNotNull(names);
         assertFalse(names.isEmpty());
 
+        // core languages
+        assertTrue(names.contains("constant"));
         assertTrue(names.contains("simple"));
-        assertTrue(names.contains("spel"));
-        assertTrue(names.contains("xpath"));
+
+        // quarkus-bean
+        assertTrue(names.contains("bean"));
+
+        // spring expression language are not in quarkus
+        assertFalse(names.contains("spel"));
     }
 
     @Test
@@ -102,43 +110,44 @@ public class QuarkusRuntimeProviderTest {
         assertNotNull(names);
         assertFalse(names.isEmpty());
 
-        assertTrue(names.contains("hystrix"));
-        assertTrue(names.contains("spring-boot"));
-        assertTrue(names.contains("zipkin"));
+        assertTrue(names.contains("core-cloud"));
+        assertTrue(names.contains("platform-http"));
+        assertTrue(names.contains("reactive-executor"));
 
         assertFalse(names.contains("blueprint"));
+        assertFalse(names.contains("hystrix"));
     }
 
     @Test
     public void testComponentArtifactId() throws Exception {
-        String json = catalog.componentJSonSchema("ftp");
+        String json = catalog.componentJSonSchema("salesforce");
 
         assertNotNull(json);
-        assertTrue(json.contains("camel-ftp-starter"));
+        assertTrue(json.contains("camel-quarkus-salesforce"));
     }
 
     @Test
     public void testDataFormatArtifactId() throws Exception {
-        String json = catalog.dataFormatJSonSchema("bindy-csv");
+        String json = catalog.dataFormatJSonSchema("csv");
 
         assertNotNull(json);
-        assertTrue(json.contains("camel-bindy-starter"));
+        assertTrue(json.contains("camel-quarkus-csv"));
     }
 
     @Test
     public void testLanguageArtifactId() throws Exception {
-        String json = catalog.languageJSonSchema("spel");
+        String json = catalog.languageJSonSchema("bean");
 
         assertNotNull(json);
-        assertTrue(json.contains("camel-spring-starter"));
+        assertTrue(json.contains("camel-quarkus-bean"));
     }
 
     @Test
     public void testOtherArtifactId() throws Exception {
-        String json = catalog.otherJSonSchema("zipkin");
+        String json = catalog.otherJSonSchema("reactive-executor");
 
         assertNotNull(json);
-        assertTrue(json.contains("camel-zipkin-starter"));
+        assertTrue(json.contains("camel-quarkus-reactive-executor"));
     }
 
 }

--- a/catalog/camel-quarkus-catalog/src/test/java/org/apache/camel/catalog/quarkus/QuarkusRuntimeProviderTest.java
+++ b/catalog/camel-quarkus-catalog/src/test/java/org/apache/camel/catalog/quarkus/QuarkusRuntimeProviderTest.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.catalog.quarkus;
+
+import java.util.List;
+
+import org.apache.camel.catalog.CamelCatalog;
+import org.apache.camel.catalog.DefaultCamelCatalog;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+// TODO: Update
+
+@Ignore
+public class QuarkusRuntimeProviderTest {
+
+    static CamelCatalog catalog;
+
+    @BeforeClass
+    public static void createCamelCatalog() {
+        catalog = new DefaultCamelCatalog();
+        catalog.setRuntimeProvider(new QuarkusRuntimeProvider());
+    }
+
+    @Test
+    public void testGetVersion() throws Exception {
+        String version = catalog.getCatalogVersion();
+        assertNotNull(version);
+
+        String loaded = catalog.getLoadedVersion();
+        assertNotNull(loaded);
+        assertEquals(version, loaded);
+    }
+
+    @Test
+    public void testProviderName() throws Exception {
+        assertEquals("quarkus", catalog.getRuntimeProvider().getProviderName());
+    }
+
+    @Test
+    public void testFindComponentNames() throws Exception {
+        List<String> names = catalog.findComponentNames();
+
+        assertNotNull(names);
+        assertFalse(names.isEmpty());
+
+        assertTrue(names.contains("file"));
+        assertTrue(names.contains("ftp"));
+        assertTrue(names.contains("jms"));
+        // camel-pax-logging does not work in quarkus
+        assertFalse(names.contains("paxlogging"));
+    }
+
+    @Test
+    public void testFindDataFormatNames() throws Exception {
+        List<String> names = catalog.findDataFormatNames();
+
+        assertNotNull(names);
+        assertFalse(names.isEmpty());
+
+        assertTrue(names.contains("bindy-csv"));
+        assertTrue(names.contains("zipdeflater"));
+        assertTrue(names.contains("zipfile"));
+    }
+
+    @Test
+    public void testFindLanguageNames() throws Exception {
+        List<String> names = catalog.findLanguageNames();
+
+        assertNotNull(names);
+        assertFalse(names.isEmpty());
+
+        assertTrue(names.contains("simple"));
+        assertTrue(names.contains("spel"));
+        assertTrue(names.contains("xpath"));
+    }
+
+    @Test
+    public void testFindOtherNames() throws Exception {
+        List<String> names = catalog.findOtherNames();
+
+        assertNotNull(names);
+        assertFalse(names.isEmpty());
+
+        assertTrue(names.contains("hystrix"));
+        assertTrue(names.contains("spring-boot"));
+        assertTrue(names.contains("zipkin"));
+
+        assertFalse(names.contains("blueprint"));
+    }
+
+    @Test
+    public void testComponentArtifactId() throws Exception {
+        String json = catalog.componentJSonSchema("ftp");
+
+        assertNotNull(json);
+        assertTrue(json.contains("camel-ftp-starter"));
+    }
+
+    @Test
+    public void testDataFormatArtifactId() throws Exception {
+        String json = catalog.dataFormatJSonSchema("bindy-csv");
+
+        assertNotNull(json);
+        assertTrue(json.contains("camel-bindy-starter"));
+    }
+
+    @Test
+    public void testLanguageArtifactId() throws Exception {
+        String json = catalog.languageJSonSchema("spel");
+
+        assertNotNull(json);
+        assertTrue(json.contains("camel-spring-starter"));
+    }
+
+    @Test
+    public void testOtherArtifactId() throws Exception {
+        String json = catalog.otherJSonSchema("zipkin");
+
+        assertNotNull(json);
+        assertTrue(json.contains("camel-zipkin-starter"));
+    }
+
+}

--- a/catalog/pom.xml
+++ b/catalog/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.camel.quarkus</groupId>
+        <artifactId>camel-quarkus-parent</artifactId>
+        <version>0.2.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>catalog</artifactId>
+    <packaging>pom</packaging>
+
+    <name>Camel Quarkus :: Catalog</name>
+
+    <modules>
+        <module>camel-quarkus-catalog</module>
+    </modules>
+
+</project>

--- a/extensions/core-cloud/runtime/pom.xml
+++ b/extensions/core-cloud/runtime/pom.xml
@@ -28,6 +28,13 @@
 
     <artifactId>camel-quarkus-core-cloud</artifactId>
     <name>Camel Quarkus :: Core :: Cloud :: Runtime</name>
+    <description>The Camel Quarkus core cloud module</description>
+
+    <properties>
+        <title>Camel Quarkus Core Cloud</title>
+        <firstVersion>0.2.0</firstVersion>
+        <label>core,cloud</label>
+    </properties>
 
     <dependencyManagement>
         <dependencies>

--- a/extensions/core/runtime/pom.xml
+++ b/extensions/core/runtime/pom.xml
@@ -27,6 +27,13 @@
 
     <artifactId>camel-quarkus-core</artifactId>
     <name>Camel Quarkus :: Core :: Runtime</name>
+    <description>The Camel Quarkus core module</description>
+
+    <properties>
+        <title>Camel Quarkus Core</title>
+        <firstVersion>0.2.0</firstVersion>
+        <label>core</label>
+    </properties>
 
     <dependencyManagement>
         <dependencies>

--- a/extensions/platform-http/runtime/pom.xml
+++ b/extensions/platform-http/runtime/pom.xml
@@ -30,6 +30,13 @@
 
     <artifactId>camel-quarkus-platform-http</artifactId>
     <name>Camel Quarkus :: Platform HTTP :: Runtime</name>
+    <description>HTTP platform component is used for integrating Camel HTTP with Quarkus HTTP layer</description>
+
+    <properties>
+        <title>Camel Quarkus Platform HTTP</title>
+        <firstVersion>0.2.1</firstVersion>
+        <label>core,http</label>
+    </properties>
 
     <dependencyManagement>
         <dependencies>

--- a/extensions/reactive-executor/pom.xml
+++ b/extensions/reactive-executor/pom.xml
@@ -31,6 +31,7 @@
     <artifactId>camel-quarkus-reactive-executor-parent</artifactId>
     <name>Camel Quarkus :: Core :: Reactive Executor</name>
     <packaging>pom</packaging>
+
     <modules>
         <module>deployment</module>
         <module>runtime</module>

--- a/extensions/reactive-executor/runtime/pom.xml
+++ b/extensions/reactive-executor/runtime/pom.xml
@@ -28,6 +28,11 @@
 
     <artifactId>camel-quarkus-reactive-executor</artifactId>
     <name>Camel Quarkus :: Core :: Reactive Executor :: Runtime</name>
+    <description>To use Quarkus reactive executor with Camel</description>
+
+    <properties>
+        <firstVersion>0.2.1</firstVersion>
+    </properties>
 
     <dependencyManagement>
         <dependencies>

--- a/extensions/reactive-executor/runtime/pom.xml
+++ b/extensions/reactive-executor/runtime/pom.xml
@@ -31,7 +31,9 @@
     <description>To use Quarkus reactive executor with Camel</description>
 
     <properties>
+        <title>Camel Quarkus Reactive Executor</title>
         <firstVersion>0.2.1</firstVersion>
+        <label>core</label>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -74,8 +74,9 @@
         <module>poms/bom</module>
         <module>poms/bom-deployment</module>
         <module>poms/build-parent</module>
-        <module>poms/tooling</module>
+        <module>tooling</module>
         <module>extensions</module>
+        <module>catalog</module>
         <module>integration-tests</module>
         <module>examples</module>
         <module>docs</module>

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@
         <module>poms/bom</module>
         <module>poms/bom-deployment</module>
         <module>poms/build-parent</module>
+        <module>poms/tooling</module>
         <module>extensions</module>
         <module>integration-tests</module>
         <module>examples</module>

--- a/tooling/maven/package-maven-plugin/pom.xml
+++ b/tooling/maven/package-maven-plugin/pom.xml
@@ -84,6 +84,13 @@
             <groupId>org.sonatype.plexus</groupId>
             <artifactId>plexus-build-api</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.mvel</groupId>
+            <artifactId>mvel2</artifactId>
+            <version>2.4.4.Final</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/tooling/maven/package-maven-plugin/pom.xml
+++ b/tooling/maven/package-maven-plugin/pom.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.camel.quarkus</groupId>
+        <artifactId>camel-quarkus-tooling-maven</artifactId>
+        <version>0.2.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>camel-quarkus-package-maven-plugin</artifactId>
+    <packaging>maven-plugin</packaging>
+
+    <name>Camel Quarkus :: Tooling :: Maven :: Camel Quarkus Package Maven Plugin</name>
+    <description>Maven plugin to help package Camel quarkus components and plugins</description>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.camel.quarkus</groupId>
+                <artifactId>tooling-parent</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.codehaus.plexus</groupId>
+                    <artifactId>plexus-classworlds</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.plexus</groupId>
+                    <artifactId>plexus-component-annotations</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugin-tools</groupId>
+            <artifactId>maven-plugin-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-container-default</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-utils</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.sonatype.plexus</groupId>
+            <artifactId>plexus-build-api</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-plugin-plugin</artifactId>
+                <configuration>
+                    <mojoDependencies>
+                        <dep>org.apache.maven:maven-plugin-api</dep>
+                    </mojoDependencies>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/tooling/maven/package-maven-plugin/src/main/java/org/apache/camel/quarkus/maven/PackageHelper.java
+++ b/tooling/maven/package-maven-plugin/src/main/java/org/apache/camel/quarkus/maven/PackageHelper.java
@@ -67,6 +67,35 @@ public final class PackageHelper {
         }
     }
 
+    /**
+     * Converts the value to use title style instead of dash cased
+     */
+    public static String camelDashToTitle(String value) {
+        StringBuilder sb = new StringBuilder(value.length());
+        boolean dash = false;
+
+        for (char c : value.toCharArray()) {
+            if ('-' == c) {
+                dash = true;
+                continue;
+            }
+
+            if (dash) {
+                sb.append(' ');
+                sb.append(Character.toUpperCase(c));
+            } else {
+                // upper case first
+                if (sb.length() == 0) {
+                    sb.append(Character.toUpperCase(c));
+                } else {
+                    sb.append(c);
+                }
+            }
+            dash = false;
+        }
+        return sb.toString();
+    }
+
     public static void writeText(File file, String text) throws IOException {
         FileOutputStream fos = new FileOutputStream(file, false);
         try {

--- a/tooling/maven/package-maven-plugin/src/main/java/org/apache/camel/quarkus/maven/PackageHelper.java
+++ b/tooling/maven/package-maven-plugin/src/main/java/org/apache/camel/quarkus/maven/PackageHelper.java
@@ -18,20 +18,11 @@ package org.apache.camel.quarkus.maven;
 
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileFilter;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.LineNumberReader;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
-
-// TODO: Remove not needed stuff
 
 public final class PackageHelper {
 
@@ -102,106 +93,6 @@ public final class PackageHelper {
             fos.write(text.getBytes());
         } finally {
             fos.close();
-        }
-    }
-
-    public static String after(String text, String after) {
-        if (!text.contains(after)) {
-            return null;
-        }
-        return text.substring(text.indexOf(after) + after.length());
-    }
-
-    /**
-     * Parses the text as a map (eg key=value)
-     * @param data the data
-     * @return the map
-     */
-    public static Map<String, String> parseAsMap(String data) {
-        Map<String, String> answer = new HashMap<>();
-        if (data != null) {
-            String[] lines = data.split("\n");
-            for (String line : lines) {
-                int idx = line.indexOf('=');
-                if (idx != -1) {
-                    String key = line.substring(0, idx);
-                    String value = line.substring(idx + 1);
-                    // remove ending line break for the values
-                    value = value.trim().replaceAll("\n", "");
-                    answer.put(key.trim(), value);
-                }
-            }
-        }
-        return answer;
-    }
-
-    public static Set<File> findJsonFiles(File dir, FileFilter filter) {
-        Set<File> files = new TreeSet<>();
-        findJsonFiles(dir, files, filter);
-
-        return files;
-    }
-
-    public static void findJsonFiles(File dir, Set<File> found, FileFilter filter) {
-        File[] files = dir.listFiles(filter);
-        if (files != null) {
-            for (File file : files) {
-                // skip files in root dirs as Camel does not store information there but others may do
-                boolean jsonFile = file.isFile() && file.getName().endsWith(".json");
-                if (jsonFile) {
-                    found.add(file);
-                } else if (file.isDirectory()) {
-                    findJsonFiles(file, found, filter);
-                }
-            }
-        }
-    }
-
-    public static class CamelComponentsModelFilter implements FileFilter {
-
-        @Override
-        public boolean accept(File pathname) {
-            return pathname.isDirectory() || pathname.getName().endsWith(".json");
-        }
-    }
-
-    public static class CamelOthersModelFilter implements FileFilter {
-
-        @Override
-        public boolean accept(File pathname) {
-            String name = pathname.getName();
-            boolean special = "camel-core-osgi".equals(name)
-                || "camel-core-xml".equals(name)
-                || "camel-http-common".equals(name)
-                || "camel-jetty-common".equals(name);
-            boolean special2 = "camel-as2".equals(name)
-                || "camel-box".equals(name)
-                || "camel-linkedin".equals(name)
-                || "camel-olingo2".equals(name)
-                || "camel-olingo4".equals(name)
-                || "camel-salesforce".equals(name);
-            if (special || special2) {
-                return false;
-            }
-
-            return pathname.isDirectory() || name.endsWith(".json");
-        }
-    }
-
-    public static File findCamelCoreDirectory(File dir) {
-        return findCamelDirectory(dir, "core/camel-core-engine");
-    }
-
-    public static File findCamelDirectory(File dir, String path) {
-        if (dir == null) {
-            return null;
-        }
-        Path p = dir.toPath().resolve(path);
-        if (Files.isDirectory(p)) {
-            return p.toFile();
-        } else {
-            // okay walk up the parent dir
-            return findCamelDirectory(dir.getParentFile(), path);
         }
     }
 

--- a/tooling/maven/package-maven-plugin/src/main/java/org/apache/camel/quarkus/maven/PackageHelper.java
+++ b/tooling/maven/package-maven-plugin/src/main/java/org/apache/camel/quarkus/maven/PackageHelper.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.maven;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileFilter;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.LineNumberReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+// TODO: Remove not needed stuff
+
+public final class PackageHelper {
+
+    private PackageHelper() {
+    }
+    
+    /**
+     * Loads the entire stream into memory as a String and returns it.
+     * <p/>
+     * <b>Notice:</b> This implementation appends a <tt>\n</tt> as line
+     * terminator at the of the text.
+     * <p/>
+     * Warning, don't use for crazy big streams :)
+     */
+    public static String loadText(InputStream in) throws IOException {
+        StringBuilder builder = new StringBuilder();
+        InputStreamReader isr = new InputStreamReader(in);
+        try {
+            BufferedReader reader = new LineNumberReader(isr);
+            while (true) {
+                String line = reader.readLine();
+                if (line != null) {
+                    builder.append(line);
+                    builder.append("\n");
+                } else {
+                    break;
+                }
+            }
+            return builder.toString();
+        } finally {
+            isr.close();
+            in.close();
+        }
+    }
+
+    public static void writeText(File file, String text) throws IOException {
+        FileOutputStream fos = new FileOutputStream(file, false);
+        try {
+            fos.write(text.getBytes());
+        } finally {
+            fos.close();
+        }
+    }
+
+    public static String after(String text, String after) {
+        if (!text.contains(after)) {
+            return null;
+        }
+        return text.substring(text.indexOf(after) + after.length());
+    }
+
+    /**
+     * Parses the text as a map (eg key=value)
+     * @param data the data
+     * @return the map
+     */
+    public static Map<String, String> parseAsMap(String data) {
+        Map<String, String> answer = new HashMap<>();
+        if (data != null) {
+            String[] lines = data.split("\n");
+            for (String line : lines) {
+                int idx = line.indexOf('=');
+                if (idx != -1) {
+                    String key = line.substring(0, idx);
+                    String value = line.substring(idx + 1);
+                    // remove ending line break for the values
+                    value = value.trim().replaceAll("\n", "");
+                    answer.put(key.trim(), value);
+                }
+            }
+        }
+        return answer;
+    }
+
+    public static Set<File> findJsonFiles(File dir, FileFilter filter) {
+        Set<File> files = new TreeSet<>();
+        findJsonFiles(dir, files, filter);
+
+        return files;
+    }
+
+    public static void findJsonFiles(File dir, Set<File> found, FileFilter filter) {
+        File[] files = dir.listFiles(filter);
+        if (files != null) {
+            for (File file : files) {
+                // skip files in root dirs as Camel does not store information there but others may do
+                boolean jsonFile = file.isFile() && file.getName().endsWith(".json");
+                if (jsonFile) {
+                    found.add(file);
+                } else if (file.isDirectory()) {
+                    findJsonFiles(file, found, filter);
+                }
+            }
+        }
+    }
+
+    public static class CamelComponentsModelFilter implements FileFilter {
+
+        @Override
+        public boolean accept(File pathname) {
+            return pathname.isDirectory() || pathname.getName().endsWith(".json");
+        }
+    }
+
+    public static class CamelOthersModelFilter implements FileFilter {
+
+        @Override
+        public boolean accept(File pathname) {
+            String name = pathname.getName();
+            boolean special = "camel-core-osgi".equals(name)
+                || "camel-core-xml".equals(name)
+                || "camel-http-common".equals(name)
+                || "camel-jetty-common".equals(name);
+            boolean special2 = "camel-as2".equals(name)
+                || "camel-box".equals(name)
+                || "camel-linkedin".equals(name)
+                || "camel-olingo2".equals(name)
+                || "camel-olingo4".equals(name)
+                || "camel-salesforce".equals(name);
+            if (special || special2) {
+                return false;
+            }
+
+            return pathname.isDirectory() || name.endsWith(".json");
+        }
+    }
+
+    public static File findCamelCoreDirectory(File dir) {
+        return findCamelDirectory(dir, "core/camel-core-engine");
+    }
+
+    public static File findCamelDirectory(File dir, String path) {
+        if (dir == null) {
+            return null;
+        }
+        Path p = dir.toPath().resolve(path);
+        if (Files.isDirectory(p)) {
+            return p.toFile();
+        } else {
+            // okay walk up the parent dir
+            return findCamelDirectory(dir.getParentFile(), path);
+        }
+    }
+
+}

--- a/tooling/maven/package-maven-plugin/src/main/java/org/apache/camel/quarkus/maven/PrepareCatalogQuarkusMojo.java
+++ b/tooling/maven/package-maven-plugin/src/main/java/org/apache/camel/quarkus/maven/PrepareCatalogQuarkusMojo.java
@@ -59,8 +59,6 @@ import static org.apache.camel.quarkus.maven.PackageHelper.loadText;
 @Mojo(name = "prepare-catalog-quarkus", threadSafe = true, requiresDependencyCollection = ResolutionScope.COMPILE_PLUS_RUNTIME)
 public class PrepareCatalogQuarkusMojo extends AbstractMojo {
 
-    // TODO: match by artifact-id instead of directory name (mail -> camel-mail JAR -> component names (alias files, so copy over)
-
     private static final String[] EXCLUDE_EXTENSIONS = {
             "http-common", "jetty-common", "support", "xml-common", "xstream-common"
     };
@@ -133,7 +131,7 @@ public class PrepareCatalogQuarkusMojo extends AbstractMojo {
         executeComponents(artifacts);
         executeLanguages(artifacts);
         executeDataFormats(artifacts);
-//        executeOthers(artifacts);
+//        executeOthers(artifacts); // TODO: implement me
     }
 
     private Set<String> extractArtifactIds(Set<String> extensions) throws MojoFailureException {
@@ -378,12 +376,7 @@ public class PrepareCatalogQuarkusMojo extends AbstractMojo {
     }
 
     private static boolean isExcludedExtension(String name) {
-        for (String exclude : EXCLUDE_EXTENSIONS) {
-            if (exclude.equals(name)) {
-                return true;
-            }
-        }
-        return false;
+        return Arrays.asList(EXCLUDE_EXTENSIONS).contains(name);
     }
 
 }

--- a/tooling/maven/package-maven-plugin/src/main/java/org/apache/camel/quarkus/maven/PrepareCatalogQuarkusMojo.java
+++ b/tooling/maven/package-maven-plugin/src/main/java/org/apache/camel/quarkus/maven/PrepareCatalogQuarkusMojo.java
@@ -18,7 +18,6 @@ package org.apache.camel.quarkus.maven;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -53,6 +52,7 @@ import org.mvel2.templates.TemplateRuntime;
 
 import static org.apache.camel.quarkus.maven.PackageHelper.camelDashToTitle;
 import static org.apache.camel.quarkus.maven.PackageHelper.loadText;
+import static org.apache.camel.quarkus.maven.PackageHelper.writeText;
 
 /**
  * Prepares the Quarkus provider camel catalog to include component it supports
@@ -226,13 +226,8 @@ public class PrepareCatalogQuarkusMojo extends AbstractMojo {
                     String scheme = matcher.group(1);
 
                     try {
-                        // write new json file
                         File to = new File(outsDir, scheme + ".json");
-                        FileOutputStream fos = new FileOutputStream(to, false);
-
-                        fos.write(text.getBytes());
-
-                        fos.close();
+                        writeText(to, text);
                     } catch (IOException e) {
                         throw new MojoFailureException("Cannot write json file " + scheme, e);
                     }
@@ -242,11 +237,8 @@ public class PrepareCatalogQuarkusMojo extends AbstractMojo {
 
         File all = new File(outsDir, "../" + kind + ".properties");
         try {
-            FileOutputStream fos = new FileOutputStream(all, false);
-
             String[] names = outsDir.list();
             List<String> lines = new ArrayList<>();
-            // sort the names
             for (String name : names) {
                 if (name.endsWith(".json")) {
                     // strip out .json from the name
@@ -254,14 +246,11 @@ public class PrepareCatalogQuarkusMojo extends AbstractMojo {
                     lines.add(shortName);
                 }
             }
-
+            // sort lines
             Collections.sort(lines);
-            for (String name : lines) {
-                fos.write(name.getBytes());
-                fos.write("\n".getBytes());
-            }
-
-            fos.close();
+            // write properties file
+            String text = String.join("\n", lines);
+            writeText(all, text);
 
             getLog().info("Added " + lines.size() + " " + kind + " to quarkus-camel-catalog");
 
@@ -313,11 +302,7 @@ public class PrepareCatalogQuarkusMojo extends AbstractMojo {
 
                 // write new json file
                 File to = new File(othersOutDir, extension + ".json");
-                FileOutputStream fos = new FileOutputStream(to, false);
-
-                fos.write(text.getBytes());
-
-                fos.close();
+                writeText(to, text);
 
             } catch (IOException e) {
                 throw new MojoFailureException("Cannot write json file " + extension, e);
@@ -328,8 +313,6 @@ public class PrepareCatalogQuarkusMojo extends AbstractMojo {
 
         File all = new File(othersOutDir, "../others.properties");
         try {
-            FileOutputStream fos = new FileOutputStream(all, false);
-
             String[] names = othersOutDir.list();
             List<String> others = new ArrayList<>();
             // sort the names
@@ -342,12 +325,9 @@ public class PrepareCatalogQuarkusMojo extends AbstractMojo {
             }
 
             Collections.sort(others);
-            for (String name : others) {
-                fos.write(name.getBytes());
-                fos.write("\n".getBytes());
-            }
-
-            fos.close();
+            // write properties file
+            String text = String.join("\n", others);
+            writeText(all, text);
 
             getLog().info("Added " + others.size() + " others to quarkus-camel-catalog");
 

--- a/tooling/maven/package-maven-plugin/src/main/java/org/apache/camel/quarkus/maven/PrepareCatalogQuarkusMojo.java
+++ b/tooling/maven/package-maven-plugin/src/main/java/org/apache/camel/quarkus/maven/PrepareCatalogQuarkusMojo.java
@@ -1,0 +1,715 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.maven;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Pattern;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.MavenProjectHelper;
+
+import static org.apache.camel.quarkus.maven.PackageHelper.loadText;
+
+/**
+ * Prepares the Quarkus provider camel catalog to include component it supports
+ */
+@Mojo(name = "prepare-catalog-quarkus", threadSafe = true)
+public class PrepareCatalogQuarkusMojo extends AbstractMojo {
+
+    public static final int BUFFER_SIZE = 128 * 1024;
+
+    private static final Pattern ARTIFACT_PATTERN = Pattern.compile("\"artifactId\": \"camel-(.*)\"");
+
+    /**
+     * The maven project.
+     */
+    @Parameter(property = "project", required = true, readonly = true)
+    protected MavenProject project;
+
+    /**
+     * The output directory for components catalog
+     */
+    @Parameter(defaultValue = "${project.build.directory}/classes/org/apache/camel/catalog/springboot/components")
+    protected File componentsOutDir;
+
+    /**
+     * The output directory for dataformats catalog
+     */
+    @Parameter(defaultValue = "${project.build.directory}/classes/org/apache/camel/catalog/springboot/dataformats")
+    protected File dataFormatsOutDir;
+
+    /**
+     * The output directory for languages catalog
+     */
+    @Parameter(defaultValue = "${project.build.directory}/classes/org/apache/camel/catalog/springboot/languages")
+    protected File languagesOutDir;
+
+    /**
+     * The output directory for others catalog
+     */
+    @Parameter(defaultValue = "${project.build.directory}/classes/org/apache/camel/catalog/springboot/others")
+    protected File othersOutDir;
+
+    /**
+     * The directory where all spring-boot starters are
+     */
+    @Parameter(defaultValue = "${project.build.directory}/../../../platforms/spring-boot/quarkus-starter")
+    protected File componentsStarterDir;
+
+    /**
+     * The components directory where all the Apache Camel components are
+     */
+    @Parameter(defaultValue = "${project.build.directory}/../../../components")
+    protected File componentsDir;
+
+    /**
+     * The camel-core directory
+     */
+    @Parameter(defaultValue = "${project.build.directory}/../../../core/camel-core-engine")
+    protected File coreDir;
+
+    /**
+     * The camel-base directory
+     */
+    @Parameter(defaultValue = "${project.build.directory}/../../../core/camel-base")
+    protected File baseDir;
+
+    /**
+     * Maven ProjectHelper.
+     */
+    @Component
+    private MavenProjectHelper projectHelper;
+
+    /**
+     * Execute goal.
+     *
+     * @throws MojoExecutionException execution of the main class or one of the
+     *                                                        threads it generated failed.
+     * @throws MojoFailureException   something bad happened...
+     */
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        Set<String> starters = findSpringBootStarters();
+        executeComponents(starters);
+        executeDataFormats(starters);
+        executeLanguages(starters);
+        executeOthers(starters);
+    }
+
+    protected void executeComponents(Set<String> starters) throws MojoExecutionException, MojoFailureException {
+        getLog().info("Copying all Camel component json descriptors");
+
+        // lets use sorted set/maps
+        Set<File> jsonFiles = new TreeSet<>();
+        Set<File> componentFiles = new TreeSet<>();
+
+        // find all json files in components and camel-core
+        if (componentsDir != null && componentsDir.isDirectory()) {
+            File[] components = componentsDir.listFiles();
+            if (components != null) {
+                for (File dir : components) {
+                    if (dir.isDirectory() && !"target".equals(dir.getName())) {
+                        File target = new File(dir, "target/classes");
+
+                        // the directory must be in the list of known features
+                        if (!starters.contains(dir.getName())) {
+                            continue;
+                        }
+
+                        // special for some which is in a sub dir
+                        if ("camel-as2".equals(dir.getName())) {
+                            target = new File(dir, "camel-as2-component/target/classes");
+                        } else if ("camel-box".equals(dir.getName())) {
+                            target = new File(dir, "camel-box-component/target/classes");
+                        } else if ("camel-salesforce".equals(dir.getName())) {
+                            target = new File(dir, "camel-salesforce-component/target/classes");
+                        } else if ("camel-linkedin".equals(dir.getName())) {
+                            target = new File(dir, "camel-linkedin-component/target/classes");
+                        } else if ("camel-servicenow".equals(dir.getName())) {
+                            target = new File(dir, "camel-servicenow-component/target/classes");
+                        } else {
+                            // this module must be active with a source folder
+                            File src = new File(dir, "src");
+                            boolean active = src.isDirectory() && src.exists();
+                            if (!active) {
+                                continue;
+                            }
+                        }
+
+
+                        findComponentFilesRecursive(target, jsonFiles, componentFiles, new CamelComponentsFileFilter());
+                    }
+                }
+            }
+        }
+        if (coreDir != null && coreDir.isDirectory()) {
+            File target = new File(coreDir, "target/classes");
+            findComponentFilesRecursive(target, jsonFiles, componentFiles, new CamelComponentsFileFilter());
+        }
+
+        getLog().info("Found " + componentFiles.size() + " component.properties files");
+        getLog().info("Found " + jsonFiles.size() + " component json files");
+
+        // make sure to create out dir
+        componentsOutDir.mkdirs();
+
+        for (File file : jsonFiles) {
+            // for spring-boot we need to amend the json file to use -starter as the artifact-id
+            try {
+                String text = loadText(new FileInputStream(file));
+
+                text = ARTIFACT_PATTERN.matcher(text).replaceFirst("\"artifactId\": \"camel-$1-starter\"");
+
+                // write new json file
+                File to = new File(componentsOutDir, file.getName());
+                FileOutputStream fos = new FileOutputStream(to, false);
+
+                fos.write(text.getBytes());
+
+                fos.close();
+
+            } catch (IOException e) {
+                throw new MojoFailureException("Cannot write json file " + file, e);
+            }
+        }
+
+        File all = new File(componentsOutDir, "../components.properties");
+        try {
+            FileOutputStream fos = new FileOutputStream(all, false);
+
+            String[] names = componentsOutDir.list();
+            List<String> components = new ArrayList<>();
+            // sort the names
+            for (String name : names) {
+                if (name.endsWith(".json")) {
+                    // strip out .json from the name
+                    String componentName = name.substring(0, name.length() - 5);
+                    components.add(componentName);
+                }
+            }
+
+            Collections.sort(components);
+            for (String name : components) {
+                fos.write(name.getBytes());
+                fos.write("\n".getBytes());
+            }
+
+            fos.close();
+
+        } catch (IOException e) {
+            throw new MojoFailureException("Error writing to file " + all);
+        }
+    }
+
+    protected void executeDataFormats(Set<String> starters) throws MojoExecutionException, MojoFailureException {
+        getLog().info("Copying all Camel dataformat json descriptors");
+
+        // lets use sorted set/maps
+        Set<File> jsonFiles = new TreeSet<>();
+        Set<File> dataFormatFiles = new TreeSet<>();
+
+        // find all data formats from the components directory
+        if (componentsDir != null && componentsDir.isDirectory()) {
+            File[] dataFormats = componentsDir.listFiles();
+            if (dataFormats != null) {
+                for (File dir : dataFormats) {
+                    if (dir.isDirectory() && !"target".equals(dir.getName())) {
+                        // the directory must be in the list of known starters
+                        if (!starters.contains(dir.getName())) {
+                            continue;
+                        }
+                        // this module must be active with a source folder
+                        File src = new File(dir, "src");
+                        boolean active = src.isDirectory() && src.exists();
+                        if (!active) {
+                            continue;
+                        }
+                        File target = new File(dir, "target/classes");
+                        findDataFormatFilesRecursive(target, jsonFiles, dataFormatFiles, new CamelDataFormatsFileFilter());
+                    }
+                }
+            }
+        }
+        if (coreDir != null && coreDir.isDirectory()) {
+            File target = new File(coreDir, "target/classes");
+            findDataFormatFilesRecursive(target, jsonFiles, dataFormatFiles, new CamelDataFormatsFileFilter());
+        }
+
+        getLog().info("Found " + dataFormatFiles.size() + " dataformat.properties files");
+        getLog().info("Found " + jsonFiles.size() + " dataformat json files");
+
+        // make sure to create out dir
+        dataFormatsOutDir.mkdirs();
+
+        for (File file : jsonFiles) {
+            // for spring-boot we need to amend the json file to use -starter as the artifact-id
+            try {
+                String text = loadText(new FileInputStream(file));
+
+                text = ARTIFACT_PATTERN.matcher(text).replaceFirst("\"artifactId\": \"camel-$1-starter\"");
+
+                // write new json file
+                File to = new File(dataFormatsOutDir, file.getName());
+                FileOutputStream fos = new FileOutputStream(to, false);
+
+                fos.write(text.getBytes());
+
+                fos.close();
+
+            } catch (IOException e) {
+                throw new MojoFailureException("Cannot write json file " + file, e);
+            }
+        }
+
+        File all = new File(dataFormatsOutDir, "../dataformats.properties");
+        try {
+            FileOutputStream fos = new FileOutputStream(all, false);
+
+            String[] names = dataFormatsOutDir.list();
+            List<String> dataFormats = new ArrayList<>();
+            // sort the names
+            for (String name : names) {
+                if (name.endsWith(".json")) {
+                    // strip out .json from the name
+                    String dataFormatName = name.substring(0, name.length() - 5);
+                    dataFormats.add(dataFormatName);
+                }
+            }
+
+            Collections.sort(dataFormats);
+            for (String name : dataFormats) {
+                fos.write(name.getBytes());
+                fos.write("\n".getBytes());
+            }
+
+            fos.close();
+
+        } catch (IOException e) {
+            throw new MojoFailureException("Error writing to file " + all);
+        }
+    }
+
+    protected void executeLanguages(Set<String> starters) throws MojoExecutionException, MojoFailureException {
+        getLog().info("Copying all Camel language json descriptors");
+
+        // lets use sorted set/maps
+        Set<File> jsonFiles = new TreeSet<>();
+        Set<File> languageFiles = new TreeSet<>();
+
+        // find all languages from the components directory
+        if (componentsDir != null && componentsDir.isDirectory()) {
+            File[] languages = componentsDir.listFiles();
+            if (languages != null) {
+                for (File dir : languages) {
+                    // the directory must be in the list of known starters
+                    if (!starters.contains(dir.getName())) {
+                        continue;
+                    }
+                    // this module must be active with a source folder
+                    File src = new File(dir, "src");
+                    boolean active = src.isDirectory() && src.exists();
+                    if (!active) {
+                        continue;
+                    }
+                    if (dir.isDirectory() && !"target".equals(dir.getName())) {
+                        File target = new File(dir, "target/classes");
+                        findLanguageFilesRecursive(target, jsonFiles, languageFiles, new CamelLanguagesFileFilter());
+                    }
+                }
+            }
+        }
+        if (baseDir != null && baseDir.isDirectory()) {
+            File target = new File(baseDir, "target/classes");
+            findLanguageFilesRecursive(target, jsonFiles, languageFiles, new CamelLanguagesFileFilter());
+            // also look in camel-jaxp
+            target = new File(coreDir, "../camel-jaxp/target/classes");
+            findLanguageFilesRecursive(target, jsonFiles, languageFiles, new CamelLanguagesFileFilter());
+        }
+
+        getLog().info("Found " + languageFiles.size() + " language.properties files");
+        getLog().info("Found " + jsonFiles.size() + " language json files");
+
+        // make sure to create out dir
+        languagesOutDir.mkdirs();
+
+        for (File file : jsonFiles) {
+            // for spring-boot we need to amend the json file to use -starter as the artifact-id
+            try {
+                String text = loadText(new FileInputStream(file));
+
+                text = ARTIFACT_PATTERN.matcher(text).replaceFirst("\"artifactId\": \"camel-$1-starter\"");
+
+                // write new json file
+                File to = new File(languagesOutDir, file.getName());
+                FileOutputStream fos = new FileOutputStream(to, false);
+
+                fos.write(text.getBytes());
+
+                fos.close();
+
+            } catch (IOException e) {
+                throw new MojoFailureException("Cannot write json file " + file, e);
+            }
+        }
+
+        File all = new File(languagesOutDir, "../languages.properties");
+        try {
+            FileOutputStream fos = new FileOutputStream(all, false);
+
+            String[] names = languagesOutDir.list();
+            List<String> languages = new ArrayList<>();
+            // sort the names
+            for (String name : names) {
+                if (name.endsWith(".json")) {
+                    // strip out .json from the name
+                    String languageName = name.substring(0, name.length() - 5);
+                    languages.add(languageName);
+                }
+            }
+
+            Collections.sort(languages);
+            for (String name : languages) {
+                fos.write(name.getBytes());
+                fos.write("\n".getBytes());
+            }
+
+            fos.close();
+
+        } catch (IOException e) {
+            throw new MojoFailureException("Error writing to file " + all);
+        }
+    }
+
+    protected void executeOthers(Set<String> starters) throws MojoExecutionException, MojoFailureException {
+        getLog().info("Copying all Camel other json descriptors");
+
+        // lets use sorted set/maps
+        Set<File> jsonFiles = new TreeSet<>();
+        Set<File> otherFiles = new TreeSet<>();
+
+        // find all other from the components directory
+        if (componentsDir != null && componentsDir.isDirectory()) {
+            File[] others = componentsDir.listFiles();
+            if (others != null) {
+                for (File dir : others) {
+                    // the directory must be in the list of known starters
+                    if (!starters.contains(dir.getName())) {
+                        continue;
+                    }
+
+                    // skip these special cases
+                    boolean special = "camel-core-osgi".equals(dir.getName())
+                        || "camel-core-xml".equals(dir.getName())
+                        || "camel-http-common".equals(dir.getName())
+                        || "camel-jetty-common".equals(dir.getName());
+                    boolean special2 = "camel-as2".equals(dir.getName())
+                        || "camel-box".equals(dir.getName())
+                        || "camel-linkedin".equals(dir.getName())
+                        || "camel-olingo2".equals(dir.getName())
+                        || "camel-olingo4".equals(dir.getName())
+                        || "camel-servicenow".equals(dir.getName())
+                        || "camel-salesforce".equals(dir.getName());
+                    if (special || special2) {
+                        continue;
+                    }
+
+                    // this module must be active with a source folder
+                    File src = new File(dir, "src");
+                    boolean active = src.isDirectory() && src.exists();
+                    if (!active) {
+                        continue;
+                    }
+
+                    if (dir.isDirectory() && !"target".equals(dir.getName())) {
+                        File target = new File(dir, "target/classes");
+                        findOtherFilesRecursive(target, jsonFiles, otherFiles, new CamelOthersFileFilter());
+                    }
+                }
+            }
+        }
+
+        getLog().info("Found " + otherFiles.size() + " other.properties files");
+        getLog().info("Found " + jsonFiles.size() + " other json files");
+
+        // make sure to create out dir
+        othersOutDir.mkdirs();
+
+        for (File file : jsonFiles) {
+            // for spring-boot we need to amend the json file to use -starter as the artifact-id
+            try {
+                String text = loadText(new FileInputStream(file));
+
+                text = ARTIFACT_PATTERN.matcher(text).replaceFirst("\"artifactId\": \"camel-$1-starter\"");
+
+                // write new json file
+                File to = new File(othersOutDir, file.getName());
+                FileOutputStream fos = new FileOutputStream(to, false);
+
+                fos.write(text.getBytes());
+
+                fos.close();
+
+            } catch (IOException e) {
+                throw new MojoFailureException("Cannot write json file " + file, e);
+            }
+        }
+
+        File all = new File(othersOutDir, "../others.properties");
+        try {
+            FileOutputStream fos = new FileOutputStream(all, false);
+
+            String[] names = othersOutDir.list();
+            List<String> others = new ArrayList<>();
+            // sort the names
+            for (String name : names) {
+                if (name.endsWith(".json")) {
+                    // strip out .json from the name
+                    String otherName = name.substring(0, name.length() - 5);
+                    others.add(otherName);
+                }
+            }
+
+            Collections.sort(others);
+            for (String name : others) {
+                fos.write(name.getBytes());
+                fos.write("\n".getBytes());
+            }
+
+            fos.close();
+
+        } catch (IOException e) {
+            throw new MojoFailureException("Error writing to file " + all);
+        }
+    }
+
+    private void findComponentFilesRecursive(File dir, Set<File> found, Set<File> components, FileFilter filter) {
+        File[] files = dir.listFiles(filter);
+        if (files != null) {
+            for (File file : files) {
+                // skip files in root dirs as Camel does not store information there but others may do
+                boolean rootDir = "classes".equals(dir.getName()) || "META-INF".equals(dir.getName());
+                boolean jsonFile = !rootDir && file.isFile() && file.getName().endsWith(".json");
+                boolean componentFile = !rootDir && file.isFile() && file.getName().equals("component.properties");
+                if (jsonFile) {
+                    found.add(file);
+                } else if (componentFile) {
+                    components.add(file);
+                } else if (file.isDirectory()) {
+                    findComponentFilesRecursive(file, found, components, filter);
+                }
+            }
+        }
+    }
+
+    private void findDataFormatFilesRecursive(File dir, Set<File> found, Set<File> dataFormats, FileFilter filter) {
+        File[] files = dir.listFiles(filter);
+        if (files != null) {
+            for (File file : files) {
+                // skip files in root dirs as Camel does not store information there but others may do
+                boolean rootDir = "classes".equals(dir.getName()) || "META-INF".equals(dir.getName());
+                boolean jsonFile = !rootDir && file.isFile() && file.getName().endsWith(".json");
+                boolean dataFormatFile = !rootDir && file.isFile() && file.getName().equals("dataformat.properties");
+                if (jsonFile) {
+                    found.add(file);
+                } else if (dataFormatFile) {
+                    dataFormats.add(file);
+                } else if (file.isDirectory()) {
+                    findDataFormatFilesRecursive(file, found, dataFormats, filter);
+                }
+            }
+        }
+    }
+
+    private void findLanguageFilesRecursive(File dir, Set<File> found, Set<File> languages, FileFilter filter) {
+        File[] files = dir.listFiles(filter);
+        if (files != null) {
+            for (File file : files) {
+                // skip files in root dirs as Camel does not store information there but others may do
+                boolean rootDir = "classes".equals(dir.getName()) || "META-INF".equals(dir.getName());
+                boolean jsonFile = !rootDir && file.isFile() && file.getName().endsWith(".json");
+                boolean languageFile = !rootDir && file.isFile() && file.getName().equals("language.properties");
+                if (jsonFile) {
+                    found.add(file);
+                } else if (languageFile) {
+                    languages.add(file);
+                } else if (file.isDirectory()) {
+                    findLanguageFilesRecursive(file, found, languages, filter);
+                }
+            }
+        }
+    }
+
+    private void findOtherFilesRecursive(File dir, Set<File> found, Set<File> others, FileFilter filter) {
+        File[] files = dir.listFiles(filter);
+        if (files != null) {
+            for (File file : files) {
+                // skip files in root dirs as Camel does not store information there but others may do
+                boolean rootDir = "classes".equals(dir.getName()) || "META-INF".equals(dir.getName());
+                boolean jsonFile = rootDir && file.isFile() && file.getName().endsWith(".json");
+                boolean otherFile = !rootDir && file.isFile() && file.getName().equals("other.properties");
+                if (jsonFile) {
+                    found.add(file);
+                } else if (otherFile) {
+                    others.add(file);
+                } else if (file.isDirectory()) {
+                    findOtherFilesRecursive(file, found, others, filter);
+                }
+            }
+        }
+    }
+
+    private class CamelComponentsFileFilter implements FileFilter {
+
+        @Override
+        public boolean accept(File pathname) {
+            if (pathname.isDirectory() && pathname.getName().equals("model")) {
+                // do not check the camel-core model packages as there is no components there
+                return false;
+            }
+            if (pathname.isFile() && pathname.getName().endsWith(".json")) {
+                // must be a components json file
+                try {
+                    String json = loadText(new FileInputStream(pathname));
+                    return json != null && json.contains("\"kind\": \"component\"");
+                } catch (IOException e) {
+                    // ignore
+                }
+            }
+            return pathname.isDirectory() || (pathname.isFile() && pathname.getName().equals("component.properties"));
+        }
+    }
+
+    private class CamelDataFormatsFileFilter implements FileFilter {
+
+        @Override
+        public boolean accept(File pathname) {
+            if (pathname.isDirectory() && pathname.getName().equals("model")) {
+                // do not check the camel-core model packages as there is no components there
+                return false;
+            }
+            if (pathname.isFile() && pathname.getName().endsWith(".json")) {
+                // must be a dataformat json file
+                try {
+                    String json = loadText(new FileInputStream(pathname));
+                    return json != null && json.contains("\"kind\": \"dataformat\"");
+                } catch (IOException e) {
+                    // ignore
+                }
+            }
+            return pathname.isDirectory() || (pathname.isFile() && pathname.getName().equals("dataformat.properties"));
+        }
+    }
+
+    private class CamelLanguagesFileFilter implements FileFilter {
+
+        @Override
+        public boolean accept(File pathname) {
+            if (pathname.isDirectory() && pathname.getName().equals("model")) {
+                // do not check the camel-core model packages as there is no components there
+                return false;
+            }
+            if (pathname.isFile() && pathname.getName().endsWith(".json")) {
+                // must be a language json file
+                try {
+                    String json = loadText(new FileInputStream(pathname));
+                    return json != null && json.contains("\"kind\": \"language\"");
+                } catch (IOException e) {
+                    // ignore
+                }
+            }
+            return pathname.isDirectory() || (pathname.isFile() && pathname.getName().equals("language.properties"));
+        }
+    }
+
+    private class CamelOthersFileFilter implements FileFilter {
+
+        @Override
+        public boolean accept(File pathname) {
+            if (pathname.isFile() && pathname.getName().endsWith(".json")) {
+                // must be a language json file
+                try {
+                    String json = loadText(new FileInputStream(pathname));
+                    return json != null && json.contains("\"kind\": \"other\"");
+                } catch (IOException e) {
+                    // ignore
+                }
+            }
+            return pathname.isDirectory() || (pathname.isFile() && pathname.getName().equals("other.properties"));
+        }
+    }
+
+    public static void copyFile(File from, File to) throws IOException {
+        FileChannel in = null;
+        FileChannel out = null;
+        try (FileInputStream fis = new FileInputStream(from); FileOutputStream fos = new FileOutputStream(to)) {
+            try {
+                in = fis.getChannel();
+                out = fos.getChannel();
+
+                long size = in.size();
+                long position = 0;
+                while (position < size) {
+                    position += in.transferTo(position, BUFFER_SIZE, out);
+                }
+            } finally {
+                if (in != null) {
+                    in.close();
+                }
+                if (out != null) {
+                    out.close();
+                }
+            }
+        }
+    }
+
+    private Set<String> findSpringBootStarters() {
+        Set<String> answer = new LinkedHashSet<>();
+
+        String[] names = componentsStarterDir.list();
+        if (names != null) {
+            for (String name : names) {
+                if (name.startsWith("camel-") && name.endsWith("-starter")) {
+                    // remove ending -starter
+                    String regular = name.substring(0, name.length() - 8);
+                    answer.add(regular);
+                }
+            }
+        }
+
+        getLog().info("Found " + answer.size() + " Camel Spring Boot starters from: " + componentsStarterDir);
+
+        return answer;
+    }
+
+}

--- a/tooling/maven/package-maven-plugin/src/main/resources/META-INF/LICENSE.txt
+++ b/tooling/maven/package-maven-plugin/src/main/resources/META-INF/LICENSE.txt
@@ -1,0 +1,203 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/tooling/maven/package-maven-plugin/src/main/resources/META-INF/NOTICE.txt
+++ b/tooling/maven/package-maven-plugin/src/main/resources/META-INF/NOTICE.txt
@@ -1,0 +1,11 @@
+   =========================================================================
+   ==  NOTICE file corresponding to the section 4 d of                    ==
+   ==  the Apache License, Version 2.0,                                   ==
+   ==  in this case for the Apache Camel distribution.                    ==
+   =========================================================================
+
+   This product includes software developed by
+   The Apache Software Foundation (http://www.apache.org/).
+
+   Please read the different LICENSE files present in the licenses directory of
+   this distribution.

--- a/tooling/maven/package-maven-plugin/src/main/resources/camel-quarkus-package-maven-plugin.properties
+++ b/tooling/maven/package-maven-plugin/src/main/resources/camel-quarkus-package-maven-plugin.properties
@@ -1,0 +1,16 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------

--- a/tooling/maven/package-maven-plugin/src/main/resources/other-template.mvel
+++ b/tooling/maven/package-maven-plugin/src/main/resources/other-template.mvel
@@ -1,0 +1,14 @@
+{
+ "other": {
+    "name": "@{name}",
+    "kind": "other",
+    "title": "@{title}",
+    "description": "@{description}",
+    "deprecated": @{deprecated},
+    "firstVersion": "@{firstVersion}",
+    "label": "@{label}",
+    "groupId": "@{groupId}",
+    "artifactId": "@{artifactId}",
+    "version": "@{version}"
+  }
+}

--- a/tooling/maven/pom.xml
+++ b/tooling/maven/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.camel.quarkus</groupId>
+        <artifactId>camel-quarkus-tooling</artifactId>
+        <version>0.2.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>camel-quarkus-tooling-maven</artifactId>
+    <packaging>pom</packaging>
+
+    <name>Camel Quarkus :: Tooling :: Maven</name>
+
+    <modules>
+        <!--
+        <module></module>
+    -->
+    </modules>
+
+</project>

--- a/tooling/maven/pom.xml
+++ b/tooling/maven/pom.xml
@@ -17,7 +17,8 @@
     limitations under the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
     <parent>
@@ -32,9 +33,7 @@
     <name>Camel Quarkus :: Tooling :: Maven</name>
 
     <modules>
-        <!--
-        <module></module>
-    -->
+        <module>package-maven-plugin</module>
     </modules>
 
 </project>

--- a/tooling/parent/pom.xml
+++ b/tooling/parent/pom.xml
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.quarkus</groupId>
+        <artifactId>camel-quarkus-tooling</artifactId>
+        <version>0.2.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>tooling-parent</artifactId>
+    <packaging>pom</packaging>
+
+    <name>Camel Quarkus :: Tooling Parent</name>
+    <description>Camel Quarkus Tooling Parent POM</description>
+
+    <properties>
+
+        <!-- TODO: Update these -->
+        <maven-version>3.6.2</maven-version>
+        <maven-maven-plugin-descriptor-version>2.2.1</maven-maven-plugin-descriptor-version>
+        <maven-project-version>2.2.1</maven-project-version>
+        <maven-dependency-tree-version>3.0.1</maven-dependency-tree-version>
+        <maven-plugin-annotations-version>3.6.0</maven-plugin-annotations-version>
+        <maven-reporting-api-version>3.0</maven-reporting-api-version>
+        <maven-reporting-impl-version>3.0.0</maven-reporting-impl-version>
+        <maven-resolver-version>1.4.1</maven-resolver-version>
+        <plexus-build-api-version>0.0.7</plexus-build-api-version>
+        <plexus-container-default-version>2.0.0</plexus-container-default-version>
+        <plexus-utils-version>3.2.1</plexus-utils-version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-core</artifactId>
+                <version>${maven-version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-jdk14</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>jcl-over-slf4j</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-nop</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-artifact</artifactId>
+                <version>${maven-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-plugin-api</artifactId>
+                <version>${maven-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-compat</artifactId>
+                <version>${maven-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven.plugin-tools</groupId>
+                <artifactId>maven-plugin-annotations</artifactId>
+                <version>${maven-plugin-annotations-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-plugin-descriptor</artifactId>
+                <version>${maven-maven-plugin-descriptor-version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>log4j</groupId>
+                        <artifactId>log4j</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-project</artifactId>
+                <version>${maven-project-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven.shared</groupId>
+                <artifactId>maven-dependency-tree</artifactId>
+                <version>${maven-dependency-tree-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven.reporting</groupId>
+                <artifactId>maven-reporting-api</artifactId>
+                <version>${maven-reporting-api-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven.reporting</groupId>
+                <artifactId>maven-reporting-impl</artifactId>
+                <version>${maven-reporting-impl-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven.resolver</groupId>
+                <artifactId>maven-resolver-api</artifactId>
+                <version>${maven-resolver-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven.resolver</groupId>
+                <artifactId>maven-resolver-util</artifactId>
+                <version>${maven-resolver-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-container-default</artifactId>
+                <version>${plexus-container-default-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-utils</artifactId>
+                <version>${plexus-utils-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.sonatype.plexus</groupId>
+                <artifactId>plexus-build-api</artifactId>
+                <version>${plexus-build-api-version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/tooling/parent/pom.xml
+++ b/tooling/parent/pom.xml
@@ -34,8 +34,6 @@
     <description>Camel Quarkus Tooling Parent POM</description>
 
     <properties>
-
-        <!-- TODO: Update these -->
         <maven-version>3.6.2</maven-version>
         <maven-maven-plugin-descriptor-version>2.2.1</maven-maven-plugin-descriptor-version>
         <maven-project-version>2.2.1</maven-project-version>

--- a/tooling/pom.xml
+++ b/tooling/pom.xml
@@ -32,6 +32,7 @@
     <name>Camel Quarkus :: Tooling</name>
 
     <modules>
+        <module>parent</module>
         <module>maven</module>
     </modules>
 

--- a/tooling/pom.xml
+++ b/tooling/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.camel.quarkus</groupId>
+        <artifactId>camel-quarkus-parent</artifactId>
+        <version>0.2.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>camel-quarkus-tooling</artifactId>
+    <packaging>pom</packaging>
+
+    <name>Camel Quarkus :: Tooling</name>
+
+    <modules>
+        <module>maven</module>
+    </modules>
+
+</project>


### PR DESCRIPTION
Fixes #75: Adding camel-quarkus-catalog

This implementation is similar to what we do at apache camel using maven plugins as tools to generate catalog metadata that gets included in the camel-quarkus-catalog JAR. 