### PR TITLE
Update Quarkus extension description for zip-deflater and lzf

### DIFF
--- a/extensions/lzf/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/lzf/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -16,8 +16,8 @@
 #
 
 ---
-name: "Camel Quarkus Zipfile"
-description: "Camel Zip file support"
+name: "Camel Quarkus LZF"
+description: "Camel LZF compression support"
 metadata:
   keywords:
   - "camel"

--- a/extensions/zip-deflater/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/zip-deflater/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -16,8 +16,8 @@
 #
 
 ---
-name: "Camel Quarkus Zipfile"
-description: "Camel Zip file support"
+name: "Camel Quarkus Zip Deflate"
+description: "Camel Zip Deflate compression support"
 metadata:
   keywords:
   - "camel"


### PR DESCRIPTION
Update Quarkus extension description for zip-deflater and lzf

Fixes following issue:
```
$ mvn quarkus:list-extensions | grep "Camel Quarkus Zipfile"
Camel Quarkus Zipfile                              camel-quarkus-lzf
Camel Quarkus Zipfile                              camel-quarkus-zip-deflater
Camel Quarkus Zipfile                              camel-quarkus-zipfile
```