### PR TITLE
CAMEL-15948: examples.json instead of .adoc files

### DIFF
--- a/docs/modules/ROOT/pages/user-guide/examples.adoc
+++ b/docs/modules/ROOT/pages/user-guide/examples.adoc
@@ -1,17 +1,14 @@
 = Camel Quarkus Examples
 :page-aliases: examples.adoc
-:indexer-version: latest
-:indexer-component: camel-quarkus-examples
-:indexer-module: ROOT
-:indexer-rel-filter: examples/*.adoc
+:quarkus-examples-version: latest
 
 We offer several examples in https://github.com/apache/camel-quarkus-examples[Camel Quarkus examples repository]. To
 learn how to use them, please follow the xref:user-guide/first-steps.adoc[First steps] chapter of the User guide.
 
-Number of Examples: indexCount:[version="{indexer-version}",component="{indexer-component}",module="{indexer-module}",relative="{indexer-rel-filter}"]
+Number of Examples: jsonpathCount:{quarkus-examples-version}@camel-quarkus-examples:ROOT:attachment$examples.json[$[*\]]
 [width="100%",cols="3,7",options="header"]
 |===
 | Example | Description
 |===
 
-indexTable::[version="{indexer-version}",component="{indexer-component}",module="{indexer-module}",relative="{indexer-rel-filter}",cells="=`$\{cqExampleUrl}[$\{cqExampleTitle}]`,cq-example-description"]
+jsonpathTable::{quarkus-examples-version}@camel-quarkus-examples:ROOT:attachment$examples.json['$[*]', '$\{link}[$\{title}],description']


### PR DESCRIPTION
This makes use of a change in the camel-quarkus-examples repository to
generate the `examples.json` file instead of empty `.adoc` files to as
a data source for generating the examples table in
`user-guide/examples.adoc`.
It does this by utilizing `@djencks/asciidoctor-jsonpath` Antora
extension, which similarly to the `@djencks/asciidoctor-antora-indexer`
can generate rows for Asciidoc table.

This requires https://github.com/apache/camel-quarkus-examples/pull/14 to get merged
