### PR TITLE
Add integration test for Jackson unmarshalling with different POJOs

### DIFF
--- a/integration-tests/jackson/src/main/java/org/apache/camel/quarkus/component/jackson/CamelResource.java
+++ b/integration-tests/jackson/src/main/java/org/apache/camel/quarkus/component/jackson/CamelResource.java
@@ -55,6 +55,36 @@ public class CamelResource {
         return consumer.receive("vm:out").getMessage().getBody().toString();
     }
 
+    @Path("/in-a")
+    @POST
+    @Consumes(MediaType.TEXT_PLAIN)
+    @Produces(MediaType.TEXT_PLAIN)
+    public String processPojoA(String statement) {
+        return template.requestBody("direct:in-a", statement, String.class);
+    }
+
+    @Path("/in-b")
+    @POST
+    @Consumes(MediaType.TEXT_PLAIN)
+    @Produces(MediaType.TEXT_PLAIN)
+    public String processPojoB(String statement) {
+        return template.requestBody("direct:in-b", statement, String.class);
+    }
+
+    @Path("/out-a")
+    @POST
+    @Produces(MediaType.TEXT_PLAIN)
+    public String testPojoA() {
+        return consumer.receive("vm:out-a").getMessage().getBody().toString();
+    }
+
+    @Path("/out-b")
+    @POST
+    @Produces(MediaType.TEXT_PLAIN)
+    public String testPojoB() {
+        return consumer.receive("vm:out-b").getMessage().getBody().toString();
+    }
+
     @Path("/unmarshal/{direct-id}")
     @POST
     @Consumes(MediaType.TEXT_PLAIN)

--- a/integration-tests/jackson/src/main/java/org/apache/camel/quarkus/component/jackson/CamelRoute.java
+++ b/integration-tests/jackson/src/main/java/org/apache/camel/quarkus/component/jackson/CamelRoute.java
@@ -18,7 +18,10 @@ package org.apache.camel.quarkus.component.jackson;
 
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.jackson.JacksonDataFormat;
+import org.apache.camel.model.dataformat.JsonLibrary;
 import org.apache.camel.quarkus.component.jackson.model.DummyObject;
+import org.apache.camel.quarkus.component.jackson.model.PojoA;
+import org.apache.camel.quarkus.component.jackson.model.PojoB;
 
 public class CamelRoute extends RouteBuilder {
 
@@ -37,6 +40,23 @@ public class CamelRoute extends RouteBuilder {
                 .marshal(format)
                 .convertBodyTo(String.class)
                 .to("vm:out");
+        from("direct:in-a")
+                .wireTap("direct:tap-a")
+                .setBody(constant("ok"));
+        from("direct:tap-a")
+                .unmarshal().json(JsonLibrary.Jackson, PojoA.class)
+                .to("log:out")
+                .marshal(new JacksonDataFormat(PojoA.class))
+                .convertBodyTo(String.class)
+                .to("vm:out-a");
+        from("direct:in-b")
+                .wireTap("direct:tap-b")
+                .setBody(constant("ok"));
+        from("direct:tap-b")
+                .unmarshal().json(JsonLibrary.Jackson, PojoB.class)
+                .to("log:out")
+                .marshal(new JacksonDataFormat(PojoB.class))
+                .convertBodyTo(String.class)
+                .to("vm:out-b");
     }
-
 }

--- a/integration-tests/jackson/src/main/java/org/apache/camel/quarkus/component/jackson/model/PojoA.java
+++ b/integration-tests/jackson/src/main/java/org/apache/camel/quarkus/component/jackson/model/PojoA.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.jackson.model;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+public class PojoA {
+
+    private String name;
+
+    public PojoA() {
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/integration-tests/jackson/src/main/java/org/apache/camel/quarkus/component/jackson/model/PojoB.java
+++ b/integration-tests/jackson/src/main/java/org/apache/camel/quarkus/component/jackson/model/PojoB.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.jackson.model;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+public class PojoB {
+
+    private Double value;
+
+    public PojoB() {
+    }
+
+    public Double getValue() {
+        return value;
+    }
+
+    public void setString(Double string) {
+        this.value = string;
+    }
+}

--- a/integration-tests/jackson/src/test/java/org/apache/camel/quarkus/component/jackson/JacksonTest.java
+++ b/integration-tests/jackson/src/test/java/org/apache/camel/quarkus/component/jackson/JacksonTest.java
@@ -46,6 +46,25 @@ public class JacksonTest {
                 .body(equalTo("{\"dummy\":\"value2\"}"));
     }
 
+    @Test
+    public void testUnmarshallingDifferentPojos() {
+        String bodyA = "{\"name\":\"name A\"}";
+        String bodyB = "{\"value\":1.0}";
+
+        RestAssured.given().contentType(ContentType.TEXT)
+                .body(bodyA)
+                .post("/jackson/in-a");
+        RestAssured.given().contentType(ContentType.TEXT)
+                .body(bodyB)
+                .post("/jackson/in-b");
+        RestAssured.post("/jackson/out-a")
+                .then()
+                .body(equalTo(bodyA));
+        RestAssured.post("/jackson/out-b")
+                .then()
+                .body(equalTo(bodyB));
+    }
+
     @ParameterizedTest
     @ValueSource(strings = { "type-as-attribute", "type-as-header" })
     public void testUnmarshal(String directId) {


### PR DESCRIPTION
Additional test for already fixed problem described in #637.
Fails with 1.0.0-M2, succeeds with 1.0.0-M3 and master.