### PR TITLE
Create enforce profile that disables dependency checks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -210,27 +210,6 @@
 
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-enforcer-plugin</artifactId>
-                    <executions>
-                        <execution>
-                            <id>camel-quarkus-enforcer-rules</id>
-                            <goals>
-                                <goal>enforce</goal>
-                            </goals>
-                            <configuration>
-                                <rules>
-                                    <dependencyConvergence />
-                                    <requireMavenVersion>
-                                        <version>${supported-maven-versions}</version>
-                                    </requireMavenVersion>
-                                </rules>
-                            </configuration>
-                        </execution>
-                    </executions>
-                </plugin>
-
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${maven-surefire-plugin.version}</version>
                     <configuration>
@@ -332,6 +311,42 @@
     </build>
 
     <profiles>
+        <profile>
+            <!-- To disable sanity checks while building: add '-Denforce=false' to the command line -->
+            <id>enforce</id>
+            <activation>
+                <property>
+                    <name>enforce</name>
+                    <value>!false</value>
+                </property>
+            </activation>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-enforcer-plugin</artifactId>
+                            <executions>
+                                <execution>
+                                    <id>camel-quarkus-enforcer-rules</id>
+                                    <goals>
+                                        <goal>enforce</goal>
+                                    </goals>
+                                    <configuration>
+                                        <rules>
+                                            <dependencyConvergence />
+                                            <requireMavenVersion>
+                                                <version>${supported-maven-versions}</version>
+                                            </requireMavenVersion>
+                                        </rules>
+                                    </configuration>
+                                </execution>
+                            </executions>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
         <profile>
             <id>linux</id>
             <activation>

--- a/poms/build-parent/pom.xml
+++ b/poms/build-parent/pom.xml
@@ -145,22 +145,6 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.gmaven</groupId>
-                <artifactId>groovy-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>sanity-checks</id>
-                        <goals>
-                            <goal>execute</goal>
-                        </goals>
-                        <phase>validate</phase>
-                        <configuration>
-                            <source>file://${camel.quarkus.project.root}/tooling/scripts/validate-dependencies.groovy</source>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-remote-resources-plugin</artifactId>
                 <executions>
@@ -219,6 +203,36 @@
     </build>
 
     <profiles>
+        <profile>
+            <!-- To disable sanity checks while building: add '-Denforce=false' to the command line -->
+            <id>enforce</id>
+            <activation>
+                <property>
+                    <name>enforce</name>
+                    <value>!false</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.gmaven</groupId>
+                        <artifactId>groovy-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>sanity-checks</id>
+                                <goals>
+                                    <goal>execute</goal>
+                                </goals>
+                                <phase>validate</phase>
+                                <configuration>
+                                    <source>file://${camel.quarkus.project.root}/tooling/scripts/validate-dependencies.groovy</source>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>check-format</id>
             <activation>


### PR DESCRIPTION
Hello,

Often when developing I find myself commenting out these checks so I moved them into a profile? To disable checking one can set the `dev` property e.g `maven clean install -Ddev`. Thanks !