### PR TITLE
Fix protobuf itest dependency on deployment

### DIFF
--- a/extensions/protobuf/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/protobuf/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -24,9 +24,8 @@
 name: "Camel Protobuf"
 description: "Serialize and deserialize Java objects using Google's Protocol buffers"
 metadata:
-  unlisted: true
   guide: "https://camel.apache.org/camel-quarkus/latest/reference/extensions/protobuf.html"
   categories:
   - "integration"
   status:
-  - "preview"
+  - "stable"

--- a/integration-tests/protobuf/pom.xml
+++ b/integration-tests/protobuf/pom.xml
@@ -54,6 +54,34 @@
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- The following dependencies guarantee that this module is built after them. You can update them by running `mvn process-resources -Pformat -N` from the source tree root directory -->
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-direct-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-protobuf-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
I've did `mvn process-resources -Pformat -N`, not sure the changes in `quarkus-extension.yaml` are needed.