### PR TITLE
Remove enableJni from integration tests as JNI si always enabled on GraalVM 19.3.1

### DIFF
--- a/integration-tests/aws/pom.xml
+++ b/integration-tests/aws/pom.xml
@@ -156,7 +156,6 @@
                                     <enableHttpUrlHandler>true</enableHttpUrlHandler>
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
-                                    <enableJni>true</enableJni>
                                     <enableAllSecurityServices>true</enableAllSecurityServices>
                                     <disableReports>true</disableReports>
                                 </configuration>

--- a/integration-tests/base64/pom.xml
+++ b/integration-tests/base64/pom.xml
@@ -115,7 +115,6 @@
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
                                     <graalvmHome>${graalvmHome}</graalvmHome>
-                                    <enableJni>true</enableJni>
                                     <enableAllSecurityServices>true</enableAllSecurityServices>
                                     <disableReports>true</disableReports>
                                 </configuration>

--- a/integration-tests/bean-validator/pom.xml
+++ b/integration-tests/bean-validator/pom.xml
@@ -115,7 +115,6 @@
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
                                     <graalvmHome>${graalvmHome}</graalvmHome>
-                                    <enableJni>true</enableJni>
                                     <enableAllSecurityServices>true</enableAllSecurityServices>
                                     <disableReports>true</disableReports>
                                 </configuration>

--- a/integration-tests/bean/pom.xml
+++ b/integration-tests/bean/pom.xml
@@ -125,7 +125,6 @@
                                     <enableHttpUrlHandler>true</enableHttpUrlHandler>
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
-                                    <enableJni>false</enableJni>
                                     <disableReports>true</disableReports>
                                 </configuration>
                             </execution>

--- a/integration-tests/bindy/pom.xml
+++ b/integration-tests/bindy/pom.xml
@@ -121,7 +121,6 @@
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
                                     <graalvmHome>${graalvmHome}</graalvmHome>
-                                    <enableJni>true</enableJni>
                                     <enableAllSecurityServices>true</enableAllSecurityServices>
                                     <disableReports>true</disableReports>
                                 </configuration>

--- a/integration-tests/consul/pom.xml
+++ b/integration-tests/consul/pom.xml
@@ -118,7 +118,6 @@
                                     <enableHttpsUrlHandler>true</enableHttpsUrlHandler>
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
-                                    <enableJni>true</enableJni>
                                     <enableAllSecurityServices>true</enableAllSecurityServices>
                                     <disableReports>true</disableReports>
                                 </configuration>

--- a/integration-tests/controlbus/pom.xml
+++ b/integration-tests/controlbus/pom.xml
@@ -123,7 +123,6 @@
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
                                     <graalvmHome>${graalvmHome}</graalvmHome>
-                                    <enableJni>true</enableJni>
                                     <enableAllSecurityServices>true</enableAllSecurityServices>
                                     <disableReports>true</disableReports>
                                 </configuration>

--- a/integration-tests/core-impl/pom.xml
+++ b/integration-tests/core-impl/pom.xml
@@ -99,7 +99,6 @@
                                     <enableHttpUrlHandler>true</enableHttpUrlHandler>
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
-                                    <enableJni>false</enableJni>
                                     <disableReports>true</disableReports>
                                 </configuration>
                             </execution>

--- a/integration-tests/core-main-xml/pom.xml
+++ b/integration-tests/core-main-xml/pom.xml
@@ -132,7 +132,6 @@
                                     <enableHttpUrlHandler>true</enableHttpUrlHandler>
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
-                                    <enableJni>false</enableJni>
                                     <disableReports>true</disableReports>
                                 </configuration>
                             </execution>

--- a/integration-tests/core-main/pom.xml
+++ b/integration-tests/core-main/pom.xml
@@ -154,7 +154,6 @@
                                     <enableHttpUrlHandler>true</enableHttpUrlHandler>
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
-                                    <enableJni>false</enableJni>
                                     <disableReports>true</disableReports>
                                 </configuration>
                             </execution>

--- a/integration-tests/core/pom.xml
+++ b/integration-tests/core/pom.xml
@@ -127,7 +127,6 @@
                                     <enableHttpUrlHandler>true</enableHttpUrlHandler>
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
-                                    <enableJni>false</enableJni>
                                     <disableReports>true</disableReports>
                                 </configuration>
                             </execution>

--- a/integration-tests/csv/pom.xml
+++ b/integration-tests/csv/pom.xml
@@ -117,7 +117,6 @@
                                     <enableHttpsUrlHandler>true</enableHttpsUrlHandler>
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
-                                    <enableJni>true</enableJni>
                                     <enableAllSecurityServices>true</enableAllSecurityServices>
                                     <disableReports>true</disableReports>
                                 </configuration>

--- a/integration-tests/dataformat/pom.xml
+++ b/integration-tests/dataformat/pom.xml
@@ -119,7 +119,6 @@
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
                                     <graalvmHome>${graalvmHome}</graalvmHome>
-                                    <enableJni>true</enableJni>
                                     <enableAllSecurityServices>true</enableAllSecurityServices>
                                     <disableReports>true</disableReports>
                                 </configuration>

--- a/integration-tests/dozer/pom.xml
+++ b/integration-tests/dozer/pom.xml
@@ -119,7 +119,6 @@
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
                                     <graalvmHome>${graalvmHome}</graalvmHome>
-                                    <enableJni>true</enableJni>
                                     <enableAllSecurityServices>true</enableAllSecurityServices>
                                     <disableReports>true</disableReports>
                                 </configuration>

--- a/integration-tests/exec/pom.xml
+++ b/integration-tests/exec/pom.xml
@@ -115,7 +115,6 @@
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
                                     <graalvmHome>${graalvmHome}</graalvmHome>
-                                    <enableJni>true</enableJni>
                                     <enableAllSecurityServices>true</enableAllSecurityServices>
                                     <disableReports>true</disableReports>
                                 </configuration>

--- a/integration-tests/fhir/pom.xml
+++ b/integration-tests/fhir/pom.xml
@@ -143,7 +143,6 @@
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
                                     <graalvmHome>${graalvmHome}</graalvmHome>
-                                    <enableJni>true</enableJni>
                                     <enableAllSecurityServices>true</enableAllSecurityServices>
                                     <disableReports>true</disableReports>
                                 </configuration>

--- a/integration-tests/file/pom.xml
+++ b/integration-tests/file/pom.xml
@@ -111,7 +111,6 @@
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
                                     <graalvmHome>${graalvmHome}</graalvmHome>
-                                    <enableJni>true</enableJni>
                                     <enableAllSecurityServices>true</enableAllSecurityServices>
                                     <disableReports>true</disableReports>
                                 </configuration>

--- a/integration-tests/ftp/pom.xml
+++ b/integration-tests/ftp/pom.xml
@@ -145,7 +145,6 @@
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
                                     <graalvmHome>${graalvmHome}</graalvmHome>
-                                    <enableJni>true</enableJni>
                                     <enableAllSecurityServices>true</enableAllSecurityServices>
                                     <disableReports>true</disableReports>
                                 </configuration>

--- a/integration-tests/http/pom.xml
+++ b/integration-tests/http/pom.xml
@@ -138,7 +138,6 @@
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
                                     <graalvmHome>${graalvmHome}</graalvmHome>
-                                    <enableJni>true</enableJni>
                                     <enableAllSecurityServices>true</enableAllSecurityServices>
                                     <disableReports>true</disableReports>
                                 </configuration>

--- a/integration-tests/hystrix/pom.xml
+++ b/integration-tests/hystrix/pom.xml
@@ -126,7 +126,6 @@
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
                                     <graalvmHome>${graalvmHome}</graalvmHome>
-                                    <enableJni>true</enableJni>
                                     <enableAllSecurityServices>true</enableAllSecurityServices>
                                     <disableReports>true</disableReports>
                                 </configuration>

--- a/integration-tests/infinispan/pom.xml
+++ b/integration-tests/infinispan/pom.xml
@@ -224,7 +224,6 @@
                                     <enableHttpUrlHandler>true</enableHttpUrlHandler>
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
-                                    <enableJni>false</enableJni>
                                     <disableReports>true</disableReports>
                                 </configuration>
                             </execution>

--- a/integration-tests/jackson/pom.xml
+++ b/integration-tests/jackson/pom.xml
@@ -141,7 +141,6 @@
                                     <enableHttpUrlHandler>true</enableHttpUrlHandler>
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
-                                    <enableJni>false</enableJni>
                                     <disableReports>true</disableReports>
                                 </configuration>
                             </execution>

--- a/integration-tests/jdbc/pom.xml
+++ b/integration-tests/jdbc/pom.xml
@@ -124,7 +124,6 @@
                                 <configuration>
                                     <cleanupServer>true</cleanupServer>
                                     <enableHttpUrlHandler>true</enableHttpUrlHandler>
-                                    <enableJni>false</enableJni>
                                     <debugBuildProcess>false</debugBuildProcess>
                                     <disableReports>true</disableReports>
                                 </configuration>

--- a/integration-tests/jsonpath/pom.xml
+++ b/integration-tests/jsonpath/pom.xml
@@ -119,7 +119,6 @@
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
                                     <graalvmHome>${graalvmHome}</graalvmHome>
-                                    <enableJni>true</enableJni>
                                     <enableAllSecurityServices>true</enableAllSecurityServices>
                                     <disableReports>true</disableReports>
                                 </configuration>

--- a/integration-tests/kafka/pom.xml
+++ b/integration-tests/kafka/pom.xml
@@ -140,7 +140,6 @@
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
                                     <graalvmHome>${graalvmHome}</graalvmHome>
-                                    <enableJni>true</enableJni>
                                     <enableAllSecurityServices>true</enableAllSecurityServices>
                                     <disableReports>true</disableReports>
                                 </configuration>

--- a/integration-tests/mail/pom.xml
+++ b/integration-tests/mail/pom.xml
@@ -137,7 +137,6 @@
                                     <enableHttpUrlHandler>true</enableHttpUrlHandler>
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
-                                    <enableJni>false</enableJni>
                                     <disableReports>true</disableReports>
                                 </configuration>
                             </execution>

--- a/integration-tests/microprofile/pom.xml
+++ b/integration-tests/microprofile/pom.xml
@@ -121,7 +121,6 @@
                                     <enableHttpsUrlHandler>true</enableHttpsUrlHandler>
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
-                                    <enableJni>true</enableJni>
                                     <enableAllSecurityServices>true</enableAllSecurityServices>
                                     <disableReports>true</disableReports>
                                 </configuration>

--- a/integration-tests/mongodb/pom.xml
+++ b/integration-tests/mongodb/pom.xml
@@ -122,7 +122,6 @@
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
                                     <graalvmHome>${graalvmHome}</graalvmHome>
-                                    <enableJni>true</enableJni>
                                     <enableAllSecurityServices>true</enableAllSecurityServices>
                                     <disableReports>true</disableReports>
                                 </configuration>

--- a/integration-tests/netty/pom.xml
+++ b/integration-tests/netty/pom.xml
@@ -120,7 +120,6 @@
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
                                     <graalvmHome>${graalvmHome}</graalvmHome>
-                                    <enableJni>true</enableJni>
                                     <enableAllSecurityServices>true</enableAllSecurityServices>
                                     <disableReports>true</disableReports>
                                 </configuration>

--- a/integration-tests/olingo4/pom.xml
+++ b/integration-tests/olingo4/pom.xml
@@ -117,7 +117,6 @@
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
                                     <graalvmHome>${graalvmHome}</graalvmHome>
-                                    <enableJni>true</enableJni>
                                     <enableAllSecurityServices>true</enableAllSecurityServices>
                                     <disableReports>true</disableReports>
                                 </configuration>

--- a/integration-tests/opentracing/pom.xml
+++ b/integration-tests/opentracing/pom.xml
@@ -123,7 +123,6 @@
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
                                     <graalvmHome>${graalvmHome}</graalvmHome>
-                                    <enableJni>true</enableJni>
                                     <enableAllSecurityServices>true</enableAllSecurityServices>
                                     <disableReports>true</disableReports>
                                 </configuration>

--- a/integration-tests/paho/pom.xml
+++ b/integration-tests/paho/pom.xml
@@ -133,7 +133,6 @@
                                     <enableHttpsUrlHandler>true</enableHttpsUrlHandler>
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
-                                    <enableJni>true</enableJni>
                                     <enableAllSecurityServices>true</enableAllSecurityServices>
                                     <disableReports>true</disableReports>
                                 </configuration>

--- a/integration-tests/pdf/pom.xml
+++ b/integration-tests/pdf/pom.xml
@@ -104,7 +104,6 @@
                   <enableServer>false</enableServer>
                   <dumpProxies>false</dumpProxies>
                   <graalvmHome>${graalvmHome}</graalvmHome>
-                  <enableJni>true</enableJni>
                   <enableAllSecurityServices>true</enableAllSecurityServices>
                   <disableReports>true</disableReports>
                 </configuration>

--- a/integration-tests/platform-http-engine/pom.xml
+++ b/integration-tests/platform-http-engine/pom.xml
@@ -121,7 +121,6 @@
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
                                     <graalvmHome>${graalvmHome}</graalvmHome>
-                                    <enableJni>true</enableJni>
                                     <enableAllSecurityServices>true</enableAllSecurityServices>
                                     <disableReports>true</disableReports>
                                 </configuration>

--- a/integration-tests/platform-http/pom.xml
+++ b/integration-tests/platform-http/pom.xml
@@ -125,7 +125,6 @@
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
                                     <graalvmHome>${graalvmHome}</graalvmHome>
-                                    <enableJni>true</enableJni>
                                     <enableAllSecurityServices>true</enableAllSecurityServices>
                                     <disableReports>true</disableReports>
                                 </configuration>

--- a/integration-tests/salesforce/pom.xml
+++ b/integration-tests/salesforce/pom.xml
@@ -117,7 +117,6 @@
                                     <enableHttpUrlHandler>true</enableHttpUrlHandler>
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
-                                    <enableJni>true</enableJni>
                                     <disableReports>true</disableReports>
                                 </configuration>
                             </execution>

--- a/integration-tests/scheduler/pom.xml
+++ b/integration-tests/scheduler/pom.xml
@@ -126,7 +126,6 @@
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
                                     <graalvmHome>${graalvmHome}</graalvmHome>
-                                    <enableJni>true</enableJni>
                                     <enableAllSecurityServices>true</enableAllSecurityServices>
                                     <disableReports>true</disableReports>
                                 </configuration>

--- a/integration-tests/seda/pom.xml
+++ b/integration-tests/seda/pom.xml
@@ -111,7 +111,6 @@
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
                                     <graalvmHome>${graalvmHome}</graalvmHome>
-                                    <enableJni>true</enableJni>
                                     <enableAllSecurityServices>true</enableAllSecurityServices>
                                     <disableReports>true</disableReports>
                                 </configuration>

--- a/integration-tests/servlet/pom.xml
+++ b/integration-tests/servlet/pom.xml
@@ -111,7 +111,6 @@
                                 <configuration>
                                     <cleanupServer>true</cleanupServer>
                                     <enableHttpUrlHandler>true</enableHttpUrlHandler>
-                                    <enableJni>false</enableJni>
                                     <debugBuildProcess>false</debugBuildProcess>
                                     <disableReports>true</disableReports>
                                 </configuration>

--- a/integration-tests/sjms/pom.xml
+++ b/integration-tests/sjms/pom.xml
@@ -171,7 +171,6 @@
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
                                     <graalvmHome>${graalvmHome}</graalvmHome>
-                                    <enableJni>true</enableJni>
                                     <enableAllSecurityServices>true</enableAllSecurityServices>
                                     <disableReports>true</disableReports>
                                 </configuration>

--- a/integration-tests/slack/pom.xml
+++ b/integration-tests/slack/pom.xml
@@ -119,7 +119,6 @@
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
                                     <graalvmHome>${graalvmHome}</graalvmHome>
-                                    <enableJni>true</enableJni>
                                     <enableAllSecurityServices>true</enableAllSecurityServices>
                                     <disableReports>true</disableReports>
                                 </configuration>

--- a/integration-tests/snakeyaml/pom.xml
+++ b/integration-tests/snakeyaml/pom.xml
@@ -115,7 +115,6 @@
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
                                     <graalvmHome>${graalvmHome}</graalvmHome>
-                                    <enableJni>true</enableJni>
                                     <enableAllSecurityServices>true</enableAllSecurityServices>
                                     <disableReports>true</disableReports>
                                 </configuration>

--- a/integration-tests/sql/pom.xml
+++ b/integration-tests/sql/pom.xml
@@ -120,7 +120,6 @@
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
                                     <graalvmHome>${graalvmHome}</graalvmHome>
-                                    <enableJni>true</enableJni>
                                     <enableAllSecurityServices>true</enableAllSecurityServices>
                                     <disableReports>true</disableReports>
                                 </configuration>

--- a/integration-tests/stream/pom.xml
+++ b/integration-tests/stream/pom.xml
@@ -113,7 +113,6 @@
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
                                     <graalvmHome>${graalvmHome}</graalvmHome>
-                                    <enableJni>true</enableJni>
                                     <enableAllSecurityServices>true</enableAllSecurityServices>
                                     <disableReports>true</disableReports>
                                 </configuration>

--- a/integration-tests/tagsoup/pom.xml
+++ b/integration-tests/tagsoup/pom.xml
@@ -123,7 +123,6 @@
                                     <enableHttpsUrlHandler>true</enableHttpsUrlHandler>
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
-                                    <enableJni>true</enableJni>
                                     <enableAllSecurityServices>true</enableAllSecurityServices>
                                     <disableReports>true</disableReports>
                                 </configuration>

--- a/integration-tests/tarfile/pom.xml
+++ b/integration-tests/tarfile/pom.xml
@@ -113,7 +113,6 @@
                                     <enableHttpsUrlHandler>true</enableHttpsUrlHandler>
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
-                                    <enableJni>true</enableJni>
                                     <enableAllSecurityServices>true</enableAllSecurityServices>
                                     <disableReports>true</disableReports>
                                 </configuration>

--- a/integration-tests/twitter/pom.xml
+++ b/integration-tests/twitter/pom.xml
@@ -109,7 +109,6 @@
                                     <enableHttpsUrlHandler>true</enableHttpsUrlHandler>
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
-                                    <enableJni>true</enableJni>
                                     <enableAllSecurityServices>true</enableAllSecurityServices>
                                     <disableReports>true</disableReports>
                                 </configuration>

--- a/integration-tests/validator/pom.xml
+++ b/integration-tests/validator/pom.xml
@@ -117,7 +117,6 @@
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
                                     <graalvmHome>${graalvmHome}</graalvmHome>
-                                    <enableJni>true</enableJni>
                                     <enableAllSecurityServices>true</enableAllSecurityServices>
                                     <disableReports>true</disableReports>
                                 </configuration>

--- a/integration-tests/xslt/pom.xml
+++ b/integration-tests/xslt/pom.xml
@@ -123,7 +123,6 @@
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
                                     <graalvmHome>${graalvmHome}</graalvmHome>
-                                    <enableJni>true</enableJni>
                                     <enableAllSecurityServices>true</enableAllSecurityServices>
                                     <disableReports>true</disableReports>
                                 </configuration>

--- a/integration-tests/zipfile/pom.xml
+++ b/integration-tests/zipfile/pom.xml
@@ -113,7 +113,6 @@
                                     <enableHttpsUrlHandler>true</enableHttpsUrlHandler>
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
-                                    <enableJni>true</enableJni>
                                     <enableAllSecurityServices>true</enableAllSecurityServices>
                                     <disableReports>true</disableReports>
                                 </configuration>

--- a/tooling/create-extension-templates/integration-test-pom.xml
+++ b/tooling/create-extension-templates/integration-test-pom.xml
@@ -113,7 +113,6 @@
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
                                     <graalvmHome>${graalvmHome}</graalvmHome>
-                                    <enableJni>true</enableJni>
                                     <enableAllSecurityServices>true</enableAllSecurityServices>
                                     <disableReports>true</disableReports>
                                 </configuration>


### PR DESCRIPTION
See https://github.com/quarkusio/quarkus/blob/1.3/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java#L196-L229