### PR TITLE
Fix #963 Build processor class template may create redundant LOG field

### DIFF
--- a/tooling/create-extension-templates/Processor.java
+++ b/tooling/create-extension-templates/Processor.java
@@ -26,7 +26,8 @@ import org.jboss.logging.Logger;
 
 class [=toCapCamelCase(artifactIdBase)]Processor {
 
-    private static final Logger LOG = Logger.getLogger([=toCapCamelCase(artifactIdBase)]Processor.class);
+[#if !nativeSupported ]    private static final Logger LOG = Logger.getLogger([=toCapCamelCase(artifactIdBase)]Processor.class);
+[/#if]
     private static final String FEATURE = "camel-[=artifactIdBase]";
 
     @BuildStep


### PR DESCRIPTION
Fix #963