### PR TITLE
Disable ryuk on CI builds

### DIFF
--- a/.github/workflows/camel-master-cron.yaml
+++ b/.github/workflows/camel-master-cron.yaml
@@ -26,6 +26,7 @@ env:
   LANG: en_US.UTF-8
   MAVEN_OPTS: -Xmx3000m
   MAVEN_ARGS: -V -ntp -Dhttp.keepAlive=false -e
+  TESTCONTAINERS_RYUK_DISABLED: true
 
 jobs:
   build:

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -47,6 +47,7 @@ env:
   LANG: en_US.UTF-8
   MAVEN_OPTS: -Xmx3000m
   MAVEN_ARGS: -V -ntp -Dhttp.keepAlive=false -e
+  TESTCONTAINERS_RYUK_DISABLED: true
 
 jobs:
   initial-mvn-install:

--- a/.github/workflows/quarkus-master-cron.yaml
+++ b/.github/workflows/quarkus-master-cron.yaml
@@ -26,6 +26,7 @@ env:
   LANG: en_US.UTF-8
   MAVEN_OPTS: -Xmx3000m
   MAVEN_ARGS: -V -ntp -Dhttp.keepAlive=false -e
+  TESTCONTAINERS_RYUK_DISABLED: true
 
 jobs:
   build:


### PR DESCRIPTION
I think `ryuk` may be behind some of the build hangs that I've seen. It's not really needed for the CI builds, so this is an experiment with it disabled.