### PR TITLE
CI build improvements

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -56,9 +56,9 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ~/.m2/repository
-          key: maven-${{ github.sha }}
+          key: maven-${{ github.run_id }}-${{ github.run_number }}
           restore-keys: |
-            maven-${{ github.sha }}
+            maven-${{ github.run_id }}-${{ github.run_number }}
   build-alternative-jvm:
     runs-on: ubuntu-latest
     needs: build
@@ -81,9 +81,9 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ~/.m2/repository
-          key: maven-${{ github.sha }}
+          key: maven-${{ github.run_id }}-${{ github.run_number }}
           restore-keys: |
-            maven-${{ github.sha }}
+            maven-${{ github.run_id }}-${{ github.run_number }}
       - name: Build on ${{ matrix.java }}
         run: |
           ./mvnw -V -ntp ${BRANCH_OPTIONS} \
@@ -218,9 +218,9 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ~/.m2/repository
-          key: maven-${{ github.sha }}
+          key: maven-${{ github.run_id }}-${{ github.run_number }}
           restore-keys: |
-            maven-${{ github.sha }}
+            maven-${{ github.run_id }}-${{ github.run_number }}
       - name: Integration Tests
         env:
           TEST_MODULES: ${{matrix.test-modules}}
@@ -248,9 +248,9 @@ jobs:
   #       uses: actions/cache@v1
   #       with:
   #         path: ~/.m2/repository
-  #         key: maven-${{ github.sha }}
+  #         key: maven-${{ github.run_id }}-${{ github.run_number }}
   #         restore-keys: |
-  #           maven-${{ github.sha }}
+  #           maven-${{ github.run_id }}-${{ github.run_number }}
   #     # run the :camel-quarkus-integration-test-fhir as standalone process
   #     # as it building the native image including camel-fhir requires lot
   #     # of memory this we nee to limit it to avoid the process fail for OOM.

--- a/.github/workflows/sync-camel-master.yaml
+++ b/.github/workflows/sync-camel-master.yaml
@@ -1,0 +1,38 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Sync Camel Master Branch
+
+on:
+  schedule:
+    # Run every Monday at midnight
+    - cron:  '0 0 * * 1'
+
+jobs:
+  sync-camel-master-branch:
+    if: github.repository == 'apache/camel-quarkus'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: GitHub Pull Request Action
+        uses: repo-sync/pull-request@v2.0.1
+        with:
+          source_branch: master
+          destination_branch: camel-master
+          pr_title: Automatic sync branch master to camel-master
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-quarkus-master.yaml
+++ b/.github/workflows/sync-quarkus-master.yaml
@@ -15,27 +15,24 @@
 # limitations under the License.
 #
 
-name: Sync Camel + Quarkus master branches
+name: Sync Quarkus Master Branch
 
 on:
   schedule:
-    # Run every Monday at midnight
-    - cron:  '0 0 * * 1'
+    # Run every day at 2AM
+    - cron:  '0 2 * * *'
 
 jobs:
-  sync-branches:
+  sync-quarkus-master-branch:
+    if: github.repository == 'apache/camel-quarkus'
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        branch: [ 'camel-master' , 'quarkus-master' ]
     steps:
-      # Note: checkout@v2 seems to break the pull-request action hence v1 is used
       - name: Checkout
         uses: actions/checkout@v1
       - name: GitHub Pull Request Action
         uses: repo-sync/pull-request@v2.0.1
         with:
           source_branch: master
-          destination_branch: ${{ matrix.branch }}
-          pr_title: Automatic sync branch master to ${{ matrix.branch }}
+          destination_branch: quarkus-master
+          pr_title: Automatic sync branch master to quarkus-master
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Some CI tweaks:


- Create a cache for each workflow run, so that we don't hit those annoying issues where PRs fail and then keep failing because the cache has expired

- Split up the branch sync workflows for camel-master & quarkus-master. I moved the sync for quarkus-master to be a daily thing. We can revisit this later if we need to.