### PR TITLE
fix(rest-json/pom.xml): use quarkus-based dependency

### DIFF
--- a/examples/rest-json/pom.xml
+++ b/examples/rest-json/pom.xml
@@ -37,8 +37,8 @@
             <artifactId>camel-quarkus-platform-http</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.camel</groupId>
-            <artifactId>camel-jackson</artifactId>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-jackson</artifactId>
         </dependency>
 
         <!-- test dependencies -->


### PR DESCRIPTION
Just switch dependency from `camel-jackson` to `camel-quarkus-jackson` in the `rest-json` example