### PR TITLE
Adjust capability configuration for Quarkus 2.x

### DIFF
--- a/extensions-core/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/CamelFeature.java
+++ b/extensions-core/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/CamelFeature.java
@@ -17,9 +17,7 @@
 package org.apache.camel.quarkus.core.deployment;
 
 import io.quarkus.deployment.annotations.BuildStep;
-import io.quarkus.deployment.builditem.CapabilityBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
-import org.apache.camel.quarkus.support.common.CamelCapabilities;
 
 class CamelFeature {
     private static final String FEATURE = "camel-core";
@@ -27,10 +25,5 @@ class CamelFeature {
     @BuildStep
     FeatureBuildItem feature() {
         return new FeatureBuildItem(FEATURE);
-    }
-
-    @BuildStep
-    CapabilityBuildItem capability() {
-        return new CapabilityBuildItem(CamelCapabilities.CORE);
     }
 }

--- a/extensions-core/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/CamelProcessor.java
+++ b/extensions-core/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/CamelProcessor.java
@@ -276,7 +276,7 @@ class CamelProcessor {
     @BuildStep
     @Record(ExecutionTime.STATIC_INIT)
     void disableXmlReifiers(CamelRecorder recorder, Capabilities capabilities) {
-        if (!capabilities.isCapabilityPresent(CamelCapabilities.XML)) {
+        if (!capabilities.isCapabilityWithPrefixPresent(CamelCapabilities.XML)) {
             LOGGER.debug("Camel XML capability not detected, disable XML reifiers");
             recorder.disableXmlReifiers();
         }

--- a/extensions-core/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/main/CamelMainProcessor.java
+++ b/extensions-core/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/main/CamelMainProcessor.java
@@ -29,7 +29,6 @@ import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Overridable;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.AdditionalIndexedClassesBuildItem;
-import io.quarkus.deployment.builditem.CapabilityBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.QuarkusMain;
@@ -55,7 +54,6 @@ import org.apache.camel.quarkus.main.CamelMainApplication;
 import org.apache.camel.quarkus.main.CamelMainConfig;
 import org.apache.camel.quarkus.main.CamelMainProducers;
 import org.apache.camel.quarkus.main.CamelMainRecorder;
-import org.apache.camel.quarkus.support.common.CamelCapabilities;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
 
@@ -64,11 +62,6 @@ public class CamelMainProcessor {
     @BuildStep(onlyIf = CamelMainEnabled.class)
     void unremovableBeans(BuildProducer<AdditionalBeanBuildItem> beanProducer) {
         beanProducer.produce(AdditionalBeanBuildItem.unremovableOf(CamelMainProducers.class));
-    }
-
-    @BuildStep(onlyIf = CamelMainEnabled.class)
-    CapabilityBuildItem capability() {
-        return new CapabilityBuildItem(CamelCapabilities.MAIN);
     }
 
     @BuildStep(onlyIf = CamelMainEnabled.class)

--- a/extensions-core/core/runtime/pom.xml
+++ b/extensions-core/core/runtime/pom.xml
@@ -113,6 +113,15 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+                <configuration>
+                    <capabilities>
+                        <provides>org.apache.camel</provides>
+                        <providesIf>
+                            <positive>org.apache.camel.quarkus.core.deployment.main.spi.CamelMainEnabled</positive>
+                            <name>org.apache.camel.main</name>
+                        </providesIf>
+                    </capabilities>
+                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/CamelQuarkusClassResolver.java
+++ b/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/CamelQuarkusClassResolver.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.camel.quarkus.core;
 
 import java.io.InputStream;

--- a/extensions-core/xml-io-dsl/deployment/src/main/java/org/apache/camel/quarkus/dsl/xml/io/deployment/XmlIoDslProcessor.java
+++ b/extensions-core/xml-io-dsl/deployment/src/main/java/org/apache/camel/quarkus/dsl/xml/io/deployment/XmlIoDslProcessor.java
@@ -18,9 +18,7 @@
 package org.apache.camel.quarkus.dsl.xml.io.deployment;
 
 import io.quarkus.deployment.annotations.BuildStep;
-import io.quarkus.deployment.builditem.CapabilityBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
-import org.apache.camel.quarkus.support.common.CamelCapabilities;
 
 public class XmlIoDslProcessor {
     private static final String FEATURE = "camel-xml-io-dsl";
@@ -29,10 +27,4 @@ public class XmlIoDslProcessor {
     FeatureBuildItem feature() {
         return new FeatureBuildItem(FEATURE);
     }
-
-    @BuildStep
-    CapabilityBuildItem capability() {
-        return new CapabilityBuildItem(CamelCapabilities.XML);
-    }
-
 }

--- a/extensions-core/xml-io-dsl/runtime/pom.xml
+++ b/extensions-core/xml-io-dsl/runtime/pom.xml
@@ -67,6 +67,11 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+                <configuration>
+                    <capabilities>
+                        <provides>org.apache.camel.xml.io.dsl</provides>
+                    </capabilities>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/extensions-core/xml-jaxb/deployment/src/main/java/org/apache/camel/quarkus/component/xml/jaxb/deployment/XmlJaxbProcessor.java
+++ b/extensions-core/xml-jaxb/deployment/src/main/java/org/apache/camel/quarkus/component/xml/jaxb/deployment/XmlJaxbProcessor.java
@@ -16,20 +16,15 @@
  */
 package org.apache.camel.quarkus.component.xml.jaxb.deployment;
 
-import java.util.Arrays;
-import java.util.List;
-
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
-import io.quarkus.deployment.builditem.CapabilityBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.jaxb.deployment.JaxbFileRootBuildItem;
 import org.apache.camel.quarkus.component.xml.jaxb.XmlJaxbRecorder;
 import org.apache.camel.quarkus.core.deployment.spi.CamelModelJAXBContextFactoryBuildItem;
 import org.apache.camel.quarkus.core.deployment.spi.CamelModelToXMLDumperBuildItem;
 import org.apache.camel.quarkus.core.deployment.util.CamelSupport;
-import org.apache.camel.quarkus.support.common.CamelCapabilities;
 
 class XmlJaxbProcessor {
 
@@ -43,13 +38,6 @@ class XmlJaxbProcessor {
     @BuildStep
     FeatureBuildItem feature() {
         return new FeatureBuildItem(FEATURE);
-    }
-
-    @BuildStep
-    List<CapabilityBuildItem> capabilities() {
-        return Arrays.asList(
-                new CapabilityBuildItem(CamelCapabilities.XML),
-                new CapabilityBuildItem(CamelCapabilities.XML_JAXB));
     }
 
     @BuildStep

--- a/extensions-core/xml-jaxb/runtime/pom.xml
+++ b/extensions-core/xml-jaxb/runtime/pom.xml
@@ -89,6 +89,11 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+                <configuration>
+                    <capabilities>
+                        <provides>org.apache.camel.xml.jaxb</provides>
+                    </capabilities>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/extensions-core/xml-jaxp/deployment/src/main/java/org/apache/camel/quarkus/component/xml/jaxp/deployment/XmlJaxpProcessor.java
+++ b/extensions-core/xml-jaxp/deployment/src/main/java/org/apache/camel/quarkus/component/xml/jaxp/deployment/XmlJaxpProcessor.java
@@ -18,10 +18,8 @@ package org.apache.camel.quarkus.component.xml.jaxp.deployment;
 
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
-import io.quarkus.deployment.builditem.CapabilityBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
-import org.apache.camel.quarkus.support.common.CamelCapabilities;
 
 class XmlJaxpProcessor {
 
@@ -30,11 +28,6 @@ class XmlJaxpProcessor {
     @BuildStep
     FeatureBuildItem feature() {
         return new FeatureBuildItem(FEATURE);
-    }
-
-    @BuildStep
-    CapabilityBuildItem capability() {
-        return new CapabilityBuildItem(CamelCapabilities.XML);
     }
 
     @BuildStep

--- a/extensions-core/xml-jaxp/runtime/pom.xml
+++ b/extensions-core/xml-jaxp/runtime/pom.xml
@@ -66,6 +66,11 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+                <configuration>
+                    <capabilities>
+                        <provides>org.apache.camel.xml.jaxp</provides>
+                    </capabilities>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/extensions-jvm/apns/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/apns/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,4 @@ metadata:
   - "integration"
   status:
   - "preview"
+  - "deprecated"

--- a/extensions-support/common/runtime/src/main/java/org/apache/camel/quarkus/support/common/CamelCapabilities.java
+++ b/extensions-support/common/runtime/src/main/java/org/apache/camel/quarkus/support/common/CamelCapabilities.java
@@ -20,7 +20,9 @@ public final class CamelCapabilities {
     public static final String CORE = "org.apache.camel";
     public static final String MAIN = "org.apache.camel.main";
     public static final String XML = "org.apache.camel.xml";
+    public static final String XML_IO_DSL = "org.apache.camel.xml.io.dsl";
     public static final String XML_JAXB = "org.apache.camel.xml.jaxb";
+    public static final String XML_JAXP = "org.apache.camel.xml.jaxp";
 
     private CamelCapabilities() {
     }

--- a/extensions/atlasmap/runtime/src/main/java/org/apache/camel/quarkus/component/atlasmap/graalvm/Substitutions.java
+++ b/extensions/atlasmap/runtime/src/main/java/org/apache/camel/quarkus/component/atlasmap/graalvm/Substitutions.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.camel.quarkus.component.atlasmap.graalvm;
 
 import java.util.Set;

--- a/poms/bom/pom.xml
+++ b/poms/bom/pom.xml
@@ -5839,6 +5839,11 @@
                 <version>${eddsa.version}</version>
             </dependency>
             <dependency>
+                <groupId>net.minidev</groupId>
+                <artifactId>json-smart</artifactId>
+                <version>${json-smart.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.antlr</groupId>
                 <artifactId>antlr</artifactId>
                 <version>${antlr3.version}</version>
@@ -6103,11 +6108,6 @@
                 <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>
                 <version>${snakeyaml.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>net.minidev</groupId>
-                <artifactId>json-smart</artifactId>
-                <version>${json-smart.version}</version>
             </dependency>
             <dependency>
                 <groupId>xalan</groupId>


### PR DESCRIPTION
This PR adjusts capability configurations found in Camel Quarkus extensions to the Quarkus 2.x capability contracts established in https://github.com/quarkusio/quarkus/pull/13960 and https://github.com/quarkusio/quarkus/pull/16741 This is the readable doc https://github.com/quarkusio/quarkus/blob/main/docs/src/main/asciidoc/capabilities.adoc

Basically, `CapabilityBuildItem`s shouldn't be produced directly from the build steps but moved to the extension descriptor, so that the dev tools could benefit from the info and not suggest extensions that are in conflict.