### PR TITLE
Improve master -> quarkus-master branch scheduled synchronization workflow

### DIFF
--- a/.github/test-categories.yaml
+++ b/.github/test-categories.yaml
@@ -1,0 +1,113 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Association of test categories and integration test modules. Used by GitHub workflows.
+categories:
+  cloud:
+    - aws
+    - aws2
+    - azure
+    - consul
+  core:
+    - core
+    - core-impl
+    - core-main
+    - core-main-caffeine-lrucache
+    - core-main-collector
+    - core-main-xml-io
+    - core-main-xml-jaxb
+  database:
+    - couchdb
+    - influxdb
+    - jdbc
+    - kudu
+    - mongodb
+    - sql
+  dataformats:
+    - base64
+    - bindy
+    - csv
+    - dataformat
+    - jaxb
+    - xstream
+    - soap
+  foundation:
+    - bean
+    - controlbus
+    - exec
+    - file
+    - hystrix
+    - jsonpath
+    - quartz
+    - scheduler
+    - seda
+    - send-dynamic-http
+    - ref
+  memoryhog-dataformat-json:
+    - dataformats-json
+  memoryhog-dozer:
+    - dozer
+  memoryhog-infinispan:
+    - dozer
+  memoryhog-olingo4:
+    - olingo4
+  memoryhog-xml:
+    - rest-binding-mode-xml
+    - xml
+  messaging:
+    - activemq
+    - amqp
+    - kafka
+    - messaging
+  misc:
+    - braintree
+    - compression
+    - graphql
+    - mustache
+    - pdf
+    - qute
+    - stream
+    - tarfile
+    - infinispan
+  networking:
+    - ftp
+    - http
+    - mail
+    - netty
+    - servlet
+    - websocket-jsr356
+  platform:
+    - microprofile
+    - opentracing
+    - platform-http
+    - platform-http-engine
+    - reactive-streams
+  saas:
+    - box
+    - github
+    - google
+    - jira
+    - salesforce
+    - sap-netweaver
+    - servicenow
+    - slack
+  social:
+    - telegram
+    - twitter
+  validation:
+    - bean-validator
+    - validator

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -49,15 +49,15 @@ jobs:
       MAVEN_OPTS: -Xmx3000m
     steps:
       - name: Setup apache-snapshots profile
-        if: github.base_ref == 'camel-master'
+        if: github.ref == 'refs/heads/camel-master' || github.base_ref == 'camel-master'
         run: |
           echo '::set-env name=BRANCH_OPTIONS::-Papache-snapshots'
       - name: Setup oss-snapshots profile
-        if: github.base_ref == 'quarkus-master'
+        if: github.ref == 'refs/heads/quarkus-master' || github.base_ref == 'quarkus-master'
         run: |
-          echo '::set-env name=BRANCH_OPTIONS::-Poss-snapshots'
+          echo '::set-env name=BRANCH_OPTIONS::-Poss-snapshots -Dquarkus.version=999-SNAPSHOT'
       - name: Build Quarkus
-        if: github.base_ref == 'quarkus-master'
+        if: github.ref == 'refs/heads/quarkus-master' || github.base_ref == 'quarkus-master'
         run: |
           git clone --depth 1 --branch master https://github.com/quarkusio/quarkus.git \
             && cd quarkus \
@@ -90,13 +90,13 @@ jobs:
       MAVEN_OPTS: -Xmx3000m
     steps:
       - name: Setup apache-snapshots profile
-        if: github.base_ref == 'camel-master'
+        if: github.ref == 'refs/heads/camel-master' || github.base_ref == 'camel-master'
         run: |
           echo '::set-env name=BRANCH_OPTIONS::-Papache-snapshots'
       - name: Setup oss-snapshots profile
-        if: github.base_ref == 'quarkus-master'
+        if: github.ref == 'refs/heads/quarkus-master' || github.base_ref == 'quarkus-master'
         run: |
-          echo '::set-env name=BRANCH_OPTIONS::-Poss-snapshots'
+          echo '::set-env name=BRANCH_OPTIONS::-Poss-snapshots -Dquarkus.version=999-SNAPSHOT'
       - uses: actions/checkout@v2
       - name: Set up JDK ${{ matrix.java }}
         uses: joschi/setup-jdk@v1
@@ -120,127 +120,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        category: [Core, Foundation, Platform, Messaging, Dataformats, Networking, Database, Cloud, Misc, SAAS, Social, Validation, Memoryhog Dozer, Memoryhog Dataformat JSON, Memoryhog Infinispan, Memoryhog Olingo4, Memoryhog XML]
-        include:
-          - category: Cloud
-            test-modules: >
-              aws
-              aws2
-              azure
-              consul
-          - category: Core
-            test-modules: >
-              core
-              core-impl
-              core-main
-              core-main-caffeine-lrucache
-              core-main-collector
-              core-main-xml-io
-              core-main-xml-jaxb
-          - category: Dataformats
-            test-modules: >
-              base64
-              bindy
-              csv
-              dataformat
-              jaxb
-              xstream
-              soap
-          - category: Foundation
-            test-modules: >
-              bean
-              controlbus
-              exec
-              file
-              hystrix
-              jsonpath
-              quartz
-              scheduler
-              seda
-              send-dynamic-http
-              ref
-          - category: Memoryhog Dataformat JSON
-            test-modules: >
-              dataformats-json
-          - category: Memoryhog Dozer
-            test-modules: >
-              dozer
-          - category: Memoryhog Infinispan
-            test-modules: >
-              infinispan
-          - category: Memoryhog Olingo4
-            test-modules: >
-              olingo4
-          - category: Memoryhog XML
-            test-modules: >
-              xml
-              rest-binding-mode-xml
-          - category: Messaging
-            test-modules: >
-              activemq
-              amqp
-              kafka
-              messaging
-          - category: Misc
-            test-modules: >
-              braintree
-              compression
-              graphql
-              mustache
-              pdf
-              qute
-              stream
-              tarfile
-          - category: Networking
-            test-modules: >
-              ftp
-              http
-              mail
-              netty
-              servlet
-              websocket-jsr356
-          - category: Platform
-            test-modules: >
-              microprofile
-              opentracing
-              platform-http
-              platform-http-engine
-              reactive-streams
-          - category: SAAS
-            test-modules: >
-              box
-              github
-              google
-              jira
-              salesforce
-              sap-netweaver
-              servicenow
-              slack
-          - category: Database
-            test-modules: >
-              couchdb
-              influxdb
-              jdbc
-              kudu
-              mongodb
-              sql
-          - category: Social
-            test-modules: >
-              telegram
-              twitter
-          - category: Validation
-            test-modules: >
-              bean-validator
-              validator
+        category: [core, foundation, platform, messaging, database, dataformats, networking, cloud, misc, saas, social, validation, memoryhog-dozer, memoryhog-dataformat-json, memoryhog-infinispan, memoryhog-olingo4, memoryhog-xml]
     steps:
       - name: Setup apache-snapshots profile
-        if: github.base_ref == 'camel-master'
+        if: github.ref == 'refs/heads/camel-master' || github.base_ref == 'camel-master'
         run: |
           echo '::set-env name=BRANCH_OPTIONS::-Papache-snapshots'
       - name: Setup oss-snapshots profile
-        if: github.base_ref == 'quarkus-master'
+        if: github.ref == 'refs/heads/quarkus-master' || github.base_ref == 'quarkus-master'
         run: |
-          echo '::set-env name=BRANCH_OPTIONS::-Poss-snapshots'
+          echo '::set-env name=BRANCH_OPTIONS::-Poss-snapshots -Dquarkus.version=999-SNAPSHOT'
       - name: Checkout
         uses: actions/checkout@v2
       - name: Set up JDK 11
@@ -254,10 +143,28 @@ jobs:
           key: maven-${{ github.run_id }}-${{ github.run_number }}
           restore-keys: |
             maven-${{ github.run_id }}-${{ github.run_number }}
+      - name: Install yq
+        run: |
+          sudo wget -O /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/3.2.1/yq_linux_amd64"
+          sudo chmod +x /usr/local/bin/yq
       - name: Integration Tests
         env:
           TEST_MODULES: ${{matrix.test-modules}}
         run: |
+          TEST_MODULES=""
+          for MODULE in $(cat .github/test-categories.yaml | yq r - categories.${{ matrix.category }}); do
+            if [ "${MODULE}" == "-" ]; then
+              continue
+            fi
+            TEST_MODULES="${TEST_MODULES} ${MODULE}"
+          done
+          TEST_MODULES=$(echo ${TEST_MODULES} | sed 's/^[ \t]*//;s/[ \t]*$//')
+
+          if [ -z "${TEST_MODULES}" ]; then
+            echo "No test modules were found for category ${{ matrix.category }}"
+            exit 1
+          fi
+
           for i in $TEST_MODULES
           do modules+=("integration-tests/$i"); done
           IFS=,

--- a/.github/workflows/purge-stale-artifacts-cron.yaml
+++ b/.github/workflows/purge-stale-artifacts-cron.yaml
@@ -15,24 +15,23 @@
 # limitations under the License.
 #
 
-name: Sync Quarkus Master Branch
+name: Purge Stale Build Artifacts
 
 on:
   schedule:
-    # Run every day at 2AM
-    - cron:  '0 2 * * *'
+    # Run every 4 hours
+    - cron: '0 */4 * * *'
 
 jobs:
-  sync-quarkus-master-branch:
+  pruge-stale-build-artifacts:
     if: github.repository == 'apache/camel-quarkus'
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v1
-      - name: GitHub Pull Request Action
-        uses: repo-sync/pull-request@v2.0.1
-        with:
-          source_branch: master
-          destination_branch: quarkus-master
-          pr_title: Automatic sync branch master to quarkus-master
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Purge Stale Artifacts
+        run: |
+          ARTIFACTS=$(curl -s -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/artifacts)
+          for ID in $(echo ${ARTIFACTS} | jq '.artifacts[] | select (.expired == false and .name == "maven-repo") | .id'); do
+              echo "Deleting artifact ${ID} from ${GITHUB_REPOSITORY}"
+              curl -s -X DELETE -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/artifacts/${ID}
+              sleep 5
+          done

--- a/.github/workflows/quarkus-master-cron.yaml
+++ b/.github/workflows/quarkus-master-cron.yaml
@@ -1,0 +1,189 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Daily Build Quarkus Master
+
+on:
+  schedule:
+    # Run every day at 2AM
+    - cron:  '0 2 * * *'
+
+env:
+  LANG: en_US
+
+jobs:
+  build:
+    if: github.repository == 'apache/camel-quarkus'
+    runs-on: ubuntu-latest
+    env:
+      MAVEN_OPTS: -Xmx3000m
+    steps:
+      - name: Clean VM
+        run: |
+          echo "Removing unwanted SDKs"
+          sudo rm -rf /usr/local/lib/android \
+               rm -rf /usr/local/share/boost \
+               rm -rf /usr/local/go \
+               rm -rf /usr/share/dotnet \
+               rm -rf /usr/share/rust
+
+          echo "Available disk space:"
+          df -h
+      - name: Set Workflow Build ID
+        run: |
+          [ ! -d ~/build-data ] && mkdir -p ~/build-data
+          echo "${{ github.run_id }}-${{ github.run_number }}-$(uuidgen)" > ~/build-data/build-id.txt
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: quarkus-master
+          fetch-depth: 0
+      - name: Rebase branch master onto quarkus-master
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git fetch origin master
+          git rebase origin/master
+          git rev-parse origin/master > ~/build-data/master-sha.txt
+      - name: Set up JDK 11
+        uses: joschi/setup-jdk@v1
+        with:
+          java-version: 11
+      - name: Build Quarkus
+        run: |
+          git clone --depth 1 --branch master https://github.com/quarkusio/quarkus.git \
+            && cd quarkus \
+            && echo "Current Quarkus commit:" $(git rev-parse HEAD) \
+            && ./mvnw -B -ntp clean install -DskipTests -DskipITs
+      - name: Build Camel Quarkus
+        run: |
+          ./mvnw -B -ntp clean install -Dquarkus.version=999-SNAPSHOT
+      - name: Tar Maven Repo
+        shell: bash
+        run: tar -czvf maven-repo.tgz -C ~ build-data .m2/repository
+      - name: Persist Maven Repo
+        uses: actions/upload-artifact@v1
+        with:
+          name: maven-repo
+          path: maven-repo.tgz
+      - name: Report Build Failure
+        if: failure()
+        run: |
+          # Abort rebase in case someting went wrong as we may have broken pom.xml files
+          if [[ -e ".git/rebase" || -e ".git/rebase-apply" || -e ".git/rebase-merge" ]]; then
+            git rebase --abort
+          fi
+
+          ./mvnw verify -N -B -ntp -Pbuild-notification -Dstatus=${{ job.status }} -Dtoken=${{ secrets.GITHUB_TOKEN }} -DbuildId=$(cat ~/build-data/build-id.txt) -Drepo=${GITHUB_REPOSITORY}
+
+  native-tests:
+    name: Native Tests - ${{matrix.category}}
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        category: [core, foundation, platform, messaging, database, dataformats, networking, cloud, misc, saas, social, validation, memoryhog-dozer, memoryhog-dataformat-json, memoryhog-infinispan, memoryhog-olingo4, memoryhog-xml]
+    steps:
+      - name: Download Maven Repo
+        uses: actions/download-artifact@v1
+        with:
+          name: maven-repo
+          path: .
+      - name: Extract Maven Repo
+        shell: bash
+        run: tar -xzvf maven-repo.tgz -C ~
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: quarkus-master
+          fetch-depth: 0
+      - name: Rebase branch master onto quarkus-master
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git fetch origin master
+          git rebase $(cat ~/build-data/master-sha.txt)
+      - name: Install yq
+        run: |
+          sudo wget -O /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/3.2.1/yq_linux_amd64"
+          sudo chmod +x /usr/local/bin/yq
+      - name: Set up JDK 11
+        uses: joschi/setup-jdk@v1
+        with:
+          java-version: 11
+      - name: Integration Tests
+        run: |
+          TEST_MODULES=""
+          for MODULE in $(cat .github/test-categories.yaml | yq r - categories.${{ matrix.category }}); do
+            if [ "${MODULE}" == "-" ]; then
+              continue
+            fi
+            TEST_MODULES="${TEST_MODULES} ${MODULE}"
+          done
+          TEST_MODULES=$(echo ${TEST_MODULES} | sed 's/^[ \t]*//;s/[ \t]*$//')
+
+          if [ -z "${TEST_MODULES}" ]; then
+            echo "No test modules were found for category ${{ matrix.category }}"
+            exit 1
+          fi
+
+          for i in ${TEST_MODULES}
+            do modules+=("integration-tests/$i");
+          done
+          IFS=,
+          eval ./mvnw -B -ntp clean verify \
+            -Dnative \
+            -Ddocker \
+            -Dquarkus.version=999-SNAPSHOT \
+            -pl "${modules[*]}"
+      - name: Report Build Failure
+        if: failure()
+        run: |
+          ./mvnw verify -N -B -Pbuild-notification -Dstatus=${{ job.status }} -Dtoken=${{ secrets.GITHUB_TOKEN }} -DbuildId=$(cat ~/build-data/build-id.txt) -Drepo=${GITHUB_REPOSITORY}
+
+  handle-build-status:
+    needs: native-tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Maven Repo
+        uses: actions/download-artifact@v1
+        with:
+          name: maven-repo
+          path: .
+      - name: Extract Maven Repo
+        shell: bash
+        run: tar -xzvf maven-repo.tgz -C ~
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: quarkus-master
+          fetch-depth: 0
+      - name: Rebase branch master onto quarkus-master
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git fetch origin master
+          git rebase $(cat ~/build-data/master-sha.txt)
+      - name: Report build status
+        id: report
+        run: |
+          ./mvnw verify -N -B -ntp -Pbuild-notification -Dstatus=verify -Dtoken=${{ secrets.GITHUB_TOKEN }} -DbuildId=$(cat ~/build-data/build-id.txt) -Drepo=${GITHUB_REPOSITORY}
+      - name: Sync branch Master to Quarkus Master
+        if: steps.report.outputs.overall_build_status == 'success'
+        run: |
+          git push --force-with-lease origin quarkus-master

--- a/README.adoc
+++ b/README.adoc
@@ -4,6 +4,13 @@ image:https://img.shields.io/maven-central/v/org.apache.camel.quarkus/camel-quar
 image:https://img.shields.io/github/license/openshift/origin.svg?maxAge=2592000["Licensed under Apache License version 2.0", link="https://www.apache.org/licenses/LICENSE-2.0"]
 image:https://badges.gitter.im/apache/camel-quarkus.svg["Chat on Gitter", link="https://gitter.im/apache/camel-quarkus"]
 
+==== CI Branch Status
+[width="50%"]
+|===
+|master | image:https://github.com/apache/camel-quarkus/workflows/Camel%20Quarkus%20CI/badge.svg?branch=master["Master Branch Build", link="https://github.com/apache/camel-quarkus/actions?query=workflow%3A%22Camel+Quarkus+CI%22"]
+|camel-master | image:https://github.com/apache/camel-quarkus/workflows/Camel%20Quarkus%20CI/badge.svg?branch=camel-master["Camel Master Branch Build", link="https://github.com/apache/camel-quarkus/actions?query=workflow%3A%22Camel+Quarkus+CI%22"]
+|quarkus-master| image:https://github.com/apache/camel-quarkus/workflows/Camel%20Quarkus%20CI/badge.svg?branch=quarkus-master["Quarkus Master Branch Build", link="https://github.com/apache/camel-quarkus/actions?query=workflow%3A%22Camel+Quarkus+CI%22"]
+|===
 
 == What is this
 

--- a/docs/modules/ROOT/pages/promote-jvm-to-native.adoc
+++ b/docs/modules/ROOT/pages/promote-jvm-to-native.adoc
@@ -95,13 +95,13 @@ $ {
 * Ensure keyword `camel` is present
 * Remove the `preview` status
 
-9. Add itests to `.github/workflows/ci-build.yaml`, for instance:
+9. Add itests to `.github/test-categories.yaml`, for instance:
 +
 [source,yaml]
 ----
-- category: Rpc
- test-modules: >
-   grpc
+categories:
+  rpc:
+    - grpc
 ----
 
 10. Unify source files format, update docs and rebuild the whole project:

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
         <awssdk2.version>2.11.5</awssdk2.version>
         <camel.version>3.2.0</camel.version>
         <freemarker.version>2.3.30</freemarker.version>
+        <github-api.version>1.101</github-api.version>
         <google-http-client.version>1.22.0</google-http-client.version>
         <guava.version>26.0-jre</guava.version>
         <grpc.version>1.27.0</grpc.version>
@@ -875,6 +876,38 @@
                     </snapshots>
                 </pluginRepository>
             </pluginRepositories>
+        </profile>
+
+        <profile>
+            <id>build-notification</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.gmaven</groupId>
+                        <artifactId>groovy-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>build-notify</id>
+                                <inherited>false</inherited>
+                                <goals>
+                                    <goal>execute</goal>
+                                </goals>
+                                <phase>verify</phase>
+                                <configuration>
+                                    <source>file:///${project.basedir}/tooling/scripts/report-build-status.groovy</source>
+                                </configuration>
+                            </execution>
+                        </executions>
+                        <dependencies>
+                            <dependency>
+                                <groupId>org.kohsuke</groupId>
+                                <artifactId>github-api</artifactId>
+                                <version>${github-api.version}</version>
+                            </dependency>
+                        </dependencies>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 

--- a/tooling/scripts/report-build-status.groovy
+++ b/tooling/scripts/report-build-status.groovy
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.kohsuke.github.*
+
+/**
+ * A script to report on the build status of daily Camel Quarkus branch synchronization.
+ *
+ * If failures were encountered in the build, a new GitHub issue is opened labeled with build/quarkus-master, with the body containing
+ * information about the commit SHA and a link to the build. If an existing open issue labeled with build/quarkus-master exists, then
+ * a new comment about the build failure is added.
+ *
+ * If the build was successful, any open GitHub issue labeled build/quarkus-master will be closed.
+ *
+ * The script also outputs a GitHub action step variable named 'overall_build_status', this is used by the build to determine whether it
+ * should automatically merge the latest changes from the master branch, to the target branch.
+ */
+
+final String TOKEN = properties['token']
+final String STATUS = properties['status'].toLowerCase(Locale.US)
+final String BUILD_ID = properties['buildId']
+final String REPO = properties['repo']
+final String BRANCH = "quarkus-master"
+final String ACTIONS_URL = "https://github.com/${REPO}/actions/runs/${BUILD_ID.split("-")[0]}"
+final String BRANCH_URL = "https://github.com/${REPO}/tree/${BRANCH}"
+final String ISSUE_LABEL = "build/${BRANCH}"
+
+class Utils {
+    static boolean workflowHasPreviousFailures(GHIssue issue, String buildId) {
+        String issueCommentMatch = "Build ID: ${buildId}"
+        int failureCount = issue.getComments().count { comment ->
+            comment.getBody().contains(issueCommentMatch)
+        }
+        return issue.getBody().contains(issueCommentMatch) || failureCount > 0
+    }
+}
+
+if (STATUS == "cancelled") {
+    println("Job status is cancelled - exiting")
+    return
+}
+println("Workflow status is ${STATUS}")
+
+final GitHub github = new GitHubBuilder().withOAuthToken(TOKEN, "github-actions").build()
+final GHRepository repository = github.getRepository(REPO)
+final String camelQuarkusCommit = "git rev-parse HEAD".execute().text
+
+GHIssue issue = null
+def issues = repository.getIssues(GHIssueState.ALL)
+issues.each { i ->
+    i.getLabels().each { label ->
+        if (label.getName() == ISSUE_LABEL && i.getState() == GHIssueState.OPEN) {
+            issue = i
+            return
+        }
+    }
+}
+
+if (issue == null) {
+    println("Unable to find the issue labeled ${ISSUE_LABEL} in project ${REPO}")
+} else {
+    println("Report issue found: ${issue.getTitle()} - ${issue.getHtmlUrl()}")
+}
+
+if (STATUS == "failure") {
+    if (issue == null) {
+        final String issueBody = """The [${BRANCH}](${BRANCH_URL}) branch build is failing:
+
+* Build ID: ${BUILD_ID}
+* Commit: ${camelQuarkusCommit}
+* Link to build: ${ACTIONS_URL}
+"""
+
+        issue = repository.createIssue("[CI] - Quarkus Master Branch Build Failure")
+                .body(issueBody)
+                .label(ISSUE_LABEL)
+                .create();
+
+        println("Created new issue ${issue.getHtmlUrl()}")
+    } else {
+        if (Utils.workflowHasPreviousFailures(issue, BUILD_ID)) {
+            println("Workflow for Build ID ${BUILD_ID} has already reported failures - exiting")
+        } else {
+            issue.comment("""The [${BRANCH}](${BRANCH_URL}) branch build is still failing:
+
+* Build ID: ${BUILD_ID}
+* Commit: ${camelQuarkusCommit}
+* Link to build: ${ACTIONS_URL}""")
+
+            println("Commented on issue ${issue.getHtmlUrl()}")
+        }
+    }
+}
+
+if (STATUS == "verify") {
+    if (issue != null) {
+        if (Utils.workflowHasPreviousFailures(issue, BUILD_ID)) {
+            println("Overall build status is: failure")
+            println "::set-output name=overall_build_status::failure"
+            return
+        } else {
+            final GHIssueComment comment = issue.comment("""Build fixed with:
+
+* Commit: ${camelQuarkusCommit}
+* Link to build: ${ACTIONS_URL}""")
+            issue.close()
+            println("Comment added on issue ${issue.getHtmlUrl()} - ${comment.getHtmlUrl()}, the issue has also been closed")
+        }
+    }
+    println "::set-output name=overall_build_status::success"
+}


### PR DESCRIPTION
Some changes to improve the process of syncing the latest work on the master branch to the quarkus-master branch. There's a few things I'd like to improve, but I think this is a decent starting point.

Some things to be aware of:

* I externalized the native integration test categories so they can be shared across workflow files in `.github/test-categories.yaml`.

* Added build status reporting functionality to the sync job. It'll automatically create an issue for investigating failures and will auto close it when the build is successful.

* The cache action does not support the schedule event :upside_down_face:. So instead I use the artifact action to upload / download the m2 repository between jobs. This actually turns out to be more reliable than the cache anyway. To avoid exceeding quotas I added another workflow to periodically clean up the generated artifacts.

If this works well, I'll look at applying the same thing for the master -> camel-master branch sync.