### PR TITLE
Do not use deprecated BuildStep.applicationArchiveMarkers()

### DIFF
--- a/extensions/aws2-athena/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/athena/deployment/Aws2AthenaProcessor.java
+++ b/extensions/aws2-athena/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/athena/deployment/Aws2AthenaProcessor.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.AdditionalApplicationArchiveMarkerBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
@@ -45,7 +46,7 @@ class Aws2AthenaProcessor {
         return new FeatureBuildItem(FEATURE);
     }
 
-    @BuildStep(applicationArchiveMarkers = { AWS_SDK_APPLICATION_ARCHIVE_MARKERS })
+    @BuildStep
     void process(CombinedIndexBuildItem combinedIndexBuildItem,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClasses,
             BuildProducer<NativeImageResourceBuildItem> resource) {
@@ -62,5 +63,10 @@ class Aws2AthenaProcessor {
 
         reflectiveClasses.produce(new ReflectiveClassBuildItem(true, false,
                 String.class.getCanonicalName()));
+    }
+
+    @BuildStep
+    void archiveMarkers(BuildProducer<AdditionalApplicationArchiveMarkerBuildItem> archiveMarkers) {
+        archiveMarkers.produce(new AdditionalApplicationArchiveMarkerBuildItem(AWS_SDK_APPLICATION_ARCHIVE_MARKERS));
     }
 }

--- a/extensions/aws2-cw/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/cw/deployment/Aws2CwProcessor.java
+++ b/extensions/aws2-cw/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/cw/deployment/Aws2CwProcessor.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.AdditionalApplicationArchiveMarkerBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
@@ -45,7 +46,7 @@ class Aws2CwProcessor {
         return new FeatureBuildItem(FEATURE);
     }
 
-    @BuildStep(applicationArchiveMarkers = { AWS_SDK_APPLICATION_ARCHIVE_MARKERS })
+    @BuildStep
     void process(CombinedIndexBuildItem combinedIndexBuildItem,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClasses,
             BuildProducer<NativeImageResourceBuildItem> resource) {
@@ -62,5 +63,10 @@ class Aws2CwProcessor {
 
         reflectiveClasses.produce(new ReflectiveClassBuildItem(true, false,
                 String.class.getCanonicalName()));
+    }
+
+    @BuildStep
+    void archiveMarkers(BuildProducer<AdditionalApplicationArchiveMarkerBuildItem> archiveMarkers) {
+        archiveMarkers.produce(new AdditionalApplicationArchiveMarkerBuildItem(AWS_SDK_APPLICATION_ARCHIVE_MARKERS));
     }
 }

--- a/extensions/aws2-ddb/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/ddb/deployment/Aws2DdbProcessor.java
+++ b/extensions/aws2-ddb/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/ddb/deployment/Aws2DdbProcessor.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.AdditionalApplicationArchiveMarkerBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
@@ -45,7 +46,7 @@ class Aws2DdbProcessor {
         return new FeatureBuildItem(FEATURE);
     }
 
-    @BuildStep(applicationArchiveMarkers = { AWS_SDK_APPLICATION_ARCHIVE_MARKERS })
+    @BuildStep
     void process(CombinedIndexBuildItem combinedIndexBuildItem,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClasses,
             BuildProducer<NativeImageResourceBuildItem> resource) {
@@ -64,4 +65,8 @@ class Aws2DdbProcessor {
                 String.class.getCanonicalName()));
     }
 
+    @BuildStep
+    void archiveMarkers(BuildProducer<AdditionalApplicationArchiveMarkerBuildItem> archiveMarkers) {
+        archiveMarkers.produce(new AdditionalApplicationArchiveMarkerBuildItem(AWS_SDK_APPLICATION_ARCHIVE_MARKERS));
+    }
 }

--- a/extensions/aws2-ec2/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/ec2/deployment/Aws2Ec2Processor.java
+++ b/extensions/aws2-ec2/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/ec2/deployment/Aws2Ec2Processor.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.AdditionalApplicationArchiveMarkerBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
@@ -45,7 +46,7 @@ class Aws2Ec2Processor {
         return new FeatureBuildItem(FEATURE);
     }
 
-    @BuildStep(applicationArchiveMarkers = { AWS_SDK_APPLICATION_ARCHIVE_MARKERS })
+    @BuildStep
     void process(CombinedIndexBuildItem combinedIndexBuildItem,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClasses,
             BuildProducer<NativeImageResourceBuildItem> resource) {
@@ -64,4 +65,8 @@ class Aws2Ec2Processor {
                 String.class.getCanonicalName()));
     }
 
+    @BuildStep
+    void archiveMarkers(BuildProducer<AdditionalApplicationArchiveMarkerBuildItem> archiveMarkers) {
+        archiveMarkers.produce(new AdditionalApplicationArchiveMarkerBuildItem(AWS_SDK_APPLICATION_ARCHIVE_MARKERS));
+    }
 }

--- a/extensions/aws2-ecs/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/ecs/deployment/Aws2EcsProcessor.java
+++ b/extensions/aws2-ecs/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/ecs/deployment/Aws2EcsProcessor.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.AdditionalApplicationArchiveMarkerBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
@@ -44,7 +45,7 @@ class Aws2EcsProcessor {
         return new FeatureBuildItem(FEATURE);
     }
 
-    @BuildStep(applicationArchiveMarkers = { AWS_SDK_APPLICATION_ARCHIVE_MARKERS })
+    @BuildStep
     void process(CombinedIndexBuildItem combinedIndexBuildItem,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClasses,
             BuildProducer<NativeImageResourceBuildItem> resource) {
@@ -63,4 +64,8 @@ class Aws2EcsProcessor {
                 String.class.getCanonicalName()));
     }
 
+    @BuildStep
+    void archiveMarkers(BuildProducer<AdditionalApplicationArchiveMarkerBuildItem> archiveMarkers) {
+        archiveMarkers.produce(new AdditionalApplicationArchiveMarkerBuildItem(AWS_SDK_APPLICATION_ARCHIVE_MARKERS));
+    }
 }

--- a/extensions/aws2-eks/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/eks/deployment/Aws2EksProcessor.java
+++ b/extensions/aws2-eks/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/eks/deployment/Aws2EksProcessor.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.AdditionalApplicationArchiveMarkerBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
@@ -44,7 +45,7 @@ class Aws2EksProcessor {
         return new FeatureBuildItem(FEATURE);
     }
 
-    @BuildStep(applicationArchiveMarkers = { AWS_SDK_APPLICATION_ARCHIVE_MARKERS })
+    @BuildStep
     void process(CombinedIndexBuildItem combinedIndexBuildItem,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClasses,
             BuildProducer<NativeImageResourceBuildItem> resource) {
@@ -63,4 +64,8 @@ class Aws2EksProcessor {
                 String.class.getCanonicalName()));
     }
 
+    @BuildStep
+    void archiveMarkers(BuildProducer<AdditionalApplicationArchiveMarkerBuildItem> archiveMarkers) {
+        archiveMarkers.produce(new AdditionalApplicationArchiveMarkerBuildItem(AWS_SDK_APPLICATION_ARCHIVE_MARKERS));
+    }
 }

--- a/extensions/aws2-eventbridge/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/eventbridge/deployment/Aws2EventbridgeProcessor.java
+++ b/extensions/aws2-eventbridge/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/eventbridge/deployment/Aws2EventbridgeProcessor.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.AdditionalApplicationArchiveMarkerBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
@@ -45,7 +46,7 @@ class Aws2EventbridgeProcessor {
         return new FeatureBuildItem(FEATURE);
     }
 
-    @BuildStep(applicationArchiveMarkers = { AWS_SDK_APPLICATION_ARCHIVE_MARKERS })
+    @BuildStep
     void process(CombinedIndexBuildItem combinedIndexBuildItem,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClasses,
             BuildProducer<NativeImageResourceBuildItem> resource) {
@@ -62,5 +63,10 @@ class Aws2EventbridgeProcessor {
 
         reflectiveClasses.produce(new ReflectiveClassBuildItem(true, false,
                 String.class.getCanonicalName()));
+    }
+
+    @BuildStep
+    void archiveMarkers(BuildProducer<AdditionalApplicationArchiveMarkerBuildItem> archiveMarkers) {
+        archiveMarkers.produce(new AdditionalApplicationArchiveMarkerBuildItem(AWS_SDK_APPLICATION_ARCHIVE_MARKERS));
     }
 }

--- a/extensions/aws2-iam/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/iam/deployment/Aws2IamProcessor.java
+++ b/extensions/aws2-iam/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/iam/deployment/Aws2IamProcessor.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.AdditionalApplicationArchiveMarkerBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
@@ -45,7 +46,7 @@ class Aws2IamProcessor {
         return new FeatureBuildItem(FEATURE);
     }
 
-    @BuildStep(applicationArchiveMarkers = { AWS_SDK_APPLICATION_ARCHIVE_MARKERS })
+    @BuildStep
     void process(CombinedIndexBuildItem combinedIndexBuildItem,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClasses,
             BuildProducer<NativeImageResourceBuildItem> resource) {
@@ -64,4 +65,8 @@ class Aws2IamProcessor {
                 String.class.getCanonicalName()));
     }
 
+    @BuildStep
+    void archiveMarkers(BuildProducer<AdditionalApplicationArchiveMarkerBuildItem> archiveMarkers) {
+        archiveMarkers.produce(new AdditionalApplicationArchiveMarkerBuildItem(AWS_SDK_APPLICATION_ARCHIVE_MARKERS));
+    }
 }

--- a/extensions/aws2-kms/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/kms/deployment/Aws2KmsProcessor.java
+++ b/extensions/aws2-kms/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/kms/deployment/Aws2KmsProcessor.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.AdditionalApplicationArchiveMarkerBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
@@ -44,7 +45,7 @@ class Aws2KmsProcessor {
         return new FeatureBuildItem(FEATURE);
     }
 
-    @BuildStep(applicationArchiveMarkers = { AWS_SDK_APPLICATION_ARCHIVE_MARKERS })
+    @BuildStep
     void process(CombinedIndexBuildItem combinedIndexBuildItem,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClasses,
             BuildProducer<NativeImageResourceBuildItem> resource) {
@@ -61,5 +62,10 @@ class Aws2KmsProcessor {
 
         reflectiveClasses.produce(new ReflectiveClassBuildItem(true, false,
                 String.class.getCanonicalName()));
+    }
+
+    @BuildStep
+    void archiveMarkers(BuildProducer<AdditionalApplicationArchiveMarkerBuildItem> archiveMarkers) {
+        archiveMarkers.produce(new AdditionalApplicationArchiveMarkerBuildItem(AWS_SDK_APPLICATION_ARCHIVE_MARKERS));
     }
 }

--- a/extensions/aws2-lambda/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/lambda/deployment/Aws2LambdaProcessor.java
+++ b/extensions/aws2-lambda/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/lambda/deployment/Aws2LambdaProcessor.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.AdditionalApplicationArchiveMarkerBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
@@ -45,7 +46,7 @@ class Aws2LambdaProcessor {
         return new FeatureBuildItem(FEATURE);
     }
 
-    @BuildStep(applicationArchiveMarkers = { AWS_SDK_APPLICATION_ARCHIVE_MARKERS })
+    @BuildStep
     void process(CombinedIndexBuildItem combinedIndexBuildItem,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClasses,
             BuildProducer<NativeImageResourceBuildItem> resource) {
@@ -62,5 +63,10 @@ class Aws2LambdaProcessor {
 
         reflectiveClasses.produce(new ReflectiveClassBuildItem(true, false,
                 String.class.getCanonicalName()));
+    }
+
+    @BuildStep
+    void archiveMarkers(BuildProducer<AdditionalApplicationArchiveMarkerBuildItem> archiveMarkers) {
+        archiveMarkers.produce(new AdditionalApplicationArchiveMarkerBuildItem(AWS_SDK_APPLICATION_ARCHIVE_MARKERS));
     }
 }

--- a/extensions/aws2-mq/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/mq/deployment/Aws2MqProcessor.java
+++ b/extensions/aws2-mq/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/mq/deployment/Aws2MqProcessor.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.AdditionalApplicationArchiveMarkerBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
@@ -44,7 +45,7 @@ class Aws2MqProcessor {
         return new FeatureBuildItem(FEATURE);
     }
 
-    @BuildStep(applicationArchiveMarkers = { AWS_SDK_APPLICATION_ARCHIVE_MARKERS })
+    @BuildStep
     void process(CombinedIndexBuildItem combinedIndexBuildItem,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClasses,
             BuildProducer<NativeImageResourceBuildItem> resource) {
@@ -63,4 +64,8 @@ class Aws2MqProcessor {
                 String.class.getCanonicalName()));
     }
 
+    @BuildStep
+    void archiveMarkers(BuildProducer<AdditionalApplicationArchiveMarkerBuildItem> archiveMarkers) {
+        archiveMarkers.produce(new AdditionalApplicationArchiveMarkerBuildItem(AWS_SDK_APPLICATION_ARCHIVE_MARKERS));
+    }
 }

--- a/extensions/aws2-msk/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/msk/deployment/Aws2MskProcessor.java
+++ b/extensions/aws2-msk/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/msk/deployment/Aws2MskProcessor.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.AdditionalApplicationArchiveMarkerBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
@@ -44,7 +45,7 @@ class Aws2MskProcessor {
         return new FeatureBuildItem(FEATURE);
     }
 
-    @BuildStep(applicationArchiveMarkers = { AWS_SDK_APPLICATION_ARCHIVE_MARKERS })
+    @BuildStep
     void process(CombinedIndexBuildItem combinedIndexBuildItem,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClasses,
             BuildProducer<NativeImageResourceBuildItem> resource) {
@@ -63,4 +64,8 @@ class Aws2MskProcessor {
                 String.class.getCanonicalName()));
     }
 
+    @BuildStep
+    void archiveMarkers(BuildProducer<AdditionalApplicationArchiveMarkerBuildItem> archiveMarkers) {
+        archiveMarkers.produce(new AdditionalApplicationArchiveMarkerBuildItem(AWS_SDK_APPLICATION_ARCHIVE_MARKERS));
+    }
 }

--- a/extensions/aws2-s3/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/s3/deployment/Aws2S3Processor.java
+++ b/extensions/aws2-s3/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/s3/deployment/Aws2S3Processor.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.AdditionalApplicationArchiveMarkerBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
@@ -46,7 +47,7 @@ class Aws2S3Processor {
         return new FeatureBuildItem(FEATURE);
     }
 
-    @BuildStep(applicationArchiveMarkers = { AWS_SDK_APPLICATION_ARCHIVE_MARKERS })
+    @BuildStep
     void process(CombinedIndexBuildItem combinedIndexBuildItem,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClasses,
             BuildProducer<NativeImageResourceBuildItem> resource) {
@@ -63,5 +64,10 @@ class Aws2S3Processor {
 
         reflectiveClasses.produce(new ReflectiveClassBuildItem(true, false,
                 String.class.getCanonicalName()));
+    }
+
+    @BuildStep
+    void archiveMarkers(BuildProducer<AdditionalApplicationArchiveMarkerBuildItem> archiveMarkers) {
+        archiveMarkers.produce(new AdditionalApplicationArchiveMarkerBuildItem(AWS_SDK_APPLICATION_ARCHIVE_MARKERS));
     }
 }

--- a/extensions/aws2-ses/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/ses/deployment/Aws2SesProcessor.java
+++ b/extensions/aws2-ses/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/ses/deployment/Aws2SesProcessor.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.AdditionalApplicationArchiveMarkerBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
@@ -44,7 +45,7 @@ class Aws2SesProcessor {
         return new FeatureBuildItem(FEATURE);
     }
 
-    @BuildStep(applicationArchiveMarkers = { AWS_SDK_APPLICATION_ARCHIVE_MARKERS })
+    @BuildStep
     void process(CombinedIndexBuildItem combinedIndexBuildItem,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClasses,
             BuildProducer<NativeImageResourceBuildItem> resource) {
@@ -63,4 +64,8 @@ class Aws2SesProcessor {
                 String.class.getCanonicalName()));
     }
 
+    @BuildStep
+    void archiveMarkers(BuildProducer<AdditionalApplicationArchiveMarkerBuildItem> archiveMarkers) {
+        archiveMarkers.produce(new AdditionalApplicationArchiveMarkerBuildItem(AWS_SDK_APPLICATION_ARCHIVE_MARKERS));
+    }
 }

--- a/extensions/aws2-sns/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/sns/deployment/Aws2SnsProcessor.java
+++ b/extensions/aws2-sns/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/sns/deployment/Aws2SnsProcessor.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.AdditionalApplicationArchiveMarkerBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
@@ -46,7 +47,7 @@ class Aws2SnsProcessor {
         return new FeatureBuildItem(FEATURE);
     }
 
-    @BuildStep(applicationArchiveMarkers = { AWS_SDK_APPLICATION_ARCHIVE_MARKERS })
+    @BuildStep
     void process(CombinedIndexBuildItem combinedIndexBuildItem,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClasses,
             BuildProducer<NativeImageResourceBuildItem> resource) {
@@ -63,5 +64,10 @@ class Aws2SnsProcessor {
 
         reflectiveClasses.produce(new ReflectiveClassBuildItem(true, false,
                 String.class.getCanonicalName()));
+    }
+
+    @BuildStep
+    void archiveMarkers(BuildProducer<AdditionalApplicationArchiveMarkerBuildItem> archiveMarkers) {
+        archiveMarkers.produce(new AdditionalApplicationArchiveMarkerBuildItem(AWS_SDK_APPLICATION_ARCHIVE_MARKERS));
     }
 }

--- a/extensions/aws2-sqs/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/sqs/deployment/Aws2SqsProcessor.java
+++ b/extensions/aws2-sqs/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/sqs/deployment/Aws2SqsProcessor.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.AdditionalApplicationArchiveMarkerBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
@@ -45,7 +46,7 @@ class Aws2SqsProcessor {
         return new FeatureBuildItem(FEATURE);
     }
 
-    @BuildStep(applicationArchiveMarkers = { AWS_SDK_APPLICATION_ARCHIVE_MARKERS })
+    @BuildStep
     void process(CombinedIndexBuildItem combinedIndexBuildItem,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClasses,
             BuildProducer<NativeImageResourceBuildItem> resource) {
@@ -62,5 +63,10 @@ class Aws2SqsProcessor {
 
         reflectiveClasses.produce(new ReflectiveClassBuildItem(true, false,
                 String.class.getCanonicalName()));
+    }
+
+    @BuildStep
+    void archiveMarkers(BuildProducer<AdditionalApplicationArchiveMarkerBuildItem> archiveMarkers) {
+        archiveMarkers.produce(new AdditionalApplicationArchiveMarkerBuildItem(AWS_SDK_APPLICATION_ARCHIVE_MARKERS));
     }
 }

--- a/extensions/aws2-sts/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/sts/deployment/Aws2StsProcessor.java
+++ b/extensions/aws2-sts/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/sts/deployment/Aws2StsProcessor.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.AdditionalApplicationArchiveMarkerBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
@@ -44,7 +45,7 @@ class Aws2StsProcessor {
         return new FeatureBuildItem(FEATURE);
     }
 
-    @BuildStep(applicationArchiveMarkers = { AWS_SDK_APPLICATION_ARCHIVE_MARKERS })
+    @BuildStep
     void process(CombinedIndexBuildItem combinedIndexBuildItem,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClasses,
             BuildProducer<NativeImageResourceBuildItem> resource) {
@@ -61,5 +62,10 @@ class Aws2StsProcessor {
 
         reflectiveClasses.produce(new ReflectiveClassBuildItem(true, false,
                 String.class.getCanonicalName()));
+    }
+
+    @BuildStep
+    void archiveMarkers(BuildProducer<AdditionalApplicationArchiveMarkerBuildItem> archiveMarkers) {
+        archiveMarkers.produce(new AdditionalApplicationArchiveMarkerBuildItem(AWS_SDK_APPLICATION_ARCHIVE_MARKERS));
     }
 }

--- a/extensions/aws2-translate/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/translate/deployment/Aws2TranslateProcessor.java
+++ b/extensions/aws2-translate/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/translate/deployment/Aws2TranslateProcessor.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.AdditionalApplicationArchiveMarkerBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
@@ -44,7 +45,7 @@ class Aws2TranslateProcessor {
         return new FeatureBuildItem(FEATURE);
     }
 
-    @BuildStep(applicationArchiveMarkers = { AWS_SDK_APPLICATION_ARCHIVE_MARKERS })
+    @BuildStep
     void process(CombinedIndexBuildItem combinedIndexBuildItem,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClasses,
             BuildProducer<NativeImageResourceBuildItem> resource) {
@@ -61,5 +62,10 @@ class Aws2TranslateProcessor {
 
         reflectiveClasses.produce(new ReflectiveClassBuildItem(true, false,
                 String.class.getCanonicalName()));
+    }
+
+    @BuildStep
+    void archiveMarkers(BuildProducer<AdditionalApplicationArchiveMarkerBuildItem> archiveMarkers) {
+        archiveMarkers.produce(new AdditionalApplicationArchiveMarkerBuildItem(AWS_SDK_APPLICATION_ARCHIVE_MARKERS));
     }
 }


### PR DESCRIPTION
Supersedes #2574. No harm in having this on the `main` branch.