### PR TITLE
Make sure that Telegram tests are not run against mock API by setting…

### DIFF
--- a/integration-tests-support/mock-backend/pom.xml
+++ b/integration-tests-support/mock-backend/pom.xml
@@ -18,33 +18,21 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
-    <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-build-parent</artifactId>
+        <artifactId>camel-quarkus-integration-tests-support</artifactId>
         <version>1.1.0-SNAPSHOT</version>
-        <relativePath>../poms/build-parent/pom.xml</relativePath>
+        <relativePath>../pom.xml</relativePath>
     </parent>
+    <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>camel-quarkus-integration-tests-support</artifactId>
-    <packaging>pom</packaging>
+    <artifactId>camel-quarkus-integration-test-support-mock-backend</artifactId>
+    <name>Camel Quarkus :: Integration Tests :: Support :: Mock Backend</name>
 
-    <name>Camel Quarkus :: Integration Tests :: Support :: Parent</name>
-    <description>Ancillary modules required by some integration tests. Hosted outside the integration-tests directory
-        so that we can keep a flat hierarchy in the integration-tests directory.
-    </description>
-
-    <modules>
-        <module>custom-dataformat</module>
-        <module>custom-log-component</module>
-        <module>custom-routes-collector</module>
-        <module>custom-type-converter</module>
-        <module>custom-main-listener</module>
-        <module>process-executor-support</module>
-        <module>test-support</module>
-        <module>testcontainers-support</module>
-        <module>mock-backend</module>
-    </modules>
-
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+        </dependency>
+    </dependencies>
 </project>

--- a/integration-tests-support/mock-backend/src/main/java/org/apache/camel/quarkus/test/mock/backend/MockBackendUtils.java
+++ b/integration-tests-support/mock-backend/src/main/java/org/apache/camel/quarkus/test/mock/backend/MockBackendUtils.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.test.mock.backend;
+
+import org.jboss.logging.Logger;
+
+public class MockBackendUtils {
+
+    private static final Logger LOG = Logger.getLogger(MockBackendUtils.class);
+
+    /**
+     * @param serviceName a human readable name of the service that is being mocked
+     * @param uri         the URI under which the mock is accessible
+     */
+    public static void logMockBackendUsed(String serviceName, String uri) {
+        LOG.infof("Mock backend will be used for %s: %s", serviceName, uri);
+    }
+
+    /**
+     * @param serviceName a human readable name of the real service that is being used
+     * @param uri         the URI under which the service is accessible
+     */
+    public static void logRealBackendUsed(String serviceName, String uri) {
+        LOG.infof("Real backend will be used for %s: %s", serviceName, uri);
+    }
+}

--- a/integration-tests/telegram/README.adoc
+++ b/integration-tests/telegram/README.adoc
@@ -1,8 +1,8 @@
 == Camel Quarkus Telegram Integration Tests
 
-A work in progress, see https://github.com/apache/camel-quarkus/issues/74
-
-To run `camel-quarkus-telegram` integration tests, you must first create a Telegram bot following this guide: https://www.nicolaferraro.me/2016/05/27/creating-a-telegram-bot-in-5-minutes-with-apache-camel/ .
+To run `camel-quarkus-telegram` integration tests against the real remote Telegram API, you must first create
+a Telegram bot following this guide:
+https://www.nicolaferraro.me/2016/05/27/creating-a-telegram-bot-in-5-minutes-with-apache-camel/
 
 Then set the following environment variables:
 
@@ -11,3 +11,9 @@ Then set the following environment variables:
 $ export TELEGRAM_AUTHORIZATION_TOKEN=my-autorization-token
 $ export TELEGRAM_CHAT_ID=my-chatId
 ----
+
+If you do not set `TELEGRAM_AUTHORIZATION_TOKEN` environment variable, the test will be run against a mock
+Telegram API started on `localhost`.
+
+You may want to `export CAMEL_QUARKUS_START_MOCK_BACKEND=false` to avoid starting he the mock Telegram API
+to make sure that you test against the real remote Telegram API.

--- a/integration-tests/telegram/pom.xml
+++ b/integration-tests/telegram/pom.xml
@@ -56,6 +56,10 @@
             <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-attachments</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-integration-test-support-mock-backend</artifactId>
+        </dependency>
 
         <!-- test dependencies -->
         <dependency>

--- a/integration-tests/telegram/src/main/java/org/apache/camel/quarkus/component/telegram/it/TelegramRoutes.java
+++ b/integration-tests/telegram/src/main/java/org/apache/camel/quarkus/component/telegram/it/TelegramRoutes.java
@@ -21,37 +21,86 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.stream.Stream;
 
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+import javax.inject.Named;
+
+import io.quarkus.arc.Unremovable;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.telegram.TelegramComponent;
+import org.apache.camel.quarkus.test.mock.backend.MockBackendUtils;
 import org.apache.camel.support.ResourceHelper;
 import org.apache.camel.util.IOHelper;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 
+@ApplicationScoped
 public class TelegramRoutes extends RouteBuilder {
+
+    @ConfigProperty(name = "camel.quarkus.start-mock-backend", defaultValue = "true")
+    boolean startMockBackend;
+
+    @ConfigProperty(name = "telegram.authorization-token", defaultValue = "default-dummy-token")
+    String authToken;
+
+    @ConfigProperty(name = "quarkus.http.test-port")
+    int httpTestPort;
+    @ConfigProperty(name = "quarkus.http.port")
+    int httpPort;
+
+    private String getBaseUri() {
+        final boolean isNativeMode = "executable".equals(System.getProperty("org.graalvm.nativeimage.kind"));
+        return "default-dummy-token".equals(authToken)
+                ? "http://localhost:" + (isNativeMode ? httpPort : httpTestPort)
+                : "https://api.telegram.org";
+    }
+
+    /**
+     * We need to implement some conditional configuration of the {@link TelegramComponent} thus we create it
+     * programmatically and publish via CDI.
+     *
+     * @return a configured {@link TelegramComponent}
+     */
+    @Produces
+    @ApplicationScoped
+    @Unremovable
+    @Named
+    TelegramComponent telegram() {
+        final TelegramComponent result = new TelegramComponent();
+        result.setCamelContext(getContext());
+        result.setBaseUri(getBaseUri());
+        result.setAuthorizationToken(authToken);
+        return result;
+    }
 
     @Override
     public void configure() throws Exception {
+        if (startMockBackend) {
+            MockBackendUtils.logMockBackendUsed("telegram", getBaseUri());
+            /* Start the mock Telegram API unless the user did export CAMEL_QUARKUS_FALLBACK_MOCK=false */
+            from("platform-http:/bot" + authToken + "/getUpdates?httpMethodRestrict=GET")
+                    .process(e -> load("mock-messages/getUpdates.json", e));
 
-        /* Mock Telegram API */
-        from("platform-http:/bot{authToken}/getUpdates?httpMethodRestrict=GET")
-                .process(e -> load("mock-messages/getUpdates.json", e));
-
-        Stream.of(
-                "sendMessage",
-                "sendAudio",
-                "sendVideo",
-                "sendDocument",
-                "sendPhoto",
-                "sendVenue",
-                "sendLocation",
-                "stopMessageLiveLocation")
-                .forEach(endpoint -> {
-                    from("platform-http:/{authToken}/" + endpoint + "?httpMethodRestrict=POST")
-                            .process(e -> load("mock-messages/" + endpoint + ".json", e));
-                });
+            Stream.of(
+                    "sendMessage",
+                    "sendAudio",
+                    "sendVideo",
+                    "sendDocument",
+                    "sendPhoto",
+                    "sendVenue",
+                    "sendLocation",
+                    "stopMessageLiveLocation")
+                    .forEach(endpoint -> {
+                        from("platform-http:/bot" + authToken + "/" + endpoint + "?httpMethodRestrict=POST")
+                                .process(e -> load("mock-messages/" + endpoint + ".json", e));
+                    });
+        } else {
+            MockBackendUtils.logRealBackendUsed("telegram", getBaseUri());
+        }
 
     }
 
-    private static void load(String path, Exchange exchange) {
+    private void load(String path, Exchange exchange) {
         try (ByteArrayOutputStream out = new ByteArrayOutputStream(IOHelper.DEFAULT_BUFFER_SIZE);
                 InputStream in = ResourceHelper.resolveMandatoryResourceAsInputStream(exchange.getContext(), path)) {
             IOHelper.copy(in, out, IOHelper.DEFAULT_BUFFER_SIZE);

--- a/integration-tests/telegram/src/main/resources/application.properties
+++ b/integration-tests/telegram/src/main/resources/application.properties
@@ -27,6 +27,11 @@ quarkus.native.additional-build-args = -H:IncludeResources=.*mock-messages/.*
 #
 # Camel :: Telegram
 #
-camel.component.telegram.authorizationToken={{env:TELEGRAM_AUTHORIZATION_TOKEN:default-dummy-token}}
-camel.component.telegram.baseUri={{env:TELEGRAM_BASE_URI:https://api.telegram.org}}
-telegram.chatId={{env:TELEGRAM_CHAT_ID:-1}}
+# Set the authorization token here or via environment variable TELEGRAM_AUTHORIZATION_TOKEN
+#telegram.authorization-token=...
+
+telegram.chatId=${TELEGRAM_CHAT_ID:-1}
+
+# You may want to export CAMEL_QUARKUS_START_MOCK_BACKEND=false to avoid starting he the mock Telegram API
+# to make sure that you test against the real remote Telegram API
+camel.quarkus.start-mock-backend=true

--- a/integration-tests/telegram/src/test/java/org/apache/camel/quarkus/component/telegram/it/TelegramIT.java
+++ b/integration-tests/telegram/src/test/java/org/apache/camel/quarkus/component/telegram/it/TelegramIT.java
@@ -17,10 +17,8 @@
 package org.apache.camel.quarkus.component.telegram.it;
 
 import io.quarkus.test.junit.NativeImageTest;
-import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
 @NativeImageTest
-@EnabledIfEnvironmentVariable(named = "TELEGRAM_AUTHORIZATION_TOKEN", matches = "[^ ]+")
 class TelegramIT extends TelegramTest {
 
 }

--- a/integration-tests/telegram/src/test/java/org/apache/camel/quarkus/component/telegram/it/TelegramTest.java
+++ b/integration-tests/telegram/src/test/java/org/apache/camel/quarkus/component/telegram/it/TelegramTest.java
@@ -34,7 +34,6 @@ import org.apache.camel.quarkus.test.TrustStoreResource;
 import org.awaitility.Awaitility;
 import org.jboss.logging.Logger;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
 import static org.hamcrest.Matchers.both;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -43,7 +42,6 @@ import static org.hamcrest.Matchers.lessThan;
 
 @QuarkusTest
 @QuarkusTestResource(TrustStoreResource.class)
-@EnabledIfEnvironmentVariable(named = "TELEGRAM_AUTHORIZATION_TOKEN", matches = "[^ ]+")
 public class TelegramTest {
 
     private static final Logger LOG = Logger.getLogger(TelegramTest.class);

--- a/poms/bom-test/pom.xml
+++ b/poms/bom-test/pom.xml
@@ -90,6 +90,11 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
+                <artifactId>camel-quarkus-integration-test-support-mock-backend</artifactId>
+                <version>${camel-quarkus.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel.quarkus</groupId>
                 <artifactId>camel-quarkus-integration-testcontainers-support</artifactId>
                 <version>${camel-quarkus.version}</version>
             </dependency>


### PR DESCRIPTION
… CAMEL_QUARKUS_START_MOCK_BACKEND=false #1717

@llowinge this is an idea how we could do that. Done only for Telegram, but other tests could use the same pattern with the same env var `CAMEL_QUARKUS_START_MOCK_BACKEND`, so that you can set it once for all tests. WDYT?