### PR TITLE
Feat(mongodb): add support for named client

### DIFF
--- a/docs/modules/ROOT/pages/reference/extensions/mongodb.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/mongodb.adoc
@@ -39,3 +39,26 @@ The Camel Quarkus MongoDB extension automatically registers a MongoDB client bea
     from("direct:start")
     .to("mongodb:camelMongoClient?database=myDb&collection=myCollection&operation=findAll")
 
+You can also create a "named" client and reference in your route by injecting a client and the related configuration as explained in the https://quarkus.io/guides/mongodb#named-mongo-client-injection[Quarkus MongoDB extension client injection]. For example:
+
+....
+//application.properties
+quarkus.mongodb.mongoClient1.connection-string = mongodb://root:example@localhost:27017/
+....
+....
+//Routes.java
+
+    @ApplicationScoped
+    public class Routes extends RouteBuilder {
+        @Inject
+        @MongoClientName("mongoClient1")
+        MongoClient mongoClient1;
+
+        @Override
+        public void configure() throws Exception {
+            from("direct:start")
+                    .to("mongodb:mongoClient1?database=myDb&collection=myCollection&operation=findAll");
+        }
+    }
+....
+

--- a/extensions-support/mongodb/deployment/src/main/java/org/apache/camel/quarkus/support/mongodb/deployment/SupportMongoDBProcessor.java
+++ b/extensions-support/mongodb/deployment/src/main/java/org/apache/camel/quarkus/support/mongodb/deployment/SupportMongoDBProcessor.java
@@ -35,20 +35,23 @@ class SupportMongoDBProcessor {
     }
 
     @BuildStep
-    void registerCamelMongoClientProducer(
+    void registerCamelMongoClientProducers(
             List<MongoClientBuildItem> mongoClients,
             BuildProducer<CamelRuntimeBeanBuildItem> runtimeBeans) {
 
         for (MongoClientBuildItem mongoClient : mongoClients) {
-            // If there is a default mongo client instance, then bind it to the camel registry
-            // with the default mongo client name used by the camel-mongodb component
-            if (MongoClientBeanUtil.isDefault(mongoClient.getName())) {
-                runtimeBeans.produce(
-                        new CamelRuntimeBeanBuildItem(
-                                "camelMongoClient",
-                                "com.mongodb.client.MongoClient",
-                                mongoClient.getClient()));
-            }
+            String clientName = getMongoClientName(mongoClient.getName());
+            runtimeBeans.produce(
+                    new CamelRuntimeBeanBuildItem(
+                            clientName,
+                            "com.mongodb.client.MongoClient",
+                            mongoClient.getClient()));
         }
     }
+
+    private String getMongoClientName(String clientName) {
+        // Use the default mongo client instance name if it is the default connection
+        return MongoClientBeanUtil.isDefault(clientName) ? "camelMongoClient" : clientName;
+    }
+
 }

--- a/extensions/mongodb/runtime/src/main/doc/configuration.adoc
+++ b/extensions/mongodb/runtime/src/main/doc/configuration.adoc
@@ -6,3 +6,26 @@ The Camel Quarkus MongoDB extension automatically registers a MongoDB client bea
 
     from("direct:start")
     .to("mongodb:camelMongoClient?database=myDb&collection=myCollection&operation=findAll")
+
+You can also create a "named" client and reference in your route by injecting a client and the related configuration as explained in the https://quarkus.io/guides/mongodb#named-mongo-client-injection[Quarkus MongoDB extension client injection]. For example:
+
+....
+//application.properties
+quarkus.mongodb.mongoClient1.connection-string = mongodb://root:example@localhost:27017/
+....
+....
+//Routes.java
+
+    @ApplicationScoped
+    public class Routes extends RouteBuilder {
+        @Inject
+        @MongoClientName("mongoClient1")
+        MongoClient mongoClient1;
+
+        @Override
+        public void configure() throws Exception {
+            from("direct:start")
+                    .to("mongodb:mongoClient1?database=myDb&collection=myCollection&operation=findAll");
+        }
+    }
+....

--- a/integration-tests/mongodb/src/test/java/org/apache/camel/quarkus/component/mongodb/it/MongoDbTestResource.java
+++ b/integration-tests/mongodb/src/test/java/org/apache/camel/quarkus/component/mongodb/it/MongoDbTestResource.java
@@ -47,6 +47,8 @@ public class MongoDbTestResource implements ContainerResourceLifecycleManager {
 
             return CollectionHelper.mapOf(
                     "quarkus.mongodb.hosts",
+                    container.getContainerIpAddress() + ":" + container.getMappedPort(MONGODB_PORT).toString(),
+                    "quarkus.mongodb." + MongoDbResource.NAMED_MONGO_CLIENT_NAME + ".hosts",
                     container.getContainerIpAddress() + ":" + container.getMappedPort(MONGODB_PORT).toString());
         } catch (Exception e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
As referenced in #1608 we were not yet supporting the possibility to inject named client connection. With a fix provided to quarkus extension and this work PR we will be able to inject a "named" client that can be configurable in `application.properties` and referenced in route with its name.

Closes #1608 