### PR TITLE
A JUnit dependency is required to run our integration tests outside of

### DIFF
--- a/integration-tests/aws/pom.xml
+++ b/integration-tests/aws/pom.xml
@@ -69,12 +69,12 @@
 
 
         <!-- test dependencies -->
-        <!--
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>
             <scope>test</scope>
         </dependency>
+        <!--
         <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>

--- a/integration-tests/core-impl/pom.xml
+++ b/integration-tests/core-impl/pom.xml
@@ -34,6 +34,12 @@
             <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-core-cloud</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
our source tree, e.g. inside Quarkus Platform