### PR TITLE
Move quarkus.camel.resources.* config options to quarkus.camel.native…

### DIFF
--- a/docs/modules/ROOT/pages/extensions/mustache.adoc
+++ b/docs/modules/ROOT/pages/extensions/mustache.adoc
@@ -32,7 +32,7 @@ from("direct:start").to("mustache://template/simple.mustache");
 In order to work in native mode the `include-patterns` configuration should be set. For instance, in the `application.properties` file as below :
 [source,properties]
 ----
-quarkus.camel.resources.include-patterns = template/*.mustache
+quarkus.camel.native.resources.include-patterns = template/*.mustache
 ----
 
 More information about selecting resources for inclusion in the native executable could be found at xref:native-mode.adoc#embedding-resource-in-native-executable[Embedding resource in native executable].

--- a/docs/modules/ROOT/pages/list-of-camel-quarkus-extensions.adoc
+++ b/docs/modules/ROOT/pages/list-of-camel-quarkus-extensions.adoc
@@ -18,7 +18,7 @@ In case you are missing some Camel feature in the list:
 == Camel Components
 
 // components: START
-Number of Camel components: 145 in 110 JAR artifacts (0 deprecated)
+Number of Camel components: 146 in 111 JAR artifacts (0 deprecated)
 
 [width="100%",cols="4,1,1,5",options="header"]
 |===

--- a/docs/modules/ROOT/pages/native-mode.adoc
+++ b/docs/modules/ROOT/pages/native-mode.adoc
@@ -30,8 +30,8 @@ in Quarkus documentation.
 Resources needed at runtime need to be explicitly embedded in the built native executable. In such situations, the `include-patterns` and `exclude-patterns` configurations could be set in `application.properties` as demonstrated below:
 [source,properties]
 ----
-quarkus.camel.resources.include-patterns = docs/*,images/*
-quarkus.camel.resources.exclude-patterns = docs/ignored.adoc,images/ignored.png
+quarkus.camel.native.resources.include-patterns = docs/*,images/*
+quarkus.camel.native.resources.exclude-patterns = docs/ignored.adoc,images/ignored.png
 ----
 In the example above, resources named _docs/included.adoc_ and _images/included.png_ would be embedded in the native executable while _docs/ignored.adoc_ and _images/ignored.png_ would not.
 

--- a/extensions-core/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/NativeImageProcessor.java
+++ b/extensions-core/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/NativeImageProcessor.java
@@ -44,6 +44,7 @@ import org.apache.camel.impl.engine.DefaultComponentResolver;
 import org.apache.camel.impl.engine.DefaultDataFormatResolver;
 import org.apache.camel.impl.engine.DefaultLanguageResolver;
 import org.apache.camel.quarkus.core.CamelConfig;
+import org.apache.camel.quarkus.core.CamelConfig.ResourcesConfig;
 import org.apache.camel.quarkus.core.Flags;
 import org.apache.camel.quarkus.core.deployment.util.PathFilter;
 import org.apache.camel.spi.DataFormat;
@@ -214,16 +215,17 @@ class NativeImageProcessor {
         void embedSelectResourcesInNativeExecutable(CamelConfig config, ApplicationArchivesBuildItem archives,
                 BuildProducer<NativeImageResourceBuildItem> resources) {
 
-            if (!config.resources.includePatterns.isPresent()) {
+            final ResourcesConfig resourcesConfig = config.native_.resources;
+            if (!resourcesConfig.includePatterns.isPresent()) {
                 LOGGER.debug("Not scanning resources for native inclusion as include-patterns is not set");
                 return;
             }
 
             PathFilter.Builder builder = new PathFilter.Builder();
             LOGGER.debug("Scanning resources for native inclusion from include-patterns {}",
-                    config.resources.includePatterns.get());
-            builder.include(config.resources.includePatterns);
-            builder.exclude(config.resources.excludePatterns);
+                    resourcesConfig.includePatterns.get());
+            builder.include(resourcesConfig.includePatterns);
+            builder.exclude(resourcesConfig.excludePatterns);
             PathFilter pathFilter = builder.build();
 
             for (ApplicationArchive archive : archives.getAllApplicationArchives()) {

--- a/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/CamelConfig.java
+++ b/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/CamelConfig.java
@@ -45,10 +45,10 @@ public class CamelConfig {
     public RuntimeCatalogConfig runtimeCatalog;
 
     /**
-     * Build time configuration options for resources inclusion in the native executable.
+     * Build time configuration options related to the building of native executable.
      */
-    @ConfigItem
-    public ResourcesConfig resources;
+    @ConfigItem(name = "native")
+    public NativeConfig native_;
 
     @ConfigGroup
     public static class MainConfig {
@@ -184,6 +184,16 @@ public class CamelConfig {
          */
         @ConfigItem
         public Optional<List<String>> includePatterns;
+    }
+
+    @ConfigGroup
+    public static class NativeConfig {
+        /**
+         * Build time configuration options for resources inclusion in the native executable.
+         */
+        @ConfigItem
+        public ResourcesConfig resources;
+
     }
 
     @ConfigGroup

--- a/integration-tests/core/src/main/resources/application.properties
+++ b/integration-tests/core/src/main/resources/application.properties
@@ -25,8 +25,8 @@ quarkus.log.category."org.apache.camel.quarkus.core".level = DEBUG
 #
 quarkus.camel.main.enabled = false
 quarkus.camel.runtime-catalog.languages = false
-quarkus.camel.resources.include-patterns = include-pattern-folder/*
-quarkus.camel.resources.exclude-patterns = exclude-pattern-folder/*,include-pattern-folder/excluded.txt
+quarkus.camel.native.resources.include-patterns = include-pattern-folder/*
+quarkus.camel.native.resources.exclude-patterns = exclude-pattern-folder/*,include-pattern-folder/excluded.txt
 
 #
 # Camel

--- a/integration-tests/mustache/src/main/resources/application.properties
+++ b/integration-tests/mustache/src/main/resources/application.properties
@@ -15,4 +15,4 @@
 ## limitations under the License.
 ## ---------------------------------------------------------------------------
 
-quarkus.camel.resources.include-patterns = template/*.mustache
+quarkus.camel.native.resources.include-patterns = template/*.mustache


### PR DESCRIPTION
….resources.*

I think `quarkus.camel.native` is the right place for these options because they are native related. WDYT, @aldettinger ?