### PR TITLE
Add servlet-api to classpath to help pointsto analysis #1319

### DIFF
--- a/extensions/olingo4/runtime/pom.xml
+++ b/extensions/olingo4/runtime/pom.xml
@@ -74,6 +74,10 @@
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
         </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
* No classes in the jar will make it to the native image,
it's just to help the reflection JVMCI layer of pointsto analysis.

Closes https://github.com/apache/camel-quarkus/issues/1319.