### PR TITLE
Improve the documentations for camel-quarkus under user guide

### DIFF
--- a/docs/modules/ROOT/pages/examples.adoc
+++ b/docs/modules/ROOT/pages/examples.adoc
@@ -1,4 +1,0 @@
-= Camel Quarkus Examples
-
-We offer several examples in our https://github.com/apache/camel-quarkus/tree/master/examples[source tree]. To learn
-how to use them, please follow the xref:first-steps.adoc[First steps] chapter of the User guide.

--- a/docs/modules/ROOT/pages/first-steps.adoc
+++ b/docs/modules/ROOT/pages/first-steps.adoc
@@ -198,3 +198,8 @@ That's under 35 MB of RAM!
 TIP: https://quarkus.io/guides/building-native-image-guide.html[Quarkus Native executable quide] contains more details
 including
 https://quarkus.io/guides/building-native-image-guide.html#creating-a-container[steps for creating a container image].
+
+== Examples
+
+We offer several examples in our https://github.com/apache/camel-quarkus/tree/master/examples[source tree]. To learn
+how to use them, please follow through the xref:first-steps.adoc[First steps] of the User guide.


### PR DESCRIPTION
* Within the camel-quarkus documentation, there exists an **Examples** page within the user guide. This page only states to go through the source examples after reading the **First Steps** chapter. I think that the use of a separate page for **Examples** is unnecessary and can be appended to the **First Steps** page at the end of the documentation itself.