### PR TITLE
Remove redundant quarkus.ssl.native=true from box application.properties

### DIFF
--- a/integration-tests/box/src/main/resources/application.properties
+++ b/integration-tests/box/src/main/resources/application.properties
@@ -14,10 +14,6 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 ## ---------------------------------------------------------------------------
-#
-# Quarkus
-#
-quarkus.ssl.native=true
 
 #
 # Camel :: Box


### PR DESCRIPTION
@johnpoth could you please test this with your credentials? I was not able to authenticate with mine within a reasonable time.