### PR TITLE
Add missing security configuration to azure test #1269

### DIFF
--- a/integration-tests/azure/pom.xml
+++ b/integration-tests/azure/pom.xml
@@ -48,6 +48,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-security</artifactId>
+        </dependency>
 
         <!-- test dependencies -->
         <dependency>

--- a/integration-tests/azure/src/main/resources/application.properties
+++ b/integration-tests/azure/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+quarkus.security.security-providers=SunJCE


### PR DESCRIPTION
Fix for https://github.com/apache/camel-quarkus/issues/1269.

* Security provider needs to enabled and security extension needs adding.