### PR TITLE
Startup a FHIR server when running the FHIR integration tests

### DIFF
--- a/extensions/fhir/deployment/src/main/java/org/apache/camel/quarkus/component/fhir/deployment/FhirProcessor.java
+++ b/extensions/fhir/deployment/src/main/java/org/apache/camel/quarkus/component/fhir/deployment/FhirProcessor.java
@@ -26,6 +26,7 @@ import ca.uhn.fhir.model.dstu2.FhirDstu2;
 import ca.uhn.fhir.model.dstu2.resource.BaseResource;
 import ca.uhn.fhir.model.dstu2.valueset.*;
 import ca.uhn.fhir.rest.client.apache.ApacheRestfulClientFactory;
+import ca.uhn.fhir.util.jar.DependencyLogImpl;
 import ca.uhn.fhir.validation.schematron.SchematronBaseValidator;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -101,10 +102,10 @@ class FhirProcessor {
     }
 
     @BuildStep(applicationArchiveMarkers = { "org/hl7/fhir", "ca/uhn/fhir" })
-    void processFhir(BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
-            BuildProducer<NativeImageResourceBundleBuildItem> resource) {
+    void processFhir(BuildProducer<ReflectiveClassBuildItem> reflectiveClass) {
         Set<String> classes = new HashSet<>();
         classes.add(SchematronBaseValidator.class.getCanonicalName());
+        classes.add(DependencyLogImpl.class.getCanonicalName());
         reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, true, classes.toArray(new String[0])));
         reflectiveClass
                 .produce(new ReflectiveClassBuildItem(true, true, true, ApacheRestfulClientFactory.class.getCanonicalName()));

--- a/integration-tests/fhir/pom.xml
+++ b/integration-tests/fhir/pom.xml
@@ -29,6 +29,11 @@
     <name>Camel Quarkus :: Integration Tests :: FHIR</name>
     <description>Integration tests for Camel Quarkus FHIR extension</description>
 
+    <properties>
+    <!-- By default hapi-fhir's http client will not be tested. Activate the fhir-it Maven profile to do so -->
+        <fhir.http.client>false</fhir.http.client>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -74,6 +79,12 @@
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>io.quarkus</groupId>
@@ -90,13 +101,11 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <systemProperties combine.children="append">
-                        <!--
-                            temporary disabled as FHIR testing service is down
-                        -->
-                        <quarkus.camel.fhir.enable-dstu2>false</quarkus.camel.fhir.enable-dstu2>
-                        <quarkus.camel.fhir.enable-r4>false</quarkus.camel.fhir.enable-r4>
-                    </systemProperties>
+                    <excludes>
+                        <exclude>**/FhirClientIntegrationTest.java</exclude>
+                        <exclude>**/FhirClientJvmIntegrationTest.java</exclude>
+                        <exclude>**/FhirDataformatIntegrationTest.java</exclude>
+                    </excludes>
                 </configuration>
             </plugin>
         </plugins>
@@ -125,6 +134,13 @@
                                     <systemProperties>
                                         <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
                                     </systemProperties>
+                                    <excludes>
+                                        <exclude>**/FhirClientJvmIntegrationTest.java</exclude>
+                                    </excludes>
+                                    <includes combine.children="append">
+                                        <include>**/FhirClientIntegrationTest.java</include>
+                                        <include>**/FhirDataformatIntegrationTest.java</include>
+                                    </includes>
                                 </configuration>
                             </execution>
                         </executions>
@@ -149,6 +165,154 @@
                                     <enableJni>true</enableJni>
                                     <enableAllSecurityServices>true</enableAllSecurityServices>
                                     <disableReports>true</disableReports>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>fhir-it</id>
+            <activation>
+                <property>
+                    <name>fhir-it</name>
+                </property>
+            </activation>
+            <properties>
+                <fhir.http.client>true</fhir.http.client>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <version>${maven-dependency-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>deploy-converter-factory</id>
+                                <phase>generate-test-resources</phase>
+                                <goals>
+                                    <goal>copy</goal>
+                                </goals>
+                                <configuration>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>ca.uhn.hapi.fhir</groupId>
+                                            <artifactId>hapi-fhir-jpaserver-starter</artifactId>
+                                            <version>${hapi.server.version}</version>
+                                            <type>war</type>
+                                            <outputDirectory>${project.build.directory}/war</outputDirectory>
+                                        </artifactItem>
+                                    </artifactItems>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <version>${build-helper-maven-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>reserve-fhir-port</id>
+                                <goals>
+                                    <goal>reserve-network-port</goal>
+                                </goals>
+                                <phase>generate-test-sources</phase>
+                                <configuration>
+                                    <portNames>
+                                        <portName>fhir.port</portName>
+                                        <portName>fhir.stop.port</portName>
+                                    </portNames>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-resources-plugin</artifactId>
+                        <version>${maven-resources-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>filter-resources</id>
+                                <phase>generate-test-sources</phase>
+                                <goals>
+                                    <goal>resources</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>properties-maven-plugin</artifactId>
+                        <version>${properties-maven-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>set-system-properties</goal>
+                                </goals>
+                                <configuration>
+                                    <properties>
+                                        <property>
+                                            <name>hapi.properties</name>
+                                            <value>src/test/resources/hapi.properties</value>
+                                        </property>
+                                    </properties>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.eclipse.jetty</groupId>
+                        <artifactId>jetty-maven-plugin</artifactId>
+                        <version>${jetty-maven-plugin.version}</version>
+                        <configuration>
+                            <war>${project.build.directory}/war/hapi-fhir-jpaserver-starter-${hapi.server.version}.war</war>
+                            <stopKey>alpha</stopKey>
+                            <stopPort>${fhir.stop.port}</stopPort>
+                            <httpConnector>
+                                <port>${fhir.port}</port>
+                            </httpConnector>
+                            <supportedPackagings>
+                                <supportedPackaging>jar</supportedPackaging>
+                            </supportedPackagings>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>start-jetty</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>deploy-war</goal>
+                                </goals>
+                                <configuration>
+                                    <scanIntervalSeconds>0</scanIntervalSeconds>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>stop-jetty</id>
+                                <phase>post-integration-test</phase>
+                                <goals>
+                                    <goal>stop</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                                <configuration>
+                                    <systemProperties>
+                                        <fhir.port>${fhir.port}</fhir.port>
+                                    </systemProperties>
+                                    <includes>
+                                        <include>**/FhirClientJvmIntegrationTest.java</include>
+                                    </includes>
                                 </configuration>
                             </execution>
                         </executions>

--- a/integration-tests/fhir/src/main/java/org/apache/camel/quarkus/component/fhir/it/FhirDstu2RouteBuilder.java
+++ b/integration-tests/fhir/src/main/java/org/apache/camel/quarkus/component/fhir/it/FhirDstu2RouteBuilder.java
@@ -26,6 +26,7 @@ import org.apache.camel.component.fhir.FhirXmlDataFormat;
 import org.apache.camel.quarkus.component.fhir.FhirFlags;
 
 public class FhirDstu2RouteBuilder extends RouteBuilder {
+
     private static final Boolean ENABLED = new FhirFlags.Dstu2Enabled().getAsBoolean();
 
     @Override
@@ -50,9 +51,10 @@ public class FhirDstu2RouteBuilder extends RouteBuilder {
             from("direct:xml-to-dstu2")
                     .unmarshal(fhirXmlDataFormat)
                     .marshal(fhirXmlDataFormat);
-
-            from("direct:create-dstu2")
-                    .to("fhir://create/resource?inBody=resourceAsString&log={{fhir.verbose}}&serverUrl={{fhir.dstu2.url}}&fhirVersion=DSTU2&fhirContext=#fhirContext");
+            if (Boolean.valueOf(getContext().resolvePropertyPlaceholders("{{fhir.http.client}}"))) {
+                from("direct:create-dstu2")
+                        .to("fhir://create/resource?inBody=resourceAsString&log={{fhir.verbose}}&serverUrl={{fhir.dstu2.url}}&fhirVersion=DSTU2&fhirContext=#fhirContext");
+            }
         }
     }
 }

--- a/integration-tests/fhir/src/main/java/org/apache/camel/quarkus/component/fhir/it/FhirDstu3RouteBuilder.java
+++ b/integration-tests/fhir/src/main/java/org/apache/camel/quarkus/component/fhir/it/FhirDstu3RouteBuilder.java
@@ -26,6 +26,7 @@ import org.apache.camel.component.fhir.FhirXmlDataFormat;
 import org.apache.camel.quarkus.component.fhir.FhirFlags;
 
 public class FhirDstu3RouteBuilder extends RouteBuilder {
+
     private static final Boolean ENABLED = new FhirFlags.Dstu3Enabled().getAsBoolean();
 
     @Override
@@ -52,8 +53,10 @@ public class FhirDstu3RouteBuilder extends RouteBuilder {
                     .unmarshal(fhirXmlDataFormat)
                     .marshal(fhirXmlDataFormat);
 
-            from("direct:create-dstu3")
-                    .to("fhir://create/resource?inBody=resourceAsString&log={{fhir.verbose}}&serverUrl={{fhir.dstu3.url}}&fhirVersion=DSTU3&fhirContext=#fhirContext");
+            if (Boolean.valueOf(getContext().resolvePropertyPlaceholders("{{fhir.http.client}}"))) {
+                from("direct:create-dstu3")
+                        .to("fhir://create/resource?inBody=resourceAsString&log={{fhir.verbose}}&serverUrl={{fhir.dstu3.url}}&fhirVersion=DSTU3&fhirContext=#fhirContext");
+            }
         }
     }
 }

--- a/integration-tests/fhir/src/main/java/org/apache/camel/quarkus/component/fhir/it/FhirR4RouteBuilder.java
+++ b/integration-tests/fhir/src/main/java/org/apache/camel/quarkus/component/fhir/it/FhirR4RouteBuilder.java
@@ -26,6 +26,7 @@ import org.apache.camel.component.fhir.FhirXmlDataFormat;
 import org.apache.camel.quarkus.component.fhir.FhirFlags;
 
 public class FhirR4RouteBuilder extends RouteBuilder {
+
     private static final Boolean ENABLED = new FhirFlags.R4Enabled().getAsBoolean();
 
     @Override
@@ -51,8 +52,10 @@ public class FhirR4RouteBuilder extends RouteBuilder {
                     .unmarshal(fhirXmlDataFormat)
                     .marshal(fhirXmlDataFormat);
 
-            from("direct:create-r4")
-                    .to("fhir://create/resource?inBody=resourceAsString&log={{fhir.verbose}}&serverUrl={{fhir.r4.url}}&fhirVersion=R4&fhirContext=#fhirContext");
+            if (Boolean.valueOf(getContext().resolvePropertyPlaceholders("{{fhir.http.client}}"))) {
+                from("direct:create-r4")
+                        .to("fhir://create/resource?inBody=resourceAsString&log={{fhir.verbose}}&serverUrl={{fhir.r4.url}}&fhirVersion=R4&fhirContext=#fhirContext");
+            }
         }
     }
 }

--- a/integration-tests/fhir/src/test/java/org/apache/camel/quarkus/component/fhir/it/FhirClientIntegrationTest.java
+++ b/integration-tests/fhir/src/test/java/org/apache/camel/quarkus/component/fhir/it/FhirClientIntegrationTest.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.fhir.it;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+class FhirClientIntegrationTest extends FhirClientJvmIntegrationTest {
+
+}

--- a/integration-tests/fhir/src/test/java/org/apache/camel/quarkus/component/fhir/it/FhirClientJvmIntegrationTest.java
+++ b/integration-tests/fhir/src/test/java/org/apache/camel/quarkus/component/fhir/it/FhirClientJvmIntegrationTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.fhir.it;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.model.dstu2.composite.AddressDt;
+import ca.uhn.fhir.model.dstu2.composite.HumanNameDt;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import org.apache.camel.quarkus.component.fhir.FhirFlags;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.hl7.fhir.dstu3.model.Address;
+import org.hl7.fhir.dstu3.model.HumanName;
+import org.hl7.fhir.dstu3.model.Patient;
+import org.jboss.logging.Logger;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+class FhirClientJvmIntegrationTest {
+
+    private static final Logger LOG = Logger.getLogger(FhirClientJvmIntegrationTest.class);
+
+    private static final Boolean DSTU2 = new FhirFlags.Dstu2Enabled().getAsBoolean();
+    private static final Boolean DSTU3 = new FhirFlags.Dstu3Enabled().getAsBoolean();
+    private static final Boolean R4 = new FhirFlags.R4Enabled().getAsBoolean();
+    private static final Boolean CLIENT = ConfigProvider.getConfig().getOptionalValue("fhir.http.client", Boolean.class)
+            .orElse(Boolean.FALSE);
+
+    @Test
+    public void fhirClientR4() {
+        if (!R4 || !CLIENT) {
+            return;
+        }
+        LOG.info("Running R4 Client test");
+        final org.hl7.fhir.r4.model.Patient patient = getR4Patient();
+        String patientString = FhirContext.forR4().newJsonParser().encodeResourceToString(patient);
+        RestAssured.given()
+                .contentType(ContentType.JSON).body(patientString.getBytes()).post("/r4/createPatient")
+                .then().statusCode(201);
+    }
+
+    @Test
+    public void fhirClientDstu3() {
+        if (!DSTU3 || !CLIENT) {
+            return;
+        }
+        LOG.info("Running DSTU3 Client test");
+        final Patient patient = getDstu3Patient();
+        String patientString = FhirContext.forDstu3().newJsonParser().encodeResourceToString(patient);
+        RestAssured.given()
+                .contentType(ContentType.JSON).body(patientString).post("/dstu3/createPatient")
+                .then().statusCode(201);
+    }
+
+    @Test
+    public void fhirClientDstu2() {
+        if (!DSTU2 || !CLIENT) {
+            return;
+        }
+        LOG.info("Running DSTU2 CLIENT test");
+        final ca.uhn.fhir.model.dstu2.resource.Patient patient = getDstu2Patient();
+        String patientString = FhirContext.forDstu2().newJsonParser().encodeResourceToString(patient);
+        RestAssured.given()
+                .contentType(ContentType.JSON).body(patientString).post("/dstu2/createPatient")
+                .then().statusCode(201);
+    }
+
+    private ca.uhn.fhir.model.dstu2.resource.Patient getDstu2Patient() {
+        return new ca.uhn.fhir.model.dstu2.resource.Patient().addName(new HumanNameDt().addGiven("Sherlock")
+                .addFamily("Holmes"))
+                .addAddress(new AddressDt().addLine("221b Baker St, Marylebone, London NW1 6XE, UK"));
+    }
+
+    private Patient getDstu3Patient() {
+        return new Patient().addName(new HumanName().addGiven("Sherlock")
+                .setFamily("Holmes"))
+                .addAddress(new Address().addLine("221b Baker St, Marylebone, London NW1 6XE, UK"));
+    }
+
+    private org.hl7.fhir.r4.model.Patient getR4Patient() {
+        org.hl7.fhir.r4.model.Patient patient = new org.hl7.fhir.r4.model.Patient();
+        patient.addAddress().addLine("221b Baker St, Marylebone, London NW1 6XE, UK");
+        patient.addName().addGiven("Sherlock").setFamily("Holmes");
+        return patient;
+    }
+}

--- a/integration-tests/fhir/src/test/java/org/apache/camel/quarkus/component/fhir/it/FhirDataformatIntegrationTest.java
+++ b/integration-tests/fhir/src/test/java/org/apache/camel/quarkus/component/fhir/it/FhirDataformatIntegrationTest.java
@@ -19,5 +19,5 @@ package org.apache.camel.quarkus.component.fhir.it;
 import io.quarkus.test.junit.NativeImageTest;
 
 @NativeImageTest
-class FhirIT extends FhirTest {
+class FhirDataformatIntegrationTest extends FhirDataformatTest {
 }

--- a/integration-tests/fhir/src/test/java/org/apache/camel/quarkus/component/fhir/it/FhirDataformatTest.java
+++ b/integration-tests/fhir/src/test/java/org/apache/camel/quarkus/component/fhir/it/FhirDataformatTest.java
@@ -26,20 +26,24 @@ import org.apache.camel.quarkus.component.fhir.FhirFlags;
 import org.hl7.fhir.dstu3.model.Address;
 import org.hl7.fhir.dstu3.model.HumanName;
 import org.hl7.fhir.dstu3.model.Patient;
+import org.jboss.logging.Logger;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
-class FhirTest {
+class FhirDataformatTest {
 
-    Boolean dstu2 = new FhirFlags.Dstu2Enabled().getAsBoolean();
-    Boolean dstu3 = new FhirFlags.Dstu3Enabled().getAsBoolean();
-    Boolean r4 = new FhirFlags.R4Enabled().getAsBoolean();
+    private static final Logger LOG = Logger.getLogger(FhirDataformatTest.class);
+
+    private static final Boolean DSTU2 = new FhirFlags.Dstu2Enabled().getAsBoolean();
+    private static final Boolean DSTU3 = new FhirFlags.Dstu3Enabled().getAsBoolean();
+    private static final Boolean R4 = new FhirFlags.R4Enabled().getAsBoolean();
 
     @Test
     public void jsonDstu2() {
-        if (!dstu2) {
+        if (!DSTU2) {
             return;
         }
+        LOG.info("Running DSTU2 JSON test");
         final ca.uhn.fhir.model.dstu2.resource.Patient patient = getDstu2Patient();
         String patientString = FhirContext.forDstu2().newJsonParser().encodeResourceToString(patient);
         RestAssured.given()
@@ -49,10 +53,10 @@ class FhirTest {
 
     @Test
     public void xmlDstu2() {
-        if (!dstu2) {
+        if (!DSTU2) {
             return;
         }
-
+        LOG.info("Running DSTU2 XML test");
         final ca.uhn.fhir.model.dstu2.resource.Patient patient = getDstu2Patient();
         String patientString = FhirContext.forDstu2().newXmlParser().encodeResourceToString(patient);
         RestAssured.given()
@@ -61,24 +65,11 @@ class FhirTest {
     }
 
     @Test
-    public void fhirClientDstu2() {
-        if (!dstu2) {
-            return;
-        }
-
-        final ca.uhn.fhir.model.dstu2.resource.Patient patient = getDstu2Patient();
-        String patientString = FhirContext.forDstu2().newJsonParser().encodeResourceToString(patient);
-        RestAssured.given()
-                .contentType(ContentType.JSON).body(patientString).post("/dstu2/createPatient") //
-                .then().statusCode(201);
-    }
-
-    @Test
     public void jsonDstu3() {
-        if (!dstu3) {
+        if (!DSTU3) {
             return;
         }
-
+        LOG.info("Running DSTU3 JSON test");
         final Patient patient = getDstu3Patient();
         String patientString = FhirContext.forDstu3().newJsonParser().encodeResourceToString(patient);
         RestAssured.given()
@@ -88,10 +79,10 @@ class FhirTest {
 
     @Test
     public void xmlDstu3() {
-        if (!dstu3) {
+        if (!DSTU3) {
             return;
         }
-
+        LOG.info("Running DSTU3 XML test");
         final Patient patient = getDstu3Patient();
         String patientString = FhirContext.forDstu3().newXmlParser().encodeResourceToString(patient);
         RestAssured.given()
@@ -100,24 +91,11 @@ class FhirTest {
     }
 
     @Test
-    public void fhirClientDstu3() {
-        if (!dstu3) {
-            return;
-        }
-
-        final Patient patient = getDstu3Patient();
-        String patientString = FhirContext.forDstu3().newJsonParser().encodeResourceToString(patient);
-        RestAssured.given()
-                .contentType(ContentType.JSON).body(patientString).post("/dstu3/createPatient") //
-                .then().statusCode(201);
-    }
-
-    @Test
     public void jsonR4() {
-        if (!r4) {
+        if (!R4) {
             return;
         }
-
+        LOG.info("Running R4 JSON test");
         final org.hl7.fhir.r4.model.Patient patient = getR4Patient();
         String patientString = FhirContext.forR4().newJsonParser().encodeResourceToString(patient);
         RestAssured.given()
@@ -127,27 +105,14 @@ class FhirTest {
 
     @Test
     public void xmlR4() {
-        if (!r4) {
+        if (!R4) {
             return;
         }
-
+        LOG.info("Running R4 XML test");
         final org.hl7.fhir.r4.model.Patient patient = getR4Patient();
         String patientString = FhirContext.forR4().newXmlParser().encodeResourceToString(patient);
         RestAssured.given()
                 .contentType(ContentType.XML).body(patientString).post("/r4/fhir2xml")
-                .then().statusCode(201);
-    }
-
-    @Test
-    public void fhirClientR4() {
-        if (!r4) {
-            return;
-        }
-
-        final org.hl7.fhir.r4.model.Patient patient = getR4Patient();
-        String patientString = FhirContext.forR4().newJsonParser().encodeResourceToString(patient);
-        RestAssured.given()
-                .contentType(ContentType.JSON).body(patientString.getBytes()).post("/r4/createPatient") //
                 .then().statusCode(201);
     }
 
@@ -169,5 +134,4 @@ class FhirTest {
         patient.addName().addGiven("Sherlock").setFamily("Holmes");
         return patient;
     }
-
 }

--- a/integration-tests/fhir/src/test/resources/hapi.properties
+++ b/integration-tests/fhir/src/test/resources/hapi.properties
@@ -1,4 +1,4 @@
-## ---------------------------------------------------------------------------
+ ## ---------------------------------------------------------------------------
 ## Licensed to the Apache Software Foundation (ASF) under one or more
 ## contributor license agreements.  See the NOTICE file distributed with
 ## this work for additional information regarding copyright ownership.
@@ -15,26 +15,9 @@
 ## limitations under the License.
 ## ---------------------------------------------------------------------------
 #
-# Quarkus
+# FHIR Server
 #
-quarkus.ssl.native=true
-
-#
-# Quarkus :: Camel :: FHIR
-#
-# The HAPI-FHIR library, on which camel-fhir depends on, heavily uses reflection which affects performance in Quarkus
-# (memory footprint, build time, CPU resources etc...). For the sake of time, only DSTU3 (which is the default FHIR version)
-# tests are enabled by default.
-# Be sure to modify src/test/resources/hapi.properties file accordingly when switching FHIR specification versions.
-quarkus.camel.fhir.enable-dstu2=false
-quarkus.camel.fhir.enable-dstu3=true
-quarkus.camel.fhir.enable-r4=false
-
-#
-# Camel
-#
-fhir.dstu2.url=http://localhost:${fhir.port}/fhir
-fhir.dstu3.url=http://localhost:${fhir.port}/fhir
-fhir.r4.url=http://localhost:${fhir.port}/fhir
-fhir.verbose=false
-fhir.http.client=${fhir.http.client}
+# Currently, only one FHIR version can be set at a time.
+#fhir_version=DSTU2
+fhir_version=DSTU3
+#fhir_version=R4

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
 
         <camel.version>3.0.0-RC3</camel.version>
         <hapi.version>3.7.0</hapi.version>
+        <hapi.server.version>4.1.0</hapi.server.version>
         <quarkus.version>1.0.0.CR2</quarkus.version>
         <jetty.version>9.4.18.v20190429</jetty.version>
         <xstream.version>1.4.11</xstream.version>
@@ -59,16 +60,20 @@
         <!-- maven-enforcer-plugin -->
         <supported-maven-versions>[3.5.3,)</supported-maven-versions>
 
+        <build-helper-maven-plugin.version>3.0.0</build-helper-maven-plugin.version>
         <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
         <groovy-maven-plugin.version>2.1.1</groovy-maven-plugin.version>
         <groovy.version>2.5.8</groovy.version>
         <jandex-maven-plugin.version>1.0.6</jandex-maven-plugin.version>
+        <jetty-maven-plugin.version>9.4.20.v20190813</jetty-maven-plugin.version>
+        <properties-maven-plugin.version>1.0.0</properties-maven-plugin.version>
         <mycila-license.version>3.0</mycila-license.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
         <maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
         <maven-javadoc-plugin.version>3.1.1</maven-javadoc-plugin.version>
         <maven-source-plugin.version>3.1.0</maven-source-plugin.version>
         <maven-assembly-plugin.version>3.1.1</maven-assembly-plugin.version>
+        <maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
 
         <!-- maven-release-plugin -->
         <tagNameFormat>@{project.version}</tagNameFormat>


### PR DESCRIPTION
cc @lburgazzoli addresses #352 

This will fire up a FHIR server when running tests and the  `fhir-it` Maven profile is activated.

Note that the FHIR server, based on hapi-fhir-jpaserver-starter, only supports running _one_ FHIR version at a time. I'm working on a PR to address this. Therefore to test all FHIR specification versions, multiple runs are necessary.

The jetty-maven-plugin's deploy-war goal re-runs the _validate_ Maven phase therefore some plugins are run twice namely:

- directory-maven-plugin:0.3.1:highest-basedir (directories)
- groovy-maven-plugin:2.1.1:execute (sanity-checks)
- maven-enforcer-plugin:1.4.1:enforce ((enforce-maven-version, camel-quarkus-enforcer-rules)

By default, only the `FhirDataformatTest` tests are run and the FHIR server isn't started.

Thanks !