### PR TITLE
Fix #1037 to support the quarkus command mode

### DIFF
--- a/extensions-core/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/BuildProcessor.java
+++ b/extensions-core/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/BuildProcessor.java
@@ -478,7 +478,7 @@ class BuildProcessor {
             return new CamelRoutesLoaderBuildItems.Registry(recorder.newDefaultRegistryRoutesLoader());
         }
 
-        @BuildStep(onlyIf = { Flags.MainEnabled.class, Flags.RoutesDiscoveryEnabled.class })
+        @BuildStep(onlyIf = Flags.RoutesDiscoveryEnabled.class)
         public List<CamelRoutesBuilderClassBuildItem> discoverRoutesBuilderClassNames(
                 CombinedIndexBuildItem combinedIndex,
                 CamelConfig config) {
@@ -515,7 +515,7 @@ class BuildProcessor {
                     recorder.newRoutesCollector(registryRoutesLoader.getLoader(), xmlRoutesLoader.getLoader()));
         }
 
-        @BuildStep(onlyIf = Flags.MainEnabled.class)
+        @BuildStep
         void beans(BuildProducer<AdditionalBeanBuildItem> beanProducer) {
             beanProducer.produce(AdditionalBeanBuildItem.unremovableOf(CamelMainProducers.class));
         }
@@ -524,7 +524,7 @@ class BuildProcessor {
          * Camel is not pulling the RouteBuilders from the CDI container when the main is off so there is no point in
          * making the lazy beans unremovable in that case.
          */
-        @BuildStep(onlyIf = Flags.MainEnabled.class)
+        @BuildStep
         UnremovableBeanBuildItem unremovableRoutesBuilders() {
             return new UnremovableBeanBuildItem(
                     b -> b.getTypes().stream().map(Type::name).anyMatch(UNREMOVABLE_BEANS_TYPES::contains));
@@ -532,7 +532,7 @@ class BuildProcessor {
 
         @Overridable
         @Record(value = ExecutionTime.RUNTIME_INIT, optional = true)
-        @BuildStep(onlyIf = Flags.MainEnabled.class)
+        @BuildStep
         CamelReactiveExecutorBuildItem reactiveExecutor(CamelMainRecorder recorder) {
             return new CamelReactiveExecutorBuildItem(recorder.createReactiveExecutor());
         }
@@ -546,7 +546,7 @@ class BuildProcessor {
          */
         @SuppressWarnings("unchecked")
         @Record(ExecutionTime.STATIC_INIT)
-        @BuildStep(onlyIf = Flags.MainEnabled.class)
+        @BuildStep
         CamelMainBuildItem main(
                 ContainerBeansBuildItem containerBeans,
                 CamelMainRecorder recorder,
@@ -608,7 +608,7 @@ class BuildProcessor {
          *                  container thus we need it to be fully initialized to avoid unexpected behaviors.
          */
         @Record(ExecutionTime.RUNTIME_INIT)
-        @BuildStep(onlyIf = Flags.MainEnabled.class)
+        @BuildStep
         void start(
                 CamelMainRecorder recorder,
                 ShutdownContextBuildItem shutdown,

--- a/extensions-core/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/BuildProcessor.java
+++ b/extensions-core/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/BuildProcessor.java
@@ -545,7 +545,7 @@ class BuildProcessor {
          * at runtime.
          */
         @SuppressWarnings("unchecked")
-        @Record(ExecutionTime.STATIC_INIT)
+        @Record(value = ExecutionTime.STATIC_INIT, optional = true)
         @BuildStep
         CamelMainBuildItem main(
                 ContainerBeansBuildItem containerBeans,
@@ -555,7 +555,6 @@ class BuildProcessor {
                 List<CamelRoutesBuilderClassBuildItem> routesBuilderClasses,
                 List<CamelMainListenerBuildItem> listeners,
                 BeanContainerBuildItem beanContainer) {
-
             RuntimeValue<CamelMain> main = recorder.createCamelMain(
                     context.getCamelContext(),
                     routesCollector.getValue(),
@@ -585,7 +584,7 @@ class BuildProcessor {
          * @param main     a reference to a {@link CamelMain}
          */
         @Overridable
-        @BuildStep
+        @BuildStep(onlyIf = Flags.BootstrapEnabled.class)
         @Record(ExecutionTime.RUNTIME_INIT)
         public CamelBootstrapBuildItem assembler(
                 CamelMainRecorder recorder,
@@ -593,6 +592,12 @@ class BuildProcessor {
                 CamelMainBuildItem main) {
             recorder.setReactiveExecutor(main.getInstance(), executor.getInstance());
             return new CamelBootstrapBuildItem(recorder.setupBootstrap(main.getInstance()));
+        }
+
+        @BuildStep(onlyIfNot = Flags.BootstrapEnabled.class)
+        @Record(ExecutionTime.STATIC_INIT)
+        public CamelBootstrapBuildItem disableBootstrap(CamelMainRecorder recorder) {
+            return new CamelBootstrapBuildItem(recorder.emptyBootstrap());
         }
 
         /**

--- a/extensions-core/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/CamelBootstrapBuildItem.java
+++ b/extensions-core/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/CamelBootstrapBuildItem.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.quarkus.core.deployment;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+import io.quarkus.runtime.RuntimeValue;
+import org.apache.camel.quarkus.core.CamelBootstrap;
+
+public final class CamelBootstrapBuildItem extends SimpleBuildItem {
+    private final RuntimeValue<CamelBootstrap> value;
+
+    public CamelBootstrapBuildItem(RuntimeValue<CamelBootstrap> value) {
+        this.value = value;
+    }
+
+    public RuntimeValue<CamelBootstrap> getCamelBootstrap() {
+        return value;
+    }
+}

--- a/extensions-core/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/NativeImageProcessor.java
+++ b/extensions-core/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/NativeImageProcessor.java
@@ -281,7 +281,7 @@ public class NativeImageProcessor {
      * disabled by setting quarkus.camel.main.enabled = false
      */
     public static class Main {
-        @BuildStep(onlyIf = Flags.MainEnabled.class)
+        @BuildStep
         void process(
                 List<CamelRoutesBuilderClassBuildItem> camelRoutesBuilders,
                 BuildProducer<ReflectiveClassBuildItem> reflectiveClass) {

--- a/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/CamelBootstrap.java
+++ b/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/CamelBootstrap.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.core;
+
+public interface CamelBootstrap {
+    void start();
+
+    void stop();
+}

--- a/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/CamelConfig.java
+++ b/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/CamelConfig.java
@@ -27,6 +27,12 @@ import io.quarkus.runtime.annotations.ConfigRoot;
 @ConfigRoot(name = "camel", phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
 public class CamelConfig {
     /**
+     * Build time configuration options for {@link CamelBootstrap}.
+     */
+    @ConfigItem
+    public BootstrapConfig bootstrap;
+
+    /**
      * Build time configuration options for {@code camel-main}.
      */
     @ConfigItem
@@ -49,6 +55,16 @@ public class CamelConfig {
      */
     @ConfigItem(name = "native")
     public NativeConfig native_;
+
+    @ConfigGroup
+    public static class BootstrapConfig {
+        /**
+         * Enable the camel bootstrap. If {@code true}, the core extension will bootstrap
+         * the camel context.
+         */
+        @ConfigItem(defaultValue = "true")
+        public boolean enabled;
+    }
 
     @ConfigGroup
     public static class MainConfig {

--- a/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/CamelMainRecorder.java
+++ b/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/CamelMainRecorder.java
@@ -84,6 +84,18 @@ public class CamelMainRecorder {
         return new RuntimeValue<>(new DefaultCamelBootstrap(main.getValue()));
     }
 
+    public RuntimeValue<CamelBootstrap> emptyBootstrap() {
+        return new RuntimeValue<>(new CamelBootstrap() {
+            @Override
+            public void start() {
+            }
+
+            @Override
+            public void stop() {
+            }
+        });
+    }
+
     public void boostrap(ShutdownContext shutdown, RuntimeValue<CamelBootstrap> bootstrap) {
         shutdown.addShutdownTask(new Runnable() {
             @Override

--- a/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/CamelMainRecorder.java
+++ b/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/CamelMainRecorder.java
@@ -80,12 +80,16 @@ public class CamelMainRecorder {
         main.getValue().getCamelContext().adapt(ExtendedCamelContext.class).setReactiveExecutor(executor.getValue());
     }
 
-    public void start(ShutdownContext shutdown, RuntimeValue<CamelMain> main) {
+    public RuntimeValue<CamelBootstrap> setupBootstrap(RuntimeValue<CamelMain> main) {
+        return new RuntimeValue<>(new DefaultCamelBootstrap(main.getValue()));
+    }
+
+    public void boostrap(ShutdownContext shutdown, RuntimeValue<CamelBootstrap> bootstrap) {
         shutdown.addShutdownTask(new Runnable() {
             @Override
             public void run() {
                 try {
-                    main.getValue().stop();
+                    bootstrap.getValue().stop();
                 } catch (Exception e) {
                     throw new RuntimeException(e);
                 }
@@ -93,7 +97,7 @@ public class CamelMainRecorder {
         });
 
         try {
-            main.getValue().start();
+            bootstrap.getValue().start();
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/DefaultCamelBootstrap.java
+++ b/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/DefaultCamelBootstrap.java
@@ -30,7 +30,7 @@ public class DefaultCamelBootstrap implements CamelBootstrap {
 
     @Override
     public void start() {
-        LOGGER.info("Bootstrap Camel from the embbed ");
+        LOGGER.info("Bootstrap Camel in the embedded mode");
         main.start();
     }
 

--- a/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/DefaultCamelBootstrap.java
+++ b/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/DefaultCamelBootstrap.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.core;
+
+public class DefaultCamelBootstrap implements CamelBootstrap {
+    private CamelMain main;
+
+    public DefaultCamelBootstrap(CamelMain main) {
+        this.main = main;
+    }
+
+    @Override
+    public void start() {
+        main.start();
+    }
+
+    @Override
+    public void stop() {
+        main.stop();
+    }
+}

--- a/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/DefaultCamelBootstrap.java
+++ b/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/DefaultCamelBootstrap.java
@@ -16,7 +16,12 @@
  */
 package org.apache.camel.quarkus.core;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class DefaultCamelBootstrap implements CamelBootstrap {
+    private static final Logger LOGGER = LoggerFactory.getLogger(CamelBootstrap.class);
+
     private CamelMain main;
 
     public DefaultCamelBootstrap(CamelMain main) {
@@ -25,6 +30,7 @@ public class DefaultCamelBootstrap implements CamelBootstrap {
 
     @Override
     public void start() {
+        LOGGER.info("Bootstrap Camel from the embbed ");
         main.start();
     }
 

--- a/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/Flags.java
+++ b/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/Flags.java
@@ -28,13 +28,6 @@ public final class Flags {
         return ConfigProvider.getConfig().getOptionalValue(key, Boolean.class).orElse(defaultValue);
     }
 
-    public static final class MainEnabled implements BooleanSupplier {
-        @Override
-        public boolean getAsBoolean() {
-            return asBoolean("quarkus.camel.main.enabled", true);
-        }
-    }
-
     public static final class RoutesDiscoveryEnabled implements BooleanSupplier {
         @Override
         public boolean getAsBoolean() {

--- a/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/Flags.java
+++ b/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/Flags.java
@@ -28,6 +28,13 @@ public final class Flags {
         return ConfigProvider.getConfig().getOptionalValue(key, Boolean.class).orElse(defaultValue);
     }
 
+    public static final class BootstrapEnabled implements BooleanSupplier {
+        @Override
+        public boolean getAsBoolean() {
+            return asBoolean("quarkus.camel.bootstrap.enabled", true);
+        }
+    }
+
     public static final class RoutesDiscoveryEnabled implements BooleanSupplier {
         @Override
         public boolean getAsBoolean() {

--- a/extensions-core/reactive-executor/deployment/src/main/java/org/apache/camel/quarkus/reactive/executor/deployment/BuildProcessor.java
+++ b/extensions-core/reactive-executor/deployment/src/main/java/org/apache/camel/quarkus/reactive/executor/deployment/BuildProcessor.java
@@ -20,13 +20,12 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.vertx.deployment.VertxBuildItem;
-import org.apache.camel.quarkus.core.Flags;
 import org.apache.camel.quarkus.core.deployment.CamelReactiveExecutorBuildItem;
 import org.apache.camel.quarkus.reactive.executor.ReactiveExecutorRecorder;
 
 public class BuildProcessor {
     @Record(value = ExecutionTime.RUNTIME_INIT, optional = true)
-    @BuildStep(onlyIf = Flags.MainEnabled.class)
+    @BuildStep
     CamelReactiveExecutorBuildItem reactiveExecutor(ReactiveExecutorRecorder recorder, VertxBuildItem vertx) {
         return new CamelReactiveExecutorBuildItem(recorder.createReactiveExecutor(vertx.getVertx()));
     }

--- a/extensions/reactive-streams/deployment/src/main/java/org/apache/camel/quarkus/component/reactive/streams/deployment/ReactiveStreamsProcessor.java
+++ b/extensions/reactive-streams/deployment/src/main/java/org/apache/camel/quarkus/component/reactive/streams/deployment/ReactiveStreamsProcessor.java
@@ -46,7 +46,7 @@ class ReactiveStreamsProcessor {
         return new CamelServiceFilterBuildItem(CamelServiceFilter.forComponent(SCHEME));
     }
 
-    @BuildStep(onlyIf = Flags.MainEnabled.class)
+    @BuildStep
     void beans(BuildProducer<AdditionalBeanBuildItem> beanProducer) {
         // thi extension will made some reactive camel reactive streams object availbale
         // for injection in order to easy the use CamelReactiveStreams in CDI.

--- a/integration-tests/core/src/main/resources/application.properties
+++ b/integration-tests/core/src/main/resources/application.properties
@@ -23,7 +23,7 @@ quarkus.log.category."org.apache.camel.quarkus.core".level = DEBUG
 #
 # Quarkus :: Camel
 #
-quarkus.camel.main.enabled = false
+quarkus.camel.bootstrap.enabled = false
 quarkus.camel.runtime-catalog.languages = false
 quarkus.camel.native.resources.include-patterns = include-pattern-folder/*
 quarkus.camel.native.resources.exclude-patterns = exclude-pattern-folder/*,include-pattern-folder/excluded.txt


### PR DESCRIPTION
- introduce the CamelBootstrap
- refactor the core extension to do bootstrap
- next will add a "main" bootstrap extension to override the ```assembler``` which should be started in the QuarkusApplication main method by using the camel-main