### PR TITLE
Fix #1313 Upgrade to Kubernetes Client 4.10.2 to align with Quarkus

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <javassist.version>3.22.0-CR2</javassist.version><!-- debezium -->
         <jetty.version>9.4.18.v20190429</jetty.version>
         <kafka.version>2.5.0</kafka.version>
-        <kubernetes-client.version>4.10.1</kubernetes-client.version>
+        <kubernetes-client.version>4.10.2</kubernetes-client.version>
         <kotlin.version>1.3.72</kotlin.version>
         <okhttp.version>3.14.6</okhttp.version><!-- keep in sync with okio -->
         <okio.version>1.17.2</okio.version><!-- keep in sync with okhttp -->


### PR DESCRIPTION
Unresolved method AutoscalingAPIGroupDSL.v1() error in Kubernetes native
image generation

Fix #1313