### PR TITLE
Exclude org.bouncycastle:bcprov-debug-jdk15on from camel-as2 because we

### DIFF
--- a/extensions/as2/runtime/pom.xml
+++ b/extensions/as2/runtime/pom.xml
@@ -57,8 +57,12 @@
             <artifactId>camel-as2</artifactId>
             <exclusions>
                 <exclusion>
-                    <artifactId>log4j-slf4j-impl</artifactId>
                     <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-slf4j-impl</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcprov-debug-jdk15on</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
get a non-debug variant of it managed from Quarkus.

This is to avoid version clashes when bouncy castle is upgraded in Quarkus (as is the case in current Quarkus main)