### PR TITLE
Automatically cancel redundant workflow runs

### DIFF
--- a/.github/workflows/cancel-previous-runs-cron.yaml
+++ b/.github/workflows/cancel-previous-runs-cron.yaml
@@ -1,0 +1,33 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Cancel Stale Workflow Runs
+on:
+  schedule:
+    # Run every 30 minutes
+    - cron:  '*/30 * * * *'
+
+jobs:
+  cancel-runs:
+    if: github.repository == 'apache/camel-quarkus'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel Previous Runs
+        uses: n1hility/cancel-previous-runs@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: ci-build.yaml

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -50,6 +50,10 @@ jobs:
     outputs:
       matrix: ${{ steps.set-native-matrix.outputs.matrix }}
     steps:
+      - name: Cancel Previous Runs
+        uses: n1hility/cancel-previous-runs@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Clean VM
         run: |
           df -h /


### PR DESCRIPTION
Some info about the action here:

https://github.com/n1hility/cancel-previous-runs

Saves on needlessly running workflows that have become stale because they have been superseded by newer commits etc.