### PR TITLE
docs: add xref support for adoc file sourced from javadoc

### DIFF
--- a/docs/modules/ROOT/pages/reference/extensions/core.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/core.adoc
@@ -168,7 +168,7 @@ What to do if it is not possible to extract CSimple expressions from a route def
 
 |icon:lock[title=Fixed at build time] [[quarkus.camel.main.enabled]]`link:#quarkus.camel.main.enabled[quarkus.camel.main.enabled]`
 
-If `true` all `camel-main` features are enabled; otherwise no `camel-main` features are enabled. See the Bootstrap documentation on the camel webiste for more details.
+If `true` all `camel-main` features are enabled; otherwise no `camel-main` features are enabled. See described the xref:user-guide/bootstrap.adoc#_camel_main[Bootstrap] section of Camel Quarkus documentation for more details.
 | `boolean`
 | `true`
 

--- a/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/main/CamelMainConfig.java
+++ b/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/main/CamelMainConfig.java
@@ -28,7 +28,9 @@ import org.apache.camel.quarkus.core.CamelConfig.FailureRemedy;
 public class CamelMainConfig {
     /**
      * If {@code true} all {@code camel-main} features are enabled; otherwise no {@code camel-main} features are
-     * enabled. See the Bootstrap documentation on the camel webiste for more details.
+     * enabled. See described the
+     * <a href="https://camel.apache.org/camel-quarkus/latest/user-guide/bootstrap.html#_camel_main">Bootstrap</a>
+     * section of Camel Quarkus documentation for more details.
      */
     @ConfigItem(defaultValue = "true")
     public boolean enabled;

--- a/tooling/maven-plugin/src/main/resources/doc-templates/extension-doc-page.adoc
+++ b/tooling/maven-plugin/src/main/resources/doc-templates/extension-doc-page.adoc
@@ -75,13 +75,13 @@ The `allowContextMapAll` option is not supported in native mode as it requires r
 |===
 | Configuration property | Type | Default
 
-[#list configOptions as configDocItem][#assign anchor = toAnchor(configDocItem.configDocKey.key)]
+[#list configOptions as configDocItem][#assign anchor = toAnchor(configDocItem.key)]
 
-|[=configDocItem.configDocKey.configPhase.illustration] [[[=anchor]]]`link:#[=anchor][[=configDocItem.configDocKey.key]]`
+|[=configDocItem.illustration] [[[=anchor]]]`link:#[=anchor][[=configDocItem.key]]`
 
-[=configDocItem.configDocKey.configDoc]
-| `[=configDocItem.configDocKey.type]`
-| [#if configDocItem.configDocKey.defaultValue?has_content]`[=configDocItem.configDocKey.defaultValue]`[#elseif ! configDocItem.configDocKey.optional]required icon:exclamation-circle[title=Configuration property is required][/#if]
+[=configDocItem.configDoc]
+| `[=configDocItem.type]`
+| [#if configDocItem.defaultValue?has_content]`[=configDocItem.defaultValue]`[#elseif ! configDocItem.optional]required icon:exclamation-circle[title=Configuration property is required][/#if]
 [/#list]
 |===
 


### PR DESCRIPTION
Fix #2417

@aldettinger this is the most straightforward way to solve it. For now it works only for Camel Quarkus doc links and does not work for e.g. Camel doc links. We can add that once we need it. 