### PR TITLE
Move spring's kotlin processors and substitutions to a dedicated file

### DIFF
--- a/extensions-support/spring/deployment/src/main/java/org/apache/camel/quarkus/support/spring/deployment/SpringKotlinProcessor.java
+++ b/extensions-support/spring/deployment/src/main/java/org/apache/camel/quarkus/support/spring/deployment/SpringKotlinProcessor.java
@@ -23,10 +23,10 @@ import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
 import io.quarkus.deployment.pkg.steps.NativeBuild;
 import io.quarkus.gizmo.ClassCreator;
 
-public class SpringProcessor {
+public class SpringKotlinProcessor {
 
     @BuildStep(onlyIf = NativeBuild.class)
-    void generateKParameterClass(BuildProducer<GeneratedClassBuildItem> generatedClass) {
+    void generateKotlinReflectClasses(BuildProducer<GeneratedClassBuildItem> generatedClass) {
         // TODO: Investigate removing this. See https://github.com/apache/camel-quarkus/issues/534
         // The native image build fails with a NoClassDefFoundError without this. Possibly similar to https://github.com/oracle/graal/issues/656.
 

--- a/extensions-support/spring/runtime/src/main/java/org/apache/camel/quarkus/support/spring/graal/SpringKotlinSubstitutions.java
+++ b/extensions-support/spring/runtime/src/main/java/org/apache/camel/quarkus/support/spring/graal/SpringKotlinSubstitutions.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.support.spring.graal;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+
+import com.oracle.svm.core.annotate.Delete;
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+import org.springframework.core.MethodParameter;
+
+final class SpringKotlinSubstitutions {
+}
+
+@TargetClass(className = "org.springframework.core.KotlinDetector")
+@Substitute
+final class SubstituteKotlinDetector {
+    @Substitute
+    public static boolean isKotlinPresent() {
+        return false;
+    }
+
+    @Substitute
+    public static boolean isKotlinReflectPresent() {
+        return false;
+    }
+
+    @Substitute
+    public static boolean isKotlinType(Class<?> clazz) {
+        return false;
+    }
+}
+
+@TargetClass(className = "org.springframework.core.KotlinReflectionParameterNameDiscoverer")
+@Delete
+final class SubstituteKotlinReflectionParameterNameDiscoverer {
+}
+
+@TargetClass(className = "org.springframework.beans.BeanUtils$KotlinDelegate")
+final class SubstituteBeanUtilsKotlinDelegate {
+    @Substitute
+    public static <T> Constructor<T> findPrimaryConstructor(Class<T> clazz) {
+        throw new UnsupportedOperationException("Kotlin is not supported");
+    }
+
+    @Substitute
+    public static <T> T instantiateClass(Constructor<T> ctor, Object... args)
+            throws IllegalAccessException, InvocationTargetException, InstantiationException {
+        throw new UnsupportedOperationException("Kotlin is not supported");
+    }
+}
+
+@TargetClass(className = "org.springframework.core.MethodParameter$KotlinDelegate")
+final class SubstituteMethodParameterKotlinDelegate {
+    @Substitute
+    public static boolean isOptional(MethodParameter param) {
+        throw new UnsupportedOperationException("Kotlin is not supported");
+    }
+
+    @Substitute
+    static private Type getGenericReturnType(Method method) {
+        throw new UnsupportedOperationException("Kotlin is not supported");
+    }
+
+    @Substitute
+    private static Class<?> getReturnType(Method method) {
+        throw new UnsupportedOperationException("Kotlin is not supported");
+    }
+}

--- a/extensions-support/spring/runtime/src/main/java/org/apache/camel/quarkus/support/spring/graal/SpringSubstitutions.java
+++ b/extensions-support/spring/runtime/src/main/java/org/apache/camel/quarkus/support/spring/graal/SpringSubstitutions.java
@@ -17,10 +17,6 @@
 package org.apache.camel.quarkus.support.spring.graal;
 
 import java.io.IOException;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.lang.reflect.Type;
 import java.net.URI;
 import java.net.URL;
 import java.util.Set;
@@ -29,8 +25,6 @@ import com.oracle.svm.core.annotate.Alias;
 import com.oracle.svm.core.annotate.Delete;
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
-import org.springframework.core.KotlinDetector;
-import org.springframework.core.MethodParameter;
 import org.springframework.core.io.Resource;
 import org.springframework.util.PathMatcher;
 
@@ -39,93 +33,29 @@ final class SpringSubstitutions {
 
 @TargetClass(className = "org.springframework.core.DefaultParameterNameDiscoverer")
 final class SubstituteDefaultParameterNameDiscoverer {
-
     @Alias
     public SubstituteDefaultParameterNameDiscoverer() {
         // Discoverers are not meant to be registered on graal
     }
 }
 
-@TargetClass(KotlinDetector.class)
-@Substitute
-final class SubstituteKotlinDetector {
-    @Substitute
-    public static boolean isKotlinPresent() {
-        return false;
-    }
-
-    @Substitute
-    public static boolean isKotlinReflectPresent() {
-        return false;
-    }
-
-    @Substitute
-    public static boolean isKotlinType(Class<?> clazz) {
-        return false;
-    }
-}
-
-@TargetClass(className = "org.springframework.core.KotlinReflectionParameterNameDiscoverer")
-@Delete
-final class SubstituteKotlinReflectionParameterNameDiscoverer {
-
-}
-
 @TargetClass(className = "org.springframework.core.StandardReflectionParameterNameDiscoverer")
 @Delete
 final class SubstituteStandardReflectionParameterNameDiscoverer {
-
 }
 
 @TargetClass(className = "org.springframework.core.LocalVariableTableParameterNameDiscoverer")
 @Delete
 final class SubstituteLocalVariableTableParameterNameDiscoverer {
-
-}
-
-@TargetClass(className = "org.springframework.beans.BeanUtils$KotlinDelegate")
-final class SubstituteBeanUtilsKotlinDelegate {
-
-    @Substitute
-    public static <T> Constructor<T> findPrimaryConstructor(Class<T> clazz) {
-        throw new UnsupportedOperationException("Kotlin is not supported");
-    }
-
-    @Substitute
-    public static <T> T instantiateClass(Constructor<T> ctor, Object... args)
-            throws IllegalAccessException, InvocationTargetException, InstantiationException {
-        throw new UnsupportedOperationException("Kotlin is not supported");
-    }
-}
-
-@TargetClass(className = "org.springframework.core.MethodParameter$KotlinDelegate")
-final class SubstituteMethodParameterKotlinDelegate {
-
-    @Substitute
-    public static boolean isOptional(MethodParameter param) {
-        throw new UnsupportedOperationException("Kotlin is not supported");
-    }
-
-    @Substitute
-    static private Type getGenericReturnType(Method method) {
-        throw new UnsupportedOperationException("Kotlin is not supported");
-    }
-
-    @Substitute
-    private static Class<?> getReturnType(Method method) {
-        throw new UnsupportedOperationException("Kotlin is not supported");
-    }
 }
 
 @TargetClass(className = "org.springframework.core.io.VfsUtils")
 @Delete
 final class SubstituteVfsUtils {
-
 }
 
 @TargetClass(className = "org.springframework.core.io.AbstractFileResolvingResource$VfsResourceDelegate")
 final class SubstituteVfsResourceDelegate {
-
     @Substitute
     public static Resource getResource(URL url) throws IOException {
         throw new UnsupportedOperationException("VFS resources are not supported");
@@ -139,7 +69,6 @@ final class SubstituteVfsResourceDelegate {
 
 @TargetClass(className = "org.springframework.core.io.support.PathMatchingResourcePatternResolver$VfsResourceMatchingDelegate")
 final class SubstituteVfsResourceMatchingDelegate {
-
     @Substitute
     public static Set<Resource> findMatchingResources(
             URL rootDirURL, String locationPattern, PathMatcher pathMatcher) throws IOException {


### PR DESCRIPTION
As the number of kotlin related substitutions and processing logic
seems to grow, it is better to move them to a separate file/class
to make it easier to locate kotlin specific logic.

