### PR TITLE
Enable Spring dependent extensions to work with Quarkus Spring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ pom.xml.releaseBackup
 pom.xml.versionsBackup
 pom.xml.next
 release.properties
+dependency-reduced-pom.xml
 
 # Eclipse
 .project

--- a/extensions-support/spring/README.adoc
+++ b/extensions-support/spring/README.adoc
@@ -1,0 +1,49 @@
+= Spring Support
+
+This extension provides common support for Camel components that depend on `org.springframework` libraries:
+
+* spring-beans
+* spring-context
+* spring-core
+
+== Repackaging of core Spring libraries
+
+The Quarkus Spring extensions offers a limited set of supported packages for the Spring framework. This is achieved by shading the desired packages into a new quarkus-spring-*-api dependency. These can be found at the https://github.com/quarkusio/quarkus-spring-api[quarkus-spring-api] project.
+
+A side effect of this is that the Quarkus Spring extensions enforce the exclusion of the original Spring artifacts from the build via the `quarkus-bootstrap-maven-plugin`. For example:
+
+[source,xml]
+----
+<plugin>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+    <configuration>
+        <excludedArtifacts>
+            <excludedArtifact>org.springframework:spring-core</excludedArtifact>
+            <excludedArtifact>org.springframework:spring-beans</excludedArtifact>
+            <excludedArtifact>org.springframework:spring-context</excludedArtifact>
+        </excludedArtifacts>
+    </configuration>
+</plugin>
+----
+
+Therefore, in order to circumvent the artifact exclusion, the excluded Spring artifacts are shaded and repackaged with relevant packages required by various Camel extensions.
+
+[width="100%",cols="30,70",options="header"]
+|===
+| Original Spring Artifact Name | Repackaged Artifact Name
+
+
+| `spring-beans`
+| `camel-quarkus-support-spring-beans`
+
+| `spring-context`
+| `camel-quarkus-support-spring-context`
+
+| `spring-core`
+| `camel-quarkus-support-spring-core`
+|=== 
+
+== Native support
+
+This extension contains the relevant Quarkus `BuildStep`s and GraalVM substitutions that enable the Spring core libraries to work properly in native mode.

--- a/extensions-support/spring/beans/pom.xml
+++ b/extensions-support/spring/beans/pom.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.apache.camel.quarkus</groupId>
+        <artifactId>camel-quarkus-support-spring-parent</artifactId>
+        <version>1.4.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>camel-quarkus-support-spring-beans</artifactId>
+    <name>Camel Quarkus :: Support :: Spring :: Beans</name>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.camel.quarkus</groupId>
+                <artifactId>camel-quarkus-bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-support-spring-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-beans</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <createSourcesJar>true</createSourcesJar>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.springframework:spring-beans</include>
+                                </includes>
+                            </artifactSet>
+                            <filters>
+                                <filter>
+                                    <artifact>org.springframework:spring-beans</artifact>
+                                    <includes>
+                                        <include>META-INF/spring.factories</include>
+                                        <include>org/springframework/beans/*</include>
+                                        <include>org/springframework/beans/factory/**</include>
+                                        <include>org/springframework/beans/propertyeditors/**</include>
+                                        <include>org/springframework/beans/support/**</include>
+                                    </includes>
+                                    <excludes>
+                                        <exclude>org/springframework/beans/factory/groovy/**</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions-support/spring/context/pom.xml
+++ b/extensions-support/spring/context/pom.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.apache.camel.quarkus</groupId>
+        <artifactId>camel-quarkus-support-spring-parent</artifactId>
+        <version>1.4.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>camel-quarkus-support-spring-context</artifactId>
+    <name>Camel Quarkus :: Support :: Spring :: Context</name>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.camel.quarkus</groupId>
+                <artifactId>camel-quarkus-bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-support-spring-beans</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-support-spring-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <createSourcesJar>true</createSourcesJar>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.springframework:spring-context</include>
+                                </includes>
+                            </artifactSet>
+                            <filters>
+                                <filter>
+                                    <artifact>org.springframework:spring-context</artifact>
+                                    <includes>
+                                        <include>org/springframework/context/*</include>
+                                        <include>org/springframework/context/event/**</include>
+                                        <include>org/springframework/context/expression/**</include>
+                                        <include>org/springframework/context/support/**</include>
+                                        <include>org/springframework/context/weaving/**</include>
+                                        <include>org/springframework/jndi/JndiCallback**</include>
+                                        <include>org/springframework/jndi/JndiTemplate.**</include>
+                                        <include>org/springframework/jndi/TypeMismatchNamingException**</include>
+                                        <include>org/springframework/scheduling/**</include>
+                                    </includes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions-support/spring/core/pom.xml
+++ b/extensions-support/spring/core/pom.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.apache.camel.quarkus</groupId>
+        <artifactId>camel-quarkus-support-spring-parent</artifactId>
+        <version>1.4.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>camel-quarkus-support-spring-core</artifactId>
+    <name>Camel Quarkus :: Support :: Spring :: Core</name>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.camel.quarkus</groupId>
+                <artifactId>camel-quarkus-bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-core</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <createSourcesJar>true</createSourcesJar>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.springframework:spring-core</include>
+                                </includes>
+                            </artifactSet>
+                            <filters>
+                                <filter>
+                                    <artifact>org.springframework:spring-core</artifact>
+                                    <includes>
+                                        <include>org/springframework/asm/**</include>
+                                        <include>org/springframework/core/*</include>
+                                        <include>org/springframework/core/annotation/**</include>
+                                        <include>org/springframework/core/convert/**</include>
+                                        <include>org/springframework/core/env/**</include>
+                                        <include>org/springframework/core/io/**</include>
+                                        <include>org/springframework/core/log/**</include>
+                                        <include>org/springframework/core/task/**</include>
+                                        <include>org/springframework/lang/**</include>
+                                        <include>org/springframework/util/*</include>
+                                        <include>org/springframework/util/backoff/**</include>
+                                        <include>org/springframework/util/concurrent/**</include>
+                                        <include>org/springframework/util/comparator/**</include>
+                                        <include>org/springframework/util/function/**</include>
+                                        <include>org/springframework/util/xml/**</include>
+                                    </includes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions-support/spring/integration-test/pom.xml
+++ b/extensions-support/spring/integration-test/pom.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.apache.camel.quarkus</groupId>
+    <artifactId>camel-quarkus-build-parent-it</artifactId>
+    <version>1.4.0-SNAPSHOT</version>
+    <relativePath>../../../poms/build-parent-it/pom.xml</relativePath>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>camel-quarkus-support-spring-integration-test</artifactId>
+  <name>Camel Quarkus :: Support Spring :: Integration Test</name>
+  <description>Integration tests for Camel Quarkus Support Spring extension</description>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.camel.quarkus</groupId>
+        <artifactId>camel-quarkus-bom-test</artifactId>
+        <version>${project.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-support-spring</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-spring-di</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy</artifactId>
+    </dependency>
+
+    <!-- test dependencies -->
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.rest-assured</groupId>
+      <artifactId>rest-assured</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- The following dependencies guarantee that this module is built after them. You can update them by running `mvn process-resources -Pformat -N` from the source tree root directory -->
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-support-spring-deployment</artifactId>
+      <version>${project.version}</version>
+      <type>pom</type>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>build</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+  
+</project>

--- a/extensions-support/spring/integration-test/src/main/java/org/apache/camel/quarkus/support/spring/ClassLoadingService.java
+++ b/extensions-support/spring/integration-test/src/main/java/org/apache/camel/quarkus/support/spring/ClassLoadingService.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.support.spring;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
+@Path("/classloading")
+public class ClassLoadingService {
+
+    @GET
+    @Path("/{className}")
+    public void loadClass(@PathParam("className") String className) throws ClassNotFoundException {
+        Thread.currentThread().getContextClassLoader().loadClass(className);
+    }
+}

--- a/extensions-support/spring/integration-test/src/test/java/org/apache/camel/quarkus/support/spring/test/SpringSupportTest.java
+++ b/extensions-support/spring/integration-test/src/test/java/org/apache/camel/quarkus/support/spring/test/SpringSupportTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.support.spring.test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+public class SpringSupportTest {
+
+    @Test
+    public void springClassLoading() {
+        // Verify that classes excluded by the Quarkus Spring extensions can be loaded
+        // I.e check they are not blacklisted since the camel-quarkus-support-spring-(beans,context,core) jars will provide them
+        String[] classNames = new String[] {
+                // From: org.springframework:spring-beans
+                "org.springframework.beans.factory.InitializingBean",
+                // From: org.springframework:spring-context
+                "org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor",
+                // From: org.springframework:spring-core
+                "org.springframework.core.SpringVersion",
+        };
+
+        for (String className : classNames) {
+            RestAssured.given()
+                    .pathParam("className", className)
+                    .when()
+                    .get("/classloading/{className}")
+                    .then()
+                    .statusCode(204);
+        }
+    }
+}

--- a/extensions-support/spring/pom.xml
+++ b/extensions-support/spring/pom.xml
@@ -33,8 +33,12 @@
     <packaging>pom</packaging>
 
     <modules>
+        <module>beans</module>
+        <module>context</module>
+        <module>core</module>
         <module>deployment</module>
         <module>runtime</module>
+        <module>integration-test</module>
     </modules>
 
 </project>

--- a/extensions-support/spring/runtime/pom.xml
+++ b/extensions-support/spring/runtime/pom.xml
@@ -50,8 +50,16 @@
             <artifactId>camel-quarkus-support-commons-logging</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-core</artifactId>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-support-spring-beans</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-support-spring-context</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-support-spring-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>

--- a/extensions/jpa/runtime/pom.xml
+++ b/extensions/jpa/runtime/pom.xml
@@ -64,10 +64,6 @@
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-jpa</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-context</artifactId>
-        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,7 @@
         <maven-source-plugin.version>3.1.0</maven-source-plugin.version>
         <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
         <maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>
+        <maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
         <!-- NOTE: We pin to this version due to https://github.com/apache/camel-quarkus/issues/723 -->
         <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
         <os-maven-plugin.version>1.6.2</os-maven-plugin.version>
@@ -307,6 +308,12 @@
                   <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-resources-plugin</artifactId>
                   <version>${maven-resources-plugin.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-shade-plugin</artifactId>
+                    <version>${maven-shade-plugin.version}</version>
                 </plugin>
 
                 <plugin>

--- a/poms/bom/pom.xml
+++ b/poms/bom/pom.xml
@@ -1113,6 +1113,16 @@
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-jdbc</artifactId>
                 <version>${camel.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.springframework</groupId>
+                        <artifactId>spring-beans</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.springframework</groupId>
+                        <artifactId>spring-core</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
@@ -1165,6 +1175,18 @@
                         <groupId>org.apache.camel</groupId>
                         <artifactId>camel-spring</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>org.springframework</groupId>
+                        <artifactId>spring-beans</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.springframework</groupId>
+                        <artifactId>spring-context</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.springframework</groupId>
+                        <artifactId>spring-core</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>
@@ -1190,6 +1212,18 @@
                     <exclusion>
                         <groupId>org.apache.camel</groupId>
                         <artifactId>camel-spring</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.springframework</groupId>
+                        <artifactId>spring-beans</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.springframework</groupId>
+                        <artifactId>spring-context</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.springframework</groupId>
+                        <artifactId>spring-core</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -1770,6 +1804,14 @@
                     <exclusion>
                         <groupId>commons-logging</groupId>
                         <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.springframework</groupId>
+                        <artifactId>spring-beans</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.springframework</groupId>
+                        <artifactId>spring-core</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -4783,6 +4825,21 @@
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
                 <artifactId>camel-quarkus-support-spring</artifactId>
+                <version>${camel-quarkus.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel.quarkus</groupId>
+                <artifactId>camel-quarkus-support-spring-beans</artifactId>
+                <version>${camel-quarkus.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel.quarkus</groupId>
+                <artifactId>camel-quarkus-support-spring-context</artifactId>
+                <version>${camel-quarkus.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel.quarkus</groupId>
+                <artifactId>camel-quarkus-support-spring-core</artifactId>
                 <version>${camel-quarkus.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
Works around the issue I identified in https://github.com/apache/camel-quarkus/issues/1759.

I did some analysis of Spring code paths that get executed in the Camel unit tests and came up with a list of package includes & excludes for shading. 

The itests pass ok, but I can't check for every possible code path. Is it better / safer to shade all packages, instead of selectively including them? Obviously there's a chance that some required stuff may have been left out.