### PR TITLE
removing sjms-component

### DIFF
--- a/docs/modules/ROOT/pages/list-of-camel-quarkus-extensions.adoc
+++ b/docs/modules/ROOT/pages/list-of-camel-quarkus-extensions.adoc
@@ -120,9 +120,6 @@ Number of Camel components: 46 in 39 JAR artifacts (0 deprecated)
 | link:https://camel.apache.org/components/latest/sftp-component.html[SFTP] (camel-quarkus-ftp) +
 `sftp:host:port/directoryName` | 0.5 | The \sftp (FTP over SSH) component is used for uploading or downloading files from SFTP servers.
 
-| link:https://camel.apache.org/components/latest/sjms-component.html[Simple JMS] (camel-quarkus-sjms) +
-`sjms:destinationType:destinationName` | 0.5 | The sjms component (simple jms) allows messages to be sent to (or consumed from) a JMS Queue or Topic (uses JMS 1.x API).
-
 | link:https://camel.apache.org/components/latest/sjms-batch-component.html[Simple JMS Batch] (camel-quarkus-sjms) +
 `sjms-batch:destinationName` | 0.5 | The sjms-batch component is a specialized for highly performant, transactional batch consumption from a JMS queue.
 


### PR DESCRIPTION
sjms-component can not be loaded as a dependency. Is this ready?