### PR TITLE
#257 The cp -R command on Mac OS X behaves differently

### DIFF
--- a/docs/modules/ROOT/pages/user-guide.adoc
+++ b/docs/modules/ROOT/pages/user-guide.adoc
@@ -46,7 +46,7 @@ git checkout $(git describe --abbrev=0)
 [source,shell]
 ----
 cd ..
-cp -r camel-quarkus/integration-tests/servlet/ .
+cp -r camel-quarkus/integration-tests/servlet .
 cd servlet
 ----
 


### PR DESCRIPTION
The way is compatible with Mac OS X and Linux / UNIX
```
cp -r camel-quarkus/integration-tests/servlet .
```

The following is the description of the -R parameter in the man pages for cp on Mac OS X:

If source_file designates a directory, cp copies the directory and the entire subtree connected at that point. If the source_file ends in a /, the contents of the directory are copied rather than the directory itself. This option also causes symbolic links to be copied, rather than indirected through, and for cp to create special files rather than copying them as normal files. Created directories have the same mode as the corresponding source directory, unmodified by the process' umask.