### PR TITLE
Add jaxb as dependency and allow skipping formatting

### DIFF
--- a/extensions-core/core/deployment/pom.xml
+++ b/extensions-core/core/deployment/pom.xml
@@ -49,7 +49,7 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc-deployment</artifactId>
         </dependency>
-        <dependency>
+        <dependency><!-- temporary fix for #1161, remove with Camel 3.3 -->
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jaxb-deployment</artifactId>
         </dependency>

--- a/extensions-core/core/deployment/pom.xml
+++ b/extensions-core/core/deployment/pom.xml
@@ -49,6 +49,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc-deployment</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jaxb-deployment</artifactId>
+        </dependency>
 
         <!-- camel -->
         <dependency>

--- a/extensions-core/core/runtime/pom.xml
+++ b/extensions-core/core/runtime/pom.xml
@@ -56,7 +56,7 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc</artifactId>
         </dependency>
-        <dependency>
+        <dependency><!-- temporary fix for #1161, remove with Camel 3.3 -->
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jaxb</artifactId>
         </dependency>

--- a/extensions-core/core/runtime/pom.xml
+++ b/extensions-core/core/runtime/pom.xml
@@ -57,6 +57,10 @@
             <artifactId>quarkus-arc</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jaxb</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-support-common</artifactId>
         </dependency>

--- a/poms/build-parent/pom.xml
+++ b/poms/build-parent/pom.xml
@@ -106,6 +106,7 @@
                     <version>${formatter-maven-plugin.version}</version>
                     <configuration>
                         <configFile>${camel.quarkus.project.root}/tooling/eclipse-formatter-config.xml</configFile>
+                        <skip>${format.skip}</skip>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -117,6 +118,7 @@
                         <removeUnused>true</removeUnused>
                         <staticAfter>true</staticAfter>
                         <staticGroups>java.,javax.,org.w3c.,org.xml.,junit.</staticGroups>
+                        <skip>${format.skip}</skip>
                     </configuration>
                 </plugin>
             </plugins>


### PR DESCRIPTION
Fixes extra commits issues in https://github.com/apache/camel-quarkus/pull/1163, and added a commit to allow formatting checks to be skipped altogether (present in quarkus).