### PR TITLE
Do not skip tests in native jobs using -DskipTest it skips also

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -203,7 +203,6 @@ jobs:
           eval ./mvnw -V -ntp ${BRANCH_OPTIONS} clean verify \
             -Dnative \
             -Ddocker \
-            -DskipTests \
             -pl "${modules[*]}"
 
   # memoryhogs:


### PR DESCRIPTION
integration tests, not only JVM tests

Related to https://github.com/apache/camel-quarkus/commit/310277c04ef11db70a276c5a92b913c7508b3600#r39032262