### PR TITLE
Fix github itest to use oauth token instead username/password

### DIFF
--- a/integration-tests/github/src/main/java/org/apache/camel/quarkus/component/github/it/GithubResource.java
+++ b/integration-tests/github/src/main/java/org/apache/camel/quarkus/component/github/it/GithubResource.java
@@ -28,7 +28,7 @@ import org.eclipse.egit.github.core.CommitFile;
 @Path("/github")
 public class GithubResource {
 
-    private static final String GITHUB_AUTH_PARAMS = "username={{env:GITHUB_USERNAME:}}&password={{env:GITHUB_PASSWORD:}}";
+    private static final String GITHUB_AUTH_PARAMS = "oauthToken={{env:GITHUB_TOKEN:}}";
 
     @Inject
     ProducerTemplate producerTemplate;


### PR DESCRIPTION
With username/password i've received

```
github://GETCOMMITFILE?password=xxxxxx&repoName=camel-quarkus&repoOwner=apache&username=****. Reason: org.eclipse.egit.github.core.client.RequestException: Bad credentials. The API can't be accessed using username/password authentication. Please create a personal access token to access this endpoint: http://github.com/settings/tokens (401)
```