### PR TITLE
Remove docker.io prefix for images

### DIFF
--- a/integration-tests/infinispan/src/test/java/org/apache/camel/quarkus/component/infinispan/InfinispanServerTestResource.java
+++ b/integration-tests/infinispan/src/test/java/org/apache/camel/quarkus/component/infinispan/InfinispanServerTestResource.java
@@ -30,7 +30,7 @@ import static org.apache.camel.quarkus.testcontainers.ContainerSupport.getHostAn
 
 public class InfinispanServerTestResource implements ContainerResourceLifecycleManager {
     private static final Logger LOGGER = LoggerFactory.getLogger(InfinispanServerTestResource.class);
-    private static final String CONTAINER_IMAGE = "docker.io/infinispan/server:10.1.5.Final";
+    private static final String CONTAINER_IMAGE = "infinispan/server:10.1.5.Final";
     private static final int HOTROD_PORT = 11222;
     private static final String USER = "camel";
     private static final String PASS = "camel";

--- a/integration-tests/kubernetes/src/main/java/org/apache/camel/quarkus/component/kubernetes/it/KubernetesResource.java
+++ b/integration-tests/kubernetes/src/main/java/org/apache/camel/quarkus/component/kubernetes/it/KubernetesResource.java
@@ -92,7 +92,7 @@ public class KubernetesResource {
         PodSpec podSpec = new PodSpec();
 
         Container container = new Container();
-        container.setImage("docker.io/busybox:latest");
+        container.setImage("busybox:latest");
         container.setName(containerName);
 
         List<Container> containers = new ArrayList<>();

--- a/integration-tests/kubernetes/src/test/java/org/apache/camel/quarkus/component/kubernetes/it/KubernetesTest.java
+++ b/integration-tests/kubernetes/src/test/java/org/apache/camel/quarkus/component/kubernetes/it/KubernetesTest.java
@@ -39,7 +39,7 @@ public class KubernetesTest {
     @Test
     public void testKubernetesComponent() {
         Container container = new Container();
-        container.setImage("docker.io/busybox:latest");
+        container.setImage("busybox:latest");
         container.setName("camel-pod");
 
         Pod pod = new PodBuilder()


### PR DESCRIPTION
With docker.io prefix the auth from `docker login` is not working in testcontainers because this line (https://github.com/docker-java/docker-java/blob/master/docker-java-core/src/main/java/com/github/dockerjava/core/DockerConfigFile.java#L51) compare with `https://index.docker.io/v1/` which fails and no auth is used. And from documentation (https://www.testcontainers.org/quickstart/junit_5_quickstart#2-get-testcontainers-to-run-a-redis-container-during-our-tests) i can see there is no docker.io prefix used either.

wdyt @ppalaga @jamesnetherton should i raise issue on testcontainers/docker-java as well ?