### PR TITLE
Updated Maven version in Prerequisites section

### DIFF
--- a/docs/modules/ROOT/pages/first-steps.adoc
+++ b/docs/modules/ROOT/pages/first-steps.adoc
@@ -8,7 +8,7 @@ as a base for your real world project.
 * A `git` client
 * An IDE
 * JDK 1.8+ with JAVA_HOME configured appropriately
-* Apache Maven 3.5.3+
+* Apache Maven 3.6.2+
 * GraalVM with `native-image` command installed and `GRAALVM_HOME` environment variable set, see
   https://quarkus.io/guides/building-native-image-guide[Building a native executable] section of the Quarkus
   documentation.


### PR DESCRIPTION
The build command fails with the following error when using Maven < 3.6.2:
[ERROR] Failed to execute goal io.quarkus:quarkus-maven-plugin:1.3.0.Final:dev (default-cli) on project camel-quarkus-tutorial: Detected Maven Version (3.5.4)  is not supported, it must be in [3.6.2,).