### PR TITLE
Load a classpath resource using current thread's context class loader…

### DIFF
--- a/integration-tests/saxon/src/test/java/org/apache/camel/quarkus/component/saxon/it/SaxonTest.java
+++ b/integration-tests/saxon/src/test/java/org/apache/camel/quarkus/component/saxon/it/SaxonTest.java
@@ -37,7 +37,7 @@ class SaxonTest {
 
     @Test
     public void xqueryTransformShouldConcatEmployeeIdAndSuffix() throws IOException {
-        String xml = resourceToString("/myinput.xml", StandardCharsets.UTF_8);
+        String xml = resourceToString("myinput.xml", StandardCharsets.UTF_8, Thread.currentThread().getContextClassLoader());
         given().body(xml).get("/xquery/transform").then().statusCode(200).body(is("123Suffix"));
     }
 


### PR DESCRIPTION
… in Saxon test, because otherwise it cannot be found
