### PR TITLE
Make a tabular list of examples for the examples page

### DIFF
--- a/docs/modules/ROOT/pages/examples.adoc
+++ b/docs/modules/ROOT/pages/examples.adoc
@@ -2,3 +2,19 @@
 
 We offer several examples in our https://github.com/apache/camel-quarkus/tree/master/examples[source tree]. To learn
 how to use them, please follow the xref:first-steps.adoc[First steps] chapter of the User guide.
+
+// examples: START
+Number of Examples: 8 (0 deprecated)
+[width="100%",cols="3,7",options="header"]
+|===
+| Example | Description
+| link:https://github.com/apache/camel-quarkus/tree/master/examples/observability/README.adoc[Observability] (observability) | An example that demonstrates how to add support for metrics, health checks and distributed tracing 
+| link:https://github.com/apache/camel-quarkus/tree/master/examples/rest-json/README.adoc[Rest Json] (rest-json) | This example is a port of Quarkus' quickstart to Camel
+| link:https://github.com/apache/camel-quarkus/tree/master/examples/timer-log/README.adoc[Timer Log] (timer-log) | An example of basic Hello World that uses a Camel timer
+| link:https://github.com/apache/camel-quarkus/tree/master/examples/timer-log-cdi/README.adoc[Timer Log CDI] (timer-log-cdi) | An example of basic Hello World that uses CDI to set-up a Camel timer
+| link:https://github.com/apache/camel-quarkus/tree/master/examples/timer-log-kotlin[Timer Log Kotlin] (timer-log-kotlin) | An example of basic Hello World that uses Kotlin to set-up a Camel timer
+| link:https://github.com/apache/camel-quarkus/tree/master/examples/timer-log-xml/README.adoc[Timer Log XML] (timer-log-xml) | An example of basic Hello World that uses XML to set-up a Camel timer
+| link:https://github.com/apache/camel-quarkus/tree/master/examples/timer-log-spring/README.adoc[Timer Log Spring] (timer-log-spring) | An example of basic Hello World that uses Spring to set-up a Camel timer
+| link:https://github.com/apache/camel-quarkus/tree/master/examples/file-split-log-xml/README.adoc[File Split Log XML] (file-split-log-xml) | An example of basic Hello World that uses XML to set-up a Camel file consumer
+|===
+// examples: END


### PR DESCRIPTION
* As the example page doesn't include the list of examples in the tabular form, I have made changes to the examples page to include the tabular form.

* However, the link to each example is to the `README.adoc` within GitHub itself, as there is no separate page for each example. Also, there doesn't exist a `README.adoc` for **timer-log-kotlin**, it direct to the GitHub repo for it.