### PR TITLE
Exclude docs module from quarkus-master sync build

### DIFF
--- a/.github/workflows/quarkus-master-cron.yaml
+++ b/.github/workflows/quarkus-master-cron.yaml
@@ -71,7 +71,7 @@ jobs:
             && ./mvnw -B -ntp clean install -DskipTests -DskipITs
       - name: Build Camel Quarkus
         run: |
-          ./mvnw -B -ntp clean install -Dquarkus.version=999-SNAPSHOT
+          ./mvnw -B -ntp clean install -Dquarkus.version=999-SNAPSHOT -pl '!docs'
       - name: Tar Maven Repo
         shell: bash
         run: tar -czvf maven-repo.tgz -C ~ build-data .m2/repository


### PR DESCRIPTION
It's one less thing that can break the build. Like [here](https://github.com/apache/camel-quarkus/runs/613987446?check_suite_focus=true).