### PR TITLE
camel-fhir record FHIR context instead of creating it at runtime. Onl…

### DIFF
--- a/extensions/fhir/deployment/pom.xml
+++ b/extensions/fhir/deployment/pom.xml
@@ -48,7 +48,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
-            <artifactId>camel-quarkus-core-xml-deployment</artifactId>
+        <artifactId>camel-quarkus-support-xml-deployment</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/extensions/fhir/deployment/src/main/java/org/apache/camel/quarkus/component/fhir/deployment/FhirProcessor.java
+++ b/extensions/fhir/deployment/src/main/java/org/apache/camel/quarkus/component/fhir/deployment/FhirProcessor.java
@@ -16,23 +16,15 @@
  */
 package org.apache.camel.quarkus.component.fhir.deployment;
 
-import java.io.InputStream;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Properties;
-import java.util.Set;
-
-import ca.uhn.fhir.model.dstu2.FhirDstu2;
-import ca.uhn.fhir.model.dstu2.resource.BaseResource;
-import ca.uhn.fhir.model.dstu2.valueset.*;
 import ca.uhn.fhir.rest.client.apache.ApacheRestfulClientFactory;
 import ca.uhn.fhir.util.jar.DependencyLogImpl;
 import ca.uhn.fhir.validation.schematron.SchematronBaseValidator;
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.AdditionalApplicationArchiveMarkerBuildItem;
 import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
-import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBundleBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import org.apache.camel.component.fhir.FhirCapabilitiesEndpointConfiguration;
@@ -49,18 +41,9 @@ import org.apache.camel.component.fhir.FhirSearchEndpointConfiguration;
 import org.apache.camel.component.fhir.FhirTransactionEndpointConfiguration;
 import org.apache.camel.component.fhir.FhirUpdateEndpointConfiguration;
 import org.apache.camel.component.fhir.FhirValidateEndpointConfiguration;
-import org.apache.camel.quarkus.component.fhir.FhirFlags;
-import org.hl7.fhir.dstu3.hapi.ctx.FhirDstu3;
-import org.hl7.fhir.dstu3.model.Base;
-import org.hl7.fhir.dstu3.model.DomainResource;
-import org.hl7.fhir.dstu3.model.Enumerations;
-import org.hl7.fhir.dstu3.model.Meta;
-import org.hl7.fhir.dstu3.model.MetadataResource;
-import org.hl7.fhir.dstu3.model.Resource;
-import org.hl7.fhir.r4.hapi.ctx.FhirR4;
-import org.hl7.fhir.r5.hapi.ctx.FhirR5;
+import org.apache.camel.quarkus.component.fhir.FhirContextProducers;
 
-class FhirProcessor {
+final class FhirProcessor {
     private static final String FEATURE = "camel-fhir";
 
     @BuildStep
@@ -97,278 +80,25 @@ class FhirProcessor {
         return new NativeImageResourceBundleBuildItem("ca.uhn.fhir.i18n.hapi-messages");
     }
 
-    @BuildStep(applicationArchiveMarkers = { "org/hl7/fhir", "ca/uhn/fhir" })
+    @BuildStep
+    AdditionalApplicationArchiveMarkerBuildItem hl7ArchiveMarker() {
+        return new AdditionalApplicationArchiveMarkerBuildItem("org/hl7/fhir");
+    }
+
+    @BuildStep
+    AdditionalApplicationArchiveMarkerBuildItem hapiArchiveMarker() {
+        return new AdditionalApplicationArchiveMarkerBuildItem("ca/uhn/fhir");
+    }
+
+    @BuildStep()
     void processFhir(BuildProducer<ReflectiveClassBuildItem> reflectiveClass) {
         reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, true, SchematronBaseValidator.class));
         reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, true, DependencyLogImpl.class));
         reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, true, ApacheRestfulClientFactory.class));
     }
 
-    @BuildStep(onlyIf = FhirFlags.Dstu2Enabled.class, applicationArchiveMarkers = { "org/hl7/fhir", "ca/uhn/fhir" })
-    void processDstu2(BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
-            BuildProducer<NativeImageResourceBuildItem> resource) {
-        Set<String> classes = new HashSet<>();
-        classes.add(FhirDstu2.class.getCanonicalName());
-        classes.add(BaseResource.class.getCanonicalName());
-        classes.addAll(getModelClasses("/ca/uhn/fhir/model/dstu2/fhirversion.properties"));
-
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, true, classes.toArray(new String[0])));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, true, getDstu2Enums()));
-        resource.produce(new NativeImageResourceBuildItem("ca/uhn/fhir/model/dstu2/fhirversion.properties"));
-    }
-
-    @BuildStep(onlyIf = FhirFlags.Dstu3Enabled.class, applicationArchiveMarkers = { "org/hl7/fhir", "ca/uhn/fhir" })
-    void processDstu3(BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
-            BuildProducer<NativeImageResourceBuildItem> resource) {
-        Set<String> classes = new HashSet<>();
-        classes.add(FhirDstu3.class.getCanonicalName());
-        classes.add(DomainResource.class.getCanonicalName());
-        classes.add(Resource.class.getCanonicalName());
-        classes.add(org.hl7.fhir.dstu3.model.BaseResource.class.getCanonicalName());
-        classes.add(Base.class.getCanonicalName());
-        classes.addAll(getModelClasses("/org/hl7/fhir/dstu3/model/fhirversion.properties"));
-        classes.addAll(getInnerClasses(Enumerations.class.getCanonicalName()));
-
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, true, Meta.class.getCanonicalName()));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, true, MetadataResource.class.getCanonicalName()));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, true, classes.toArray(new String[0])));
-        resource.produce(new NativeImageResourceBuildItem("org/hl7/fhir/dstu3/model/fhirversion.properties"));
-    }
-
-    @BuildStep(onlyIf = FhirFlags.R4Enabled.class, applicationArchiveMarkers = { "org/hl7/fhir", "ca/uhn/fhir" })
-    void processR4(BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
-            BuildProducer<NativeImageResourceBuildItem> resource) {
-        Set<String> classes = new HashSet<>();
-        classes.add(FhirR4.class.getCanonicalName());
-        classes.add(org.hl7.fhir.r4.model.DomainResource.class.getCanonicalName());
-        classes.add(org.hl7.fhir.r4.model.Resource.class.getCanonicalName());
-        classes.add(org.hl7.fhir.r4.model.BaseResource.class.getCanonicalName());
-        classes.add(org.hl7.fhir.r4.model.Base.class.getCanonicalName());
-        classes.addAll(getModelClasses("/org/hl7/fhir/r4/model/fhirversion.properties"));
-        classes.addAll(getInnerClasses(org.hl7.fhir.r4.model.Enumerations.class.getCanonicalName()));
-
-        reflectiveClass
-                .produce(new ReflectiveClassBuildItem(true, true, true, org.hl7.fhir.r4.model.Meta.class.getCanonicalName()));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, true,
-                org.hl7.fhir.r4.model.MetadataResource.class.getCanonicalName()));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, true, classes.toArray(new String[0])));
-        resource.produce(new NativeImageResourceBuildItem("org/hl7/fhir/r4/model/fhirversion.properties"));
-    }
-
-    @BuildStep(onlyIf = FhirFlags.R5Enabled.class, applicationArchiveMarkers = { "org/hl7/fhir", "ca/uhn/fhir" })
-    void processR5(BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
-            BuildProducer<NativeImageResourceBuildItem> resource) {
-        Set<String> classes = new HashSet<>();
-        classes.add(FhirR5.class.getCanonicalName());
-        classes.add(org.hl7.fhir.r5.model.DomainResource.class.getCanonicalName());
-        classes.add(org.hl7.fhir.r5.model.Resource.class.getCanonicalName());
-        classes.add(org.hl7.fhir.r5.model.BaseResource.class.getCanonicalName());
-        classes.add(org.hl7.fhir.r5.model.Base.class.getCanonicalName());
-        classes.addAll(getModelClasses("/org/hl7/fhir/r5/model/fhirversion.properties"));
-        classes.addAll(getInnerClasses(org.hl7.fhir.r5.model.Enumerations.class.getCanonicalName()));
-        reflectiveClass
-                .produce(new ReflectiveClassBuildItem(true, true, true, org.hl7.fhir.r5.model.Meta.class.getCanonicalName()));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, true,
-                org.hl7.fhir.r5.model.MetadataResource.class.getCanonicalName()));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, true, classes.toArray(new String[0])));
-        resource.produce(new NativeImageResourceBuildItem("org/hl7/fhir/r5/model/fhirversion.properties"));
-    }
-
-    private Collection<String> getModelClasses(String model) {
-        try (InputStream str = FhirDstu3.class.getResourceAsStream(model)) {
-            Properties prop = new Properties();
-            prop.load(str);
-            return getInnerClasses(prop.values().toArray(new String[0]));
-        } catch (Exception e) {
-            throw new RuntimeException("Please ensure FHIR is on the classpath", e);
-        }
-    }
-
-    private Collection<String> getInnerClasses(String... classList) {
-        try {
-            Set<String> classes = new HashSet<>();
-            for (Object value : classList) {
-                String clazz = (String) value;
-                final Class[] parent = Class.forName(clazz).getClasses();
-                for (Class aClass : parent) {
-                    String name = aClass.getName();
-                    classes.add(name);
-                }
-                classes.add(clazz);
-            }
-            return classes;
-        } catch (ClassNotFoundException e) {
-            throw new RuntimeException("Please ensure FHIR is on the classpath", e);
-        }
-    }
-
-    private String[] getDstu2Enums() {
-        return new String[] {
-                AccountStatusEnum.class.getCanonicalName(),
-                ActionListEnum.class.getCanonicalName(),
-                AddressTypeEnum.class.getCanonicalName(),
-                AddressUseEnum.class.getCanonicalName(),
-                AdjudicationCodesEnum.class.getCanonicalName(),
-                AdjudicationErrorCodesEnum.class.getCanonicalName(),
-                AdjustmentReasonCodesEnum.class.getCanonicalName(),
-                AdministrativeGenderEnum.class.getCanonicalName(),
-                AdmitSourceEnum.class.getCanonicalName(),
-                AggregationModeEnum.class.getCanonicalName(),
-                AllergyIntoleranceCategoryEnum.class.getCanonicalName(),
-                AllergyIntoleranceCertaintyEnum.class.getCanonicalName(),
-                AllergyIntoleranceCriticalityEnum.class.getCanonicalName(),
-                AllergyIntoleranceSeverityEnum.class.getCanonicalName(),
-                AllergyIntoleranceStatusEnum.class.getCanonicalName(),
-                AllergyIntoleranceTypeEnum.class.getCanonicalName(),
-                AnswerFormatEnum.class.getCanonicalName(),
-                AppointmentStatusEnum.class.getCanonicalName(),
-                AssertionDirectionTypeEnum.class.getCanonicalName(),
-                AssertionOperatorTypeEnum.class.getCanonicalName(),
-                AssertionResponseTypesEnum.class.getCanonicalName(),
-                AuditEventActionEnum.class.getCanonicalName(),
-                AuditEventObjectLifecycleEnum.class.getCanonicalName(),
-                AuditEventObjectRoleEnum.class.getCanonicalName(),
-                AuditEventObjectTypeEnum.class.getCanonicalName(),
-                AuditEventOutcomeEnum.class.getCanonicalName(),
-                AuditEventParticipantNetworkTypeEnum.class.getCanonicalName(),
-                AuditEventSourceTypeEnum.class.getCanonicalName(),
-                BindingStrengthEnum.class.getCanonicalName(),
-                BundleTypeEnum.class.getCanonicalName(),
-                CarePlanActivityStatusEnum.class.getCanonicalName(),
-                CarePlanRelationshipEnum.class.getCanonicalName(),
-                CarePlanStatusEnum.class.getCanonicalName(),
-                ClaimTypeEnum.class.getCanonicalName(),
-                ClinicalImpressionStatusEnum.class.getCanonicalName(),
-                CommunicationRequestStatusEnum.class.getCanonicalName(),
-                CommunicationStatusEnum.class.getCanonicalName(),
-                CompositionAttestationModeEnum.class.getCanonicalName(),
-                CompositionStatusEnum.class.getCanonicalName(),
-                ConceptMapEquivalenceEnum.class.getCanonicalName(),
-                ConditionalDeleteStatusEnum.class.getCanonicalName(),
-                ConditionCategoryCodesEnum.class.getCanonicalName(),
-                ConditionClinicalStatusCodesEnum.class.getCanonicalName(),
-                ConditionVerificationStatusEnum.class.getCanonicalName(),
-                ConformanceEventModeEnum.class.getCanonicalName(),
-                ConformanceResourceStatusEnum.class.getCanonicalName(),
-                ConformanceStatementKindEnum.class.getCanonicalName(),
-                ConstraintSeverityEnum.class.getCanonicalName(),
-                ContactPointSystemEnum.class.getCanonicalName(),
-                ContactPointUseEnum.class.getCanonicalName(),
-                ContentTypeEnum.class.getCanonicalName(),
-                DataElementStringencyEnum.class.getCanonicalName(),
-                DaysOfWeekEnum.class.getCanonicalName(),
-                DetectedIssueSeverityEnum.class.getCanonicalName(),
-                DeviceMetricCalibrationStateEnum.class.getCanonicalName(),
-                DeviceMetricCalibrationTypeEnum.class.getCanonicalName(),
-                DeviceMetricCategoryEnum.class.getCanonicalName(),
-                DeviceMetricColorEnum.class.getCanonicalName(),
-                DeviceMetricOperationalStatusEnum.class.getCanonicalName(),
-                DeviceStatusEnum.class.getCanonicalName(),
-                DeviceUseRequestPriorityEnum.class.getCanonicalName(),
-                DeviceUseRequestStatusEnum.class.getCanonicalName(),
-                DiagnosticOrderPriorityEnum.class.getCanonicalName(),
-                DiagnosticOrderStatusEnum.class.getCanonicalName(),
-                DiagnosticReportStatusEnum.class.getCanonicalName(),
-                DigitalMediaTypeEnum.class.getCanonicalName(),
-                DocumentModeEnum.class.getCanonicalName(),
-                DocumentReferenceStatusEnum.class.getCanonicalName(),
-                DocumentRelationshipTypeEnum.class.getCanonicalName(),
-                EncounterClassEnum.class.getCanonicalName(),
-                EncounterLocationStatusEnum.class.getCanonicalName(),
-                EncounterStateEnum.class.getCanonicalName(),
-                EpisodeOfCareStatusEnum.class.getCanonicalName(),
-                EventTimingEnum.class.getCanonicalName(),
-                ExtensionContextEnum.class.getCanonicalName(),
-                FamilyHistoryStatusEnum.class.getCanonicalName(),
-                FilterOperatorEnum.class.getCanonicalName(),
-                FlagStatusEnum.class.getCanonicalName(),
-                GoalPriorityEnum.class.getCanonicalName(),
-                GoalStatusEnum.class.getCanonicalName(),
-                GroupTypeEnum.class.getCanonicalName(),
-                GuideDependencyTypeEnum.class.getCanonicalName(),
-                GuidePageKindEnum.class.getCanonicalName(),
-                GuideResourcePurposeEnum.class.getCanonicalName(),
-                HTTPVerbEnum.class.getCanonicalName(),
-                IdentifierTypeCodesEnum.class.getCanonicalName(),
-                IdentifierUseEnum.class.getCanonicalName(),
-                IdentityAssuranceLevelEnum.class.getCanonicalName(),
-                InstanceAvailabilityEnum.class.getCanonicalName(),
-                IssueSeverityEnum.class.getCanonicalName(),
-                IssueTypeEnum.class.getCanonicalName(),
-                KOStitleEnum.class.getCanonicalName(),
-                LinkTypeEnum.class.getCanonicalName(),
-                ListModeEnum.class.getCanonicalName(),
-                ListOrderCodesEnum.class.getCanonicalName(),
-                ListStatusEnum.class.getCanonicalName(),
-                LocationModeEnum.class.getCanonicalName(),
-                LocationStatusEnum.class.getCanonicalName(),
-                LocationTypeEnum.class.getCanonicalName(),
-                MaritalStatusCodesEnum.class.getCanonicalName(),
-                MeasmntPrincipleEnum.class.getCanonicalName(),
-                MedicationAdministrationStatusEnum.class.getCanonicalName(),
-                MedicationDispenseStatusEnum.class.getCanonicalName(),
-                MedicationOrderStatusEnum.class.getCanonicalName(),
-                MedicationStatementStatusEnum.class.getCanonicalName(),
-                MessageEventEnum.class.getCanonicalName(),
-                MessageSignificanceCategoryEnum.class.getCanonicalName(),
-                MessageTransportEnum.class.getCanonicalName(),
-                NameUseEnum.class.getCanonicalName(),
-                NamingSystemIdentifierTypeEnum.class.getCanonicalName(),
-                NamingSystemTypeEnum.class.getCanonicalName(),
-                NarrativeStatusEnum.class.getCanonicalName(),
-                NoteTypeEnum.class.getCanonicalName(),
-                NutritionOrderStatusEnum.class.getCanonicalName(),
-                ObservationRelationshipTypeEnum.class.getCanonicalName(),
-                ObservationStatusEnum.class.getCanonicalName(),
-                OperationKindEnum.class.getCanonicalName(),
-                OperationParameterUseEnum.class.getCanonicalName(),
-                OrderStatusEnum.class.getCanonicalName(),
-                ParticipantRequiredEnum.class.getCanonicalName(),
-                ParticipantStatusEnum.class.getCanonicalName(),
-                ParticipantTypeEnum.class.getCanonicalName(),
-                ParticipationStatusEnum.class.getCanonicalName(),
-                PayeeTypeCodesEnum.class.getCanonicalName(),
-                ProcedureRequestPriorityEnum.class.getCanonicalName(),
-                ProcedureRequestStatusEnum.class.getCanonicalName(),
-                ProcedureStatusEnum.class.getCanonicalName(),
-                PropertyRepresentationEnum.class.getCanonicalName(),
-                ProvenanceEntityRoleEnum.class.getCanonicalName(),
-                QuantityComparatorEnum.class.getCanonicalName(),
-                QuestionnaireResponseStatusEnum.class.getCanonicalName(),
-                QuestionnaireStatusEnum.class.getCanonicalName(),
-                ReferralMethodEnum.class.getCanonicalName(),
-                ReferralStatusEnum.class.getCanonicalName(),
-                RemittanceOutcomeEnum.class.getCanonicalName(),
-                ResourceTypeEnum.class.getCanonicalName(),
-                ResourceVersionPolicyEnum.class.getCanonicalName(),
-                ResponseTypeEnum.class.getCanonicalName(),
-                RestfulConformanceModeEnum.class.getCanonicalName(),
-                RestfulSecurityServiceEnum.class.getCanonicalName(),
-                RulesetCodesEnum.class.getCanonicalName(),
-                SearchEntryModeEnum.class.getCanonicalName(),
-                SearchModifierCodeEnum.class.getCanonicalName(),
-                SearchParamTypeEnum.class.getCanonicalName(),
-                ServiceProvisionConditionsEnum.class.getCanonicalName(),
-                SignatureTypeCodesEnum.class.getCanonicalName(),
-                SlicingRulesEnum.class.getCanonicalName(),
-                SlotStatusEnum.class.getCanonicalName(),
-                SpecimenStatusEnum.class.getCanonicalName(),
-                StructureDefinitionKindEnum.class.getCanonicalName(),
-                SubscriptionChannelTypeEnum.class.getCanonicalName(),
-                SubscriptionStatusEnum.class.getCanonicalName(),
-                SubstanceCategoryCodesEnum.class.getCanonicalName(),
-                SupplyDeliveryStatusEnum.class.getCanonicalName(),
-                SupplyRequestStatusEnum.class.getCanonicalName(),
-                SystemRestfulInteractionEnum.class.getCanonicalName(),
-                TimingAbbreviationEnum.class.getCanonicalName(),
-                TransactionModeEnum.class.getCanonicalName(),
-                TypeRestfulInteractionEnum.class.getCanonicalName(),
-                UnitsOfTimeEnum.class.getCanonicalName(),
-                UnknownContentCodeEnum.class.getCanonicalName(),
-                UseEnum.class.getCanonicalName(),
-                VisionBaseEnum.class.getCanonicalName(),
-                VisionEyesEnum.class.getCanonicalName(),
-                XPathUsageTypeEnum.class.getCanonicalName()
-        };
+    @BuildStep
+    void beans(BuildProducer<AdditionalBeanBuildItem> beanProducer) {
+        beanProducer.produce(AdditionalBeanBuildItem.unremovableOf(FhirContextProducers.class));
     }
 }

--- a/extensions/fhir/deployment/src/main/java/org/apache/camel/quarkus/component/fhir/deployment/FhirUtil.java
+++ b/extensions/fhir/deployment/src/main/java/org/apache/camel/quarkus/component/fhir/deployment/FhirUtil.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.fhir.deployment;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+
+import ca.uhn.fhir.context.FhirContext;
+
+public final class FhirUtil {
+
+    private FhirUtil() {
+    }
+
+    public static Properties loadProperties(String path) {
+        try (InputStream str = FhirContext.class.getResourceAsStream(path)) {
+            Properties prop = new Properties();
+            prop.load(str);
+            return prop;
+        } catch (Exception e) {
+            throw new RuntimeException("Please ensure FHIR is on the classpath", e);
+        }
+    }
+
+    public static Collection<String> getModelClasses(Properties properties) {
+        return getInnerClasses(properties.values().toArray(new String[0]));
+    }
+
+    public static Collection<String> getResourceDefinitions(Properties properties) {
+        List<String> resources = new ArrayList<>();
+        for (String stringPropertyName : properties.stringPropertyNames()) {
+            if (stringPropertyName.contains("resource.")) {
+                resources.add(stringPropertyName.replace("resource.", ""));
+            }
+        }
+        return resources;
+    }
+
+    public static Collection<String> getInnerClasses(String... classList) {
+        try {
+            Set<String> classes = new HashSet<>();
+            for (Object value : classList) {
+                String clazz = (String) value;
+                final Class[] parent = Class.forName(clazz).getClasses();
+                for (Class aClass : parent) {
+                    String name = aClass.getName();
+                    classes.add(name);
+                }
+                classes.add(clazz);
+            }
+            return classes;
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException("Please ensure FHIR is on the classpath", e);
+        }
+    }
+}

--- a/extensions/fhir/deployment/src/main/java/org/apache/camel/quarkus/component/fhir/deployment/dstu2/Dstu2PropertiesBuildItem.java
+++ b/extensions/fhir/deployment/src/main/java/org/apache/camel/quarkus/component/fhir/deployment/dstu2/Dstu2PropertiesBuildItem.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.fhir.deployment.dstu2;
+
+import java.util.Properties;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+public final class Dstu2PropertiesBuildItem extends SimpleBuildItem {
+
+    private final Properties properties;
+
+    public Dstu2PropertiesBuildItem(Properties properties) {
+        this.properties = properties;
+    }
+
+    public Properties getProperties() {
+        return properties;
+    }
+}

--- a/extensions/fhir/deployment/src/main/java/org/apache/camel/quarkus/component/fhir/deployment/dstu2/FhirDstu2Processor.java
+++ b/extensions/fhir/deployment/src/main/java/org/apache/camel/quarkus/component/fhir/deployment/dstu2/FhirDstu2Processor.java
@@ -1,0 +1,400 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.fhir.deployment.dstu2;
+
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.Set;
+
+import ca.uhn.fhir.model.dstu2.resource.*;
+import ca.uhn.fhir.model.dstu2.valueset.AccountStatusEnum;
+import ca.uhn.fhir.model.dstu2.valueset.ActionListEnum;
+import ca.uhn.fhir.model.dstu2.valueset.AddressTypeEnum;
+import ca.uhn.fhir.model.dstu2.valueset.AddressUseEnum;
+import ca.uhn.fhir.model.dstu2.valueset.AdjudicationCodesEnum;
+import ca.uhn.fhir.model.dstu2.valueset.AdjudicationErrorCodesEnum;
+import ca.uhn.fhir.model.dstu2.valueset.AdjustmentReasonCodesEnum;
+import ca.uhn.fhir.model.dstu2.valueset.AdministrativeGenderEnum;
+import ca.uhn.fhir.model.dstu2.valueset.AdmitSourceEnum;
+import ca.uhn.fhir.model.dstu2.valueset.AggregationModeEnum;
+import ca.uhn.fhir.model.dstu2.valueset.AllergyIntoleranceCategoryEnum;
+import ca.uhn.fhir.model.dstu2.valueset.AllergyIntoleranceCertaintyEnum;
+import ca.uhn.fhir.model.dstu2.valueset.AllergyIntoleranceCriticalityEnum;
+import ca.uhn.fhir.model.dstu2.valueset.AllergyIntoleranceSeverityEnum;
+import ca.uhn.fhir.model.dstu2.valueset.AllergyIntoleranceStatusEnum;
+import ca.uhn.fhir.model.dstu2.valueset.AllergyIntoleranceTypeEnum;
+import ca.uhn.fhir.model.dstu2.valueset.AnswerFormatEnum;
+import ca.uhn.fhir.model.dstu2.valueset.AppointmentStatusEnum;
+import ca.uhn.fhir.model.dstu2.valueset.AssertionDirectionTypeEnum;
+import ca.uhn.fhir.model.dstu2.valueset.AssertionOperatorTypeEnum;
+import ca.uhn.fhir.model.dstu2.valueset.AssertionResponseTypesEnum;
+import ca.uhn.fhir.model.dstu2.valueset.AuditEventActionEnum;
+import ca.uhn.fhir.model.dstu2.valueset.AuditEventObjectLifecycleEnum;
+import ca.uhn.fhir.model.dstu2.valueset.AuditEventObjectRoleEnum;
+import ca.uhn.fhir.model.dstu2.valueset.AuditEventObjectTypeEnum;
+import ca.uhn.fhir.model.dstu2.valueset.AuditEventOutcomeEnum;
+import ca.uhn.fhir.model.dstu2.valueset.AuditEventParticipantNetworkTypeEnum;
+import ca.uhn.fhir.model.dstu2.valueset.AuditEventSourceTypeEnum;
+import ca.uhn.fhir.model.dstu2.valueset.BindingStrengthEnum;
+import ca.uhn.fhir.model.dstu2.valueset.BundleTypeEnum;
+import ca.uhn.fhir.model.dstu2.valueset.CarePlanActivityStatusEnum;
+import ca.uhn.fhir.model.dstu2.valueset.CarePlanRelationshipEnum;
+import ca.uhn.fhir.model.dstu2.valueset.CarePlanStatusEnum;
+import ca.uhn.fhir.model.dstu2.valueset.ClaimTypeEnum;
+import ca.uhn.fhir.model.dstu2.valueset.ClinicalImpressionStatusEnum;
+import ca.uhn.fhir.model.dstu2.valueset.CommunicationRequestStatusEnum;
+import ca.uhn.fhir.model.dstu2.valueset.CommunicationStatusEnum;
+import ca.uhn.fhir.model.dstu2.valueset.CompositionAttestationModeEnum;
+import ca.uhn.fhir.model.dstu2.valueset.CompositionStatusEnum;
+import ca.uhn.fhir.model.dstu2.valueset.ConceptMapEquivalenceEnum;
+import ca.uhn.fhir.model.dstu2.valueset.ConditionCategoryCodesEnum;
+import ca.uhn.fhir.model.dstu2.valueset.ConditionClinicalStatusCodesEnum;
+import ca.uhn.fhir.model.dstu2.valueset.ConditionVerificationStatusEnum;
+import ca.uhn.fhir.model.dstu2.valueset.ConditionalDeleteStatusEnum;
+import ca.uhn.fhir.model.dstu2.valueset.ConformanceEventModeEnum;
+import ca.uhn.fhir.model.dstu2.valueset.ConformanceResourceStatusEnum;
+import ca.uhn.fhir.model.dstu2.valueset.ConformanceStatementKindEnum;
+import ca.uhn.fhir.model.dstu2.valueset.ConstraintSeverityEnum;
+import ca.uhn.fhir.model.dstu2.valueset.ContactPointSystemEnum;
+import ca.uhn.fhir.model.dstu2.valueset.ContactPointUseEnum;
+import ca.uhn.fhir.model.dstu2.valueset.ContentTypeEnum;
+import ca.uhn.fhir.model.dstu2.valueset.DataElementStringencyEnum;
+import ca.uhn.fhir.model.dstu2.valueset.DaysOfWeekEnum;
+import ca.uhn.fhir.model.dstu2.valueset.DetectedIssueSeverityEnum;
+import ca.uhn.fhir.model.dstu2.valueset.DeviceMetricCalibrationStateEnum;
+import ca.uhn.fhir.model.dstu2.valueset.DeviceMetricCalibrationTypeEnum;
+import ca.uhn.fhir.model.dstu2.valueset.DeviceMetricCategoryEnum;
+import ca.uhn.fhir.model.dstu2.valueset.DeviceMetricColorEnum;
+import ca.uhn.fhir.model.dstu2.valueset.DeviceMetricOperationalStatusEnum;
+import ca.uhn.fhir.model.dstu2.valueset.DeviceStatusEnum;
+import ca.uhn.fhir.model.dstu2.valueset.DeviceUseRequestPriorityEnum;
+import ca.uhn.fhir.model.dstu2.valueset.DeviceUseRequestStatusEnum;
+import ca.uhn.fhir.model.dstu2.valueset.DiagnosticOrderPriorityEnum;
+import ca.uhn.fhir.model.dstu2.valueset.DiagnosticOrderStatusEnum;
+import ca.uhn.fhir.model.dstu2.valueset.DiagnosticReportStatusEnum;
+import ca.uhn.fhir.model.dstu2.valueset.DigitalMediaTypeEnum;
+import ca.uhn.fhir.model.dstu2.valueset.DocumentModeEnum;
+import ca.uhn.fhir.model.dstu2.valueset.DocumentReferenceStatusEnum;
+import ca.uhn.fhir.model.dstu2.valueset.DocumentRelationshipTypeEnum;
+import ca.uhn.fhir.model.dstu2.valueset.EncounterClassEnum;
+import ca.uhn.fhir.model.dstu2.valueset.EncounterLocationStatusEnum;
+import ca.uhn.fhir.model.dstu2.valueset.EncounterStateEnum;
+import ca.uhn.fhir.model.dstu2.valueset.EpisodeOfCareStatusEnum;
+import ca.uhn.fhir.model.dstu2.valueset.EventTimingEnum;
+import ca.uhn.fhir.model.dstu2.valueset.ExtensionContextEnum;
+import ca.uhn.fhir.model.dstu2.valueset.FamilyHistoryStatusEnum;
+import ca.uhn.fhir.model.dstu2.valueset.FilterOperatorEnum;
+import ca.uhn.fhir.model.dstu2.valueset.FlagStatusEnum;
+import ca.uhn.fhir.model.dstu2.valueset.GoalPriorityEnum;
+import ca.uhn.fhir.model.dstu2.valueset.GoalStatusEnum;
+import ca.uhn.fhir.model.dstu2.valueset.GroupTypeEnum;
+import ca.uhn.fhir.model.dstu2.valueset.GuideDependencyTypeEnum;
+import ca.uhn.fhir.model.dstu2.valueset.GuidePageKindEnum;
+import ca.uhn.fhir.model.dstu2.valueset.GuideResourcePurposeEnum;
+import ca.uhn.fhir.model.dstu2.valueset.HTTPVerbEnum;
+import ca.uhn.fhir.model.dstu2.valueset.IdentifierTypeCodesEnum;
+import ca.uhn.fhir.model.dstu2.valueset.IdentifierUseEnum;
+import ca.uhn.fhir.model.dstu2.valueset.IdentityAssuranceLevelEnum;
+import ca.uhn.fhir.model.dstu2.valueset.InstanceAvailabilityEnum;
+import ca.uhn.fhir.model.dstu2.valueset.IssueSeverityEnum;
+import ca.uhn.fhir.model.dstu2.valueset.IssueTypeEnum;
+import ca.uhn.fhir.model.dstu2.valueset.KOStitleEnum;
+import ca.uhn.fhir.model.dstu2.valueset.LinkTypeEnum;
+import ca.uhn.fhir.model.dstu2.valueset.ListModeEnum;
+import ca.uhn.fhir.model.dstu2.valueset.ListOrderCodesEnum;
+import ca.uhn.fhir.model.dstu2.valueset.ListStatusEnum;
+import ca.uhn.fhir.model.dstu2.valueset.LocationModeEnum;
+import ca.uhn.fhir.model.dstu2.valueset.LocationStatusEnum;
+import ca.uhn.fhir.model.dstu2.valueset.LocationTypeEnum;
+import ca.uhn.fhir.model.dstu2.valueset.MaritalStatusCodesEnum;
+import ca.uhn.fhir.model.dstu2.valueset.MeasmntPrincipleEnum;
+import ca.uhn.fhir.model.dstu2.valueset.MedicationAdministrationStatusEnum;
+import ca.uhn.fhir.model.dstu2.valueset.MedicationDispenseStatusEnum;
+import ca.uhn.fhir.model.dstu2.valueset.MedicationOrderStatusEnum;
+import ca.uhn.fhir.model.dstu2.valueset.MedicationStatementStatusEnum;
+import ca.uhn.fhir.model.dstu2.valueset.MessageEventEnum;
+import ca.uhn.fhir.model.dstu2.valueset.MessageSignificanceCategoryEnum;
+import ca.uhn.fhir.model.dstu2.valueset.MessageTransportEnum;
+import ca.uhn.fhir.model.dstu2.valueset.NameUseEnum;
+import ca.uhn.fhir.model.dstu2.valueset.NamingSystemIdentifierTypeEnum;
+import ca.uhn.fhir.model.dstu2.valueset.NamingSystemTypeEnum;
+import ca.uhn.fhir.model.dstu2.valueset.NarrativeStatusEnum;
+import ca.uhn.fhir.model.dstu2.valueset.NoteTypeEnum;
+import ca.uhn.fhir.model.dstu2.valueset.NutritionOrderStatusEnum;
+import ca.uhn.fhir.model.dstu2.valueset.ObservationRelationshipTypeEnum;
+import ca.uhn.fhir.model.dstu2.valueset.ObservationStatusEnum;
+import ca.uhn.fhir.model.dstu2.valueset.OperationKindEnum;
+import ca.uhn.fhir.model.dstu2.valueset.OperationParameterUseEnum;
+import ca.uhn.fhir.model.dstu2.valueset.OrderStatusEnum;
+import ca.uhn.fhir.model.dstu2.valueset.ParticipantRequiredEnum;
+import ca.uhn.fhir.model.dstu2.valueset.ParticipantStatusEnum;
+import ca.uhn.fhir.model.dstu2.valueset.ParticipantTypeEnum;
+import ca.uhn.fhir.model.dstu2.valueset.ParticipationStatusEnum;
+import ca.uhn.fhir.model.dstu2.valueset.PayeeTypeCodesEnum;
+import ca.uhn.fhir.model.dstu2.valueset.ProcedureRequestPriorityEnum;
+import ca.uhn.fhir.model.dstu2.valueset.ProcedureRequestStatusEnum;
+import ca.uhn.fhir.model.dstu2.valueset.ProcedureStatusEnum;
+import ca.uhn.fhir.model.dstu2.valueset.PropertyRepresentationEnum;
+import ca.uhn.fhir.model.dstu2.valueset.ProvenanceEntityRoleEnum;
+import ca.uhn.fhir.model.dstu2.valueset.QuantityComparatorEnum;
+import ca.uhn.fhir.model.dstu2.valueset.QuestionnaireResponseStatusEnum;
+import ca.uhn.fhir.model.dstu2.valueset.QuestionnaireStatusEnum;
+import ca.uhn.fhir.model.dstu2.valueset.ReferralMethodEnum;
+import ca.uhn.fhir.model.dstu2.valueset.ReferralStatusEnum;
+import ca.uhn.fhir.model.dstu2.valueset.RemittanceOutcomeEnum;
+import ca.uhn.fhir.model.dstu2.valueset.ResourceTypeEnum;
+import ca.uhn.fhir.model.dstu2.valueset.ResourceVersionPolicyEnum;
+import ca.uhn.fhir.model.dstu2.valueset.ResponseTypeEnum;
+import ca.uhn.fhir.model.dstu2.valueset.RestfulConformanceModeEnum;
+import ca.uhn.fhir.model.dstu2.valueset.RestfulSecurityServiceEnum;
+import ca.uhn.fhir.model.dstu2.valueset.RulesetCodesEnum;
+import ca.uhn.fhir.model.dstu2.valueset.SearchEntryModeEnum;
+import ca.uhn.fhir.model.dstu2.valueset.SearchModifierCodeEnum;
+import ca.uhn.fhir.model.dstu2.valueset.SearchParamTypeEnum;
+import ca.uhn.fhir.model.dstu2.valueset.ServiceProvisionConditionsEnum;
+import ca.uhn.fhir.model.dstu2.valueset.SignatureTypeCodesEnum;
+import ca.uhn.fhir.model.dstu2.valueset.SlicingRulesEnum;
+import ca.uhn.fhir.model.dstu2.valueset.SlotStatusEnum;
+import ca.uhn.fhir.model.dstu2.valueset.SpecimenStatusEnum;
+import ca.uhn.fhir.model.dstu2.valueset.StructureDefinitionKindEnum;
+import ca.uhn.fhir.model.dstu2.valueset.SubscriptionChannelTypeEnum;
+import ca.uhn.fhir.model.dstu2.valueset.SubscriptionStatusEnum;
+import ca.uhn.fhir.model.dstu2.valueset.SubstanceCategoryCodesEnum;
+import ca.uhn.fhir.model.dstu2.valueset.SupplyDeliveryStatusEnum;
+import ca.uhn.fhir.model.dstu2.valueset.SupplyRequestStatusEnum;
+import ca.uhn.fhir.model.dstu2.valueset.SystemRestfulInteractionEnum;
+import ca.uhn.fhir.model.dstu2.valueset.TimingAbbreviationEnum;
+import ca.uhn.fhir.model.dstu2.valueset.TransactionModeEnum;
+import ca.uhn.fhir.model.dstu2.valueset.TypeRestfulInteractionEnum;
+import ca.uhn.fhir.model.dstu2.valueset.UnitsOfTimeEnum;
+import ca.uhn.fhir.model.dstu2.valueset.UnknownContentCodeEnum;
+import ca.uhn.fhir.model.dstu2.valueset.UseEnum;
+import ca.uhn.fhir.model.dstu2.valueset.VisionBaseEnum;
+import ca.uhn.fhir.model.dstu2.valueset.VisionEyesEnum;
+import ca.uhn.fhir.model.dstu2.valueset.XPathUsageTypeEnum;
+import io.quarkus.arc.deployment.BeanContainerBuildItem;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import org.apache.camel.quarkus.component.fhir.FhirContextRecorder;
+import org.apache.camel.quarkus.component.fhir.FhirFlags;
+
+import static org.apache.camel.quarkus.component.fhir.deployment.FhirUtil.getModelClasses;
+import static org.apache.camel.quarkus.component.fhir.deployment.FhirUtil.getResourceDefinitions;
+import static org.apache.camel.quarkus.component.fhir.deployment.FhirUtil.loadProperties;
+
+public class FhirDstu2Processor {
+
+    @BuildStep(onlyIf = FhirFlags.Dstu2Enabled.class)
+    Dstu2PropertiesBuildItem properties(BuildProducer<NativeImageResourceBuildItem> resource) {
+        Properties properties = loadProperties("/ca/uhn/fhir/model/dstu2/fhirversion.properties");
+        resource.produce(new NativeImageResourceBuildItem("ca/uhn/fhir/model/dstu2/fhirversion.properties"));
+        return new Dstu2PropertiesBuildItem(properties);
+    }
+
+    @BuildStep(onlyIf = FhirFlags.Dstu2Enabled.class)
+    @Record(ExecutionTime.STATIC_INIT)
+    void recordContext(FhirContextRecorder fhirContextRecorder, BeanContainerBuildItem beanContainer,
+            Dstu2PropertiesBuildItem propertiesBuildItem) {
+        fhirContextRecorder.createDstu2FhirContext(beanContainer.getValue(),
+                getResourceDefinitions(propertiesBuildItem.getProperties()));
+    }
+
+    @BuildStep(onlyIf = FhirFlags.Dstu2Enabled.class)
+    void enableReflection(BuildProducer<ReflectiveClassBuildItem> reflectiveClass, Dstu2PropertiesBuildItem buildItem) {
+        Set<String> classes = new HashSet<>();
+        classes.add(BaseResource.class.getCanonicalName());
+        classes.addAll(getModelClasses(buildItem.getProperties()));
+
+        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, classes.toArray(new String[0])));
+        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, getDstu2Enums()));
+    }
+
+    private String[] getDstu2Enums() {
+        return new String[] {
+                AccountStatusEnum.class.getCanonicalName(),
+                ActionListEnum.class.getCanonicalName(),
+                AddressTypeEnum.class.getCanonicalName(),
+                AddressUseEnum.class.getCanonicalName(),
+                AdjudicationCodesEnum.class.getCanonicalName(),
+                AdjudicationErrorCodesEnum.class.getCanonicalName(),
+                AdjustmentReasonCodesEnum.class.getCanonicalName(),
+                AdministrativeGenderEnum.class.getCanonicalName(),
+                AdmitSourceEnum.class.getCanonicalName(),
+                AggregationModeEnum.class.getCanonicalName(),
+                AllergyIntoleranceCategoryEnum.class.getCanonicalName(),
+                AllergyIntoleranceCertaintyEnum.class.getCanonicalName(),
+                AllergyIntoleranceCriticalityEnum.class.getCanonicalName(),
+                AllergyIntoleranceSeverityEnum.class.getCanonicalName(),
+                AllergyIntoleranceStatusEnum.class.getCanonicalName(),
+                AllergyIntoleranceTypeEnum.class.getCanonicalName(),
+                AnswerFormatEnum.class.getCanonicalName(),
+                AppointmentStatusEnum.class.getCanonicalName(),
+                AssertionDirectionTypeEnum.class.getCanonicalName(),
+                AssertionOperatorTypeEnum.class.getCanonicalName(),
+                AssertionResponseTypesEnum.class.getCanonicalName(),
+                AuditEventActionEnum.class.getCanonicalName(),
+                AuditEventObjectLifecycleEnum.class.getCanonicalName(),
+                AuditEventObjectRoleEnum.class.getCanonicalName(),
+                AuditEventObjectTypeEnum.class.getCanonicalName(),
+                AuditEventOutcomeEnum.class.getCanonicalName(),
+                AuditEventParticipantNetworkTypeEnum.class.getCanonicalName(),
+                AuditEventSourceTypeEnum.class.getCanonicalName(),
+                BindingStrengthEnum.class.getCanonicalName(),
+                BundleTypeEnum.class.getCanonicalName(),
+                CarePlanActivityStatusEnum.class.getCanonicalName(),
+                CarePlanRelationshipEnum.class.getCanonicalName(),
+                CarePlanStatusEnum.class.getCanonicalName(),
+                ClaimTypeEnum.class.getCanonicalName(),
+                ClinicalImpressionStatusEnum.class.getCanonicalName(),
+                CommunicationRequestStatusEnum.class.getCanonicalName(),
+                CommunicationStatusEnum.class.getCanonicalName(),
+                CompositionAttestationModeEnum.class.getCanonicalName(),
+                CompositionStatusEnum.class.getCanonicalName(),
+                ConceptMapEquivalenceEnum.class.getCanonicalName(),
+                ConditionalDeleteStatusEnum.class.getCanonicalName(),
+                ConditionCategoryCodesEnum.class.getCanonicalName(),
+                ConditionClinicalStatusCodesEnum.class.getCanonicalName(),
+                ConditionVerificationStatusEnum.class.getCanonicalName(),
+                ConformanceEventModeEnum.class.getCanonicalName(),
+                ConformanceResourceStatusEnum.class.getCanonicalName(),
+                ConformanceStatementKindEnum.class.getCanonicalName(),
+                ConstraintSeverityEnum.class.getCanonicalName(),
+                ContactPointSystemEnum.class.getCanonicalName(),
+                ContactPointUseEnum.class.getCanonicalName(),
+                ContentTypeEnum.class.getCanonicalName(),
+                DataElementStringencyEnum.class.getCanonicalName(),
+                DaysOfWeekEnum.class.getCanonicalName(),
+                DetectedIssueSeverityEnum.class.getCanonicalName(),
+                DeviceMetricCalibrationStateEnum.class.getCanonicalName(),
+                DeviceMetricCalibrationTypeEnum.class.getCanonicalName(),
+                DeviceMetricCategoryEnum.class.getCanonicalName(),
+                DeviceMetricColorEnum.class.getCanonicalName(),
+                DeviceMetricOperationalStatusEnum.class.getCanonicalName(),
+                DeviceStatusEnum.class.getCanonicalName(),
+                DeviceUseRequestPriorityEnum.class.getCanonicalName(),
+                DeviceUseRequestStatusEnum.class.getCanonicalName(),
+                DiagnosticOrderPriorityEnum.class.getCanonicalName(),
+                DiagnosticOrderStatusEnum.class.getCanonicalName(),
+                DiagnosticReportStatusEnum.class.getCanonicalName(),
+                DigitalMediaTypeEnum.class.getCanonicalName(),
+                DocumentModeEnum.class.getCanonicalName(),
+                DocumentReferenceStatusEnum.class.getCanonicalName(),
+                DocumentRelationshipTypeEnum.class.getCanonicalName(),
+                EncounterClassEnum.class.getCanonicalName(),
+                EncounterLocationStatusEnum.class.getCanonicalName(),
+                EncounterStateEnum.class.getCanonicalName(),
+                EpisodeOfCareStatusEnum.class.getCanonicalName(),
+                EventTimingEnum.class.getCanonicalName(),
+                ExtensionContextEnum.class.getCanonicalName(),
+                FamilyHistoryStatusEnum.class.getCanonicalName(),
+                FilterOperatorEnum.class.getCanonicalName(),
+                FlagStatusEnum.class.getCanonicalName(),
+                GoalPriorityEnum.class.getCanonicalName(),
+                GoalStatusEnum.class.getCanonicalName(),
+                GroupTypeEnum.class.getCanonicalName(),
+                GuideDependencyTypeEnum.class.getCanonicalName(),
+                GuidePageKindEnum.class.getCanonicalName(),
+                GuideResourcePurposeEnum.class.getCanonicalName(),
+                HTTPVerbEnum.class.getCanonicalName(),
+                IdentifierTypeCodesEnum.class.getCanonicalName(),
+                IdentifierUseEnum.class.getCanonicalName(),
+                IdentityAssuranceLevelEnum.class.getCanonicalName(),
+                InstanceAvailabilityEnum.class.getCanonicalName(),
+                IssueSeverityEnum.class.getCanonicalName(),
+                IssueTypeEnum.class.getCanonicalName(),
+                KOStitleEnum.class.getCanonicalName(),
+                LinkTypeEnum.class.getCanonicalName(),
+                ListModeEnum.class.getCanonicalName(),
+                ListOrderCodesEnum.class.getCanonicalName(),
+                ListStatusEnum.class.getCanonicalName(),
+                LocationModeEnum.class.getCanonicalName(),
+                LocationStatusEnum.class.getCanonicalName(),
+                LocationTypeEnum.class.getCanonicalName(),
+                MaritalStatusCodesEnum.class.getCanonicalName(),
+                MeasmntPrincipleEnum.class.getCanonicalName(),
+                MedicationAdministrationStatusEnum.class.getCanonicalName(),
+                MedicationDispenseStatusEnum.class.getCanonicalName(),
+                MedicationOrderStatusEnum.class.getCanonicalName(),
+                MedicationStatementStatusEnum.class.getCanonicalName(),
+                MessageEventEnum.class.getCanonicalName(),
+                MessageSignificanceCategoryEnum.class.getCanonicalName(),
+                MessageTransportEnum.class.getCanonicalName(),
+                NameUseEnum.class.getCanonicalName(),
+                NamingSystemIdentifierTypeEnum.class.getCanonicalName(),
+                NamingSystemTypeEnum.class.getCanonicalName(),
+                NarrativeStatusEnum.class.getCanonicalName(),
+                NoteTypeEnum.class.getCanonicalName(),
+                NutritionOrderStatusEnum.class.getCanonicalName(),
+                ObservationRelationshipTypeEnum.class.getCanonicalName(),
+                ObservationStatusEnum.class.getCanonicalName(),
+                OperationKindEnum.class.getCanonicalName(),
+                OperationParameterUseEnum.class.getCanonicalName(),
+                OrderStatusEnum.class.getCanonicalName(),
+                ParticipantRequiredEnum.class.getCanonicalName(),
+                ParticipantStatusEnum.class.getCanonicalName(),
+                ParticipantTypeEnum.class.getCanonicalName(),
+                ParticipationStatusEnum.class.getCanonicalName(),
+                PayeeTypeCodesEnum.class.getCanonicalName(),
+                ProcedureRequestPriorityEnum.class.getCanonicalName(),
+                ProcedureRequestStatusEnum.class.getCanonicalName(),
+                ProcedureStatusEnum.class.getCanonicalName(),
+                PropertyRepresentationEnum.class.getCanonicalName(),
+                ProvenanceEntityRoleEnum.class.getCanonicalName(),
+                QuantityComparatorEnum.class.getCanonicalName(),
+                QuestionnaireResponseStatusEnum.class.getCanonicalName(),
+                QuestionnaireStatusEnum.class.getCanonicalName(),
+                ReferralMethodEnum.class.getCanonicalName(),
+                ReferralStatusEnum.class.getCanonicalName(),
+                RemittanceOutcomeEnum.class.getCanonicalName(),
+                ResourceTypeEnum.class.getCanonicalName(),
+                ResourceVersionPolicyEnum.class.getCanonicalName(),
+                ResponseTypeEnum.class.getCanonicalName(),
+                RestfulConformanceModeEnum.class.getCanonicalName(),
+                RestfulSecurityServiceEnum.class.getCanonicalName(),
+                RulesetCodesEnum.class.getCanonicalName(),
+                SearchEntryModeEnum.class.getCanonicalName(),
+                SearchModifierCodeEnum.class.getCanonicalName(),
+                SearchParamTypeEnum.class.getCanonicalName(),
+                ServiceProvisionConditionsEnum.class.getCanonicalName(),
+                SignatureTypeCodesEnum.class.getCanonicalName(),
+                SlicingRulesEnum.class.getCanonicalName(),
+                SlotStatusEnum.class.getCanonicalName(),
+                SpecimenStatusEnum.class.getCanonicalName(),
+                StructureDefinitionKindEnum.class.getCanonicalName(),
+                SubscriptionChannelTypeEnum.class.getCanonicalName(),
+                SubscriptionStatusEnum.class.getCanonicalName(),
+                SubstanceCategoryCodesEnum.class.getCanonicalName(),
+                SupplyDeliveryStatusEnum.class.getCanonicalName(),
+                SupplyRequestStatusEnum.class.getCanonicalName(),
+                SystemRestfulInteractionEnum.class.getCanonicalName(),
+                TimingAbbreviationEnum.class.getCanonicalName(),
+                TransactionModeEnum.class.getCanonicalName(),
+                TypeRestfulInteractionEnum.class.getCanonicalName(),
+                UnitsOfTimeEnum.class.getCanonicalName(),
+                UnknownContentCodeEnum.class.getCanonicalName(),
+                UseEnum.class.getCanonicalName(),
+                VisionBaseEnum.class.getCanonicalName(),
+                VisionEyesEnum.class.getCanonicalName(),
+                XPathUsageTypeEnum.class.getCanonicalName()
+        };
+    }
+
+}

--- a/extensions/fhir/deployment/src/main/java/org/apache/camel/quarkus/component/fhir/deployment/dstu3/Dstu3PropertiesBuildItem.java
+++ b/extensions/fhir/deployment/src/main/java/org/apache/camel/quarkus/component/fhir/deployment/dstu3/Dstu3PropertiesBuildItem.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.fhir.deployment.dstu3;
+
+import java.util.Properties;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+public final class Dstu3PropertiesBuildItem extends SimpleBuildItem {
+
+    private final Properties properties;
+
+    public Dstu3PropertiesBuildItem(Properties properties) {
+        this.properties = properties;
+    }
+
+    public Properties getProperties() {
+        return properties;
+    }
+}

--- a/extensions/fhir/deployment/src/main/java/org/apache/camel/quarkus/component/fhir/deployment/dstu3/FhirDstu3Processor.java
+++ b/extensions/fhir/deployment/src/main/java/org/apache/camel/quarkus/component/fhir/deployment/dstu3/FhirDstu3Processor.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.fhir.deployment.dstu3;
+
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.Set;
+
+import io.quarkus.arc.deployment.BeanContainerBuildItem;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import org.apache.camel.quarkus.component.fhir.FhirContextRecorder;
+import org.apache.camel.quarkus.component.fhir.FhirFlags;
+import org.hl7.fhir.dstu3.model.Base;
+import org.hl7.fhir.dstu3.model.DomainResource;
+import org.hl7.fhir.dstu3.model.Enumerations;
+import org.hl7.fhir.dstu3.model.Meta;
+import org.hl7.fhir.dstu3.model.MetadataResource;
+import org.hl7.fhir.dstu3.model.Resource;
+
+import static org.apache.camel.quarkus.component.fhir.deployment.FhirUtil.getInnerClasses;
+import static org.apache.camel.quarkus.component.fhir.deployment.FhirUtil.getModelClasses;
+import static org.apache.camel.quarkus.component.fhir.deployment.FhirUtil.getResourceDefinitions;
+import static org.apache.camel.quarkus.component.fhir.deployment.FhirUtil.loadProperties;
+
+public class FhirDstu3Processor {
+
+    @BuildStep(onlyIf = FhirFlags.Dstu3Enabled.class)
+    Dstu3PropertiesBuildItem properties(BuildProducer<NativeImageResourceBuildItem> resource) {
+        Properties properties = loadProperties("/org/hl7/fhir/dstu3/model/fhirversion.properties");
+        resource.produce(new NativeImageResourceBuildItem("org/hl7/fhir/dstu3/model/fhirversion.properties"));
+        return new Dstu3PropertiesBuildItem(properties);
+    }
+
+    @BuildStep(onlyIf = FhirFlags.Dstu3Enabled.class)
+    @Record(ExecutionTime.STATIC_INIT)
+    void recordContext(FhirContextRecorder fhirContextRecorder, BeanContainerBuildItem beanContainer,
+            Dstu3PropertiesBuildItem propertiesBuildItem) {
+        fhirContextRecorder.createDstu3FhirContext(beanContainer.getValue(),
+                getResourceDefinitions(propertiesBuildItem.getProperties()));
+    }
+
+    @BuildStep(onlyIf = FhirFlags.Dstu3Enabled.class)
+    void enableReflection(BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
+            Dstu3PropertiesBuildItem propertiesBuildItem) {
+        Set<String> classes = new HashSet<>();
+        classes.add(DomainResource.class.getCanonicalName());
+        classes.add(Resource.class.getCanonicalName());
+        classes.add(org.hl7.fhir.dstu3.model.BaseResource.class.getCanonicalName());
+        classes.add(Base.class.getCanonicalName());
+        classes.addAll(getModelClasses(propertiesBuildItem.getProperties()));
+        classes.addAll(getInnerClasses(Enumerations.class.getCanonicalName()));
+        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, true, Meta.class.getCanonicalName()));
+        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, true, MetadataResource.class.getCanonicalName()));
+        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, classes.toArray(new String[0])));
+    }
+}

--- a/extensions/fhir/deployment/src/main/java/org/apache/camel/quarkus/component/fhir/deployment/r4/FhirR4Processor.java
+++ b/extensions/fhir/deployment/src/main/java/org/apache/camel/quarkus/component/fhir/deployment/r4/FhirR4Processor.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.fhir.deployment.r4;
+
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.Set;
+
+import io.quarkus.arc.deployment.BeanContainerBuildItem;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import org.apache.camel.quarkus.component.fhir.FhirContextRecorder;
+import org.apache.camel.quarkus.component.fhir.FhirFlags;
+
+import static org.apache.camel.quarkus.component.fhir.deployment.FhirUtil.getInnerClasses;
+import static org.apache.camel.quarkus.component.fhir.deployment.FhirUtil.getModelClasses;
+import static org.apache.camel.quarkus.component.fhir.deployment.FhirUtil.getResourceDefinitions;
+import static org.apache.camel.quarkus.component.fhir.deployment.FhirUtil.loadProperties;
+
+public class FhirR4Processor {
+
+    @BuildStep(onlyIf = FhirFlags.R4Enabled.class)
+    R4PropertiesBuildItem properties(BuildProducer<NativeImageResourceBuildItem> resource) {
+        resource.produce(new NativeImageResourceBuildItem("org/hl7/fhir/r4/model/fhirversion.properties"));
+        Properties properties = loadProperties("/org/hl7/fhir/r4/model/fhirversion.properties");
+        return new R4PropertiesBuildItem(properties);
+    }
+
+    @BuildStep(onlyIf = FhirFlags.R4Enabled.class)
+    @Record(ExecutionTime.STATIC_INIT)
+    void recordContext(FhirContextRecorder fhirContextRecorder, BeanContainerBuildItem beanContainer,
+            R4PropertiesBuildItem propertiesBuildItem) {
+        fhirContextRecorder.createR4FhirContext(beanContainer.getValue(),
+                getResourceDefinitions(propertiesBuildItem.getProperties()));
+    }
+
+    @BuildStep(onlyIf = FhirFlags.R4Enabled.class)
+    void enableReflection(BuildProducer<ReflectiveClassBuildItem> reflectiveClass, R4PropertiesBuildItem buildItem) {
+        Set<String> classes = new HashSet<>();
+        classes.add(org.hl7.fhir.r4.model.DomainResource.class.getCanonicalName());
+        classes.add(org.hl7.fhir.r4.model.Resource.class.getCanonicalName());
+        classes.add(org.hl7.fhir.r4.model.BaseResource.class.getCanonicalName());
+        classes.add(org.hl7.fhir.r4.model.Base.class.getCanonicalName());
+        classes.addAll(getModelClasses(buildItem.getProperties()));
+        classes.addAll(getInnerClasses(org.hl7.fhir.r4.model.Enumerations.class.getCanonicalName()));
+        reflectiveClass
+                .produce(new ReflectiveClassBuildItem(true, true, true, org.hl7.fhir.r4.model.Meta.class.getCanonicalName()));
+        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, true,
+                org.hl7.fhir.r4.model.MetadataResource.class.getCanonicalName()));
+        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, classes.toArray(new String[0])));
+    }
+}

--- a/extensions/fhir/deployment/src/main/java/org/apache/camel/quarkus/component/fhir/deployment/r4/R4PropertiesBuildItem.java
+++ b/extensions/fhir/deployment/src/main/java/org/apache/camel/quarkus/component/fhir/deployment/r4/R4PropertiesBuildItem.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.fhir.deployment.r4;
+
+import java.util.Properties;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+public final class R4PropertiesBuildItem extends SimpleBuildItem {
+
+    private final Properties properties;
+
+    public R4PropertiesBuildItem(Properties properties) {
+        this.properties = properties;
+    }
+
+    public Properties getProperties() {
+        return properties;
+    }
+}

--- a/extensions/fhir/deployment/src/main/java/org/apache/camel/quarkus/component/fhir/deployment/r5/FhirR5Processor.java
+++ b/extensions/fhir/deployment/src/main/java/org/apache/camel/quarkus/component/fhir/deployment/r5/FhirR5Processor.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.fhir.deployment.r5;
+
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.Set;
+
+import io.quarkus.arc.deployment.BeanContainerBuildItem;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import org.apache.camel.quarkus.component.fhir.FhirContextRecorder;
+import org.apache.camel.quarkus.component.fhir.FhirFlags;
+
+import static org.apache.camel.quarkus.component.fhir.deployment.FhirUtil.getInnerClasses;
+import static org.apache.camel.quarkus.component.fhir.deployment.FhirUtil.getModelClasses;
+import static org.apache.camel.quarkus.component.fhir.deployment.FhirUtil.getResourceDefinitions;
+import static org.apache.camel.quarkus.component.fhir.deployment.FhirUtil.loadProperties;
+
+public class FhirR5Processor {
+
+    @BuildStep(onlyIf = FhirFlags.R5Enabled.class)
+    R5PropertiesBuildItem properties(BuildProducer<NativeImageResourceBuildItem> resource) {
+        resource.produce(new NativeImageResourceBuildItem("org/hl7/fhir/r5/model/fhirversion.properties"));
+        Properties properties = loadProperties("/org/hl7/fhir/r5/model/fhirversion.properties");
+        return new R5PropertiesBuildItem(properties);
+    }
+
+    @BuildStep(onlyIf = FhirFlags.R5Enabled.class)
+    @Record(ExecutionTime.STATIC_INIT)
+    void recordContext(FhirContextRecorder fhirContextRecorder, BeanContainerBuildItem beanContainer,
+            R5PropertiesBuildItem propertiesBuildItem) {
+        fhirContextRecorder.createR5FhirContext(beanContainer.getValue(),
+                getResourceDefinitions(propertiesBuildItem.getProperties()));
+    }
+
+    @BuildStep(onlyIf = FhirFlags.R5Enabled.class)
+    void enableReflection(BuildProducer<ReflectiveClassBuildItem> reflectiveClass, R5PropertiesBuildItem buildItem) {
+        Set<String> classes = new HashSet<>();
+        classes.add(org.hl7.fhir.r5.model.DomainResource.class.getCanonicalName());
+        classes.add(org.hl7.fhir.r5.model.Resource.class.getCanonicalName());
+        classes.add(org.hl7.fhir.r5.model.BaseResource.class.getCanonicalName());
+        classes.add(org.hl7.fhir.r5.model.Base.class.getCanonicalName());
+        classes.addAll(getModelClasses(buildItem.getProperties()));
+        classes.addAll(getInnerClasses(org.hl7.fhir.r5.model.Enumerations.class.getCanonicalName()));
+        reflectiveClass
+                .produce(new ReflectiveClassBuildItem(true, true, true, org.hl7.fhir.r5.model.Meta.class.getCanonicalName()));
+        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, true,
+                org.hl7.fhir.r5.model.MetadataResource.class.getCanonicalName()));
+        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, classes.toArray(new String[0])));
+    }
+}

--- a/extensions/fhir/deployment/src/main/java/org/apache/camel/quarkus/component/fhir/deployment/r5/R5PropertiesBuildItem.java
+++ b/extensions/fhir/deployment/src/main/java/org/apache/camel/quarkus/component/fhir/deployment/r5/R5PropertiesBuildItem.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.fhir.deployment.r5;
+
+import java.util.Properties;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+public final class R5PropertiesBuildItem extends SimpleBuildItem {
+
+    private final Properties properties;
+
+    public R5PropertiesBuildItem(Properties properties) {
+        this.properties = properties;
+    }
+
+    public Properties getProperties() {
+        return properties;
+    }
+}

--- a/extensions/fhir/runtime/pom.xml
+++ b/extensions/fhir/runtime/pom.xml
@@ -52,15 +52,11 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
-            <artifactId>camel-quarkus-core-xml</artifactId>
+            <artifactId>camel-quarkus-support-xml</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-support-commons-logging</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.camel</groupId>
-            <artifactId>camel-fhir</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.xml.bind</groupId>
@@ -69,6 +65,10 @@
         <dependency>
             <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-fhir</artifactId>
         </dependency>
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>

--- a/extensions/fhir/runtime/src/main/java/org/apache/camel/quarkus/component/fhir/FhirContextProducers.java
+++ b/extensions/fhir/runtime/src/main/java/org/apache/camel/quarkus/component/fhir/FhirContextProducers.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.fhir;
+
+import javax.enterprise.inject.Produces;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import ca.uhn.fhir.context.FhirContext;
+
+@Singleton
+public class FhirContextProducers {
+
+    private volatile FhirContext dstu2;
+    private volatile FhirContext dstu3;
+    private volatile FhirContext r4;
+    private volatile FhirContext r5;
+
+    public void setDstu2(FhirContext dstu2) {
+        this.dstu2 = dstu2;
+    }
+
+    public void setDstu3(FhirContext dstu3) {
+        this.dstu3 = dstu3;
+    }
+
+    public void setR4(FhirContext r4) {
+        this.r4 = r4;
+    }
+
+    public void setR5(FhirContext r5) {
+        this.r5 = r5;
+    }
+
+    @Singleton
+    @Produces
+    @Named("DSTU2")
+    FhirContext dstu2() {
+        return this.dstu2;
+    }
+
+    @Singleton
+    @Produces
+    @Named("DSTU3")
+    FhirContext dstu3() {
+        return this.dstu3;
+    }
+
+    @Singleton
+    @Produces
+    @Named("R4")
+    FhirContext r4() {
+        return this.r4;
+    }
+
+    @Singleton
+    @Produces
+    @Named("R5")
+    FhirContext r5() {
+        return this.r5;
+    }
+}

--- a/extensions/fhir/runtime/src/main/java/org/apache/camel/quarkus/component/fhir/FhirContextRecorder.java
+++ b/extensions/fhir/runtime/src/main/java/org/apache/camel/quarkus/component/fhir/FhirContextRecorder.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.fhir;
+
+import java.util.Collection;
+
+import ca.uhn.fhir.context.FhirContext;
+import io.quarkus.arc.runtime.BeanContainer;
+import io.quarkus.runtime.RuntimeValue;
+import io.quarkus.runtime.annotations.Recorder;
+
+@Recorder
+public class FhirContextRecorder {
+
+    public RuntimeValue<FhirContext> createDstu2FhirContext(BeanContainer container, Collection<String> resourceDefinitions) {
+        FhirContext fhirContext = FhirContext.forDstu2();
+        initContext(resourceDefinitions, fhirContext);
+        container.instance(FhirContextProducers.class).setDstu2(fhirContext);
+        return new RuntimeValue<>(fhirContext);
+    }
+
+    public RuntimeValue<FhirContext> createDstu3FhirContext(BeanContainer container, Collection<String> resourceDefinitions) {
+        FhirContext fhirContext = FhirContext.forDstu3();
+        initContext(resourceDefinitions, fhirContext);
+        container.instance(FhirContextProducers.class).setDstu3(fhirContext);
+        return new RuntimeValue<>(fhirContext);
+    }
+
+    public RuntimeValue<FhirContext> createR4FhirContext(BeanContainer container, Collection<String> resourceDefinitions) {
+        FhirContext fhirContext = FhirContext.forR4();
+        initContext(resourceDefinitions, fhirContext);
+        container.instance(FhirContextProducers.class).setR4(fhirContext);
+        return new RuntimeValue<>(fhirContext);
+    }
+
+    public RuntimeValue<FhirContext> createR5FhirContext(BeanContainer container, Collection<String> resourceDefinitions) {
+        FhirContext fhirContext = FhirContext.forR5();
+        initContext(resourceDefinitions, fhirContext);
+        container.instance(FhirContextProducers.class).setR5(fhirContext);
+        return new RuntimeValue<>(fhirContext);
+    }
+
+    private void initContext(Collection<String> resourceDefinitions, FhirContext fhirContext) {
+        // force init
+        fhirContext.getElementDefinitions();
+        for (String resourceDefinition : resourceDefinitions) {
+            fhirContext.getResourceDefinition(resourceDefinition);
+        }
+    }
+}

--- a/integration-tests/fhir/src/main/java/org/apache/camel/quarkus/component/fhir/it/FhirDstu2RouteBuilder.java
+++ b/integration-tests/fhir/src/main/java/org/apache/camel/quarkus/component/fhir/it/FhirDstu2RouteBuilder.java
@@ -16,33 +16,37 @@
  */
 package org.apache.camel.quarkus.component.fhir.it;
 
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.inject.Named;
+
 import ca.uhn.fhir.context.FhirContext;
-import ca.uhn.fhir.context.FhirVersionEnum;
 import ca.uhn.fhir.parser.StrictErrorHandler;
-import org.apache.camel.CamelContext;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.fhir.FhirJsonDataFormat;
 import org.apache.camel.component.fhir.FhirXmlDataFormat;
 import org.apache.camel.quarkus.component.fhir.FhirFlags;
 
+@ApplicationScoped
 public class FhirDstu2RouteBuilder extends RouteBuilder {
 
     private static final Boolean ENABLED = new FhirFlags.Dstu2Enabled().getAsBoolean();
 
+    @Inject
+    @Named("DSTU2")
+    FhirContext fhirContext;
+
     @Override
     public void configure() {
         if (ENABLED) {
-            CamelContext context = getContext();
-            FhirContext fhirContext = FhirContext.forDstu2();
             fhirContext.setParserErrorHandler(new StrictErrorHandler());
-            context.getRegistry().bind("fhirContext", fhirContext);
 
             FhirJsonDataFormat fhirJsonDataFormat = new FhirJsonDataFormat();
-            fhirJsonDataFormat.setFhirVersion(FhirVersionEnum.DSTU2.name());
+            fhirJsonDataFormat.setFhirContext(fhirContext);
             fhirJsonDataFormat.setParserErrorHandler(new StrictErrorHandler());
 
             FhirXmlDataFormat fhirXmlDataFormat = new FhirXmlDataFormat();
-            fhirXmlDataFormat.setFhirVersion(FhirVersionEnum.DSTU2.name());
+            fhirXmlDataFormat.setFhirContext(fhirContext);
             fhirXmlDataFormat.setParserErrorHandler(new StrictErrorHandler());
 
             from("direct:json-to-dstu2")
@@ -54,7 +58,7 @@ public class FhirDstu2RouteBuilder extends RouteBuilder {
                     .marshal(fhirXmlDataFormat);
 
             from("direct:create-dstu2")
-                    .to("fhir://create/resource?inBody=resourceAsString&fhirVersion=DSTU2&fhirContext=#fhirContext");
+                    .to("fhir://create/resource?inBody=resourceAsString&fhirContext=#DSTU2");
         }
     }
 }

--- a/integration-tests/fhir/src/main/java/org/apache/camel/quarkus/component/fhir/it/FhirR4RouteBuilder.java
+++ b/integration-tests/fhir/src/main/java/org/apache/camel/quarkus/component/fhir/it/FhirR4RouteBuilder.java
@@ -16,33 +16,37 @@
  */
 package org.apache.camel.quarkus.component.fhir.it;
 
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.inject.Named;
+
 import ca.uhn.fhir.context.FhirContext;
-import ca.uhn.fhir.context.FhirVersionEnum;
 import ca.uhn.fhir.parser.StrictErrorHandler;
-import org.apache.camel.CamelContext;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.fhir.FhirJsonDataFormat;
 import org.apache.camel.component.fhir.FhirXmlDataFormat;
 import org.apache.camel.quarkus.component.fhir.FhirFlags;
 
+@ApplicationScoped
 public class FhirR4RouteBuilder extends RouteBuilder {
 
     private static final Boolean ENABLED = new FhirFlags.R4Enabled().getAsBoolean();
 
+    @Inject
+    @Named("R4")
+    FhirContext fhirContext;
+
     @Override
     public void configure() {
         if (ENABLED) {
-            CamelContext context = getContext();
-            FhirContext fhirContext = FhirContext.forR4();
             fhirContext.setParserErrorHandler(new StrictErrorHandler());
-            context.getRegistry().bind("fhirContext", fhirContext);
 
             FhirJsonDataFormat fhirJsonDataFormat = new FhirJsonDataFormat();
-            fhirJsonDataFormat.setFhirVersion(FhirVersionEnum.R4.name());
+            fhirJsonDataFormat.setFhirContext(fhirContext);
             fhirJsonDataFormat.setParserErrorHandler(new StrictErrorHandler());
 
             FhirXmlDataFormat fhirXmlDataFormat = new FhirXmlDataFormat();
-            fhirXmlDataFormat.setFhirVersion(FhirVersionEnum.R4.name());
+            fhirXmlDataFormat.setFhirContext(fhirContext);
             fhirXmlDataFormat.setParserErrorHandler(new StrictErrorHandler());
 
             from("direct:json-to-r4")
@@ -54,7 +58,7 @@ public class FhirR4RouteBuilder extends RouteBuilder {
                     .marshal(fhirXmlDataFormat);
 
             from("direct:create-r4")
-                    .to("fhir://create/resource?inBody=resourceAsString&fhirVersion=R4&fhirContext=#fhirContext");
+                    .to("fhir://create/resource?inBody=resourceAsString&fhirContext=#R4");
         }
     }
 }

--- a/integration-tests/fhir/src/main/java/org/apache/camel/quarkus/component/fhir/it/FhirR5RouteBuilder.java
+++ b/integration-tests/fhir/src/main/java/org/apache/camel/quarkus/component/fhir/it/FhirR5RouteBuilder.java
@@ -16,33 +16,37 @@
  */
 package org.apache.camel.quarkus.component.fhir.it;
 
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.inject.Named;
+
 import ca.uhn.fhir.context.FhirContext;
-import ca.uhn.fhir.context.FhirVersionEnum;
 import ca.uhn.fhir.parser.StrictErrorHandler;
-import org.apache.camel.CamelContext;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.fhir.FhirJsonDataFormat;
 import org.apache.camel.component.fhir.FhirXmlDataFormat;
 import org.apache.camel.quarkus.component.fhir.FhirFlags;
 
+@ApplicationScoped
 public class FhirR5RouteBuilder extends RouteBuilder {
 
     private static final Boolean ENABLED = new FhirFlags.R5Enabled().getAsBoolean();
 
+    @Inject
+    @Named("R5")
+    FhirContext fhirContext;
+
     @Override
     public void configure() {
         if (ENABLED) {
-            CamelContext context = getContext();
-            FhirContext fhirContext = FhirContext.forR5();
             fhirContext.setParserErrorHandler(new StrictErrorHandler());
-            context.getRegistry().bind("fhirContext", fhirContext);
 
             FhirJsonDataFormat fhirJsonDataFormat = new FhirJsonDataFormat();
-            fhirJsonDataFormat.setFhirVersion(FhirVersionEnum.R5.name());
+            fhirJsonDataFormat.setFhirContext(fhirContext);
             fhirJsonDataFormat.setParserErrorHandler(new StrictErrorHandler());
 
             FhirXmlDataFormat fhirXmlDataFormat = new FhirXmlDataFormat();
-            fhirXmlDataFormat.setFhirVersion(FhirVersionEnum.R5.name());
+            fhirXmlDataFormat.setFhirContext(fhirContext);
             fhirXmlDataFormat.setParserErrorHandler(new StrictErrorHandler());
 
             from("direct:json-to-r5")
@@ -54,7 +58,7 @@ public class FhirR5RouteBuilder extends RouteBuilder {
                     .marshal(fhirXmlDataFormat);
 
             from("direct:create-r5")
-                    .to("fhir://create/resource?inBody=resourceAsString&fhirVersion=R5&fhirContext=#fhirContext");
+                    .to("fhir://create/resource?inBody=resourceAsString&fhirContext=#R5");
         }
     }
 }

--- a/integration-tests/fhir/src/main/resources/application.properties
+++ b/integration-tests/fhir/src/main/resources/application.properties
@@ -37,3 +37,4 @@ quarkus.camel.fhir.enable-r5=false
 camel.component.fhir.configuration = #class:org.apache.camel.component.fhir.FhirConfiguration
 camel.component.fhir.configuration.log = false
 camel.component.fhir.configuration.server-url = {{camel.fhir.test-url}}
+camel.component.fhir.configuration.fhir-context = #bean:DSTU3


### PR DESCRIPTION
…y one FHIR context per specification is permitted in native mode

cc @lburgazzoli addresses #654 

I've changed the way HAPI FHIR integrates with Quarkus. The approach used here is similar to what camel-quarkus-core does.

Instead of enabling reflection everywhere, I've opted to record the FHIR context (for each specification). Therefore only one context per specification can be used in native mode. This limitation is in line with what is [recommended](https://github.com/jamesagnew/hapi-fhir/blob/master/hapi-fhir-base/src/main/java/ca/uhn/fhir/context/FhirContext.java#L57).

Thanks !