### PR TITLE
core: avoid referencing application classes in bean build items and loading them in core build processors

### DIFF
--- a/extensions/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/CamelBeanBuildItem.java
+++ b/extensions/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/CamelBeanBuildItem.java
@@ -34,10 +34,10 @@ import io.quarkus.runtime.RuntimeValue;
  */
 public final class CamelBeanBuildItem extends MultiBuildItem {
     private final String name;
-    private final Class<?> type;
+    private final String type;
     private final RuntimeValue<?> value;
 
-    public CamelBeanBuildItem(String name, Class<?> type, RuntimeValue<?> value) {
+    public CamelBeanBuildItem(String name, String type, RuntimeValue<?> value) {
         this.name = Objects.requireNonNull(name);
         this.type = Objects.requireNonNull(type);
         this.value = Objects.requireNonNull(value);
@@ -47,7 +47,7 @@ public final class CamelBeanBuildItem extends MultiBuildItem {
         return name;
     }
 
-    public Class<?> getType() {
+    public String getType() {
         return type;
     }
 

--- a/extensions/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/CamelRuntimeBeanBuildItem.java
+++ b/extensions/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/CamelRuntimeBeanBuildItem.java
@@ -34,10 +34,10 @@ import io.quarkus.runtime.RuntimeValue;
  */
 public final class CamelRuntimeBeanBuildItem extends MultiBuildItem {
     private final String name;
-    private final Class<?> type;
+    private final String type;
     private final RuntimeValue<?> value;
 
-    public CamelRuntimeBeanBuildItem(String name, Class<?> type, RuntimeValue<?> value) {
+    public CamelRuntimeBeanBuildItem(String name, String type, RuntimeValue<?> value) {
         this.name = Objects.requireNonNull(name);
         this.type = Objects.requireNonNull(type);
         this.value = Objects.requireNonNull(value);
@@ -47,7 +47,7 @@ public final class CamelRuntimeBeanBuildItem extends MultiBuildItem {
         return name;
     }
 
-    public Class<?> getType() {
+    public String getType() {
         return type;
     }
 

--- a/extensions/core/runtime/src/main/java/org/apache/camel/quarkus/core/CamelMainRecorder.java
+++ b/extensions/core/runtime/src/main/java/org/apache/camel/quarkus/core/CamelMainRecorder.java
@@ -21,7 +21,6 @@ import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.ShutdownContext;
 import io.quarkus.runtime.annotations.Recorder;
 import org.apache.camel.CamelContext;
-import org.apache.camel.RoutesBuilder;
 import org.apache.camel.impl.engine.DefaultReactiveExecutor;
 import org.apache.camel.main.MainListener;
 import org.apache.camel.main.RoutesCollector;
@@ -53,17 +52,6 @@ public class CamelMainRecorder {
         container.instance(CamelMainProducers.class).setMain(main);
 
         return new RuntimeValue<>(main);
-    }
-
-    public void addRouteBuilder(
-            RuntimeValue<CamelMain> main,
-            Class<? extends RoutesBuilder> routeBuilderClass) {
-
-        try {
-            main.getValue().addRouteBuilder(routeBuilderClass);
-        } catch (Exception e) {
-            throw new RuntimeException("Could not add route builder '" + routeBuilderClass.getName() + "'", e);
-        }
     }
 
     public void addListener(RuntimeValue<CamelMain> main, RuntimeValue<MainListener> listener) {

--- a/extensions/microprofile-health/deployment/src/main/java/org/apache/camel/quarkus/component/microprofile/health/deployment/MicroProfileHealthProcessor.java
+++ b/extensions/microprofile-health/deployment/src/main/java/org/apache/camel/quarkus/component/microprofile/health/deployment/MicroProfileHealthProcessor.java
@@ -83,11 +83,10 @@ class MicroProfileHealthProcessor {
                     .filter(CamelSupport::isConcrete)
                     .filter(CamelSupport::isPublic)
                     .filter(ClassInfo::hasNoArgsConstructor)
-                    .map(classInfo -> {
-                        Class<?> clazz = recorderContext.classProxy(classInfo.toString());
-                        return new CamelBeanBuildItem(classInfo.simpleName(), HealthCheck.class,
-                                recorder.createHealthCheck(clazz));
-                    })
+                    .map(classInfo -> new CamelBeanBuildItem(
+                            classInfo.simpleName(),
+                            CAMEL_HEALTH_CHECK_DOTNAME.toString(),
+                            recorderContext.newInstance(classInfo.toString())))
                     .forEach(buildItems::add);
 
             // Create CamelBeanBuildItem to bind instances of HealthCheckRepository to the camel registry
@@ -96,11 +95,10 @@ class MicroProfileHealthProcessor {
                     .filter(CamelSupport::isPublic)
                     .filter(ClassInfo::hasNoArgsConstructor)
                     .filter(classInfo -> !classInfo.simpleName().equals(DefaultHealthCheckRegistry.class.getSimpleName()))
-                    .map(classInfo -> {
-                        Class<?> clazz = recorderContext.classProxy(classInfo.toString());
-                        return new CamelBeanBuildItem(classInfo.simpleName(), HealthCheckRepository.class,
-                                recorder.createHealthCheckRepository(clazz));
-                    })
+                    .map(classInfo -> new CamelBeanBuildItem(
+                            classInfo.simpleName(),
+                            CAMEL_HEALTH_CHECK_REPOSITORY_DOTNAME.toString(),
+                            recorderContext.newInstance(classInfo.toString())))
                     .forEach(buildItems::add);
         }
 

--- a/extensions/microprofile-health/runtime/src/main/java/org/apache/camel/quarkus/component/microprofile/health/runtime/CamelMicroProfileHealthRecorder.java
+++ b/extensions/microprofile-health/runtime/src/main/java/org/apache/camel/quarkus/component/microprofile/health/runtime/CamelMicroProfileHealthRecorder.java
@@ -24,20 +24,4 @@ import org.apache.camel.health.HealthCheckRepository;
 
 @Recorder
 public class CamelMicroProfileHealthRecorder {
-
-    public RuntimeValue<HealthCheck> createHealthCheck(Class<?> clazz) {
-        try {
-            return new RuntimeValue<>(HealthCheck.class.cast(clazz.newInstance()));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    public RuntimeValue<HealthCheckRepository> createHealthCheckRepository(Class<?> clazz) {
-        try {
-            return new RuntimeValue<>(HealthCheckRepository.class.cast(clazz.newInstance()));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
 }

--- a/extensions/microprofile-metrics/deployment/src/main/java/org/apache/camel/quarkus/component/microprofile/metrics/deployment/MicroProfileMetricsProcessor.java
+++ b/extensions/microprofile-metrics/deployment/src/main/java/org/apache/camel/quarkus/component/microprofile/metrics/deployment/MicroProfileMetricsProcessor.java
@@ -16,16 +16,17 @@
  */
 package org.apache.camel.quarkus.component.microprofile.metrics.deployment;
 
-import io.quarkus.arc.deployment.BeanContainerBuildItem;
-import io.quarkus.deployment.annotations.BuildStep;
-import io.quarkus.deployment.annotations.ExecutionTime;
-import io.quarkus.deployment.annotations.Record;
-import io.quarkus.deployment.builditem.FeatureBuildItem;
 import org.apache.camel.component.microprofile.metrics.MicroProfileMetricsConstants;
 import org.apache.camel.quarkus.component.microprofile.metrics.runtime.CamelMicroProfileMetricsConfig;
 import org.apache.camel.quarkus.component.microprofile.metrics.runtime.CamelMicroProfileMetricsRecorder;
 import org.apache.camel.quarkus.core.deployment.CamelBeanBuildItem;
 import org.eclipse.microprofile.metrics.MetricRegistry;
+
+import io.quarkus.arc.deployment.BeanContainerBuildItem;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
 
 class MicroProfileMetricsProcessor {
 
@@ -41,7 +42,7 @@ class MicroProfileMetricsProcessor {
     CamelBeanBuildItem metricRegistry(CamelMicroProfileMetricsRecorder recorder) {
         return new CamelBeanBuildItem(
                 MicroProfileMetricsConstants.METRIC_REGISTRY_NAME,
-                MetricRegistry.class,
+                MetricRegistry.class.getName(),
                 recorder.createApplicationRegistry());
     }
 

--- a/extensions/opentracing/deployment/src/main/java/org/apache/camel/quarkus/component/opentracing/deployment/OpenTracingProcessor.java
+++ b/extensions/opentracing/deployment/src/main/java/org/apache/camel/quarkus/component/opentracing/deployment/OpenTracingProcessor.java
@@ -16,6 +16,10 @@
  */
 package org.apache.camel.quarkus.component.opentracing.deployment;
 
+import org.apache.camel.quarkus.component.opentracing.CamelOpenTracingConfig;
+import org.apache.camel.quarkus.component.opentracing.CamelOpenTracingRecorder;
+import org.apache.camel.quarkus.core.deployment.CamelBeanBuildItem;
+
 import io.opentracing.Tracer;
 import io.quarkus.arc.deployment.BeanContainerBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
@@ -24,9 +28,6 @@ import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
-import org.apache.camel.quarkus.component.opentracing.CamelOpenTracingConfig;
-import org.apache.camel.quarkus.component.opentracing.CamelOpenTracingRecorder;
-import org.apache.camel.quarkus.core.deployment.CamelBeanBuildItem;
 
 class OpenTracingProcessor {
 
@@ -47,7 +48,9 @@ class OpenTracingProcessor {
     CamelBeanBuildItem setupCamelOpenTracingTracer(CamelOpenTracingConfig config, CamelOpenTracingRecorder recorder,
             BeanContainerBuildItem beanContainer) {
         // Configure & bind OpenTracingTracer to the registry so that Camel can use it
-        return new CamelBeanBuildItem("tracer", Tracer.class,
+        return new CamelBeanBuildItem(
+                "tracer",
+                Tracer.class.getName(),
                 recorder.createCamelOpenTracingTracer(config, beanContainer.getValue()));
     }
 }

--- a/extensions/platform-http/deployment/src/main/java/org/apache/camel/quarkus/component/platform/http/deployment/PlatformHttpProcessor.java
+++ b/extensions/platform-http/deployment/src/main/java/org/apache/camel/quarkus/component/platform/http/deployment/PlatformHttpProcessor.java
@@ -88,7 +88,7 @@ class PlatformHttpProcessor {
     CamelRuntimeBeanBuildItem platformHttpEngineBean(PlatformHttpRecorder recorder, PlatformHttpEngineBuildItem engine) {
         return new CamelRuntimeBeanBuildItem(
                 PlatformHttpConstants.PLATFORM_HTTP_ENGINE_NAME,
-                QuarkusPlatformHttpEngine.class,
+                QuarkusPlatformHttpEngine.class.getName(),
                 engine.getInstance());
     }
 
@@ -97,7 +97,7 @@ class PlatformHttpProcessor {
     CamelRuntimeBeanBuildItem platformHttpComponentBean(PlatformHttpRecorder recorder, PlatformHttpEngineBuildItem engine) {
         return new CamelRuntimeBeanBuildItem(
                 PlatformHttpConstants.PLATFORM_HTTP_COMPONENT_NAME,
-                PlatformHttpComponent.class,
+                PlatformHttpComponent.class.getName(),
                 recorder.createComponent(engine.getInstance()));
     }
 }

--- a/integration-tests/core/deployment/src/main/java/org/apache/camel/quarkus/core/support/deployment/SupportBuildStep.java
+++ b/integration-tests/core/deployment/src/main/java/org/apache/camel/quarkus/core/support/deployment/SupportBuildStep.java
@@ -29,7 +29,7 @@ public class SupportBuildStep {
     CamelBeanBuildItem logComponent(SupportRecorder recorder) {
         return new CamelBeanBuildItem(
                 "log",
-                LogComponent.class,
+                LogComponent.class.getName(),
                 recorder.logComponent());
     }
 }

--- a/integration-tests/validator/pom.xml
+++ b/integration-tests/validator/pom.xml
@@ -82,9 +82,6 @@
     <profiles>
         <profile>
             <id>native</id>
-            <properties>
-                <quarkus.native.additional-build-args>-H:ResourceConfigurationFiles=${project.basedir}/resources-config.json</quarkus.native.additional-build-args>
-            </properties>
             <activation>
                 <property>
                     <name>native</name>

--- a/integration-tests/validator/src/main/java/org/apache/camel/quarkus/component/validator/it/ValidatorResource.java
+++ b/integration-tests/validator/src/main/java/org/apache/camel/quarkus/component/validator/it/ValidatorResource.java
@@ -16,7 +16,6 @@
  */
 package org.apache.camel.quarkus.component.validator.it;
 
-import java.net.URI;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
@@ -24,20 +23,12 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 
-import org.apache.camel.Exchange;
-import org.apache.camel.Processor;
 import org.apache.camel.ProducerTemplate;
-import org.apache.camel.builder.ExchangeBuilder;
-import org.jboss.logging.Logger;
 
 @Path("/validator")
 @ApplicationScoped
 public class ValidatorResource {
-
-    private static final Logger LOG = Logger.getLogger(ValidatorResource.class);
-
     @Inject
     ProducerTemplate producerTemplate;
 
@@ -45,7 +36,7 @@ public class ValidatorResource {
     @POST
     @Consumes(MediaType.APPLICATION_XML)
     @Produces(MediaType.TEXT_PLAIN)
-    public String processOrder(String statement) throws Exception {
+    public String processOrder(String statement) {
         return producerTemplate.requestBody("direct:start", statement, String.class);
     }
 }

--- a/integration-tests/validator/src/main/java/org/apache/camel/quarkus/component/validator/it/ValidatorRouteBuilder.java
+++ b/integration-tests/validator/src/main/java/org/apache/camel/quarkus/component/validator/it/ValidatorRouteBuilder.java
@@ -21,8 +21,7 @@ import org.apache.camel.builder.RouteBuilder;
 public class ValidatorRouteBuilder extends RouteBuilder {
     @Override
     public void configure() {
-        // Add some routes or remove this class
         from("direct:start")
-                .to("validator:message.xsd");
+                .to("validator:file:src/main/resources/message.xsd");
     }
 }


### PR DESCRIPTION
Processors should avoid loading application classes during augmentation [1] so the reference to
beans class has been removed from `Camel*BeanBuildItem` and replaced by a simple string. I will 
follow up this PR with an additional one after reviewing how `Camel*BeanBuildItem` are used by
extensions.

[1] https://quarkus.io/guides/writing-extensions#bootstrap-three-phases