### PR TITLE
Use distinct descriptions for the for the various JSON data formats

### DIFF
--- a/docs/modules/ROOT/pages/reference/extensions/fastjson.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/fastjson.adoc
@@ -4,7 +4,7 @@
 :cq-artifact-id: camel-quarkus-fastjson
 :cq-native-supported: false
 :cq-status: Preview
-:cq-description: Marshal POJOs to JSON and back.
+:cq-description: Marshal POJOs to JSON and back using Fastjson
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0
 :cq-native-since: n/a
@@ -12,7 +12,7 @@
 [.badges]
 [.badge-key]##JVM since##[.badge-supported]##1.1.0## [.badge-key]##Native##[.badge-unsupported]##unsupported##
 
-Marshal POJOs to JSON and back.
+Marshal POJOs to JSON and back using Fastjson
 
 == What's inside
 

--- a/docs/modules/ROOT/pages/reference/extensions/gson.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/gson.adoc
@@ -5,7 +5,7 @@
 :cq-artifact-id: camel-quarkus-gson
 :cq-native-supported: true
 :cq-status: Stable
-:cq-description: Marshal POJOs to JSON and back.
+:cq-description: Marshal POJOs to JSON and back using Gson
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0
 :cq-native-since: 1.0.0
@@ -13,7 +13,7 @@
 [.badges]
 [.badge-key]##JVM since##[.badge-supported]##1.0.0## [.badge-key]##Native since##[.badge-supported]##1.0.0##
 
-Marshal POJOs to JSON and back.
+Marshal POJOs to JSON and back using Gson
 
 == What's inside
 

--- a/docs/modules/ROOT/pages/reference/extensions/jackson.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/jackson.adoc
@@ -5,7 +5,7 @@
 :cq-artifact-id: camel-quarkus-jackson
 :cq-native-supported: true
 :cq-status: Stable
-:cq-description: Marshal POJOs to JSON and back.
+:cq-description: Marshal POJOs to JSON and back using Jackson
 :cq-deprecated: false
 :cq-jvm-since: 0.3.0
 :cq-native-since: 0.3.0
@@ -13,7 +13,7 @@
 [.badges]
 [.badge-key]##JVM since##[.badge-supported]##0.3.0## [.badge-key]##Native since##[.badge-supported]##0.3.0##
 
-Marshal POJOs to JSON and back.
+Marshal POJOs to JSON and back using Jackson
 
 == What's inside
 

--- a/docs/modules/ROOT/pages/reference/extensions/johnzon.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/johnzon.adoc
@@ -5,7 +5,7 @@
 :cq-artifact-id: camel-quarkus-johnzon
 :cq-native-supported: true
 :cq-status: Stable
-:cq-description: Marshal POJOs to JSON and back.
+:cq-description: Marshal POJOs to JSON and back using Johnzon
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0
 :cq-native-since: 1.0.0
@@ -13,7 +13,7 @@
 [.badges]
 [.badge-key]##JVM since##[.badge-supported]##1.0.0## [.badge-key]##Native since##[.badge-supported]##1.0.0##
 
-Marshal POJOs to JSON and back.
+Marshal POJOs to JSON and back using Johnzon
 
 == What's inside
 

--- a/extensions-jvm/fastjson/runtime/pom.xml
+++ b/extensions-jvm/fastjson/runtime/pom.xml
@@ -30,7 +30,7 @@
 
     <artifactId>camel-quarkus-fastjson</artifactId>
     <name>Camel Quarkus :: JSON Fastjson :: Runtime</name>
-    <description>Marshal POJOs to JSON and back.</description>
+    <description>Marshal POJOs to JSON and back using Fastjson</description>
 
     <properties>
         <camel.quarkus.jvmSince>1.1.0</camel.quarkus.jvmSince>

--- a/extensions-jvm/fastjson/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/fastjson/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -22,7 +22,7 @@
 #
 ---
 name: "Camel JSON Fastjson"
-description: "Marshal POJOs to JSON and back"
+description: "Marshal POJOs to JSON and back using Fastjson"
 metadata:
   unlisted: true
   guide: "https://camel.apache.org/camel-quarkus/latest/reference/extensions/fastjson.html"

--- a/extensions/gson/runtime/pom.xml
+++ b/extensions/gson/runtime/pom.xml
@@ -28,6 +28,7 @@
 
     <artifactId>camel-quarkus-gson</artifactId>
     <name>Camel Quarkus :: Gson :: Runtime</name>
+    <description>Marshal POJOs to JSON and back using Gson</description>
 
     <properties>
         <camel.quarkus.jvmSince>1.0.0</camel.quarkus.jvmSince>

--- a/extensions/gson/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/gson/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -22,7 +22,7 @@
 #
 ---
 name: "Camel Gson"
-description: "Marshal POJOs to JSON and back"
+description: "Marshal POJOs to JSON and back using Gson"
 metadata:
   guide: "https://camel.apache.org/camel-quarkus/latest/reference/extensions/gson.html"
   categories:

--- a/extensions/jackson/runtime/pom.xml
+++ b/extensions/jackson/runtime/pom.xml
@@ -27,6 +27,7 @@
 
     <artifactId>camel-quarkus-jackson</artifactId>
     <name>Camel Quarkus :: Jackson :: Runtime</name>
+    <description>Marshal POJOs to JSON and back using Jackson</description>
 
     <properties>
         <camel.quarkus.jvmSince>0.3.0</camel.quarkus.jvmSince>

--- a/extensions/jackson/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/jackson/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -22,7 +22,7 @@
 #
 ---
 name: "Camel Jackson"
-description: "Marshal POJOs to JSON and back"
+description: "Marshal POJOs to JSON and back using Jackson"
 metadata:
   guide: "https://camel.apache.org/camel-quarkus/latest/reference/extensions/jackson.html"
   categories:

--- a/extensions/johnzon/runtime/pom.xml
+++ b/extensions/johnzon/runtime/pom.xml
@@ -28,6 +28,7 @@
 
     <artifactId>camel-quarkus-johnzon</artifactId>
     <name>Camel Quarkus :: Johnzon :: Runtime</name>
+    <description>Marshal POJOs to JSON and back using Johnzon</description>
 
     <properties>
         <camel.quarkus.jvmSince>1.0.0</camel.quarkus.jvmSince>

--- a/extensions/johnzon/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/johnzon/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -22,7 +22,7 @@
 #
 ---
 name: "Camel Johnzon"
-description: "Marshal POJOs to JSON and back"
+description: "Marshal POJOs to JSON and back using Johnzon"
 metadata:
   guide: "https://camel.apache.org/camel-quarkus/latest/reference/extensions/johnzon.html"
   categories:


### PR DESCRIPTION
@rsvoboda here it is. What I have done is documented in our contributor guide https://camel.apache.org/camel-quarkus/latest/contributor-guide/create-new-extension.html step 7. The local fix of the Camel metadata can be done via `<description>` of the runtime module. `quarkus-extension.yaml` files need then be re-generated using `mvn clean process-resources -Pformat -N`. The doc pages are regenerated by the `update-extension-doc-page` bound to `process-classes` of the runtime modules.