### PR TITLE
Fix #518 Rely on configurers for Configuration classes instead of using

### DIFF
--- a/extensions/aws-ec2/deployment/src/main/java/org/apache/camel/quarkus/component/aws/ec2/deployment/AwsEc2Processor.java
+++ b/extensions/aws-ec2/deployment/src/main/java/org/apache/camel/quarkus/component/aws/ec2/deployment/AwsEc2Processor.java
@@ -29,7 +29,6 @@ import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
-import org.apache.camel.component.aws.ec2.EC2Configuration;
 
 class AwsEc2Processor {
     public static final String AWS_EC2_APPLICATION_ARCHIVE_MARKERS = "com/amazonaws";
@@ -58,8 +57,7 @@ class AwsEc2Processor {
                 Endpoint.class.getCanonicalName(),
                 Region.class.getCanonicalName(),
                 Service.class.getCanonicalName(),
-                CredentialScope.class.getCanonicalName(),
-                EC2Configuration.class.getCanonicalName()));
+                CredentialScope.class.getCanonicalName()));
     }
 
 }

--- a/extensions/aws-ecs/deployment/src/main/java/org/apache/camel/quarkus/component/aws/ecs/deployment/AwsEcsProcessor.java
+++ b/extensions/aws-ecs/deployment/src/main/java/org/apache/camel/quarkus/component/aws/ecs/deployment/AwsEcsProcessor.java
@@ -29,7 +29,6 @@ import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
-import org.apache.camel.component.aws.ecs.ECSConfiguration;
 
 class AwsEcsProcessor {
 
@@ -59,7 +58,6 @@ class AwsEcsProcessor {
                 Endpoint.class.getCanonicalName(),
                 Region.class.getCanonicalName(),
                 Service.class.getCanonicalName(),
-                CredentialScope.class.getCanonicalName(),
-                ECSConfiguration.class.getCanonicalName()));
+                CredentialScope.class.getCanonicalName()));
     }
 }

--- a/extensions/aws-eks/deployment/src/main/java/org/apache/camel/quarkus/component/aws/eks/deployment/AwsEKSProcessor.java
+++ b/extensions/aws-eks/deployment/src/main/java/org/apache/camel/quarkus/component/aws/eks/deployment/AwsEKSProcessor.java
@@ -29,7 +29,6 @@ import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
-import org.apache.camel.component.aws.eks.EKSConfiguration;
 
 class AwsEKSProcessor {
 
@@ -59,7 +58,6 @@ class AwsEKSProcessor {
                 Endpoint.class.getCanonicalName(),
                 Region.class.getCanonicalName(),
                 Service.class.getCanonicalName(),
-                CredentialScope.class.getCanonicalName(),
-                EKSConfiguration.class.getCanonicalName()));
+                CredentialScope.class.getCanonicalName()));
     }
 }

--- a/extensions/aws-iam/deployment/src/main/java/org/apache/camel/quarkus/component/aws/iam/deployment/AwsIamProcessor.java
+++ b/extensions/aws-iam/deployment/src/main/java/org/apache/camel/quarkus/component/aws/iam/deployment/AwsIamProcessor.java
@@ -29,7 +29,6 @@ import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
-import org.apache.camel.component.aws.iam.IAMConfiguration;
 
 class AwsIamProcessor {
 
@@ -59,7 +58,6 @@ class AwsIamProcessor {
                 Endpoint.class.getCanonicalName(),
                 Region.class.getCanonicalName(),
                 Service.class.getCanonicalName(),
-                CredentialScope.class.getCanonicalName(),
-                IAMConfiguration.class.getCanonicalName()));
+                CredentialScope.class.getCanonicalName()));
     }
 }

--- a/extensions/aws-kinesis/deployment/src/main/java/org/apache/camel/quarkus/component/aws/kinesis/deployment/AwsKinesisProcessor.java
+++ b/extensions/aws-kinesis/deployment/src/main/java/org/apache/camel/quarkus/component/aws/kinesis/deployment/AwsKinesisProcessor.java
@@ -29,8 +29,6 @@ import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
-import org.apache.camel.component.aws.firehose.KinesisFirehoseConfiguration;
-import org.apache.camel.component.aws.kinesis.KinesisConfiguration;
 
 class AwsKinesisProcessor {
 
@@ -60,8 +58,6 @@ class AwsKinesisProcessor {
                 Endpoint.class.getCanonicalName(),
                 Region.class.getCanonicalName(),
                 Service.class.getCanonicalName(),
-                CredentialScope.class.getCanonicalName(),
-                KinesisConfiguration.class.getCanonicalName(),
-                KinesisFirehoseConfiguration.class.getCanonicalName()));
+                CredentialScope.class.getCanonicalName()));
     }
 }

--- a/extensions/aws-kms/deployment/src/main/java/org/apache/camel/quarkus/component/aws/kms/deployment/AwsKmsProcessor.java
+++ b/extensions/aws-kms/deployment/src/main/java/org/apache/camel/quarkus/component/aws/kms/deployment/AwsKmsProcessor.java
@@ -29,7 +29,6 @@ import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
-import org.apache.camel.component.aws.kms.KMSConfiguration;
 
 class AwsKmsProcessor {
 
@@ -59,7 +58,6 @@ class AwsKmsProcessor {
                 Endpoint.class.getCanonicalName(),
                 Region.class.getCanonicalName(),
                 Service.class.getCanonicalName(),
-                CredentialScope.class.getCanonicalName(),
-                KMSConfiguration.class.getCanonicalName()));
+                CredentialScope.class.getCanonicalName()));
     }
 }

--- a/extensions/aws-lambda/deployment/src/main/java/org/apache/camel/quarkus/component/aws/lambda/deployment/AwsLambdaProcessor.java
+++ b/extensions/aws-lambda/deployment/src/main/java/org/apache/camel/quarkus/component/aws/lambda/deployment/AwsLambdaProcessor.java
@@ -29,7 +29,6 @@ import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
-import org.apache.camel.component.aws.lambda.LambdaConfiguration;
 
 class AwsLambdaProcessor {
 
@@ -59,7 +58,6 @@ class AwsLambdaProcessor {
                 Endpoint.class.getCanonicalName(),
                 Region.class.getCanonicalName(),
                 Service.class.getCanonicalName(),
-                CredentialScope.class.getCanonicalName(),
-                LambdaConfiguration.class.getCanonicalName()));
+                CredentialScope.class.getCanonicalName()));
     }
 }

--- a/extensions/aws-s3/deployment/src/main/java/org/apache/camel/quarkus/component/aws/s3/deployment/AwsS3Processor.java
+++ b/extensions/aws-s3/deployment/src/main/java/org/apache/camel/quarkus/component/aws/s3/deployment/AwsS3Processor.java
@@ -32,7 +32,6 @@ import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
-import org.apache.camel.component.aws.s3.S3Configuration;
 
 class AwsS3Processor {
 
@@ -68,8 +67,7 @@ class AwsS3Processor {
                 Region.class.getCanonicalName(),
                 Service.class.getCanonicalName(),
                 CredentialScope.class.getCanonicalName(),
-                AWSS3V4Signer.class.getCanonicalName(),
-                S3Configuration.class.getCanonicalName()));
+                AWSS3V4Signer.class.getCanonicalName()));
     }
 
 }

--- a/extensions/aws-sns/deployment/src/main/java/org/apache/camel/quarkus/component/aws/sns/deployment/AwsSNSProcessor.java
+++ b/extensions/aws-sns/deployment/src/main/java/org/apache/camel/quarkus/component/aws/sns/deployment/AwsSNSProcessor.java
@@ -30,7 +30,6 @@ import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
-import org.apache.camel.component.aws.sns.SnsConfiguration;
 
 class AwsSNSProcessor {
 
@@ -61,8 +60,7 @@ class AwsSNSProcessor {
                 Region.class.getCanonicalName(),
                 Service.class.getCanonicalName(),
                 CredentialScope.class.getCanonicalName(),
-                AWS4Signer.class.getCanonicalName(),
-                SnsConfiguration.class.getCanonicalName()));
+                AWS4Signer.class.getCanonicalName()));
     }
 
 }

--- a/extensions/aws-sqs/deployment/src/main/java/org/apache/camel/quarkus/component/aws/sqs/deployment/AwsSQSProcessor.java
+++ b/extensions/aws-sqs/deployment/src/main/java/org/apache/camel/quarkus/component/aws/sqs/deployment/AwsSQSProcessor.java
@@ -30,7 +30,6 @@ import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
-import org.apache.camel.component.aws.sqs.SqsConfiguration;
 
 class AwsSQSProcessor {
 
@@ -61,7 +60,6 @@ class AwsSQSProcessor {
                 Region.class.getCanonicalName(),
                 Service.class.getCanonicalName(),
                 CredentialScope.class.getCanonicalName(),
-                AWS4Signer.class.getCanonicalName(),
-                SqsConfiguration.class.getCanonicalName()));
+                AWS4Signer.class.getCanonicalName()));
     }
 }

--- a/extensions/aws-translate/deployment/src/main/java/org/apache/camel/quarkus/component/aws/translate/deployment/AwsTranslateProcessor.java
+++ b/extensions/aws-translate/deployment/src/main/java/org/apache/camel/quarkus/component/aws/translate/deployment/AwsTranslateProcessor.java
@@ -30,7 +30,6 @@ import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
-import org.apache.camel.component.aws.translate.TranslateConfiguration;
 
 class AwsTranslateProcessor {
 
@@ -61,7 +60,6 @@ class AwsTranslateProcessor {
                 Region.class.getCanonicalName(),
                 Service.class.getCanonicalName(),
                 CredentialScope.class.getCanonicalName(),
-                AWS4Signer.class.getCanonicalName(),
-                TranslateConfiguration.class.getCanonicalName()));
+                AWS4Signer.class.getCanonicalName()));
     }
 }

--- a/extensions/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/NativeImageProcessor.java
+++ b/extensions/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/NativeImageProcessor.java
@@ -92,7 +92,8 @@ class NativeImageProcessor {
                     .filter(ai -> {
                         AnnotationValue av = ai.value("loader");
                         boolean isLoader = av != null && av.asBoolean();
-                        // filter out camel-base converters which are automatically inlined in the CoreStaticTypeConverterLoader
+                        // filter out camel-base converters which are automatically inlined in the
+                        // CoreStaticTypeConverterLoader
                         // need to revisit with Camel 3.0.0-M3 which should improve this area
                         if (ai.target().asClass().name().toString().startsWith("org.apache.camel.converter.")) {
                             log.debug("Ignoring core " + ai + " " + ai.target().asClass().name());

--- a/extensions/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/UnbannedReflectiveBuildItem.java
+++ b/extensions/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/UnbannedReflectiveBuildItem.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.core.deployment;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+/**
+ * A {@link MultiBuildItem} holding a list of class names that would otherwise not be allowed to be registered for
+ * reflection due to a Camel Quarkus policy.
+ */
+public final class UnbannedReflectiveBuildItem extends MultiBuildItem {
+
+    final Set<String> classNames;
+
+    public UnbannedReflectiveBuildItem(Collection<String> classNames) {
+        this.classNames = new LinkedHashSet<>(classNames);
+    }
+
+    public UnbannedReflectiveBuildItem(String... classNames) {
+        this.classNames = new LinkedHashSet<>(Arrays.asList(classNames));
+    }
+
+    public Set<String> getClassNames() {
+        return Collections.unmodifiableSet(classNames);
+    }
+
+}

--- a/extensions/dozer/deployment/src/main/java/org/apache/camel/quarkus/component/dozer/deployment/DozerProcessor.java
+++ b/extensions/dozer/deployment/src/main/java/org/apache/camel/quarkus/component/dozer/deployment/DozerProcessor.java
@@ -40,7 +40,6 @@ import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.jaxb.deployment.JaxbFileRootBuildItem;
-import org.apache.camel.component.dozer.DozerConfiguration;
 import org.apache.camel.converter.dozer.DozerBeanMapperConfiguration;
 import org.apache.camel.converter.dozer.DozerThreadContextClassLoader;
 import org.apache.camel.quarkus.component.dozer.CamelDozerConfig;
@@ -121,7 +120,6 @@ class DozerProcessor {
         reflectiveClass.produce(new ReflectiveClassBuildItem(
                 true,
                 false,
-                DozerConfiguration.class,
                 DozerBeanMapperConfiguration.class));
 
         if (camelDozerConfig.mappingFiles.isPresent()) {

--- a/extensions/ftp/deployment/src/main/java/org/apache/camel/quarkus/component/ftp/deployment/FtpProcessor.java
+++ b/extensions/ftp/deployment/src/main/java/org/apache/camel/quarkus/component/ftp/deployment/FtpProcessor.java
@@ -21,10 +21,6 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
-import org.apache.camel.component.file.remote.FtpConfiguration;
-import org.apache.camel.component.file.remote.FtpsConfiguration;
-import org.apache.camel.component.file.remote.RemoteFileConfiguration;
-import org.apache.camel.component.file.remote.SftpConfiguration;
 
 class FtpProcessor {
 
@@ -37,11 +33,6 @@ class FtpProcessor {
 
     @BuildStep
     void registerForReflection(BuildProducer<ReflectiveClassBuildItem> reflectiveClass) {
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false,
-                RemoteFileConfiguration.class,
-                FtpConfiguration.class,
-                FtpsConfiguration.class,
-                SftpConfiguration.class));
 
         reflectiveClass.produce(new ReflectiveClassBuildItem(true, true,
                 "com.jcraft.jsch.CipherNone",

--- a/extensions/infinispan/deployment/src/main/java/org/apache/camel/quarkus/component/infinispan/deployment/InfinispanProcessor.java
+++ b/extensions/infinispan/deployment/src/main/java/org/apache/camel/quarkus/component/infinispan/deployment/InfinispanProcessor.java
@@ -18,17 +18,10 @@ package org.apache.camel.quarkus.component.infinispan.deployment;
 
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
-import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
-import org.apache.camel.component.infinispan.InfinispanConfiguration;
 
 class InfinispanProcessor {
 
     private static final String FEATURE = "camel-infinispan";
-
-    @BuildStep
-    ReflectiveClassBuildItem reflection() {
-        return new ReflectiveClassBuildItem(true, true, InfinispanConfiguration.class);
-    }
 
     @BuildStep
     FeatureBuildItem feature() {

--- a/extensions/paho/deployment/src/main/java/org/apache/camel/quarkus/component/paho/deployment/PahoProcessor.java
+++ b/extensions/paho/deployment/src/main/java/org/apache/camel/quarkus/component/paho/deployment/PahoProcessor.java
@@ -27,7 +27,6 @@ import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBundleBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
-import org.apache.camel.component.paho.PahoConfiguration;
 import org.eclipse.paho.client.mqttv3.internal.SSLNetworkModuleFactory;
 import org.eclipse.paho.client.mqttv3.internal.TCPNetworkModuleFactory;
 import org.eclipse.paho.client.mqttv3.logging.JSR47Logger;
@@ -40,8 +39,7 @@ class PahoProcessor {
     private static final List<Class<?>> PAHO_REFLECTIVE_CLASSES = Arrays.asList(
             JSR47Logger.class,
             TCPNetworkModuleFactory.class,
-            SSLNetworkModuleFactory.class,
-            PahoConfiguration.class);
+            SSLNetworkModuleFactory.class);
 
     @Inject
     BuildProducer<NativeImageResourceBuildItem> resource;

--- a/extensions/support/policy/deployment/pom.xml
+++ b/extensions/support/policy/deployment/pom.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.camel.quarkus</groupId>
+        <artifactId>camel-quarkus-support-policy-parent</artifactId>
+        <version>1.1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>camel-quarkus-support-policy-deployment</artifactId>
+    <name>Camel Quarkus :: Support :: Policy :: Deployment</name>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.camel.quarkus</groupId>
+                <artifactId>camel-quarkus-bom-deployment</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-core-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-support-policy</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${quarkus.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/extensions/support/policy/deployment/src/main/java/org/apache/camel/quarkus/component/support/policy/deployment/PolicyProcessor.java
+++ b/extensions/support/policy/deployment/src/main/java/org/apache/camel/quarkus/component/support/policy/deployment/PolicyProcessor.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.support.policy.deployment;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import org.apache.camel.quarkus.core.deployment.UnbannedReflectiveBuildItem;
+import org.jboss.jandex.AnnotationTarget.Kind;
+import org.jboss.jandex.DotName;
+
+class PolicyProcessor {
+
+    private static final String FEATURE = "camel-policy";
+
+    @BuildStep
+    FeatureBuildItem feature() {
+        return new FeatureBuildItem(FEATURE);
+    }
+
+    @BuildStep
+    UnbannedReflectiveBuildItem unbanReflectives() {
+        /**
+         * A list of classes annotated with <code>@UriParams</code> which we accept to be registered for reflection
+         * mostly because there are errors when they are removed. TODO: solve the underlying problems and remove as
+         * many entries as possible from the list.
+         */
+        return new UnbannedReflectiveBuildItem(
+                "org.apache.camel.support.processor.DefaultExchangeFormatter",
+                "org.apache.camel.component.pdf.PdfConfiguration",
+                "org.apache.camel.component.netty.NettyConfiguration",
+                "org.apache.camel.component.netty.NettyServerBootstrapConfiguration",
+                "org.apache.camel.component.fhir.FhirUpdateEndpointConfiguration",
+                "org.apache.camel.component.fhir.FhirOperationEndpointConfiguration",
+                "org.apache.camel.component.fhir.FhirConfiguration",
+                "org.apache.camel.component.fhir.FhirLoadPageEndpointConfiguration",
+                "org.apache.camel.component.fhir.FhirSearchEndpointConfiguration",
+                "org.apache.camel.component.fhir.FhirTransactionEndpointConfiguration",
+                "org.apache.camel.component.fhir.FhirCreateEndpointConfiguration",
+                "org.apache.camel.component.fhir.FhirValidateEndpointConfiguration",
+                "org.apache.camel.component.fhir.FhirReadEndpointConfiguration",
+                "org.apache.camel.component.fhir.FhirCapabilitiesEndpointConfiguration",
+                "org.apache.camel.component.fhir.FhirHistoryEndpointConfiguration",
+                "org.apache.camel.component.fhir.FhirMetaEndpointConfiguration",
+                "org.apache.camel.component.fhir.FhirPatchEndpointConfiguration",
+                "org.apache.camel.component.fhir.FhirDeleteEndpointConfiguration",
+
+                /* org.apache.camel.component.consul.* can be removed after the upgrade to Camel 3.1 */
+                "org.apache.camel.component.consul.ConsulConfiguration",
+                "org.apache.camel.component.consul.ConsulClientConfiguration",
+                "org.apache.camel.component.consul.health.ConsulHealthCheckRepositoryConfiguration",
+                "org.apache.camel.component.consul.cloud.ConsulServiceRegistryConfiguration");
+    }
+
+    /* Make the build fail as long as there are banned classes registered for reflection */
+    @BuildStep
+    void bannedReflectiveClasses(
+            CombinedIndexBuildItem combinedIndex,
+            List<ReflectiveClassBuildItem> reflectiveClasses,
+            List<UnbannedReflectiveBuildItem> unbannedReflectives,
+            BuildProducer<GeneratedResourceBuildItem> dummy // to force the execution of this method
+    ) {
+        final DotName uriParamsDotName = DotName.createSimple("org.apache.camel.spi.UriParams");
+
+        final Set<String> bannedClassNames = combinedIndex.getIndex()
+                .getAnnotations(uriParamsDotName)
+                .stream()
+                .filter(ai -> ai.target().kind() == Kind.CLASS)
+                .map(ai -> ai.target().asClass().name().toString())
+                .collect(Collectors.toSet());
+
+        final Set<String> unbannedClassNames = unbannedReflectives.stream()
+                .map(UnbannedReflectiveBuildItem::getClassNames)
+                .flatMap(Collection::stream)
+                .collect(Collectors.toSet());
+
+        Set<String> violations = reflectiveClasses.stream()
+                .map(ReflectiveClassBuildItem::getClassNames)
+                .flatMap(Collection::stream)
+                .filter(cl -> !unbannedClassNames.contains(cl))
+                .filter(bannedClassNames::contains)
+                .collect(Collectors.toSet());
+
+        if (!violations.isEmpty()) {
+            throw new IllegalStateException(
+                    "The following classes should either be whitelisted via an UnbannedReflectiveBuildItem or they should not be registered for reflection via ReflectiveClassBuildItem: "
+                            + violations);
+        }
+    }
+}

--- a/extensions/support/policy/pom.xml
+++ b/extensions/support/policy/pom.xml
@@ -17,33 +17,23 @@
     limitations under the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-extensions</artifactId>
+        <artifactId>camel-quarkus-build-parent</artifactId>
         <version>1.1.0-SNAPSHOT</version>
+        <relativePath>../../../poms/build-parent/pom.xml</relativePath>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
-
-    <artifactId>camel-quarkus-support-extensions</artifactId>
-    <name>Camel Quarkus :: Support</name>
+    <artifactId>camel-quarkus-support-policy-parent</artifactId>
+    <name>Camel Quarkus :: Support :: Policy</name>
     <packaging>pom</packaging>
 
     <modules>
-        <module>ahc</module>
-        <module>aws</module>
-        <module>common</module>
-        <module>commons-logging</module>
-        <module>consul-client</module>
-        <module>httpclient</module>
-        <module>jetty</module>
-        <module>policy</module>
-        <module>retrofit</module>
-        <module>spring</module>
-        <module>xstream</module>
-        <module>xml</module>
-        <module>xalan</module>
+        <module>deployment</module>
+        <module>runtime</module>
     </modules>
 </project>

--- a/extensions/support/policy/runtime/pom.xml
+++ b/extensions/support/policy/runtime/pom.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.camel.quarkus</groupId>
+        <artifactId>camel-quarkus-support-policy-parent</artifactId>
+        <version>1.1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>camel-quarkus-support-policy</artifactId>
+    <name>Camel Quarkus :: Support :: Policy :: Runtime</name>
+
+    <properties>
+        <firstVersion>1.2.0</firstVersion>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.camel.quarkus</groupId>
+                <artifactId>camel-quarkus-bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-core</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${quarkus.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/twitter/deployment/src/main/java/org/apache/camel/quarkus/component/twitter/deployment/TwitterProcessor.java
+++ b/extensions/twitter/deployment/src/main/java/org/apache/camel/quarkus/component/twitter/deployment/TwitterProcessor.java
@@ -21,7 +21,6 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import org.apache.camel.component.twitter.AbstractTwitterComponent;
-import org.apache.camel.component.twitter.TwitterConfiguration;
 
 class TwitterProcessor {
     private static final String FEATURE = "camel-twitter";
@@ -34,7 +33,6 @@ class TwitterProcessor {
     @BuildStep
     void registerForReflection(BuildProducer<ReflectiveClassBuildItem> reflectiveClass) {
         reflectiveClass.produce(new ReflectiveClassBuildItem(true, false,
-                AbstractTwitterComponent.class,
-                TwitterConfiguration.class));
+                AbstractTwitterComponent.class));
     }
 }

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -147,6 +147,13 @@
         </dependencies>
     </dependencyManagement>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-support-policy</artifactId><!-- enforce the policy in all tests -->
+        </dependency>
+    </dependencies>
+
     <modules>
         <!-- build those first -->
         <module>support</module>

--- a/poms/bom-deployment/pom.xml
+++ b/poms/bom-deployment/pom.xml
@@ -411,6 +411,11 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
+                <artifactId>camel-quarkus-support-policy-deployment</artifactId>
+                <version>${camel-quarkus.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel.quarkus</groupId>
                 <artifactId>camel-quarkus-support-retrofit-deployment</artifactId>
                 <version>${camel-quarkus.version}</version>
             </dependency>

--- a/poms/bom/pom.xml
+++ b/poms/bom/pom.xml
@@ -861,6 +861,11 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
+                <artifactId>camel-quarkus-support-policy</artifactId>
+                <version>${camel-quarkus.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel.quarkus</groupId>
                 <artifactId>camel-quarkus-support-retrofit</artifactId>
                 <version>${camel-quarkus.version}</version>
             </dependency>


### PR DESCRIPTION
reflection

Removal of NettyConfiguration, NettyServerBootstrapConfiguration, PdfConfiguration registration led to native failures so these need a separate investigation.