### PR TITLE
Trigger project build on push

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -15,9 +15,19 @@
 # limitations under the License.
 #
 
-name: Build PR
+name: Camel Quarkus CI
 
 on:
+  push:
+    branches:
+      - master
+      - camel-master
+      - quarkus-master
+    paths-ignore:
+      - '**.adoc'
+      - 'KEYS'
+      - 'LICENSE.txt'
+      - 'NOTICE.txt'
   pull_request:
     branches:
       - master

--- a/docs/modules/ROOT/pages/promote-jvm-to-native.adoc
+++ b/docs/modules/ROOT/pages/promote-jvm-to-native.adoc
@@ -95,7 +95,7 @@ $ {
 * Ensure keyword `camel` is present
 * Remove the `preview` status
 
-9. Add itests to `.github/workflows/pr-build.yaml`, for instance:
+9. Add itests to `.github/workflows/ci-build.yaml`, for instance:
 +
 [source,yaml]
 ----

--- a/tooling/scripts/validate-github-workflows.groovy
+++ b/tooling/scripts/validate-github-workflows.groovy
@@ -24,7 +24,7 @@ import org.yaml.snakeyaml.Yaml
 
 final Path treeRootDir = project.getBasedir().toPath()
 
-final String jobDefRelPath = '.github/workflows/pr-build.yaml'
+final String jobDefRelPath = '.github/workflows/ci-build.yaml'
 final Path jobDefPath = treeRootDir.resolve(jobDefRelPath)
 final Set<String> executedBaseNames = [] as Set
 


### PR DESCRIPTION
Not sure if we'll run into issues with API rate limits by building on push, but ideally we should be doing this in addition to building on PRs.