### PR TITLE
Show deprecation info in Extensions reference 

### DIFF
--- a/docs/modules/ROOT/pages/reference/components.adoc
+++ b/docs/modules/ROOT/pages/reference/components.adoc
@@ -16,4 +16,4 @@ since | Support +
 level | Description
 |===
 
-indexTable::[version="{indexer-version}",component="{indexer-component}",module="{indexer-module}",relative="{indexer-rel-filter}",attributes=cq-artifact-id,cells="=`xref:reference/extensions/$\{cqArtifactIdBase}.adoc[$\{cqCamelPartTitle}]`,cq-artifact-id,cq-jvm-since,cq-native-since,cq-status,cq-camel-part-description"]
+indexTable::[version="{indexer-version}",component="{indexer-component}",module="{indexer-module}",relative="{indexer-rel-filter}",attributes=cq-artifact-id,cells="=`xref:reference/extensions/$\{cqArtifactIdBase}.adoc[$\{cqCamelPartTitle}]`,cq-artifact-id,cq-jvm-since,cq-native-since,cq-status-deprecation,cq-camel-part-description"]

--- a/docs/modules/ROOT/pages/reference/dataformats.adoc
+++ b/docs/modules/ROOT/pages/reference/dataformats.adoc
@@ -16,4 +16,4 @@ since | Support +
 level | Description
 |===
 
-indexTable::[version="{indexer-version}",component="{indexer-component}",module="{indexer-module}",relative="{indexer-rel-filter}",attributes=cq-artifact-id,cells="=`xref:reference/extensions/$\{cqArtifactIdBase}.adoc[$\{cqCamelPartTitle}]`,cq-artifact-id,cq-jvm-since,cq-native-since,cq-status,cq-camel-part-description"]
+indexTable::[version="{indexer-version}",component="{indexer-component}",module="{indexer-module}",relative="{indexer-rel-filter}",attributes=cq-artifact-id,cells="=`xref:reference/extensions/$\{cqArtifactIdBase}.adoc[$\{cqCamelPartTitle}]`,cq-artifact-id,cq-jvm-since,cq-native-since,cq-status-deprecation,cq-camel-part-description"]

--- a/docs/modules/ROOT/pages/reference/extensions/activemq.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/activemq.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-activemq
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Send messages to (or consume from) Apache ActiveMQ. This component extends the Camel JMS component.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/ahc-ws.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/ahc-ws.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-ahc-ws
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Exchange data with external Websocket servers using Async Http Client.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/ahc.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/ahc.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-ahc
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Call external HTTP services using Async Http Client.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/amqp.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/amqp.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-amqp
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Messaging with AMQP protocol using Apache QPid Client.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/apns.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/apns.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-apns
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Send notifications to Apple iOS devices.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/arangodb.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/arangodb.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-arangodb
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Perform operations on ArangoDb documents, collections and graphs.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/as2.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/as2.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-as2
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Transfer data securely and reliably using the AS2 protocol (RFC4130).
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/asn1.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/asn1.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-asn1
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Encode and decode data structures using Abstract Syntax Notation One (ASN.1).
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/asterisk.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/asterisk.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-asterisk
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Interact with Asterisk PBX Server.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/atlasmap.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/atlasmap.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-atlasmap
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Transforms the message using an AtlasMap transformation.
 :cq-deprecated: false
 :cq-jvm-since: 1.5.0

--- a/docs/modules/ROOT/pages/reference/extensions/atmos.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/atmos.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-atmos
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Integract with EMC's ViPR object data services using the Atmos Client.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/atom.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/atom.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-atom
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Poll Atom RSS feeds.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/atomix.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/atomix.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-atomix
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Access Atomix's distributed map.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/attachments.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/attachments.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-attachments
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Support for attachments on Camel messages
 :cq-deprecated: false
 :cq-jvm-since: 0.3.0

--- a/docs/modules/ROOT/pages/reference/extensions/avro-rpc.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/avro-rpc.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-avro-rpc
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Produce or consume Apache Avro RPC services.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/avro.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/avro.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-avro
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Serialize and deserialize messages using Apache Avro binary data format.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/aws-xray.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/aws-xray.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-aws-xray
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Distributed tracing using AWS XRay
 :cq-deprecated: false
 :cq-jvm-since: 1.2.0

--- a/docs/modules/ROOT/pages/reference/extensions/aws2-athena.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/aws2-athena.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-aws2-athena
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Access AWS Athena service using AWS SDK version 2.x.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/aws2-cw.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/aws2-cw.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-aws2-cw
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Sending metrics to AWS CloudWatch using AWS SDK version 2.x.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/aws2-ddb.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/aws2-ddb.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-aws2-ddb
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Store and retrieve data from AWS DynamoDB service or receive messages from AWS DynamoDB Stream using AWS SDK version 2.x.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/aws2-ec2.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/aws2-ec2.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-aws2-ec2
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Manage AWS EC2 instances using AWS SDK version 2.x.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/aws2-ecs.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/aws2-ecs.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-aws2-ecs
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Manage AWS ECS cluster instances using AWS SDK version 2.x.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/aws2-eks.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/aws2-eks.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-aws2-eks
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Manage AWS EKS cluster instances using AWS SDK version 2.x.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/aws2-eventbridge.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/aws2-eventbridge.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-aws2-eventbridge
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Manage AWS Eventbridge cluster instances using AWS SDK version 2.x.
 :cq-deprecated: false
 :cq-jvm-since: 1.4.0

--- a/docs/modules/ROOT/pages/reference/extensions/aws2-iam.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/aws2-iam.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-aws2-iam
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Manage AWS IAM instances using AWS SDK version 2.x.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/aws2-kinesis.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/aws2-kinesis.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-aws2-kinesis
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Consume and produce records from AWS Kinesis Streams using AWS SDK version 2.x.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/aws2-kms.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/aws2-kms.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-aws2-kms
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Manage keys stored in AWS KMS instances using AWS SDK version 2.x.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/aws2-lambda.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/aws2-lambda.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-aws2-lambda
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Manage and invoke AWS Lambda functions using AWS SDK version 2.x.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/aws2-mq.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/aws2-mq.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-aws2-mq
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Manage AWS MQ instances using AWS SDK version 2.x.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/aws2-msk.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/aws2-msk.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-aws2-msk
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Manage AWS MSK instances using AWS SDK version 2.x.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/aws2-s3.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/aws2-s3.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-aws2-s3
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Store and retrieve objects from AWS S3 Storage Service using AWS SDK version 2.x.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/aws2-ses.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/aws2-ses.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-aws2-ses
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Send e-mails through AWS SES service using AWS SDK version 2.x.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/aws2-sns.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/aws2-sns.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-aws2-sns
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Send messages to an AWS Simple Notification Topic using AWS SDK version 2.x.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/aws2-sqs.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/aws2-sqs.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-aws2-sqs
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Sending and receive messages to/from AWS SQS service using AWS SDK version 2.x.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/aws2-sts.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/aws2-sts.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-aws2-sts
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Manage AWS STS cluster instances using AWS SDK version 2.x.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/aws2-translate.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/aws2-translate.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-aws2-translate
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Translate texts using AWS Translate and AWS SDK version 2.x.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/azure-eventhubs.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/azure-eventhubs.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-azure-eventhubs
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: The azure-eventhubs component that integrates Azure Event Hubs using AMQP protocol. Azure EventHubs is a highly scalable publish-subscribe service that can ingest millions of events per second and stream them to multiple consumers.
 :cq-deprecated: false
 :cq-jvm-since: 1.7.0

--- a/docs/modules/ROOT/pages/reference/extensions/azure-storage-blob.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/azure-storage-blob.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-azure-storage-blob
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Store and retrieve blobs from Azure Storage Blob Service using SDK v12.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/azure-storage-datalake.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/azure-storage-datalake.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-azure-storage-datalake
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Camel Azure Datalake Gen2 Component
 :cq-deprecated: false
 :cq-jvm-since: 1.8.0

--- a/docs/modules/ROOT/pages/reference/extensions/azure-storage-queue.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/azure-storage-queue.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-azure-storage-queue
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: The azure-storage-queue component is used for storing and retrieving the messages to/from Azure Storage Queue using Azure SDK v12.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/barcode.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/barcode.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-barcode
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Transform strings to various 1D/2D barcode bitmap formats and back.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/base64.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/base64.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-base64
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Encode and decode data using Base64.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/bean-validator.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/bean-validator.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-bean-validator
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Validate the message body using the Java Bean Validation API.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/bean.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/bean.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-bean
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Invoke methods of Java beans
 :cq-deprecated: false
 :cq-jvm-since: 0.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/beanio.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/beanio.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-beanio
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Marshal and unmarshal Java beans to and from flat files (such as CSV, delimited, or fixed length formats).
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/beanstalk.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/beanstalk.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-beanstalk
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Retrieve and post-process Beanstalk jobs.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/bindy.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/bindy.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-bindy
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Marshal and unmarshal between POJOs and Comma separated values (CSV) format using Camel Bindy Marshal and unmarshal between POJOs and fixed field length format using Camel Bindy Marshal and unmarshal between POJOs and key-value pair (KVP) format using Camel Bindy
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/bonita.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/bonita.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-bonita
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Communicate with a remote Bonita BPM process engine.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/box.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/box.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-box
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Upload, download and manage files, folders, groups, collaborations, etc. on box.com.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/braintree.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/braintree.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-braintree
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Process payments using Braintree Payments.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/browse.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/browse.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-browse
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Inspect the messages received on endpoints supporting BrowsableEndpoint.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/caffeine-lrucache.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/caffeine-lrucache.adoc
@@ -5,13 +5,14 @@
 :cq-artifact-id: camel-quarkus-caffeine-lrucache
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable Deprecated
 :cq-description: An LRUCacheFactory implementation based on Caffeine
 :cq-deprecated: true
 :cq-jvm-since: 1.0.0
 :cq-native-since: 1.0.0
 
 [.badges]
-[.badge-key]##JVM since##[.badge-supported]##1.0.0## [.badge-key]##Native since##[.badge-supported]##1.0.0##
+[.badge-key]##JVM since##[.badge-supported]##1.0.0## [.badge-key]##Native since##[.badge-supported]##1.0.0## [.badge-key]##⚠️##[.badge-unsupported]##Deprecated##
 
 An LRUCacheFactory implementation based on Caffeine
 

--- a/docs/modules/ROOT/pages/reference/extensions/caffeine.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/caffeine.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-caffeine
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Perform caching operations using Caffeine Cache.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/cassandraql.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/cassandraql.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-cassandraql
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Integrate with Cassandra 2.0 using the CQL3 API (not the Thrift API). Based on Cassandra Java Driver provided by DataStax.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/cbor.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/cbor.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-cbor
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Unmarshal a CBOR payload to POJO and back.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/chatscript.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/chatscript.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-chatscript
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Chat with a ChatScript Server.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/chunk.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/chunk.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-chunk
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Transform messages using Chunk templating engine.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/cm-sms.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/cm-sms.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-cm-sms
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Send SMS messages via CM SMS Gateway.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/cmis.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/cmis.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-cmis
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Read and write data from to/from a CMIS compliant content repositories.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/coap.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/coap.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-coap
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Send and receive messages to/from COAP capable devices.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/cometd.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/cometd.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-cometd
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Offers publish/subscribe, peer-to-peer (via a server), and RPC style messaging using the CometD/Bayeux protocol.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/componentdsl.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/componentdsl.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-componentdsl
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Create Camel components with a fluent Java DSL
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/consul.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/consul.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-consul
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Integrate with Consul service discovery and configuration store.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/controlbus.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/controlbus.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-controlbus
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Manage and monitor Camel routes.
 :cq-deprecated: false
 :cq-jvm-since: 0.4.0

--- a/docs/modules/ROOT/pages/reference/extensions/corda.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/corda.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-corda
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Perform operations against Corda blockchain platform using corda-rpc library.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/core-cloud.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/core-cloud.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-core-cloud
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: The Camel Quarkus core cloud module
 :cq-deprecated: false
 :cq-jvm-since: 0.2.0

--- a/docs/modules/ROOT/pages/reference/extensions/core.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/core.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-core
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Camel core functionality and basic Camel languages: Constant, ExchangeProperty, Header, Ref, Ref, Simple and Tokeinze
 :cq-deprecated: false
 :cq-jvm-since: 0.0.1

--- a/docs/modules/ROOT/pages/reference/extensions/couchbase.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/couchbase.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-couchbase
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Query Couchbase Views with a poll strategy and/or perform various operations against Couchbase databases.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/couchdb.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/couchdb.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-couchdb
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Consume changesets for inserts, updates and deletes in a CouchDB database, as well as get, save, update and delete documents from a CouchDB database.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/cron.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/cron.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-cron
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: A generic interface for triggering events at times specified through the Unix cron syntax.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/crypto.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/crypto.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-crypto
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Sign and verify exchanges using the Signature Service of the Java Cryptographic Extension (JCE).
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/csimple.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/csimple.adoc
@@ -3,7 +3,8 @@
 = CSimple
 :cq-artifact-id: camel-quarkus-csimple
 :cq-native-supported: true
-:cq-status: Stable
+:cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Compiled Simple language
 :cq-deprecated: false
 :cq-jvm-since: 1.5.0

--- a/docs/modules/ROOT/pages/reference/extensions/csv.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/csv.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-csv
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Handle CSV (Comma Separated Values) payloads.
 :cq-deprecated: false
 :cq-jvm-since: 0.2.0

--- a/docs/modules/ROOT/pages/reference/extensions/dataformat.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/dataformat.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-dataformat
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Use a Camel Data Format as a regular Camel Component.
 :cq-deprecated: false
 :cq-jvm-since: 0.4.0

--- a/docs/modules/ROOT/pages/reference/extensions/debezium-mongodb.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/debezium-mongodb.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-debezium-mongodb
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Capture changes from a MongoDB database.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/debezium-mysql.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/debezium-mysql.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-debezium-mysql
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Capture changes from a MySQL database.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/debezium-postgres.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/debezium-postgres.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-debezium-postgres
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Capture changes from a PostgresSQL database.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/debezium-sqlserver.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/debezium-sqlserver.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-debezium-sqlserver
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Capture changes from an SQL Server database.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/digitalocean.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/digitalocean.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-digitalocean
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Manage Droplets and resources within the DigitalOcean cloud.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/direct.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/direct.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-direct
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Call another endpoint from the same Camel Context synchronously.
 :cq-deprecated: false
 :cq-jvm-since: 0.0.1

--- a/docs/modules/ROOT/pages/reference/extensions/disruptor.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/disruptor.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-disruptor
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Provides asynchronous SEDA behavior using LMAX Disruptor.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/djl.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/djl.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-djl
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Infer Deep Learning models from message exchanges data using Deep Java Library (DJL).
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/dns.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/dns.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-dns
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Perform DNS queries using DNSJava.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/dozer.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/dozer.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-dozer
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Map between Java beans using the Dozer mapping library.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/drill.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/drill.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-drill
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Perform queries against an Apache Drill cluster.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/dropbox.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/dropbox.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-dropbox
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Upload, download and manage files, folders, groups, collaborations, etc on Dropbox.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/ehcache.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/ehcache.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-ehcache
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Perform caching operations using Ehcache.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/elasticsearch-rest.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/elasticsearch-rest.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-elasticsearch-rest
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Send requests to with an ElasticSearch via REST API.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/elsql.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/elsql.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-elsql
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Use ElSql to define SQL queries. Extends the SQL Component.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/endpointdsl.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/endpointdsl.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-endpointdsl
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Code Camel endpoint URI using Java DSL instead of plain strings
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/etcd.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/etcd.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-etcd
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Get, set or delete keys in etcd key-value store.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/exec.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/exec.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-exec
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Execute commands on the underlying operating system.
 :cq-deprecated: false
 :cq-jvm-since: 0.4.0

--- a/docs/modules/ROOT/pages/reference/extensions/facebook.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/facebook.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-facebook
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Send requests to Facebook APIs supported by Facebook4J.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/fastjson.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/fastjson.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-fastjson
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Marshal POJOs to JSON and back using Fastjson
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/fhir.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/fhir.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-fhir
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Exchange information in the healthcare domain using the FHIR (Fast Healthcare Interoperability Resources) standard. Marshall and unmarshall FHIR objects to/from JSON. Marshall and unmarshall FHIR objects to/from XML.
 :cq-deprecated: false
 :cq-jvm-since: 0.3.0

--- a/docs/modules/ROOT/pages/reference/extensions/file-watch.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/file-watch.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-file-watch
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Get notified about file events in a directory using java.nio.file.WatchService.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/file.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/file.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-file
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Read and write files.
 :cq-deprecated: false
 :cq-jvm-since: 0.4.0

--- a/docs/modules/ROOT/pages/reference/extensions/flatpack.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/flatpack.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-flatpack
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Parse fixed width and delimited files using the FlatPack library.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/flink.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/flink.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-flink
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Send DataSet jobs to an Apache Flink cluster.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/fop.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/fop.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-fop
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Render messages into PDF and other output formats supported by Apache FOP.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/freemarker.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/freemarker.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-freemarker
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Transform messages using FreeMarker templates.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/ftp.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/ftp.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-ftp
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Upload and download files to/from FTP or SFTP servers.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/ganglia.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/ganglia.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-ganglia
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Send metrics to Ganglia monitoring system.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/geocoder.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/geocoder.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-geocoder
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Find geocodes (latitude and longitude) for a given address or the other way round.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/git.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/git.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-git
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Perform operations on git repositories.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/github.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/github.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-github
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Interact with the GitHub API.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/google-bigquery.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/google-bigquery.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-google-bigquery
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Access Google Cloud BigQuery service using SQL queries or Google Client Services API
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/google-calendar.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/google-calendar.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-google-calendar
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Perform various operations on a Google Calendar. Poll for changes in a Google Calendar.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/google-drive.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/google-drive.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-google-drive
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Manage files in Google Drive.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/google-mail.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/google-mail.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-google-mail
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Manage messages in Google Mail. Poll for incoming messages in Google Mail.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/google-pubsub.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/google-pubsub.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-google-pubsub
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Send and receive messages to/from Google Cloud Platform PubSub Service.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/google-sheets.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/google-sheets.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-google-sheets
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Manage spreadsheets in Google Sheets. Poll for changes in Google Sheets.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/graphql.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/graphql.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-graphql
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Send GraphQL queries and mutations to external systems.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/grok.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/grok.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-grok
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Unmarshal unstructured data to objects using Logstash based Grok patterns.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/groovy-dsl.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/groovy-dsl.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-groovy-dsl
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Support for parsing Groovy route definitions at runtime
 :cq-deprecated: false
 :cq-jvm-since: 1.8.0

--- a/docs/modules/ROOT/pages/reference/extensions/groovy.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/groovy.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-groovy
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Evaluate a Groovy script.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/grpc.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/grpc.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-grpc
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Expose gRPC endpoints and access external gRPC endpoints.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/gson.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/gson.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-gson
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Marshal POJOs to JSON and back using Gson
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/guava-eventbus.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/guava-eventbus.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-guava-eventbus
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Send and receive messages to/from Guava EventBus.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/hazelcast.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/hazelcast.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-hazelcast
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Increment, decrement, set, etc. Hazelcast atomic number (a grid wide number).
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/hbase.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/hbase.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-hbase
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Reading and write from/to an HBase store (Hadoop database).
 :cq-deprecated: false
 :cq-jvm-since: 1.2.0

--- a/docs/modules/ROOT/pages/reference/extensions/hdfs.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/hdfs.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-hdfs
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Read and write from/to an HDFS filesystem using Hadoop 2.x.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/headersmap.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/headersmap.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-headersmap
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Fast case-insensitive headers map implementation
 :cq-deprecated: false
 :cq-jvm-since: 1.2.0

--- a/docs/modules/ROOT/pages/reference/extensions/hl7.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/hl7.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-hl7
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Marshal and unmarshal HL7 (Health Care) model objects using the HL7 MLLP codec.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/http.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/http.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-http
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Send requests to external HTTP servers using Apache HTTP Client 4.x.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/huaweicloud-smn.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/huaweicloud-smn.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-huaweicloud-smn
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Huawei Cloud component to integrate with SimpleNotification services
 :cq-deprecated: false
 :cq-jvm-since: 1.8.0

--- a/docs/modules/ROOT/pages/reference/extensions/hystrix.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/hystrix.adoc
@@ -5,13 +5,14 @@
 :cq-artifact-id: camel-quarkus-hystrix
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable Deprecated
 :cq-description: Circuit Breaker EIP using Netflix Hystrix
 :cq-deprecated: true
 :cq-jvm-since: 1.0.0
 :cq-native-since: 1.0.0
 
 [.badges]
-[.badge-key]##JVM since##[.badge-supported]##1.0.0## [.badge-key]##Native since##[.badge-supported]##1.0.0##
+[.badge-key]##JVM since##[.badge-supported]##1.0.0## [.badge-key]##Native since##[.badge-supported]##1.0.0## [.badge-key]##⚠️##[.badge-unsupported]##Deprecated##
 
 Circuit Breaker EIP using Netflix Hystrix
 

--- a/docs/modules/ROOT/pages/reference/extensions/ical.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/ical.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-ical
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Marshal and unmarshal iCal (.ics) documents to/from model objects provided by the iCal4j library.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/iec60870.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/iec60870.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-iec60870
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: IEC 60870 supervisory control and data acquisition (SCADA) client using NeoSCADA implementation.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/ignite.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/ignite.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-ignite
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Perform cache operations on an Ignite cache or consume changes from a continuous query.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/infinispan.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/infinispan.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-infinispan
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Read and write from/to Infinispan distributed key/value store and data grid.
 :cq-deprecated: false
 :cq-jvm-since: 0.0.1

--- a/docs/modules/ROOT/pages/reference/extensions/influxdb.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/influxdb.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-influxdb
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Interact with InfluxDB, a time series database.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/iota.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/iota.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-iota
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Manage financial transactions using IOTA distributed ledger.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/ipfs.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/ipfs.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-ipfs
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Access the Interplanetary File System (IPFS).
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/irc.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/irc.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-irc
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Send and receive messages to/from and IRC chat.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/jackson.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/jackson.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-jackson
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Marshal POJOs to JSON and back using Jackson
 :cq-deprecated: false
 :cq-jvm-since: 0.3.0

--- a/docs/modules/ROOT/pages/reference/extensions/jacksonxml.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/jacksonxml.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-jacksonxml
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Unmarshal a XML payloads to POJOs and back using XMLMapper extension of Jackson.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/jasypt.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/jasypt.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-jasypt
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Security using Jasypt
 :cq-deprecated: false
 :cq-jvm-since: 1.2.0

--- a/docs/modules/ROOT/pages/reference/extensions/java-joor-dsl.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/java-joor-dsl.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-java-joor-dsl
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Support for parsing Java route definitions at runtime
 :cq-deprecated: false
 :cq-jvm-since: 1.8.0

--- a/docs/modules/ROOT/pages/reference/extensions/jaxb.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/jaxb.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-jaxb
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Unmarshal XML payloads to POJOs and back using JAXB2 XML marshalling standard.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/jbpm.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/jbpm.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-jbpm
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Interact with jBPM workflow engine over REST.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/jcache.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/jcache.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-jcache
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Perform caching operations against JSR107/JCache.
 :cq-deprecated: false
 :cq-jvm-since: 1.2.0

--- a/docs/modules/ROOT/pages/reference/extensions/jclouds.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/jclouds.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-jclouds
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Interact with jclouds compute & blobstore service.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/jcr.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/jcr.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-jcr
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Read and write nodes to/from a JCR compliant content repository.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/jdbc.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/jdbc.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-jdbc
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Access databases through SQL and JDBC.
 :cq-deprecated: false
 :cq-jvm-since: 0.0.1

--- a/docs/modules/ROOT/pages/reference/extensions/jfr.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/jfr.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-jfr
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Diagnose Camel applications with Java Flight Recorder
 :cq-deprecated: false
 :cq-jvm-since: 1.7.0

--- a/docs/modules/ROOT/pages/reference/extensions/jgroups-raft.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/jgroups-raft.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-jgroups-raft
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Exchange messages with JGroups-raft clusters.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/jgroups.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/jgroups.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-jgroups
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Exchange messages with JGroups clusters.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/jing.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/jing.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-jing
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Validate XML against a RelaxNG schema (XML Syntax or Compact Syntax) using Jing library.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/jira.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/jira.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-jira
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Interact with JIRA issue tracker.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/jms.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/jms.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-jms
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Sent and receive messages to/from a JMS Queue or Topic.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/johnzon.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/johnzon.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-johnzon
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Marshal POJOs to JSON and back using Johnzon
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/jolt.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/jolt.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-jolt
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: JSON to JSON transformation using JOLT.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/jooq.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/jooq.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-jooq
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Store and retrieve Java objects from an SQL database using JOOQ.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/jpa.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/jpa.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-jpa
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Store and retrieve Java objects from databases using Java Persistence API (JPA).
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/js-dsl.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/js-dsl.adoc
@@ -3,7 +3,8 @@
 = JavaScript DSL
 :cq-artifact-id: camel-quarkus-js-dsl
 :cq-native-supported: true
-:cq-status: Stable
+:cq-status: Experimental
+:cq-status-deprecation: Experimental
 :cq-description: An JavaScript stack for parsing JavaScript route definitions
 :cq-deprecated: false
 :cq-jvm-since: 1.8.0

--- a/docs/modules/ROOT/pages/reference/extensions/jsch.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/jsch.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-jsch
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Copy files to/from remote hosts using the secure copy protocol (SCP).
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/jslt.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/jslt.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-jslt
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Query or transform JSON payloads using an JSLT.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/json-validator.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/json-validator.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-json-validator
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Validate JSON payloads using NetworkNT JSON Schema.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/jsonapi.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/jsonapi.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-jsonapi
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Marshal and unmarshal JSON:API resources using JSONAPI-Converter library.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/jsonata.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/jsonata.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-jsonata
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: JSON to JSON transformation using JSONATA.
 :cq-deprecated: false
 :cq-jvm-since: 1.6.0

--- a/docs/modules/ROOT/pages/reference/extensions/jsonb.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/jsonb.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-jsonb
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Marshal POJOs to JSON and back using JSON-B.
 :cq-deprecated: false
 :cq-jvm-since: 1.5.0

--- a/docs/modules/ROOT/pages/reference/extensions/jsonpath.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/jsonpath.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-jsonpath
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Evaluate a JsonPath expression against a JSON message body.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/jt400.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/jt400.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-jt400
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Exchanges messages with an IBM i system using data queues, message queues, or program call. IBM i is the replacement for AS/400 and iSeries servers.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/jta.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/jta.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-jta
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Enclose Camel routes in the transactions using Java Transaction API (JTA) and Narayana transaction manager
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/kafka.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/kafka.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-kafka
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Sent and receive messages to/from an Apache Kafka broker.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/kamelet.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/kamelet.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-kamelet
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: The Kamelet Component provides support for interacting with the Camel Route Template engine
 :cq-deprecated: false
 :cq-jvm-since: 1.7.0

--- a/docs/modules/ROOT/pages/reference/extensions/kotlin-dsl.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/kotlin-dsl.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-kotlin-dsl
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Support for parsing Kotlin route definitions at runtime
 :cq-deprecated: false
 :cq-jvm-since: 1.8.0

--- a/docs/modules/ROOT/pages/reference/extensions/kotlin.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/kotlin.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-kotlin
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Write Camel integration routes in Kotlin
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/kubernetes.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/kubernetes.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-kubernetes
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Perform operations against Kubernetes API
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/kudu.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/kudu.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-kudu
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Interact with Apache Kudu, a free and open source column-oriented data store of the Apache Hadoop ecosystem.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/language.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/language.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-language
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Execute scripts in any of the languages supported by Camel.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/ldap.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/ldap.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-ldap
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Perform searches on LDAP servers.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/ldif.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/ldif.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-ldif
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Perform updates on an LDAP server from an LDIF body content.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/leveldb.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/leveldb.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-leveldb
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Using LevelDB as persistent EIP store
 :cq-deprecated: false
 :cq-jvm-since: 1.2.0

--- a/docs/modules/ROOT/pages/reference/extensions/log.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/log.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-log
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Log messages to the underlying logging mechanism.
 :cq-deprecated: false
 :cq-jvm-since: 0.0.1

--- a/docs/modules/ROOT/pages/reference/extensions/lra.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/lra.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-lra
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Camel saga binding for Long-Running-Action framework
 :cq-deprecated: false
 :cq-jvm-since: 1.2.0

--- a/docs/modules/ROOT/pages/reference/extensions/lucene.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/lucene.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-lucene
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Perform inserts or queries against Apache Lucene databases.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/lumberjack.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/lumberjack.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-lumberjack
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Receive logs messages using the Lumberjack protocol.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/lzf.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/lzf.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-lzf
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Compress and decompress streams using LZF deflate algorithm.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/mail.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/mail.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-mail
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Send and receive emails using imap, pop3 and smtp protocols. Marshal Camel messages with attachments into MIME-Multipart messages and back.
 :cq-deprecated: false
 :cq-jvm-since: 0.2.0

--- a/docs/modules/ROOT/pages/reference/extensions/main.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/main.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-main
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Bootstrap Camel using Camel Main which brings advanced auto-configuration capabilities and integration with Quarkus Command Mode
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/management.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/management.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-management
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: JMX management strategy and associated managed resources.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/master.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/master.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-master
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Have only a single consumer in a cluster consuming from a given endpoint; with automatic failover if the JVM dies.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/micrometer.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/micrometer.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-micrometer
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Collect various metrics directly from Camel routes using the Micrometer library.
 :cq-deprecated: false
 :cq-jvm-since: 1.5.0

--- a/docs/modules/ROOT/pages/reference/extensions/microprofile-fault-tolerance.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/microprofile-fault-tolerance.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-microprofile-fault-tolerance
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Circuit Breaker EIP using Microprofile Fault Tolerance
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/microprofile-health.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/microprofile-health.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-microprofile-health
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Bridging Eclipse MicroProfile Health with Camel health checks
 :cq-deprecated: false
 :cq-jvm-since: 0.3.0

--- a/docs/modules/ROOT/pages/reference/extensions/microprofile-metrics.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/microprofile-metrics.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-microprofile-metrics
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Expose metrics from Camel routes.
 :cq-deprecated: false
 :cq-jvm-since: 0.2.0

--- a/docs/modules/ROOT/pages/reference/extensions/milo.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/milo.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-milo
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Connect to OPC UA servers using the binary protocol for acquiring telemetry data.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/minio.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/minio.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-minio
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Store and retrieve objects from Minio Storage Service using Minio SDK.
 :cq-deprecated: false
 :cq-jvm-since: 1.5.0

--- a/docs/modules/ROOT/pages/reference/extensions/mllp.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/mllp.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-mllp
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Communicate with external systems using the MLLP protocol.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/mock.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/mock.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-mock
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Test routes and mediation rules using mocks.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/mongodb-gridfs.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/mongodb-gridfs.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-mongodb-gridfs
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Interact with MongoDB GridFS.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/mongodb.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/mongodb.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-mongodb
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Perform operations on MongoDB documents and collections.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/msv.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/msv.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-msv
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Validate XML payloads using Multi-Schema Validator (MSV).
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/mustache.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/mustache.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-mustache
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Transform messages using a Mustache template.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/mvel.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/mvel.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-mvel
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Transform messages using an MVEL template.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/mybatis.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/mybatis.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-mybatis
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Performs a query, poll, insert, update or delete in a relational database using MyBatis.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/nagios.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/nagios.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-nagios
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Send passive checks to Nagios using JSendNSCA.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/nats.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/nats.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-nats
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Send and receive messages from NATS messaging system.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/netty-http.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/netty-http.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-netty-http
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Netty HTTP server and client using the Netty 4.x.
 :cq-deprecated: false
 :cq-jvm-since: 0.2.0

--- a/docs/modules/ROOT/pages/reference/extensions/netty.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/netty.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-netty
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Socket level networking using TCP or UDP with the Netty 4.x.
 :cq-deprecated: false
 :cq-jvm-since: 0.4.0

--- a/docs/modules/ROOT/pages/reference/extensions/nitrite.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/nitrite.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-nitrite
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Access Nitrite databases.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/nsq.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/nsq.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-nsq
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Send and receive messages from NSQ realtime distributed messaging platform.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/oaipmh.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/oaipmh.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-oaipmh
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Harvest metadata using OAI-PMH protocol
 :cq-deprecated: false
 :cq-jvm-since: 1.7.0

--- a/docs/modules/ROOT/pages/reference/extensions/ognl.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/ognl.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-ognl
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Evaluate an Apache Commons Object Graph Navigation Library (OGNL) expression against the Camel Exchange.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/olingo4.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/olingo4.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-olingo4
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Communicate with OData 4.0 services using Apache Olingo OData API.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/openapi-java.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/openapi-java.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-openapi-java
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Rest-dsl support for using OpenAPI doc
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/openstack.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/openstack.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-openstack
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Interact with OpenStack APIs
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/opentracing.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/opentracing.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-opentracing
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Distributed tracing using OpenTracing
 :cq-deprecated: false
 :cq-jvm-since: 0.3.0

--- a/docs/modules/ROOT/pages/reference/extensions/optaplanner.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/optaplanner.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-optaplanner
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Solve planning problems with OptaPlanner.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/paho-mqtt5.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/paho-mqtt5.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-paho-mqtt5
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Communicate with MQTT message brokers using Eclipse Paho MQTT v5 Client.
 :cq-deprecated: false
 :cq-jvm-since: 1.8.0

--- a/docs/modules/ROOT/pages/reference/extensions/paho.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/paho.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-paho
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Communicate with MQTT message brokers using Eclipse Paho MQTT Client.
 :cq-deprecated: false
 :cq-jvm-since: 0.2.0

--- a/docs/modules/ROOT/pages/reference/extensions/pdf.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/pdf.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-pdf
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Create, modify or extract content from PDF documents.
 :cq-deprecated: false
 :cq-jvm-since: 0.3.1

--- a/docs/modules/ROOT/pages/reference/extensions/pg-replication-slot.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/pg-replication-slot.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-pg-replication-slot
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Poll for PostgreSQL Write-Ahead Log (WAL) records using Streaming Replication Slots.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/pgevent.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/pgevent.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-pgevent
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Send and receive PostgreSQL events via LISTEN and NOTIFY commands.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/platform-http.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/platform-http.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-platform-http
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Expose HTTP endpoints using the HTTP server available in the current platform.
 :cq-deprecated: false
 :cq-jvm-since: 0.3.0

--- a/docs/modules/ROOT/pages/reference/extensions/printer.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/printer.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-printer
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Send print jobs to printers.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/protobuf.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/protobuf.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-protobuf
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Serialize and deserialize Java objects using Google's Protocol buffers.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/pubnub.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/pubnub.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-pubnub
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Send and receive messages to/from PubNub data stream network for connected devices.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/pulsar.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/pulsar.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-pulsar
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Send and receive messages from/to Apache Pulsar messaging system.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/quartz.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/quartz.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-quartz
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Schedule sending of messages using the Quartz 2.x scheduler.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/quickfix.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/quickfix.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-quickfix
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Open a Financial Interchange (FIX) session using an embedded QuickFix/J engine.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/qute.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/qute.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-qute
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Transform messages using Quarkus Qute templating engine
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/rabbitmq.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/rabbitmq.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-rabbitmq
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Send and receive messages from RabbitMQ instances.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/reactive-executor.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/reactive-executor.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-reactive-executor
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Reactive Executor for camel-core using Vert.x
 :cq-deprecated: false
 :cq-jvm-since: 0.3.0

--- a/docs/modules/ROOT/pages/reference/extensions/reactive-streams.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/reactive-streams.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-reactive-streams
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Exchange messages with reactive stream processing libraries compatible with the reactive streams standard.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/redis.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/redis.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-redis
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Aggregation repository using Redis as datastore
 :cq-deprecated: false
 :cq-jvm-since: 1.6.0

--- a/docs/modules/ROOT/pages/reference/extensions/ref.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/ref.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-ref
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Route messages to an endpoint looked up dynamically by name in the Camel Registry.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/rest-openapi.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/rest-openapi.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-rest-openapi
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Configure REST producers based on an OpenAPI specification document delegating to a component implementing the RestProducerFactory interface.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/rest.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/rest.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-rest
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Expose REST services and their OpenAPI Specification or call external REST services.
 :cq-deprecated: false
 :cq-jvm-since: 0.0.1

--- a/docs/modules/ROOT/pages/reference/extensions/ribbon.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/ribbon.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-ribbon
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Using Netflix Ribbon for client side load balancing
 :cq-deprecated: false
 :cq-jvm-since: 1.2.0

--- a/docs/modules/ROOT/pages/reference/extensions/robotframework.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/robotframework.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-robotframework
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Pass camel exchanges to acceptence test written in Robot DSL.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/rss.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/rss.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-rss
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Poll RSS feeds.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/saga.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/saga.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-saga
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Execute custom actions within a route using the Saga EIP.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/salesforce.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/salesforce.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-salesforce
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Communicate with Salesforce using Java DTOs.
 :cq-deprecated: false
 :cq-jvm-since: 0.2.0

--- a/docs/modules/ROOT/pages/reference/extensions/sap-netweaver.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/sap-netweaver.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-sap-netweaver
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Send requests to SAP NetWeaver Gateway using HTTP.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/saxon.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/saxon.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-saxon
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Query and/or transform XML payloads using XQuery and Saxon.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/scheduler.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/scheduler.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-scheduler
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Generate messages in specified intervals using java.util.concurrent.ScheduledExecutorService.
 :cq-deprecated: false
 :cq-jvm-since: 0.4.0

--- a/docs/modules/ROOT/pages/reference/extensions/schematron.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/schematron.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-schematron
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Validate XML payload using the Schematron Library.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/seda.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/seda.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-seda
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Asynchronously call another endpoint from any Camel Context in the same JVM.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/servicenow.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/servicenow.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-servicenow
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Interact with ServiceNow via its REST API.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/servlet.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/servlet.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-servlet
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Serve HTTP requests by a Servlet.
 :cq-deprecated: false
 :cq-jvm-since: 0.2.0

--- a/docs/modules/ROOT/pages/reference/extensions/shiro.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/shiro.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-shiro
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Security using Shiro
 :cq-deprecated: false
 :cq-jvm-since: 1.2.0

--- a/docs/modules/ROOT/pages/reference/extensions/sip.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/sip.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-sip
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Send and receive messages using the SIP protocol (used in telecommunications).
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/sjms.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/sjms.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-sjms
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Send and receive messages to/from a JMS Queue or Topic using plain JMS 1.x API.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/sjms2.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/sjms2.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-sjms2
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Send and receive messages to/from a JMS Queue or Topic using plain JMS 2.x API.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/slack.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/slack.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-slack
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Send and receive messages to/from Slack.
 :cq-deprecated: false
 :cq-jvm-since: 0.3.0

--- a/docs/modules/ROOT/pages/reference/extensions/smallrye-reactive-messaging.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/smallrye-reactive-messaging.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-smallrye-reactive-messaging
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Camel integration with SmallRye Reactive Messaging
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/smpp.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/smpp.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-smpp
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Send and receive SMS messages using a SMSC (Short Message Service Center).
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/snakeyaml.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/snakeyaml.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-snakeyaml
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Marshal and unmarshal Java objects to and from YAML using SnakeYAML
 :cq-deprecated: false
 :cq-jvm-since: 0.4.0

--- a/docs/modules/ROOT/pages/reference/extensions/snmp.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/snmp.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-snmp
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Receive traps and poll SNMP (Simple Network Management Protocol) capable devices.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/soap.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/soap.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-soap
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Marshal Java objects to SOAP messages and back.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/solr.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/solr.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-solr
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Perform operations against Apache Lucene Solr.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/soroush.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/soroush.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-soroush
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Send and receive messages as a Soroush chat bot.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/spark.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/spark.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-spark
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Send RDD or DataFrame jobs to Apache Spark clusters.
 :cq-deprecated: false
 :cq-jvm-since: 1.3.0

--- a/docs/modules/ROOT/pages/reference/extensions/splunk-hec.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/splunk-hec.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-splunk-hec
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: The splunk component allows to publish events in Splunk using the HTTP Event Collector.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/splunk.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/splunk.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-splunk
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Publish or search for events in Splunk.
 :cq-deprecated: false
 :cq-jvm-since: 1.8.0

--- a/docs/modules/ROOT/pages/reference/extensions/spring-rabbitmq.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/spring-rabbitmq.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-spring-rabbitmq
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Send and receive messages from RabbitMQ using Spring RabbitMQ client.
 :cq-deprecated: false
 :cq-jvm-since: 1.7.0

--- a/docs/modules/ROOT/pages/reference/extensions/sql.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/sql.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-sql
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Perform SQL queries using Spring JDBC.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/ssh.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/ssh.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-ssh
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Execute commands on remote hosts using SSH.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/stax.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/stax.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-stax
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Process XML payloads by a SAX ContentHandler.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/stitch.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/stitch.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-stitch
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Stitch is a cloud ETL service that integrates various data sources into a central data warehouse through various integrations.
 :cq-deprecated: false
 :cq-jvm-since: 1.8.0

--- a/docs/modules/ROOT/pages/reference/extensions/stomp.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/stomp.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-stomp
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Send and rececive messages to/from STOMP (Simple Text Oriented Messaging Protocol) compliant message brokers.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/stream.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/stream.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-stream
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Read from system-in and write to system-out and system-err streams.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/stringtemplate.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/stringtemplate.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-stringtemplate
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Transform messages using StringTemplate engine.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/stub.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/stub.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-stub
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Stub out any physical endpoints while in development or testing.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/syslog.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/syslog.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-syslog
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Marshall SyslogMessages to RFC3164 and RFC5424 messages and back.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/tagsoup.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/tagsoup.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-tagsoup
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Parse (potentially invalid) HTML into valid HTML or DOM.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/tarfile.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/tarfile.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-tarfile
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Archive files into tarballs or extract files from tarballs.
 :cq-deprecated: false
 :cq-jvm-since: 0.3.0

--- a/docs/modules/ROOT/pages/reference/extensions/telegram.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/telegram.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-telegram
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Send and receive messages acting as a Telegram Bot Telegram Bot API.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/threadpoolfactory-vertx.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/threadpoolfactory-vertx.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-threadpoolfactory-vertx
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: ThreadPoolFactory for camel-core using Vert.x
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/thrift.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/thrift.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-thrift
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Call and expose remote procedures (RPC) with Apache Thrift data format and serialization mechanism.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/tika.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/tika.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-tika
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Parse documents and extract metadata and text using Apache Tika.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/timer.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/timer.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-timer
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Generate messages in specified intervals using java.util.Timer.
 :cq-deprecated: false
 :cq-jvm-since: 0.2.0

--- a/docs/modules/ROOT/pages/reference/extensions/twilio.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/twilio.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-twilio
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Interact with Twilio REST APIs using Twilio Java SDK.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/twitter.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/twitter.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-twitter
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Send tweets and receive tweets, direct messages and access Twitter Search
 :cq-deprecated: false
 :cq-jvm-since: 0.2.0

--- a/docs/modules/ROOT/pages/reference/extensions/univocity-parsers.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/univocity-parsers.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-univocity-parsers
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Marshal and unmarshal Java objects from and to CSV (Comma Separated Values) using UniVocity Parsers.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/validator.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/validator.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-validator
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Validate the payload using XML Schema and JAXP Validation.
 :cq-deprecated: false
 :cq-jvm-since: 0.4.0

--- a/docs/modules/ROOT/pages/reference/extensions/velocity.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/velocity.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-velocity
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Transform messages using a Velocity template.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/vertx-http.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/vertx-http.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-vertx-http
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Camel HTTP client support with Vert.x
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/vertx-kafka.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/vertx-kafka.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-vertx-kafka
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Sent and receive messages to/from an Apache Kafka broker using vert.x Kafka client
 :cq-deprecated: false
 :cq-jvm-since: 1.6.0

--- a/docs/modules/ROOT/pages/reference/extensions/vertx-websocket.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/vertx-websocket.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-vertx-websocket
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Camel WebSocket support with Vert.x
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/vertx.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/vertx.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-vertx
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Send and receive messages to/from Vert.x Event Bus.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/vm.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/vm.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-vm
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Call another endpoint in the same CamelContext asynchronously.
 :cq-deprecated: false
 :cq-jvm-since: 0.3.0

--- a/docs/modules/ROOT/pages/reference/extensions/weather.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/weather.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-weather
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Poll the weather information from Open Weather Map.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/web3j.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/web3j.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-web3j
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Interact with Ethereum nodes using web3j client API.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/weka.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/weka.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-weka
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Perform machine learning tasks using Weka.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/wordpress.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/wordpress.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-wordpress
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Manage posts and users using Wordpress API.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/workday.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/workday.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-workday
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Detect and parse documents using Workday.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/xchange.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/xchange.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-xchange
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Access market data and trade on Bitcoin and Altcoin exchanges.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/xj.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/xj.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-xj
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Transform JSON and XML message using a XSLT.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/xml-io-dsl.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/xml-io-dsl.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-xml-io-dsl
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: An XML stack for parsing XML route definitions
 :cq-deprecated: false
 :cq-jvm-since: 1.8.0

--- a/docs/modules/ROOT/pages/reference/extensions/xml-io.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/xml-io.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-xml-io
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: An XML stack for parsing XML route definitions. A fast an light weight alternative to camel-quarkus-xml-jaxp
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/xml-jaxb.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/xml-jaxb.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-xml-jaxb
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: An XML stack for parsing XML route definitions. A legacy alternative to the fast an light weight camel-quarkus-xml-io
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/xml-jaxp.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/xml-jaxp.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-xml-jaxp
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Tokenize XML payloads using the specified path expression.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/xmlsecurity.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/xmlsecurity.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-xmlsecurity
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Sign XML payloads using the XML signature specification.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/xmpp.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/xmpp.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-xmpp
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Send and receive messages to/from an XMPP chat server.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/xpath.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/xpath.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-xpath
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Evaluate an XPath expression against an XML payload.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/xslt-saxon.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/xslt-saxon.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-xslt-saxon
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Transform XML payloads using an XSLT template using Saxon.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/xslt.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/xslt.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-xslt
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Transforms XML payload using an XSLT template.
 :cq-deprecated: false
 :cq-jvm-since: 0.4.0

--- a/docs/modules/ROOT/pages/reference/extensions/xstream.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/xstream.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-xstream
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Marshal and unmarshal POJOs to/from XML or JSON using XStream library.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/yaml-dsl.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/yaml-dsl.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-yaml-dsl
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: An YAML stack for parsing YAML route definitions
 :cq-deprecated: false
 :cq-jvm-since: 1.8.0

--- a/docs/modules/ROOT/pages/reference/extensions/yammer.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/yammer.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-yammer
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Interact with the Yammer enterprise social network.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/zendesk.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/zendesk.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-zendesk
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Manage Zendesk tickets, users, organizations, etc.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/zip-deflater.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/zip-deflater.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-zip-deflater
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Compress and decompress streams using java.util.zip.Deflater, java.util.zip.Inflater or java.util.zip.GZIPStream.
 :cq-deprecated: false
 :cq-jvm-since: 1.0.0

--- a/docs/modules/ROOT/pages/reference/extensions/zipfile.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/zipfile.adoc
@@ -5,6 +5,7 @@
 :cq-artifact-id: camel-quarkus-zipfile
 :cq-native-supported: true
 :cq-status: Stable
+:cq-status-deprecation: Stable
 :cq-description: Compression and decompress streams using java.util.zip.ZipStream.
 :cq-deprecated: false
 :cq-jvm-since: 0.2.0

--- a/docs/modules/ROOT/pages/reference/extensions/zookeeper-master.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/zookeeper-master.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-zookeeper-master
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Have only a single consumer in a cluster consuming from a given endpoint; with automatic failover if the JVM dies.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/extensions/zookeeper.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/zookeeper.adoc
@@ -4,6 +4,7 @@
 :cq-artifact-id: camel-quarkus-zookeeper
 :cq-native-supported: false
 :cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Manage ZooKeeper clusters.
 :cq-deprecated: false
 :cq-jvm-since: 1.1.0

--- a/docs/modules/ROOT/pages/reference/index.adoc
+++ b/docs/modules/ROOT/pages/reference/index.adoc
@@ -24,4 +24,4 @@ since | Support +
 level | Description
 |===
 
-indexTable::[relative='reference/extensions/*.adoc',cells="$xref,cq-artifact-id,cq-jvm-since,cq-native-since,cq-status,cq-description"]
+indexTable::[relative='reference/extensions/*.adoc',cells="$xref,cq-artifact-id,cq-jvm-since,cq-native-since,cq-status-deprecation,cq-description"]

--- a/docs/modules/ROOT/pages/reference/languages.adoc
+++ b/docs/modules/ROOT/pages/reference/languages.adoc
@@ -16,4 +16,4 @@ since | Support +
 level | Description
 |===
 
-indexTable::[version="{indexer-version}",component="{indexer-component}",module="{indexer-module}",relative="{indexer-rel-filter}",attributes=cq-artifact-id,cells="=`xref:reference/extensions/$\{cqArtifactIdBase}.adoc[$\{cqCamelPartTitle}]`,cq-artifact-id,cq-jvm-since,cq-native-since,cq-status,cq-camel-part-description"]
+indexTable::[version="{indexer-version}",component="{indexer-component}",module="{indexer-module}",relative="{indexer-rel-filter}",attributes=cq-artifact-id,cells="=`xref:reference/extensions/$\{cqArtifactIdBase}.adoc[$\{cqCamelPartTitle}]`,cq-artifact-id,cq-jvm-since,cq-native-since,cq-status-deprecation,cq-camel-part-description"]

--- a/docs/modules/ROOT/pages/reference/others.adoc
+++ b/docs/modules/ROOT/pages/reference/others.adoc
@@ -16,4 +16,4 @@ since | Support +
 level | Description
 |===
 
-indexTable::[version="{indexer-version}",component="{indexer-component}",module="{indexer-module}",relative="{indexer-rel-filter}",attributes=cq-artifact-id,cells="=`xref:reference/extensions/$\{cqArtifactIdBase}.adoc[$\{cqCamelPartTitle}]`,cq-artifact-id,cq-jvm-since,cq-native-since,cq-status,cq-camel-part-description"]
+indexTable::[version="{indexer-version}",component="{indexer-component}",module="{indexer-module}",relative="{indexer-rel-filter}",attributes=cq-artifact-id,cells="=`xref:reference/extensions/$\{cqArtifactIdBase}.adoc[$\{cqCamelPartTitle}]`,cq-artifact-id,cq-jvm-since,cq-native-since,cq-status-deprecation,cq-camel-part-description"]

--- a/tooling/maven-plugin/src/main/java/org/apache/camel/quarkus/maven/CamelQuarkusExtension.java
+++ b/tooling/maven-plugin/src/main/java/org/apache/camel/quarkus/maven/CamelQuarkusExtension.java
@@ -66,6 +66,11 @@ public class CamelQuarkusExtension {
             }
 
             final String version = CqUtils.getVersion(runtimePom);
+            final boolean nativeSupported = !runtimePomXmlPath.getParent().getParent().getParent().getFileName().toString()
+                    .endsWith("-jvm");
+            final String extensionStatus = props.getProperty("quarkus.metadata.status");
+            final ExtensionStatus status = extensionStatus == null ? ExtensionStatus.of(nativeSupported)
+                    : ExtensionStatus.valueOf(extensionStatus);
 
             return new CamelQuarkusExtension(
                     runtimePomXmlPath,
@@ -77,7 +82,8 @@ public class CamelQuarkusExtension {
                     runtimePom.getDescription(),
                     props.getProperty("label"),
                     version,
-                    !runtimePomXmlPath.getParent().getParent().getParent().getFileName().toString().endsWith("-jvm"),
+                    nativeSupported,
+                    status,
                     deps == null ? Collections.emptyList() : Collections.unmodifiableList(deps));
         } catch (IOException | XmlPullParserException e) {
             throw new RuntimeException("Could not read " + runtimePomXmlPath, e);
@@ -95,6 +101,7 @@ public class CamelQuarkusExtension {
     private final boolean nativeSupported;
     private final String nativeSince;
     private final List<Dependency> dependencies;
+    private final ExtensionStatus status;
 
     public CamelQuarkusExtension(
             Path runtimePomXmlPath,
@@ -107,6 +114,7 @@ public class CamelQuarkusExtension {
             String label,
             String version,
             boolean nativeSupported,
+            ExtensionStatus status,
             List<Dependency> dependencies) {
         super();
         this.runtimePomXmlPath = runtimePomXmlPath;
@@ -119,6 +127,7 @@ public class CamelQuarkusExtension {
         this.label = label;
         this.version = version;
         this.nativeSupported = nativeSupported;
+        this.status = status;
         this.dependencies = dependencies;
     }
 
@@ -168,6 +177,10 @@ public class CamelQuarkusExtension {
 
     public Optional<String> getNativeSince() {
         return Optional.ofNullable(nativeSince);
+    }
+
+    public ExtensionStatus getStatus() {
+        return status;
     }
 
 }

--- a/tooling/maven-plugin/src/main/java/org/apache/camel/quarkus/maven/ExtensionStatus.java
+++ b/tooling/maven-plugin/src/main/java/org/apache/camel/quarkus/maven/ExtensionStatus.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.maven;
+
+public enum ExtensionStatus {
+    preview("Preview"), stable("Stable"), experimental("Experimental");
+
+    private ExtensionStatus(String capitalized) {
+        this.capitalized = capitalized;
+    }
+
+    private final String capitalized;
+
+    static ExtensionStatus of(boolean nativeSupported) {
+        return nativeSupported ? stable : preview;
+    }
+
+    public String getCapitalized() {
+        return capitalized;
+    }
+
+}

--- a/tooling/maven-plugin/src/main/java/org/apache/camel/quarkus/maven/UpdateExtensionDocPageMojo.java
+++ b/tooling/maven-plugin/src/main/java/org/apache/camel/quarkus/maven/UpdateExtensionDocPageMojo.java
@@ -110,7 +110,11 @@ public class UpdateExtensionDocPageMojo extends AbstractDocGeneratorMojo {
         model.put("name", title);
         final String description = CqUtils.getDescription(models, ext.getDescription().orElse(null), getLog());
         model.put("description", description);
-        model.put("deprecated", CqUtils.isDeprecated(title, models));
+        model.put("status", ext.getStatus().getCapitalized());
+        final boolean deprecated = CqUtils.isDeprecated(title, models);
+        model.put("statusDeprecation",
+                deprecated ? ext.getStatus().getCapitalized() + " Deprecated" : ext.getStatus().getCapitalized());
+        model.put("deprecated", deprecated);
         model.put("jvmSince", jvmSince);
         model.put("nativeSince", ext.getNativeSince().orElse("n/a"));
         if (lowerEqual_1_0_0(jvmSince)) {

--- a/tooling/maven-plugin/src/main/resources/doc-templates/extension-doc-page.adoc
+++ b/tooling/maven-plugin/src/main/resources/doc-templates/extension-doc-page.adoc
@@ -3,14 +3,15 @@
 [/#if]
 :cq-artifact-id: camel-quarkus-[=artifactIdBase]
 :cq-native-supported: [=nativeSupported?then('true', 'false')]
-:cq-status: [=nativeSupported?then('Stable', 'Preview')]
+:cq-status: [=status]
+:cq-status-deprecation: [=statusDeprecation]
 :cq-description: [=description]
 :cq-deprecated: [=deprecated?then('true', 'false')]
 :cq-jvm-since: [=jvmSince]
 :cq-native-since: [=nativeSince]
 
 [.badges]
-[.badge-key]##JVM since##[.badge-supported]##[=jvmSince]## [.badge-key]##Native[=nativeSupported?then(' since', '')]##[.badge-[=nativeSupported?then('', 'un')]supported]##[=nativeSupported?then(nativeSince, 'unsupported')]##
+[.badge-key]##JVM since##[.badge-supported]##[=jvmSince]## [.badge-key]##Native[=nativeSupported?then(' since', '')]##[.badge-[=nativeSupported?then('', 'un')]supported]##[=nativeSupported?then(nativeSince, 'unsupported')]##[#if deprecated ] [.badge-key]##⚠️##[.badge-unsupported]##Deprecated##[/#if]
 
 [=intro]
 [#if models?size > 0]


### PR DESCRIPTION
Fix #2266

This adds a "deprecated" badge on a deprecated extension's page

![image](https://user-images.githubusercontent.com/1826249/113726651-b357e280-96f4-11eb-8887-d3eaf10ddb71.png)

and a "Deprecated" string in the list of extensions:

![image](https://user-images.githubusercontent.com/1826249/113726581-a2a76c80-96f4-11eb-9d96-10a42da44834.png)
