### PR TITLE
Tests for #1563 contextPath ignored for platform-http with REST DSL

### DIFF
--- a/integration-tests/platform-http/src/main/java/org/apache/camel/quarkus/component/platform/http/it/PlatformHttpRouteBuilder.java
+++ b/integration-tests/platform-http/src/main/java/org/apache/camel/quarkus/component/platform/http/it/PlatformHttpRouteBuilder.java
@@ -27,11 +27,18 @@ import org.apache.camel.Exchange;
 import org.apache.camel.attachment.AttachmentMessage;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.webhook.WebhookConfiguration;
+import org.apache.camel.model.rest.RestBindingMode;
 
 public class PlatformHttpRouteBuilder extends RouteBuilder {
     @SuppressWarnings("unchecked")
     @Override
     public void configure() {
+        restConfiguration().component("platform-http").bindingMode(RestBindingMode.off)
+                // and output using pretty print
+                .dataFormatProperty("prettyPrint", "true")
+                // setup context path and port number that api will use
+                .contextPath("my-context");
+
         rest()
                 .get("/platform-http/rest-get")
                 .route()

--- a/integration-tests/platform-http/src/test/java/org/apache/camel/quarkus/component/http/server/it/PlatformHttpTest.java
+++ b/integration-tests/platform-http/src/test/java/org/apache/camel/quarkus/component/http/server/it/PlatformHttpTest.java
@@ -53,11 +53,11 @@ class PlatformHttpTest {
 
     @Test
     public void rest() throws Throwable {
-        RestAssured.get("/platform-http/rest-get")
+        RestAssured.get("/my-context/platform-http/rest-get")
                 .then().body(equalTo("GET: /rest-get"));
         RestAssured.given()
                 .contentType("text/plain")
-                .post("/platform-http/rest-post")
+                .post("/my-context/platform-http/rest-post")
                 .then().body(equalTo("POST: /rest-post"));
     }
 
@@ -65,13 +65,13 @@ class PlatformHttpTest {
     public void consumes() throws Throwable {
         RestAssured.given()
                 .contentType("application/json")
-                .post("/platform-http/rest-post")
+                .post("/my-context/platform-http/rest-post")
                 .then()
                 .statusCode(415);
 
         RestAssured.given()
                 .contentType("text/plain")
-                .post("/platform-http/rest-post")
+                .post("/my-context/platform-http/rest-post")
                 .then()
                 .statusCode(200);
 
@@ -93,14 +93,14 @@ class PlatformHttpTest {
         RestAssured.given()
                 .accept("application/json")
                 .contentType("text/plain")
-                .post("/platform-http/rest-post")
+                .post("/my-context/platform-http/rest-post")
                 .then()
                 .statusCode(406);
 
         RestAssured.given()
                 .accept("text/plain")
                 .contentType("text/plain")
-                .post("/platform-http/rest-post")
+                .post("/my-context/platform-http/rest-post")
                 .then()
                 .statusCode(200);
 
@@ -123,9 +123,9 @@ class PlatformHttpTest {
     public void invalidMethod() {
         RestAssured.post("/platform-http/hello")
                 .then().statusCode(405);
-        RestAssured.post("/platform-http/rest-get")
+        RestAssured.post("/my-context/platform-http/rest-get")
                 .then().statusCode(405);
-        RestAssured.get("/platform-http/rest-post")
+        RestAssured.get("/my-context/platform-http/rest-post")
                 .then().statusCode(405);
     }
 
@@ -234,7 +234,7 @@ class PlatformHttpTest {
     @Test
     public void pathParam() throws Exception {
         RestAssured.given()
-                .get("/platform-http/hello-by-name/Kermit")
+                .get("/my-context/platform-http/hello-by-name/Kermit")
                 .then()
                 .statusCode(200)
                 .body(equalTo("Hello Kermit"));
@@ -250,9 +250,11 @@ class PlatformHttpTest {
                 .body()
                 .asString();
 
+        System.out.println("path = " + path);
+
         RestAssured.given()
                 .urlEncodingEnabled(false)
-                .post(path)
+                .post("/my-context" + path)
                 .then()
                 .statusCode(200)
                 .body(equalTo("Hello Camel Quarkus Webhook"));


### PR DESCRIPTION
blocked by https://github.com/apache/camel/pull/4117

Closes #1563 