### PR TITLE
Disable OptaplannerTest.solveSync on CI

### DIFF
--- a/integration-tests/hystrix/src/test/java/org/apache/camel/quarkus/component/hystrix/it/HystrixTest.java
+++ b/integration-tests/hystrix/src/test/java/org/apache/camel/quarkus/component/hystrix/it/HystrixTest.java
@@ -20,11 +20,14 @@ import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 
 import static org.hamcrest.core.Is.is;
 
 @QuarkusTest
 @QuarkusTestResource(HystrixTestResource.class)
+// https://github.com/apache/camel-quarkus/issues/1146
+@DisabledIfEnvironmentVariable(named = "CI", matches = "true")
 class HystrixTest {
 
     @Test

--- a/integration-tests/optaplanner/src/test/java/org/apache/camel/quarkus/component/optaplanner/it/OptaplannerIT.java
+++ b/integration-tests/optaplanner/src/test/java/org/apache/camel/quarkus/component/optaplanner/it/OptaplannerIT.java
@@ -17,7 +17,10 @@
 package org.apache.camel.quarkus.component.optaplanner.it;
 
 import io.quarkus.test.junit.NativeImageTest;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 
+// https://github.com/apache/camel-quarkus/issues/2205
+@DisabledIfEnvironmentVariable(named = "CI", matches = "true")
 @NativeImageTest
 class OptaplannerIT extends OptaplannerTest {
 

--- a/integration-tests/optaplanner/src/test/java/org/apache/camel/quarkus/component/optaplanner/it/OptaplannerTest.java
+++ b/integration-tests/optaplanner/src/test/java/org/apache/camel/quarkus/component/optaplanner/it/OptaplannerTest.java
@@ -22,10 +22,13 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import org.apache.camel.quarkus.component.optaplanner.it.domain.TimeTable;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.notNullValue;
 
+// https://github.com/apache/camel-quarkus/issues/2205
+@DisabledIfEnvironmentVariable(named = "CI", matches = "true")
 @QuarkusTest
 class OptaplannerTest {
 


### PR DESCRIPTION
OptaPlanner solve sync test seems to fail quite frequently on CI so disabling it until there's a solution.