### PR TITLE
Avoid overwriting the Qute json which breaks Camel K catalogs

### DIFF
--- a/catalog/pom.xml
+++ b/catalog/pom.xml
@@ -4403,8 +4403,27 @@
                 <executions>
                     <execution>
                         <!-- prepare the catalog and update doc files, etc. -->
+                        <id>prepare-catalog</id>
                         <goals>
                             <goal>prepare-catalog-quarkus</goal>
+                        </goals>
+                        <phase>process-resources</phase>
+                        <configuration>
+                            <extensionDirectories>
+                                <extensionDirectory>${maven.multiModuleProjectDirectory}/extensions-core</extensionDirectory>
+                                <extensionDirectory>${maven.multiModuleProjectDirectory}/extensions</extensionDirectory>
+                                <extensionDirectory>${maven.multiModuleProjectDirectory}/extensions-jvm</extensionDirectory>
+                            </extensionDirectories>
+                            <skipArtifactIdBases>
+                                <skipArtifactIdBase>http-common</skipArtifactIdBase>
+                                <skipArtifactIdBase>qute</skipArtifactIdBase>
+                            </skipArtifactIdBases>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <!-- update doc files, etc. -->
+                        <id>update-doc-files</id>
+                        <goals>
                             <goal>check-extension-pages</goal>
                         </goals>
                         <phase>process-resources</phase>


### PR DESCRIPTION
This should solve apache/camel-k-runtime#677

Without this, the catalog seems to generate its own bogus qute.json. Then, during camel-k-runtime build, it gets picked instead of the one available in camel-quarkus-qute-component jar.

<!-- Uncomment and fill this section if your PR is not trivial
[ ] An issue should be filed for the change unless this is a trivial change (fixing a typo or similar). One issue should ideally be fixed by not more than one commit and the other way round, each commit should fix just one issue, without pulling in other changes.
[ ] Each commit in the pull request should have a meaningful and properly spelled subject line and body. Copying the title of the associated issue is typically enough. Please include the issue number in the commit message prefixed by #.
[ ] The pull request description should explain what the pull request does, how, and why. If the info is available in the associated issue or some other external document, a link is enough.
[ ] Phrases like Fix #<issueNumber> or Fixes #<issueNumber> will auto-close the named issue upon merging the pull request. Using them is typically a good idea.
[ ] Please run mvn process-resources -Pformat (and amend the changes if necessary) before sending the pull request.
[ ] Contributor guide is your good friend: https://camel.apache.org/camel-quarkus/latest/contributor-guide.html
-->