### PR TITLE
Stop managing httpclient-cache as it is managed by Quarkus #1704

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,6 @@
         <guava.version>26.0-jre</guava.version>
         <gson.version>2.8.5</gson.version>
         <hapi.version>4.1.0</hapi.version>
-        <httpclient.cache.version>4.5.5</httpclient.cache.version>
         <httpclient.version>4.5.12</httpclient.version><!-- keep in sync with both Camel and Quarkus -->
         <influxdb.version>2.20</influxdb.version>
         <jackson.version>2.10.5</jackson.version>

--- a/poms/bom/pom.xml
+++ b/poms/bom/pom.xml
@@ -5255,17 +5255,6 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
-                <artifactId>httpclient-cache</artifactId>
-                <version>${httpclient.cache.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>commons-logging</groupId>
-                        <artifactId>commons-logging</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpmime</artifactId>
                 <version>${httpclient.version}</version>
             </dependency>


### PR DESCRIPTION
Fix #1704 