### PR TITLE
Exclude glassfish dependencies from hbase-testing-util

### DIFF
--- a/poms/bom-test/pom.xml
+++ b/poms/bom-test/pom.xml
@@ -128,6 +128,10 @@
                         <groupId>com.google.inject</groupId>
                         <artifactId>guice</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>org.glassfish.web</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>


### PR DESCRIPTION
Seems there's a SNAPSHOT lurking in the `hbase-testing-util` dependency tree for `org.glassfish:javax.el` which caused some failures in #1937. Hence excluding `org.glassfish.web:*`.
