### PR TITLE
Fix #326 platform-http should return 415 for an unaccepted content type

### DIFF
--- a/extensions/platform-http/component/src/main/java/org/apache/camel/component/platform/http/PlatformHttpComponent.java
+++ b/extensions/platform-http/component/src/main/java/org/apache/camel/component/platform/http/PlatformHttpComponent.java
@@ -143,6 +143,8 @@ public class PlatformHttpComponent extends DefaultComponent implements RestConsu
 
         PlatformHttpEndpoint endpoint = camelContext.getEndpoint(url, PlatformHttpEndpoint.class);
         setProperties(camelContext, endpoint, parameters);
+        endpoint.setConsumes(consumes);
+        endpoint.setProduces(produces);
 
         // configure consumer properties
         Consumer consumer = endpoint.createConsumer(processor);

--- a/extensions/platform-http/component/src/main/java/org/apache/camel/component/platform/http/PlatformHttpEndpoint.java
+++ b/extensions/platform-http/component/src/main/java/org/apache/camel/component/platform/http/PlatformHttpEndpoint.java
@@ -44,6 +44,14 @@ public class PlatformHttpEndpoint extends DefaultEndpoint implements AsyncEndpoi
             + " If no methods are specified, all methods will be served.")
     private String httpMethodRestrict;
 
+    @UriParam(label = "consumer", description = "The content type this endpoint accepts as an input, such as"
+            + " application/xml or application/json. <code>null</code> or <code>&#42;/&#42;</code> mean no restriction.")
+    private String consumes;
+
+    @UriParam(label = "consumer", description = "The content type this endpoint produces, such as"
+        + " application/xml or application/json.")
+    private String produces;
+
     @UriParam(label = "consumer,advanced", description = "A comma or whitespace separated list of file extensions."
             + " Uploads having these extensions will be stored locally."
             + " Null value or asterisk (*) will allow all files.")
@@ -106,6 +114,22 @@ public class PlatformHttpEndpoint extends DefaultEndpoint implements AsyncEndpoi
 
     public void setFileNameExtWhitelist(String fileNameExtWhitelist) {
         this.fileNameExtWhitelist = fileNameExtWhitelist;
+    }
+
+    public String getConsumes() {
+        return consumes;
+    }
+
+    public void setConsumes(String consumes) {
+        this.consumes = consumes;
+    }
+
+    public String getProduces() {
+        return produces;
+    }
+
+    public void setProduces(String produces) {
+        this.produces = produces;
     }
 
     @Override

--- a/extensions/platform-http/runtime/src/main/java/org/apache/camel/quarkus/component/platform/http/runtime/QuarkusPlatformHttpConsumer.java
+++ b/extensions/platform-http/runtime/src/main/java/org/apache/camel/quarkus/component/platform/http/runtime/QuarkusPlatformHttpConsumer.java
@@ -92,12 +92,16 @@ public class QuarkusPlatformHttpConsumer extends DefaultConsumer {
     protected void doStart() throws Exception {
         super.doStart();
 
-        final String path = getEndpoint().getPath();
+        final PlatformHttpEndpoint endpoint = getEndpoint();
+        final String path = endpoint.getPath();
         final Route newRoute = router.route(path);
 
-        final Set<Method> methods = Method.parseList(getEndpoint().getHttpMethodRestrict());
+        final Set<Method> methods = Method.parseList(endpoint.getHttpMethodRestrict());
         if (!methods.equals(Method.getAll())) {
             methods.stream().forEach(m -> newRoute.method(HttpMethod.valueOf(m.name())));
+        }
+        if (endpoint.getConsumes() != null) {
+            newRoute.consumes(endpoint.getConsumes());
         }
 
         handlers.forEach(newRoute::handler);

--- a/extensions/platform-http/runtime/src/main/java/org/apache/camel/quarkus/component/platform/http/runtime/QuarkusPlatformHttpConsumer.java
+++ b/extensions/platform-http/runtime/src/main/java/org/apache/camel/quarkus/component/platform/http/runtime/QuarkusPlatformHttpConsumer.java
@@ -103,6 +103,9 @@ public class QuarkusPlatformHttpConsumer extends DefaultConsumer {
         if (endpoint.getConsumes() != null) {
             newRoute.consumes(endpoint.getConsumes());
         }
+        if (endpoint.getProduces() != null) {
+            newRoute.produces(endpoint.getProduces());
+        }
 
         handlers.forEach(newRoute::handler);
 

--- a/integration-tests/platform-http/src/main/java/org/apache/camel/quarkus/component/platform/http/it/PlatformHttpRouteBuilder.java
+++ b/integration-tests/platform-http/src/main/java/org/apache/camel/quarkus/component/platform/http/it/PlatformHttpRouteBuilder.java
@@ -84,5 +84,8 @@ public class PlatformHttpRouteBuilder extends RouteBuilder {
         from("platform-http:/platform-http/consumes?httpMethodRestrict=POST&consumes=text/plain")
             .setBody(simple("Hello ${body}"));
 
+        from("platform-http:/platform-http/produces?httpMethodRestrict=POST&produces=text/plain")
+            .setBody(simple("Hello ${body}"));
+
     }
 }

--- a/integration-tests/platform-http/src/main/java/org/apache/camel/quarkus/component/platform/http/it/PlatformHttpRouteBuilder.java
+++ b/integration-tests/platform-http/src/main/java/org/apache/camel/quarkus/component/platform/http/it/PlatformHttpRouteBuilder.java
@@ -81,5 +81,8 @@ public class PlatformHttpRouteBuilder extends RouteBuilder {
             .to("log:response-code")
             .setHeader(Exchange.HTTP_RESPONSE_CODE).constant(299);
 
+        from("platform-http:/platform-http/consumes?httpMethodRestrict=POST&consumes=text/plain")
+            .setBody(simple("Hello ${body}"));
+
     }
 }

--- a/integration-tests/platform-http/src/test/java/org/apache/camel/quarkus/component/http/server/it/PlatformHttpTest.java
+++ b/integration-tests/platform-http/src/test/java/org/apache/camel/quarkus/component/http/server/it/PlatformHttpTest.java
@@ -89,6 +89,37 @@ class PlatformHttpTest {
             .statusCode(200);
     }
 
+
+    @Test
+    public void produces() throws Throwable {
+        RestAssured.given()
+            .accept("application/json")
+            .contentType("text/plain")
+            .post("/platform-http/rest-post")
+            .then()
+            .statusCode(406);
+
+        RestAssured.given()
+            .accept("text/plain")
+            .contentType("text/plain")
+            .post("/platform-http/rest-post")
+            .then()
+            .statusCode(200);
+
+        RestAssured.given()
+            .accept("application/json")
+            .contentType("text/plain")
+            .post("/platform-http/produces")
+            .then()
+            .statusCode(406);
+
+        RestAssured.given()
+            .accept("text/plain")
+            .contentType("text/plain")
+            .post("/platform-http/produces")
+            .then()
+            .statusCode(200);
+    }
     @Test
     public void invalidMethod() {
         RestAssured.post("/platform-http/hello")

--- a/integration-tests/platform-http/src/test/java/org/apache/camel/quarkus/component/http/server/it/PlatformHttpTest.java
+++ b/integration-tests/platform-http/src/test/java/org/apache/camel/quarkus/component/http/server/it/PlatformHttpTest.java
@@ -62,13 +62,31 @@ class PlatformHttpTest {
             .then().body(equalTo("POST: /rest-post"));
     }
 
-    @Disabled("See https://github.com/apache/camel-quarkus/issues/326")
     @Test
-    public void restConsumes() throws Throwable {
+    public void consumes() throws Throwable {
         RestAssured.given()
             .contentType("application/json")
             .post("/platform-http/rest-post")
-            .then().statusCode(415);
+            .then()
+            .statusCode(415);
+
+        RestAssured.given()
+            .contentType("text/plain")
+            .post("/platform-http/rest-post")
+            .then()
+            .statusCode(200);
+
+        RestAssured.given()
+            .contentType("application/json")
+            .post("/platform-http/consumes")
+            .then()
+            .statusCode(415);
+
+        RestAssured.given()
+            .contentType("text/plain")
+            .post("/platform-http/consumes")
+            .then()
+            .statusCode(200);
     }
 
     @Test


### PR DESCRIPTION
This is a rather straightforward fix. I found that the older HTTP components suffer from the same problem. That might also mean that a solution exists, and I just have not found it?