### PR TITLE
Updated link in testing doc

### DIFF
--- a/docs/modules/ROOT/pages/user-guide/testing.adoc
+++ b/docs/modules/ROOT/pages/user-guide/testing.adoc
@@ -22,7 +22,7 @@ class MyTest {
 }
 ----
 
-A complete implementation can be found https://github.com/apache/camel-quarkus/blob/master/integration-tests/bindy/src/test/java/org/apache/camel/quarkus/component/bindy/it/MessageRecordTest.java[here].
+An example implementation can be found https://github.com/apache/camel-quarkus/blob/master/integration-tests/bindy/src/test/java/org/apache/camel/quarkus/component/bindy/it/MessageTest.java[here].
 
 == A test running in native mode
 


### PR DESCRIPTION
The current link leads to 404, and changed "complete" to "example" as that better describes what's hiding behind that link.