### PR TITLE
Fix typo in JIRA relationship name

### DIFF
--- a/integration-tests/jira/src/main/java/org/apache/camel/quarkus/component/jira/it/JiraResource.java
+++ b/integration-tests/jira/src/main/java/org/apache/camel/quarkus/component/jira/it/JiraResource.java
@@ -194,7 +194,7 @@ public class JiraResource {
         Map<String, Object> headers = new HashMap<>();
         headers.put(PARENT_ISSUE_KEY, parentKey);
         headers.put(CHILD_ISSUE_KEY, childKey);
-        headers.put(LINK_TYPE, "Relates");
+        headers.put(LINK_TYPE, "Related");
 
         producerTemplate.requestBodyAndHeaders("jira:addIssueLink", null, headers);
 


### PR DESCRIPTION
JIRA REST API uses `Related` instead of `Relates`.  The tests also pass running against the wiremock instance. 