### PR TITLE
Publish SNAPSHOT builds

### DIFF
--- a/.github/workflows/camel-master-cron.yaml
+++ b/.github/workflows/camel-master-cron.yaml
@@ -15,12 +15,12 @@
 # limitations under the License.
 #
 
-name: Weekly Build Camel Master
+name: Daily Build Camel Master
 
 on:
   schedule:
-    # Run every Monday at midnight
-    - cron:  '0 0 * * 1'
+    # Run every day at midnight
+    - cron:  '0 0 * * *'
 
 env:
   LANG: en_US

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -26,6 +26,7 @@ on:
       - "[0-9]+.[0-9]+.x"
     paths-ignore:
       - '**.adoc'
+      - 'Jenkinsfile'
       - 'KEYS'
       - 'LICENSE.txt'
       - 'NOTICE.txt'
@@ -37,6 +38,7 @@ on:
       - "[0-9]+.[0-9]+.x"
     paths-ignore:
       - '**.adoc'
+      - 'Jenkinsfile'
       - 'KEYS'
       - 'LICENSE.txt'
       - 'NOTICE.txt'

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -26,6 +26,7 @@ on:
       - "[0-9]+.[0-9]+.x"
     paths-ignore:
       - '**.adoc'
+      - 'Jenkinsfile'
       - 'KEYS'
       - 'LICENSE.txt'
       - 'NOTICE.txt'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+def AGENT_LABEL = env.AGENT_LABEL ?: 'ubuntu'
+def JDK_NAME = env.JDK_NAME ?: 'JDK 11 (latest)'
+def MAVEN_PARAMS = '-B -e -ntp'
+def VERSION_SUFFIX = "-${env.BRANCH_NAME.toUpperCase().replace('_','-')}-SNAPSHOT"
+
+if (env.BRANCH_NAME == 'camel-master') {
+    MAVEN_PARAMS += ' -Papache-snapshots'
+}
+
+if (env.BRANCH_NAME == 'quarkus-master') {
+    MAVEN_PARAMS += ' -Poss-snapshots -Dquarkus.version=999-SNAPSHOT'
+}
+
+pipeline {
+
+    agent {
+        label AGENT_LABEL
+    }
+
+    tools {
+        jdk JDK_NAME
+    }
+
+    options {
+        buildDiscarder(
+            logRotator(artifactNumToKeepStr: '5', numToKeepStr: '10')
+        )
+        disableConcurrentBuilds()
+    }
+
+    stages {
+        stage('Set version') {
+            when {
+                expression { env.BRANCH_NAME ==~ /(.*-master)/ }
+            }
+
+            steps {
+                script {
+                    def VERSION = sh script: './mvnw ${MAVEN_PARAMS} help:evaluate -Dexpression=project.version -q -DforceStdout', returnStdout: true
+                    def NEW_SNAPSHOT_VERSION = VERSION.replace('-SNAPSHOT', '') + VERSION_SUFFIX
+                    sh "sed -i \"s/${VERSION}/${NEW_SNAPSHOT_VERSION}/g\" \$(find . -name pom.xml)"
+                }
+            }
+        }
+
+        stage('Build, Test & Deploy') {
+            steps {
+                sh "./mvnw ${MAVEN_PARAMS} clean deploy"
+            }
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -570,7 +570,7 @@
         <profile>
             <id>jdk-8-classpath</id>
             <activation>
-                <jdk>[9,</jdk>
+                <jdk>[9,)</jdk>
             </activation>
             <build>
                 <plugins>


### PR DESCRIPTION
I haven't set up a Jenkins build yet, but here's the `Jenkinsfile` that I propose to deploy SNAPSHOTs from each of the main project branches.

I had to settle on a slightly wacky version scheme to satisfy `CamelVersionHelper`, which seems to be used by the Camel tooling. So the build will generate:

`master` branch - 1.1.0-SNAPSHOT
`camel-master` branch -  1.1.0-CAMEL-MASTER-SNAPSHOT
`quarkus-master` branch -  1.1.0-QUARKUS-MASTER-SNAPSHOT

I also tweaked the camel-master sync job to run every day.
