### PR TITLE
FastCamelContext to implement ModelCamelContext

### DIFF
--- a/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/FastCamelContext.java
+++ b/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/FastCamelContext.java
@@ -19,8 +19,10 @@ package org.apache.camel.quarkus.core;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
+import java.util.function.Function;
 
 import org.apache.camel.AsyncProcessor;
 import org.apache.camel.CatalogCamelContext;
@@ -66,7 +68,17 @@ import org.apache.camel.impl.engine.RestRegistryFactoryResolver;
 import org.apache.camel.impl.health.DefaultHealthCheckRegistry;
 import org.apache.camel.impl.transformer.TransformerKey;
 import org.apache.camel.impl.validator.ValidatorKey;
+import org.apache.camel.model.DataFormatDefinition;
+import org.apache.camel.model.HystrixConfigurationDefinition;
 import org.apache.camel.model.Model;
+import org.apache.camel.model.ModelCamelContext;
+import org.apache.camel.model.ProcessorDefinition;
+import org.apache.camel.model.Resilience4jConfigurationDefinition;
+import org.apache.camel.model.RouteDefinition;
+import org.apache.camel.model.cloud.ServiceCallConfigurationDefinition;
+import org.apache.camel.model.rest.RestDefinition;
+import org.apache.camel.model.transformer.TransformerDefinition;
+import org.apache.camel.model.validator.ValidatorDefinition;
 import org.apache.camel.processor.MulticastProcessor;
 import org.apache.camel.spi.AsyncProcessorAwaitManager;
 import org.apache.camel.spi.BeanIntrospection;
@@ -112,7 +124,7 @@ import org.apache.camel.spi.XMLRoutesDefinitionLoader;
 import org.apache.camel.support.CamelContextHelper;
 import org.apache.camel.util.IOHelper;
 
-public class FastCamelContext extends AbstractCamelContext implements CatalogCamelContext {
+public class FastCamelContext extends AbstractCamelContext implements CatalogCamelContext, ModelCamelContext {
     private final Model model;
     private final String version;
     private final XMLRoutesDefinitionLoader xmlLoader;
@@ -133,13 +145,6 @@ public class FastCamelContext extends AbstractCamelContext implements CatalogCam
         setMessageHistory(Boolean.FALSE);
         setDefaultExtension(HealthCheckRegistry.class, DefaultHealthCheckRegistry::new);
 
-    }
-
-    @Override
-    protected void startRouteDefinitions() throws Exception {
-        if (model != null) {
-            model.startRouteDefinitions();
-        }
     }
 
     @Override
@@ -499,5 +504,174 @@ public class FastCamelContext extends AbstractCamelContext implements CatalogCam
         }
 
         return null;
+    }
+
+    //
+    // ModelCamelContext
+    //
+
+    @Override
+    public void startRouteDefinitions() throws Exception {
+        model.startRouteDefinitions();
+    }
+
+    @Override
+    public List<RouteDefinition> getRouteDefinitions() {
+        return model.getRouteDefinitions();
+    }
+
+    @Override
+    public RouteDefinition getRouteDefinition(String id) {
+        return model.getRouteDefinition(id);
+    }
+
+    @Override
+    public void addRouteDefinitions(Collection<RouteDefinition> routeDefinitions) throws Exception {
+        model.addRouteDefinitions(routeDefinitions);
+    }
+
+    @Override
+    public void addRouteDefinition(RouteDefinition routeDefinition) throws Exception {
+        model.addRouteDefinition(routeDefinition);
+    }
+
+    @Override
+    public void removeRouteDefinitions(Collection<RouteDefinition> routeDefinitions) throws Exception {
+        model.removeRouteDefinitions(routeDefinitions);
+    }
+
+    @Override
+    public void removeRouteDefinition(RouteDefinition routeDefinition) throws Exception {
+        model.removeRouteDefinition(routeDefinition);
+    }
+
+    @Override
+    public List<RestDefinition> getRestDefinitions() {
+        return model.getRestDefinitions();
+    }
+
+    @Override
+    public void addRestDefinitions(Collection<RestDefinition> restDefinitions, boolean addToRoutes) throws Exception {
+        model.addRestDefinitions(restDefinitions, addToRoutes);
+    }
+
+    @Override
+    public void setDataFormats(Map<String, DataFormatDefinition> dataFormats) {
+        model.setDataFormats(dataFormats);
+    }
+
+    @Override
+    public Map<String, DataFormatDefinition> getDataFormats() {
+        return model.getDataFormats();
+    }
+
+    @Override
+    public DataFormatDefinition resolveDataFormatDefinition(String name) {
+        return model.resolveDataFormatDefinition(name);
+    }
+
+    @Override
+    public ProcessorDefinition getProcessorDefinition(String id) {
+        return model.getProcessorDefinition(id);
+    }
+
+    @Override
+    public <T extends ProcessorDefinition> T getProcessorDefinition(String id, Class<T> type) {
+        return model.getProcessorDefinition(id, type);
+    }
+
+    @Override
+    public void setValidators(List<ValidatorDefinition> validators) {
+        model.setValidators(validators);
+    }
+
+    @Override
+    public HystrixConfigurationDefinition getHystrixConfiguration(String id) {
+        return model.getHystrixConfiguration(id);
+    }
+
+    @Override
+    public void setHystrixConfiguration(HystrixConfigurationDefinition configuration) {
+        model.setHystrixConfiguration(configuration);
+    }
+
+    @Override
+    public void setHystrixConfigurations(List<HystrixConfigurationDefinition> configurations) {
+        model.setHystrixConfigurations(configurations);
+    }
+
+    @Override
+    public void addHystrixConfiguration(String id, HystrixConfigurationDefinition configuration) {
+        model.addHystrixConfiguration(id, configuration);
+    }
+
+    @Override
+    public Resilience4jConfigurationDefinition getResilience4jConfiguration(String id) {
+        return model.getResilience4jConfiguration(id);
+    }
+
+    @Override
+    public void setResilience4jConfiguration(Resilience4jConfigurationDefinition configuration) {
+        model.setResilience4jConfiguration(configuration);
+    }
+
+    @Override
+    public void setResilience4jConfigurations(List<Resilience4jConfigurationDefinition> configurations) {
+        model.setResilience4jConfigurations(configurations);
+    }
+
+    @Override
+    public void addResilience4jConfiguration(String id, Resilience4jConfigurationDefinition configuration) {
+        model.addResilience4jConfiguration(id, configuration);
+    }
+
+    @Override
+    public List<ValidatorDefinition> getValidators() {
+        return model.getValidators();
+    }
+
+    @Override
+    public void setTransformers(List<TransformerDefinition> transformers) {
+        model.setTransformers(transformers);
+    }
+
+    @Override
+    public List<TransformerDefinition> getTransformers() {
+        return model.getTransformers();
+    }
+
+    @Override
+    public ServiceCallConfigurationDefinition getServiceCallConfiguration(String serviceName) {
+        return model.getServiceCallConfiguration(serviceName);
+    }
+
+    @Override
+    public void setServiceCallConfiguration(ServiceCallConfigurationDefinition configuration) {
+        model.setServiceCallConfiguration(configuration);
+    }
+
+    @Override
+    public void setServiceCallConfigurations(List<ServiceCallConfigurationDefinition> configurations) {
+        model.setServiceCallConfigurations(configurations);
+    }
+
+    @Override
+    public void addServiceCallConfiguration(String serviceName, ServiceCallConfigurationDefinition configuration) {
+        model.addServiceCallConfiguration(serviceName, configuration);
+    }
+
+    @Override
+    public void setRouteFilterPattern(String include, String exclude) {
+        model.setRouteFilterPattern(include, exclude);
+    }
+
+    @Override
+    public void setRouteFilter(Function<RouteDefinition, Boolean> filter) {
+        model.setRouteFilter(filter);
+    }
+
+    @Override
+    public Function<RouteDefinition, Boolean> getRouteFilter() {
+        return model.getRouteFilter();
     }
 }

--- a/integration-tests/core-main/src/main/java/org/apache/camel/quarkus/core/CoreMainResource.java
+++ b/integration-tests/core-main/src/main/java/org/apache/camel/quarkus/core/CoreMainResource.java
@@ -38,6 +38,7 @@ import org.apache.camel.Component;
 import org.apache.camel.ExtendedCamelContext;
 import org.apache.camel.component.log.LogComponent;
 import org.apache.camel.component.timer.TimerComponent;
+import org.apache.camel.model.ModelCamelContext;
 import org.apache.camel.quarkus.core.runtime.support.MyPair;
 import org.apache.camel.reactive.vertx.VertXReactiveExecutor;
 import org.apache.camel.spi.BeanRepository;
@@ -154,6 +155,13 @@ public class CoreMainResource {
                 .add("routeBuilders", routeBuilders)
                 .add("routes", routes)
                 .add("autoConfigurationLogSummary", main.getMainConfigurationProperties().isAutoConfigurationLogSummary())
+                .add("config", Json.createObjectBuilder()
+                        .add("rest-port",
+                                context.getRestConfiguration().getPort())
+                        .add("resilience4j-sliding-window-size",
+                                context.adapt(ModelCamelContext.class)
+                                        .getResilience4jConfiguration(null)
+                                        .getSlidingWindowSize()))
                 .add("registry", Json.createObjectBuilder()
                         .add("components", componentsInRegistry)
                         .add("dataformats", dataformatsInRegistry)

--- a/integration-tests/core-main/src/main/resources/application.properties
+++ b/integration-tests/core-main/src/main/resources/application.properties
@@ -29,6 +29,8 @@ quarkus.camel.main.routes-discovery.exclude-patterns = org/**/*Filtered
 # Camel
 #
 camel.context.name=quarkus-camel-example
+camel.rest.port = 9876
+camel.resilience4j.sliding-window-size = 1234
 
 #
 # Timer

--- a/integration-tests/core-main/src/test/java/org/apache/camel/quarkus/core/CoreMainTest.java
+++ b/integration-tests/core-main/src/test/java/org/apache/camel/quarkus/core/CoreMainTest.java
@@ -134,6 +134,16 @@ public class CoreMainTest {
         assertThat(factoryFinderMap)
                 .hasKeySatisfying(doesNotStartWith("META-INF/services/org/apache/camel/properties-component-factory"))
                 .hasKeySatisfying(doesNotStartWith("META-INF/services/org/apache/camel/reactive-executor"));
+
+        // rest properties are configured through CamelContext, this test is to spot changes
+        // done to underlying camel-main implementation that would prevent to configure it
+        // consistently across runtimes using camel-main properties.
+        assertThat(p.getString("config.rest-port")).isEqualTo("9876");
+
+        // resilience4j properties are configured through ModelCamelContext, this test is
+        // to ensure that FastCamelContext won't change in a way it cannot be configured
+        // consistently across runtimes using camel-main properties.
+        assertThat(p.getString("config.resilience4j-sliding-window-size")).isEqualTo("1234");
     }
 
     @Test

--- a/integration-tests/core/src/main/java/org/apache/camel/quarkus/core/CoreResource.java
+++ b/integration-tests/core/src/main/java/org/apache/camel/quarkus/core/CoreResource.java
@@ -29,9 +29,11 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
 import org.apache.camel.CamelContext;
+import org.apache.camel.ExtendedCamelContext;
 import org.apache.camel.NoSuchLanguageException;
 import org.apache.camel.catalog.RuntimeCamelCatalog;
 import org.apache.camel.component.log.LogComponent;
+import org.apache.camel.model.ModelCamelContext;
 import org.apache.camel.spi.Registry;
 import org.apache.camel.support.processor.DefaultExchangeFormatter;
 
@@ -97,6 +99,30 @@ public class CoreResource {
         }
 
         return true;
+    }
+
+    @Path("/adapt/model-camel-context")
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public boolean adaptToModelCamelContext() {
+        try {
+            context.adapt(ModelCamelContext.class);
+            return true;
+        } catch (ClassCastException e) {
+            return false;
+        }
+    }
+
+    @Path("/adapt/extended-camel-context")
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public boolean adaptToExtendedCamelContext() {
+        try {
+            context.adapt(ExtendedCamelContext.class);
+            return true;
+        } catch (ClassCastException e) {
+            return false;
+        }
     }
 
     @Path("/catalog/{type}/{name}")

--- a/integration-tests/core/src/test/java/org/apache/camel/quarkus/core/CoreTest.java
+++ b/integration-tests/core/src/test/java/org/apache/camel/quarkus/core/CoreTest.java
@@ -64,4 +64,10 @@ public class CoreTest {
         RestAssured.when().get("/test/catalog/component/timer").then().body(not(emptyOrNullString()));
         RestAssured.when().get("/test/catalog/language/simple").then().body(emptyOrNullString());
     }
+
+    @Test
+    public void testAdaptContext() {
+        RestAssured.when().get("/test/adapt/model-camel-context").then().body(is("true"));
+        RestAssured.when().get("/test/adapt/extended-camel-context").then().body(is("true"));
+    }
 }


### PR DESCRIPTION
Fixes #877

ModelCamelContext is used in a number of spots by camel-main and others
bit but so far camel-quarkus's FastCamelContext did not implement it
which may cause NPE or CCE