### PR TITLE
camel-quarkus-jira: Add resteasy-common dependency

### DIFF
--- a/extensions/jira/deployment/pom.xml
+++ b/extensions/jira/deployment/pom.xml
@@ -46,6 +46,10 @@
             <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-support-commons-logging-deployment</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-common-deployment</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/jira/runtime/pom.xml
+++ b/extensions/jira/runtime/pom.xml
@@ -93,6 +93,10 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-common</artifactId>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Add `quarkus-resteasy-common` dependency that allows to work extension properly and avoids exceptions like:
```
Caused by: java.lang.ClassNotFoundException: javax.ws.rs.core.UriBuilder
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:581)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
	at io.quarkus.bootstrap.classloading.QuarkusClassLoader.loadClass(QuarkusClassLoader.java:406)
	at io.quarkus.bootstrap.classloading.QuarkusClassLoader.loadClass(QuarkusClassLoader.java:363)
	... 36 more

``` 
```
Caused by: java.lang.RuntimeException: java.lang.ClassNotFoundException: org.glassfish.jersey.internal.RuntimeDelegateImpl
	at javax.ws.rs.ext.RuntimeDelegate.findDelegate(RuntimeDelegate.java:129)
	at javax.ws.rs.ext.RuntimeDelegate.getInstance(RuntimeDelegate.java:96)
	at javax.ws.rs.core.UriBuilder.newInstance(UriBuilder.java:72)
	at javax.ws.rs.core.UriBuilder.fromUri(UriBuilder.java:83)
	at com.atlassian.jira.rest.client.internal.async.AsynchronousJiraRestClient.<init>(AsynchronousJiraRestClient.java:58)
	at org.apache.camel.component.jira.oauth.OAuthAsynchronousJiraRestClientFactory.create(OAuthAsynchronousJiraRestClientFactory.java:33)
	at com.atlassian.jira.rest.client.internal.async.AsynchronousJiraRestClientFactory.createWithBasicHttpAuthentication(AsynchronousJiraRestClientFactory.java:42)
	at org.apache.camel.component.jira.JiraEndpoint.doStart(JiraEndpoint.java:119)
	at org.apache.camel.support.service.BaseService.start(BaseService.java:115)
	at org.apache.camel.support.service.ServiceHelper.startService(ServiceHelper.java:84)
	at org.apache.camel.impl.engine.RouteService.doWarmUp(RouteService.java:140)
	at org.apache.camel.impl.engine.RouteService.warmUp(RouteService.java:122)
	... 28 more
Caused by: java.lang.ClassNotFoundException: org.glassfish.jersey.internal.RuntimeDelegateImpl
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:581)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
	at io.quarkus.bootstrap.classloading.QuarkusClassLoader.loadClass(QuarkusClassLoader.java:406)
	at io.quarkus.bootstrap.classloading.QuarkusClassLoader.loadClass(QuarkusClassLoader.java:363)
	at java.base/java.lang.Class.forName0(Native Method)
	at java.base/java.lang.Class.forName(Class.java:315)
	at javax.ws.rs.ext.FactoryFinder.newInstance(FactoryFinder.java:93)
	at javax.ws.rs.ext.FactoryFinder.find(FactoryFinder.java:210)
	at javax.ws.rs.ext.RuntimeDelegate.findDelegate(RuntimeDelegate.java:111)
	... 39 more

```
Expections are caused by excluding `javax.ws.rs:jsr311-api` which is a transivite dependency of Jira REST client (`com.atlassian.jira:jira-rest-java-client-core`). 