### PR TITLE
CAMEL-15216 : Omit the warning of level index

### DIFF
--- a/docs/modules/ROOT/pages/contributor-guide/promote-jvm-to-native.adoc
+++ b/docs/modules/ROOT/pages/contributor-guide/promote-jvm-to-native.adoc
@@ -45,7 +45,7 @@ The `promote` mojo does the following for you:
 $ cd integration-tests/foo
 $ mvn clean verify -Pnative
 ----
-
++
 Consider shifting some tasks from runtime to build time.
 The https://quarkus.io/guides/extension-authors-guide[Quarkus extension author's guide] may be a good ally for this.
 


### PR DESCRIPTION
Here, within the **6** and **7** in the ordered list gets converted to **1** and **2** due to the fact a hard-break ( + ) was missing in the point number **5**.