### PR TITLE
Use correct parent version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dependencies</artifactId>
-        <version>3.8.0</version>
+        <version>3.9.0</version>
     </parent>
 
     <groupId>org.apache.camel.quarkus</groupId>
@@ -42,15 +42,13 @@
         <animal-sniffer.version>1.18</animal-sniffer.version>
         <antlr3.version>3.5.2</antlr3.version><!-- Spark, Stringtemplate and probably others -->
         <avro.version>${avro-version}</avro.version>
-        <aws-java-sdk.version>${aws-java-sdk-version}</aws-java-sdk.version>
-        <awssdk1-swf-libs.version>${aws-java-sdk-swf-libs}</awssdk1-swf-libs.version>
-        <!-- TODO: Use azure-sdk-bom once they start maintaining it properly https://github.com/Azure/azure-sdk-for-java/issues/18759 -->
-        <azure-sdk-bom.version>1.0.2</azure-sdk-bom.version><!-- TODO inherit from Camel https://issues.apache.org/jira/browse/CAMEL-16278 -->
+        <aws-java-sdk.version>1.11.714</aws-java-sdk.version>
+        <azure-sdk-bom.version>${azure-sdk-bom-version}</azure-sdk-bom.version>
 
         <bouncycastle.version>${bouncycastle-version}</bouncycastle.version><!-- keep in sync with Camel -->
 
         <camel.major.minor>3.9</camel.major.minor> <!-- run after each change: cd docs && mvndev validate -->
-	<camel.version>${camel.major.minor}.0</camel.version>
+        <camel.version>${camel.major.minor}.0</camel.version>
         <camel.docs.components.xref>${camel.major.minor}.x@components</camel.docs.components.xref><!-- the version in Camel's docs/components/antora.yml -->
         <camel.docs.branch>camel-${camel.major.minor}.x</camel.docs.branch><!-- The stable branch on which our Antora docs depends -->
 


### PR DESCRIPTION
Not sure if this thing is still needed for tests?

https://github.com/apache/camel-quarkus/blob/193956cfb18ea33443af7e38dd10525d6b15bbf6/integration-tests-support/aws2/pom.xml#L69-L78

For now, I just aligned the version with the AWS SDK 1.x version used in Camel 3.8.