### PR TITLE
Add configuration option to ignore unknown arguments

### DIFF
--- a/docs/modules/ROOT/pages/reference/extensions/main.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/main.adoc
@@ -39,6 +39,12 @@ Check the xref:user-guide/index.adoc[User guide] for more information about writ
 A timeout (with millisecond precision) to wait for `CamelMain++#++stop()` to finish
 | `java.time.Duration`
 | `PT3S`
+
+|icon:lock[title=Fixed at build time] [[quarkus.camel.main.arguments.on-unknown]]`link:#quarkus.camel.main.arguments.on-unknown[quarkus.camel.main.arguments.on-unknown]`
+
+The action to take when `CamelMain` encounters an unknown argument. fail - Prints the `CamelMain` usage statement and throws a `RuntimeException` ignore - Suppresses any warnings and the application startup proceeds as normal warn - Prints the `CamelMain` usage statement but allows the application startup to proceed as normal
+| `org.apache.camel.quarkus.core.CamelConfig.FailureRemedy`
+| `warn`
 |===
 
 [.configuration-legend]

--- a/extensions-core/main/deployment/src/main/java/org/apache/camel/quarkus/main/deployment/CamelMainProcessor.java
+++ b/extensions-core/main/deployment/src/main/java/org/apache/camel/quarkus/main/deployment/CamelMainProcessor.java
@@ -105,12 +105,14 @@ public class CamelMainProcessor {
             CamelContextBuildItem context,
             CamelRoutesCollectorBuildItem routesCollector,
             List<CamelRoutesBuilderClassBuildItem> routesBuilderClasses,
-            List<CamelMainListenerBuildItem> listeners) {
+            List<CamelMainListenerBuildItem> listeners,
+            CamelMainConfig config) {
 
         RuntimeValue<CamelMain> main = recorder.createCamelMain(
                 context.getCamelContext(),
                 routesCollector.getValue(),
-                beanContainer.getValue());
+                beanContainer.getValue(),
+                config.arguments.onUnknown);
 
         for (CamelRoutesBuilderClassBuildItem item : routesBuilderClasses) {
             // don't add routes builders that are known by the container

--- a/extensions-core/main/deployment/src/test/java/org/apache/camel/quarkus/main/deployment/CamelMainUnknownArgumentFailTest.java
+++ b/extensions-core/main/deployment/src/test/java/org/apache/camel/quarkus/main/deployment/CamelMainUnknownArgumentFailTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.main.deployment;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.Properties;
+
+import javax.inject.Inject;
+
+import io.quarkus.test.QuarkusUnitTest;
+import org.apache.camel.quarkus.main.CamelMain;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class CamelMainUnknownArgumentFailTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest CONFIG = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource(applicationProperties(), "application.properties"));
+
+    @Inject
+    CamelMain main;
+
+    @Test
+    public void unknownArgumentThrowsException() {
+        Exception exception = Assertions.assertThrows(RuntimeException.class, () -> {
+            main.parseArguments(new String[] { "-d", "10", "-foo", "bar" });
+        });
+        assertEquals("CamelMain encountered unknown arguments", exception.getMessage());
+    }
+
+    public static Asset applicationProperties() {
+        Writer writer = new StringWriter();
+
+        Properties props = new Properties();
+        props.setProperty("quarkus.banner.enabled", "false");
+        props.setProperty("quarkus.camel.main.arguments.on-unknown", "fail");
+
+        try {
+            props.store(writer, "");
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        return new StringAsset(writer.toString());
+    }
+}

--- a/extensions-core/main/deployment/src/test/java/org/apache/camel/quarkus/main/deployment/CamelMainUnknownArgumentIgnoreTest.java
+++ b/extensions-core/main/deployment/src/test/java/org/apache/camel/quarkus/main/deployment/CamelMainUnknownArgumentIgnoreTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.main.deployment;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.Properties;
+
+import javax.inject.Inject;
+
+import io.quarkus.test.QuarkusUnitTest;
+import org.apache.camel.quarkus.main.CamelMain;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static io.smallrye.common.constraint.Assert.assertFalse;
+
+public class CamelMainUnknownArgumentIgnoreTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest CONFIG = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource(applicationProperties(), "application.properties"));
+
+    @Inject
+    CamelMain main;
+
+    @Test
+    public void unknownArgumentIgnored() {
+        PrintStream oldOut = System.out;
+
+        try (ByteArrayOutputStream sysout = new ByteArrayOutputStream()) {
+            System.setOut(new PrintStream(sysout));
+
+            main.parseArguments(new String[] { "-d", "10", "-foo", "bar" });
+
+            String consoleContent = sysout.toString();
+            assertFalse(consoleContent.contains("Unknown option: -foo"));
+            assertFalse(consoleContent.contains("Apache Camel Runner takes the following options"));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        } finally {
+            System.setOut(oldOut);
+        }
+    }
+
+    public static Asset applicationProperties() {
+        Writer writer = new StringWriter();
+
+        Properties props = new Properties();
+        props.setProperty("quarkus.banner.enabled", "false");
+        props.setProperty("quarkus.camel.main.arguments.on-unknown", "ignore");
+
+        try {
+            props.store(writer, "");
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        return new StringAsset(writer.toString());
+    }
+}

--- a/extensions-core/main/deployment/src/test/java/org/apache/camel/quarkus/main/deployment/CamelMainUnknownArgumentWarnTest.java
+++ b/extensions-core/main/deployment/src/test/java/org/apache/camel/quarkus/main/deployment/CamelMainUnknownArgumentWarnTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.main.deployment;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.Properties;
+
+import javax.inject.Inject;
+
+import io.quarkus.test.QuarkusUnitTest;
+import org.apache.camel.quarkus.main.CamelMain;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class CamelMainUnknownArgumentWarnTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest CONFIG = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource(applicationProperties(), "application.properties"));
+
+    @Inject
+    CamelMain main;
+
+    @Test
+    public void unknownArgumentLogsWarning() {
+        PrintStream oldOut = System.out;
+
+        try (ByteArrayOutputStream sysout = new ByteArrayOutputStream()) {
+            System.setOut(new PrintStream(sysout));
+
+            main.parseArguments(new String[] { "-d", "10", "-foo", "bar" });
+
+            String consoleContent = sysout.toString();
+            assertTrue(consoleContent.contains("Unknown option: -foo"));
+            assertTrue(consoleContent.contains("Apache Camel Runner takes the following options"));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        } finally {
+            System.setOut(oldOut);
+        }
+    }
+
+    public static Asset applicationProperties() {
+        Writer writer = new StringWriter();
+
+        Properties props = new Properties();
+        props.setProperty("quarkus.banner.enabled", "false");
+        props.setProperty("quarkus.camel.main.arguments.on-unknown", "warn");
+
+        try {
+            props.store(writer, "");
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        return new StringAsset(writer.toString());
+    }
+}

--- a/extensions-core/main/runtime/src/main/java/org/apache/camel/quarkus/main/CamelMainConfig.java
+++ b/extensions-core/main/runtime/src/main/java/org/apache/camel/quarkus/main/CamelMainConfig.java
@@ -22,6 +22,7 @@ import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import org.apache.camel.quarkus.core.CamelConfig.FailureRemedy;
 
 @ConfigRoot(name = "camel.main", phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
 public class CamelMainConfig {
@@ -32,6 +33,12 @@ public class CamelMainConfig {
     @ConfigItem
     public ShutdownConfig shutdown;
 
+    /**
+     * Build time configuration options for {@link CamelMain} arguments
+     */
+    @ConfigItem
+    public ArgumentConfig arguments;
+
     @ConfigGroup
     public static class ShutdownConfig {
         /**
@@ -39,5 +46,19 @@ public class CamelMainConfig {
          */
         @ConfigItem(defaultValue = "PT3S")
         public Duration timeout;
+    }
+
+    @ConfigGroup
+    public static class ArgumentConfig {
+
+        /**
+         * The action to take when {@link CamelMain} encounters an unknown argument.
+         *
+         * fail - Prints the {@link CamelMain} usage statement and throws a {@link RuntimeException}
+         * ignore - Suppresses any warnings and the application startup proceeds as normal
+         * warn - Prints the {@link CamelMain} usage statement but allows the application startup to proceed as normal
+         */
+        @ConfigItem(defaultValue = "warn")
+        public FailureRemedy onUnknown;
     }
 }

--- a/extensions-core/main/runtime/src/main/java/org/apache/camel/quarkus/main/CamelMainRecorder.java
+++ b/extensions-core/main/runtime/src/main/java/org/apache/camel/quarkus/main/CamelMainRecorder.java
@@ -27,6 +27,7 @@ import org.apache.camel.main.BaseMainSupport;
 import org.apache.camel.main.MainListener;
 import org.apache.camel.main.MainListenerSupport;
 import org.apache.camel.main.RoutesCollector;
+import org.apache.camel.quarkus.core.CamelConfig.FailureRemedy;
 import org.apache.camel.quarkus.core.CamelContextCustomizer;
 import org.apache.camel.quarkus.core.CamelProducers;
 import org.apache.camel.quarkus.core.CamelRuntime;
@@ -34,11 +35,11 @@ import org.apache.camel.quarkus.core.RegistryRoutesLoader;
 
 @Recorder
 public class CamelMainRecorder {
-    public RuntimeValue<CamelMain> createCamelMain(
-            RuntimeValue<CamelContext> runtime,
+    public RuntimeValue<CamelMain> createCamelMain(RuntimeValue<CamelContext> runtime,
             RuntimeValue<RoutesCollector> routesCollector,
-            BeanContainer container) {
-        CamelMain main = new CamelMain(runtime.getValue());
+            BeanContainer container,
+            FailureRemedy failureRemedy) {
+        CamelMain main = new CamelMain(runtime.getValue(), failureRemedy);
         main.setRoutesCollector(routesCollector.getValue());
         main.addMainListener(new CamelMainEventBridge());
 


### PR DESCRIPTION
I set the default behaviour to throw an exception if unknown args are found.

Maybe the default should be to log a warning instead?