### PR TITLE
Startup a FHIR server when running the FHIR integration tests

### DIFF
--- a/docs/modules/ROOT/pages/list-of-camel-quarkus-extensions.adoc
+++ b/docs/modules/ROOT/pages/list-of-camel-quarkus-extensions.adoc
@@ -6,7 +6,7 @@ As of Camel Quarkus {camel-quarkus-last-release} the following Camel artifacts a
 == Camel Components
 
 // components: START
-Number of Camel components: 39 in 34 JAR artifacts (0 deprecated)
+Number of Camel components: 40 in 35 JAR artifacts (0 deprecated)
 
 [width="100%",cols="4,1,5",options="header"]
 |===

--- a/extensions/fhir/deployment/src/main/java/org/apache/camel/quarkus/component/fhir/deployment/FhirProcessor.java
+++ b/extensions/fhir/deployment/src/main/java/org/apache/camel/quarkus/component/fhir/deployment/FhirProcessor.java
@@ -34,7 +34,6 @@ import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBundleBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
-import io.quarkus.deployment.builditem.substrate.ReflectiveClassBuildItem;
 import org.apache.camel.component.fhir.FhirCapabilitiesEndpointConfiguration;
 import org.apache.camel.component.fhir.FhirConfiguration;
 import org.apache.camel.component.fhir.FhirCreateEndpointConfiguration;

--- a/extensions/readme.adoc
+++ b/extensions/readme.adoc
@@ -5,7 +5,7 @@ Apache Camel Quarkus supports the following Camel artifacts as Quarkus Extension
 == Camel Components
 
 // components: START
-Number of Camel components: 39 in 34 JAR artifacts (0 deprecated)
+Number of Camel components: 40 in 35 JAR artifacts (0 deprecated)
 
 [width="100%",cols="4,1,5",options="header"]
 |===

--- a/integration-tests/fhir/pom.xml
+++ b/integration-tests/fhir/pom.xml
@@ -74,6 +74,12 @@
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>io.quarkus</groupId>
@@ -88,16 +94,116 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>${maven-dependency-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>deploy-converter-factory</id>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>ca.uhn.hapi.fhir</groupId>
+                                    <artifactId>hapi-fhir-jpaserver-starter</artifactId>
+                                    <version>${hapi.server.version}</version>
+                                    <type>war</type>
+                                    <outputDirectory>${project.build.directory}/war</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>${build-helper-maven-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>reserve-fhir-port</id>
+                        <goals>
+                            <goal>reserve-network-port</goal>
+                        </goals>
+                        <phase>generate-test-sources</phase>
+                        <configuration>
+                            <portNames>
+                                <portName>fhir.port</portName>
+                                <portName>fhir.stop.port</portName>
+                            </portNames>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>${maven-resources-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>filter-resources</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>resources</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>properties-maven-plugin</artifactId>
+                <version>${properties-maven-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>set-system-properties</goal>
+                        </goals>
+                        <configuration>
+                            <properties>
+                                <property>
+                                    <name>hapi.properties</name>
+                                    <value>src/test/resources/hapi.properties</value>
+                                </property>
+                            </properties>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-maven-plugin</artifactId>
+                <version>${jetty-maven-plugin.version}</version>
                 <configuration>
-                    <systemProperties combine.children="append">
-                        <!--
-                            temporary disabled as FHIR testing service is down
-                        -->
-                        <quarkus.camel.fhir.enable-dstu2>false</quarkus.camel.fhir.enable-dstu2>
-                        <quarkus.camel.fhir.enable-r4>false</quarkus.camel.fhir.enable-r4>
-                    </systemProperties>
+                    <war>${project.build.directory}/war/hapi-fhir-jpaserver-starter-${hapi.server.version}.war</war>
+                    <stopKey>alpha</stopKey>
+                    <stopPort>${fhir.stop.port}</stopPort>
+                    <httpConnector>
+                        <port>${fhir.port}</port>
+                    </httpConnector>
+                    <supportedPackagings>
+                        <supportedPackaging>jar</supportedPackaging>
+                    </supportedPackagings>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>start-jetty</id>
+                        <phase>process-test-classes</phase>
+                        <goals>
+                            <goal>deploy-war</goal>
+                        </goals>
+                        <configuration>
+                            <scanIntervalSeconds>0</scanIntervalSeconds>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>stop-jetty</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>stop</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/integration-tests/fhir/src/main/java/org/apache/camel/quarkus/component/fhir/it/FhirDstu2RouteBuilder.java
+++ b/integration-tests/fhir/src/main/java/org/apache/camel/quarkus/component/fhir/it/FhirDstu2RouteBuilder.java
@@ -34,7 +34,7 @@ public class FhirDstu2RouteBuilder extends RouteBuilder {
             CamelContext context = getContext();
             FhirContext fhirContext = FhirContext.forDstu2();
             fhirContext.setParserErrorHandler(new StrictErrorHandler());
-            context.getRegistry().bind("fhirContext", fhirContext  );
+            context.getRegistry().bind("fhirContext", fhirContext);
             FhirJsonDataFormat fhirJsonDataFormat = new FhirJsonDataFormat();
             fhirJsonDataFormat.setFhirVersion(FhirVersionEnum.DSTU2.name());
             fhirJsonDataFormat.setParserErrorHandler(new StrictErrorHandler());
@@ -42,7 +42,6 @@ public class FhirDstu2RouteBuilder extends RouteBuilder {
             FhirXmlDataFormat fhirXmlDataFormat = new FhirXmlDataFormat();
             fhirXmlDataFormat.setFhirVersion(FhirVersionEnum.DSTU2.name());
             fhirXmlDataFormat.setParserErrorHandler(new StrictErrorHandler());
-
 
             from("direct:json-to-dstu2")
                     .unmarshal(fhirJsonDataFormat)

--- a/integration-tests/fhir/src/main/java/org/apache/camel/quarkus/component/fhir/it/FhirR4RouteBuilder.java
+++ b/integration-tests/fhir/src/main/java/org/apache/camel/quarkus/component/fhir/it/FhirR4RouteBuilder.java
@@ -34,7 +34,7 @@ public class FhirR4RouteBuilder extends RouteBuilder {
             CamelContext context = getContext();
             FhirContext fhirContext = FhirContext.forR4();
             fhirContext.setParserErrorHandler(new StrictErrorHandler());
-            context.getRegistry().bind("fhirContext", fhirContext  );
+            context.getRegistry().bind("fhirContext", fhirContext);
             FhirJsonDataFormat fhirJsonDataFormat = new FhirJsonDataFormat();
             fhirJsonDataFormat.setFhirVersion(FhirVersionEnum.R4.name());
             fhirJsonDataFormat.setParserErrorHandler(new StrictErrorHandler());

--- a/integration-tests/fhir/src/test/java/org/apache/camel/quarkus/component/fhir/it/FhirTest.java
+++ b/integration-tests/fhir/src/test/java/org/apache/camel/quarkus/component/fhir/it/FhirTest.java
@@ -26,10 +26,13 @@ import org.apache.camel.quarkus.component.fhir.FhirFlags;
 import org.hl7.fhir.dstu3.model.Address;
 import org.hl7.fhir.dstu3.model.HumanName;
 import org.hl7.fhir.dstu3.model.Patient;
+import org.jboss.logging.Logger;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
 class FhirTest {
+
+    private static final Logger LOG = Logger.getLogger(FhirTest.class);
 
     Boolean dstu2 = new FhirFlags.Dstu2Enabled().getAsBoolean();
     Boolean dstu3 = new FhirFlags.Dstu3Enabled().getAsBoolean();
@@ -40,6 +43,7 @@ class FhirTest {
         if (!dstu2) {
             return;
         }
+        LOG.info("Running DSTU2 JSON test");
         final ca.uhn.fhir.model.dstu2.resource.Patient patient = getDstu2Patient();
         String patientString = FhirContext.forDstu2().newJsonParser().encodeResourceToString(patient);
         RestAssured.given()
@@ -52,7 +56,7 @@ class FhirTest {
         if (!dstu2) {
             return;
         }
-
+        LOG.info("Running DSTU2 XML test");
         final ca.uhn.fhir.model.dstu2.resource.Patient patient = getDstu2Patient();
         String patientString = FhirContext.forDstu2().newXmlParser().encodeResourceToString(patient);
         RestAssured.given()
@@ -65,7 +69,7 @@ class FhirTest {
         if (!dstu2) {
             return;
         }
-
+        LOG.info("Running DSTU2 client test");
         final ca.uhn.fhir.model.dstu2.resource.Patient patient = getDstu2Patient();
         String patientString = FhirContext.forDstu2().newJsonParser().encodeResourceToString(patient);
         RestAssured.given()
@@ -78,7 +82,7 @@ class FhirTest {
         if (!dstu3) {
             return;
         }
-
+        LOG.info("Running DSTU3 JSON test");
         final Patient patient = getDstu3Patient();
         String patientString = FhirContext.forDstu3().newJsonParser().encodeResourceToString(patient);
         RestAssured.given()
@@ -91,7 +95,7 @@ class FhirTest {
         if (!dstu3) {
             return;
         }
-
+        LOG.info("Running DSTU3 XML test");
         final Patient patient = getDstu3Patient();
         String patientString = FhirContext.forDstu3().newXmlParser().encodeResourceToString(patient);
         RestAssured.given()
@@ -104,7 +108,7 @@ class FhirTest {
         if (!dstu3) {
             return;
         }
-
+        LOG.info("Running DSTU3 Client test");
         final Patient patient = getDstu3Patient();
         String patientString = FhirContext.forDstu3().newJsonParser().encodeResourceToString(patient);
         RestAssured.given()
@@ -117,7 +121,7 @@ class FhirTest {
         if (!r4) {
             return;
         }
-
+        LOG.info("Running R4 JSON test");
         final org.hl7.fhir.r4.model.Patient patient = getR4Patient();
         String patientString = FhirContext.forR4().newJsonParser().encodeResourceToString(patient);
         RestAssured.given()
@@ -130,7 +134,7 @@ class FhirTest {
         if (!r4) {
             return;
         }
-
+        LOG.info("Running R4 XML test");
         final org.hl7.fhir.r4.model.Patient patient = getR4Patient();
         String patientString = FhirContext.forR4().newXmlParser().encodeResourceToString(patient);
         RestAssured.given()
@@ -143,7 +147,7 @@ class FhirTest {
         if (!r4) {
             return;
         }
-
+        LOG.info("Running R4 Client test");
         final org.hl7.fhir.r4.model.Patient patient = getR4Patient();
         String patientString = FhirContext.forR4().newJsonParser().encodeResourceToString(patient);
         RestAssured.given()

--- a/integration-tests/fhir/src/test/resources/hapi.properties
+++ b/integration-tests/fhir/src/test/resources/hapi.properties
@@ -1,4 +1,4 @@
-## ---------------------------------------------------------------------------
+ ## ---------------------------------------------------------------------------
 ## Licensed to the Apache Software Foundation (ASF) under one or more
 ## contributor license agreements.  See the NOTICE file distributed with
 ## this work for additional information regarding copyright ownership.
@@ -15,24 +15,7 @@
 ## limitations under the License.
 ## ---------------------------------------------------------------------------
 #
-# Quarkus
+# FHIR Server
 #
-quarkus.ssl.native=true
-
-#
-# Quarkus :: Camel :: FHIR
-#
-# The HAPI-FHIR library, on which camel-fhir depends on, heavily uses reflection which affects performance in Quarkus
-# (memory footprint, build time, CPU resources etc...). For the sake of time, only DSTU3 (which is the default FHIR version)
-# tests are enabled by default.
-quarkus.camel.fhir.enable-dstu2=false
-quarkus.camel.fhir.enable-dstu3=true
-quarkus.camel.fhir.enable-r4=false
-
-#
-# Camel
-#
-fhir.dstu2.url=http://localhost:${fhir.port}/fhir
-fhir.dstu3.url=http://localhost:${fhir.port}/fhir
-fhir.r4.url=http://localhost:${fhir.port}/fhir
-fhir.verbose=false
+# Currently, only one FHIR version can be set at a time.
+fhir_version=DSTU3

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
 
         <camel.version>3.0.0-RC3</camel.version>
         <hapi.version>3.7.0</hapi.version>
+        <hapi.server.version>4.1.0</hapi.server.version>
         <quarkus.version>1.0.0.CR1</quarkus.version>
         <jetty.version>9.4.18.v20190429</jetty.version>
         <xstream.version>1.4.11</xstream.version>
@@ -59,16 +60,20 @@
         <!-- maven-enforcer-plugin -->
         <supported-maven-versions>[3.5.3,)</supported-maven-versions>
 
+        <build-helper-maven-plugin.version>3.0.0</build-helper-maven-plugin.version>
         <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
         <groovy-maven-plugin.version>2.1.1</groovy-maven-plugin.version>
         <groovy.version>2.5.8</groovy.version>
         <jandex-maven-plugin.version>1.0.6</jandex-maven-plugin.version>
+        <jetty-maven-plugin.version>9.4.20.v20190813</jetty-maven-plugin.version>
+        <properties-maven-plugin.version>1.0.0</properties-maven-plugin.version>
         <mycila-license.version>3.0</mycila-license.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
         <maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
         <maven-javadoc-plugin.version>3.1.1</maven-javadoc-plugin.version>
         <maven-source-plugin.version>3.1.0</maven-source-plugin.version>
         <maven-assembly-plugin.version>3.1.1</maven-assembly-plugin.version>
+        <maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
 
         <!-- maven-release-plugin -->
         <tagNameFormat>@{project.version}</tagNameFormat>


### PR DESCRIPTION
cc @lburgazzoli addresses #352 

This will fire up a FHIR server when running tests. Note that the FHIR server, based on hapi-fhir-jpaserver-starter, only supports running _one_ FHIR version at a time. I'm working on a PR to address this. Therefore to test all FHIR versions, multiple runs are necessary.

The jetty-maven-plugin's deploy-war goal re-runs the _validate_ Maven phase therefore some plugins are run twice namely:

- directory-maven-plugin:0.3.1:highest-basedir (directories)
- groovy-maven-plugin:2.1.1:execute (sanity-checks)
- maven-enforcer-plugin:1.4.1:enforce ((enforce-maven-version, camel-quarkus-enforcer-rules)

A future enhancement might be to separate the tests that don't need the FHIR server to run. This requires some work because we would have two "integration tests" profiles.

Thanks !