### PR TITLE
Salesforce - Mock existing integration tests

### DIFF
--- a/integration-tests/salesforce/README.adoc
+++ b/integration-tests/salesforce/README.adoc
@@ -1,6 +1,10 @@
 == Camel Quarkus Salesforce Integration Tests
 
-To run the `camel-quarkus-salesforce` integration tests against the real API, you must first create a Salesforce developer account https://developer.salesforce.com/.
+By default, the Salesforce integration tests use WireMock to stub the API interactions.
+
+IMPORTANT: Note that when using Wiremock, the Change Data Capture Events test is disabled.
+
+To run `camel-quarkus-salesforce` integration tests using Salesforce API interactions, you must first create a Salesforce developer account https://developer.salesforce.com/.
 
 Next create a new 'Connected App' from the app manager page. You may need to adjust the OAuth policy settings for
 `Permitted Users` and also `IP Relaxation` rules, depending on your needs. Also enable Change Data Capture for the 'Account' entity by visiting the Integrations -> Change Data Capture page.

--- a/integration-tests/salesforce/pom.xml
+++ b/integration-tests/salesforce/pom.xml
@@ -55,6 +55,13 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- dependencies needed to mock Salesforce API -->
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-integration-wiremock-support</artifactId>
+            <scope>test</scope>
+        </dependency>
+
 
         <!-- The following dependencies guarantee that this module is built after them. You can update them by running `mvn process-resources -Pformat -N` from the source tree root directory -->
         <dependency>

--- a/integration-tests/salesforce/src/main/java/org/apache/camel/quarkus/component/salesforce/SalesforceRoutes.java
+++ b/integration-tests/salesforce/src/main/java/org/apache/camel/quarkus/component/salesforce/SalesforceRoutes.java
@@ -20,9 +20,7 @@ import java.util.Optional;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Named;
-import javax.ws.rs.Produces;
 
-import io.quarkus.arc.Unremovable;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.salesforce.AuthenticationType;
 import org.apache.camel.component.salesforce.SalesforceComponent;

--- a/integration-tests/salesforce/src/main/java/org/apache/camel/quarkus/component/salesforce/SalesforceRoutes.java
+++ b/integration-tests/salesforce/src/main/java/org/apache/camel/quarkus/component/salesforce/SalesforceRoutes.java
@@ -44,9 +44,6 @@ public class SalesforceRoutes extends RouteBuilder {
     @ConfigProperty(name = "SALESFORCE_CLIENTSECRET", defaultValue = "clientSecret")
     String clientSecret;
 
-    @Produces
-    @ApplicationScoped
-    @Unremovable
     @Named("salesforce")
     SalesforceComponent salesforceComponent() {
         // check if wiremock URL exists

--- a/integration-tests/salesforce/src/main/java/org/apache/camel/quarkus/component/salesforce/SalesforceRoutes.java
+++ b/integration-tests/salesforce/src/main/java/org/apache/camel/quarkus/component/salesforce/SalesforceRoutes.java
@@ -16,13 +16,66 @@
  */
 package org.apache.camel.quarkus.component.salesforce;
 
-import org.apache.camel.builder.RouteBuilder;
+import java.util.Optional;
 
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Named;
+import javax.ws.rs.Produces;
+
+import io.quarkus.arc.Unremovable;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.salesforce.AuthenticationType;
+import org.apache.camel.component.salesforce.SalesforceComponent;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@ApplicationScoped
 public class SalesforceRoutes extends RouteBuilder {
+
+    @ConfigProperty(name = "SALESFORCE_USERNAME", defaultValue = "username")
+    String username;
+
+    @ConfigProperty(name = "SALESFORCE_PASSWORD", defaultValue = "password")
+    String password;
+
+    @ConfigProperty(name = "SALESFORCE_CLIENTID", defaultValue = "clientId")
+    String clientId;
+
+    @ConfigProperty(name = "SALESFORCE_CLIENTSECRET", defaultValue = "clientSecret")
+    String clientSecret;
+
+    @Produces
+    @ApplicationScoped
+    @Unremovable
+    @Named("salesforce")
+    SalesforceComponent salesforceComponent() {
+        // check if wiremock URL exists
+        Optional<String> wireMockUrl = ConfigProvider.getConfig().getOptionalValue("wiremock.url", String.class);
+
+        SalesforceComponent salesforceComponent = new SalesforceComponent();
+        salesforceComponent.setClientId(clientId);
+        salesforceComponent.setClientSecret(clientSecret);
+        salesforceComponent.setUserName(username);
+        salesforceComponent.setPassword(password);
+
+        // Set URL depending if mock is enabled
+        if (wireMockUrl.isPresent()) {
+            salesforceComponent.setAuthenticationType(AuthenticationType.USERNAME_PASSWORD);
+            salesforceComponent.setRefreshToken("refreshToken");
+            salesforceComponent.setLoginUrl(wireMockUrl.get());
+        } else {
+            salesforceComponent.setLoginUrl("https://login.salesforce.com");
+        }
+        return salesforceComponent;
+    }
 
     @Override
     public void configure() throws Exception {
-        from("salesforce:/data/AccountChangeEvent?replayId=-1").routeId("cdc").autoStartup(false)
-                .to("seda:events");
+        Optional<String> wireMockUrl = ConfigProvider.getConfig().getOptionalValue("wiremock.url", String.class);
+        // Wiremock used only with Templates - this Route is used only with Salesforce credentials
+        if (!wireMockUrl.isPresent()) {
+            from("salesforce:/data/AccountChangeEvent?replayId=-1").routeId("cdc").autoStartup(false)
+                    .to("seda:events");
+        }
     }
 }

--- a/integration-tests/salesforce/src/main/resources/application.properties
+++ b/integration-tests/salesforce/src/main/resources/application.properties
@@ -19,7 +19,3 @@
 # Camel :: Salesforce
 #
 camel.component.salesforce.loginUrl = https://login.salesforce.com
-camel.component.salesforce.userName = {{env:SALESFORCE_USERNAME}}
-camel.component.salesforce.password = {{env:SALESFORCE_PASSWORD}}
-camel.component.salesforce.clientId = {{env:SALESFORCE_CLIENTID}}
-camel.component.salesforce.clientSecret = {{env:SALESFORCE_CLIENTSECRET}}

--- a/integration-tests/salesforce/src/test/java/org/apache/camel/quarkus/component/salesforce/SalesforceIntegrationIT.java
+++ b/integration-tests/salesforce/src/test/java/org/apache/camel/quarkus/component/salesforce/SalesforceIntegrationIT.java
@@ -16,9 +16,11 @@
  */
 package org.apache.camel.quarkus.component.salesforce;
 
-import io.quarkus.test.junit.NativeImageTest;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
-@NativeImageTest
-class SalesforceIT extends SalesforceTest {
-
+@EnabledIfEnvironmentVariable(named = "SALESFORCE_USERNAME", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "SALESFORCE_PASSWORD", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "SALESFORCE_CLIENTID", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "SALESFORCE_CLIENTSECRET", matches = ".+")
+public class SalesforceIntegrationIT extends SalesforceIntegrationTest {
 }

--- a/integration-tests/salesforce/src/test/java/org/apache/camel/quarkus/component/salesforce/SalesforceIntegrationTest.java
+++ b/integration-tests/salesforce/src/test/java/org/apache/camel/quarkus/component/salesforce/SalesforceIntegrationTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.salesforce;
+
+import java.util.UUID;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+import static org.hamcrest.Matchers.is;
+
+@EnabledIfEnvironmentVariable(named = "SALESFORCE_USERNAME", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "SALESFORCE_PASSWORD", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "SALESFORCE_CLIENTID", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "SALESFORCE_CLIENTSECRET", matches = ".+")
+@QuarkusTest
+public class SalesforceIntegrationTest {
+
+    @Test
+    public void testChangeDataCaptureEvents() {
+        String accountId = null;
+        try {
+            // Start the Salesforce CDC consumer
+            RestAssured.post("/salesforce/cdc/start")
+                    .then()
+                    .statusCode(200);
+
+            // Create an account
+            String accountName = "Camel Quarkus Account Test: " + UUID.randomUUID().toString();
+            accountId = RestAssured.given()
+                    .body(accountName)
+                    .post("/salesforce/account")
+                    .then()
+                    .statusCode(200)
+                    .extract()
+                    .body()
+                    .asString();
+
+            // Verify we captured the account creation event
+            RestAssured.given()
+                    .get("/salesforce/cdc")
+                    .then()
+                    .statusCode(200)
+                    .body("Name", is(accountName));
+        } finally {
+            // Shut down the CDC consumer
+            RestAssured.post("/salesforce/cdc/stop")
+                    .then()
+                    .statusCode(200);
+
+            // Clean up
+            if (accountId != null) {
+                RestAssured.delete("/salesforce/account/" + accountId)
+                        .then()
+                        .statusCode(204);
+            }
+        }
+    }
+}

--- a/integration-tests/salesforce/src/test/java/org/apache/camel/quarkus/component/salesforce/SalesforceTestResource.java
+++ b/integration-tests/salesforce/src/test/java/org/apache/camel/quarkus/component/salesforce/SalesforceTestResource.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.salesforce;
+
+import java.util.Map;
+
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer;
+import org.apache.camel.quarkus.test.wiremock.WireMockTestResourceLifecycleManager;
+
+public class SalesforceTestResource extends WireMockTestResourceLifecycleManager {
+    private static final String SALESFORCE_BASE_URL = "login.salesforce.com";
+    private static final String SALESFORCE_CLIENT_ID = "SALESFORCE_CLIENTID";
+    private static final String SALESFORCE_CLIENT_SECRET = "SALESFORCE_CLIENTSECRET";
+    private static final String SALESFORCE_USERNAME = "SALESFORCE_USERNAME";
+    private static final String SALESFORCE_PASSWORD = "SALESFORCE_PASSWORD";
+
+    @Override
+    protected String getRecordTargetBaseUrl() {
+        return SALESFORCE_BASE_URL;
+    }
+
+    @Override
+    protected boolean isMockingEnabled() {
+        return !envVarsPresent(SALESFORCE_CLIENT_ID, SALESFORCE_CLIENT_SECRET, SALESFORCE_USERNAME, SALESFORCE_PASSWORD);
+    }
+
+    @Override
+    public Map<String, String> start() {
+        Map<String, String> options = super.start();
+        if (options.containsKey("wiremock.url")) {
+            options.put("camel.component.salesforce.loginUrl", options.get("wiremock.url"));
+            options.put("camel.component.salesforce.userName", "username");
+            options.put("camel.component.salesforce.password", "password");
+            options.put("camel.component.salesforce.clientId", "clientId");
+        }
+        return options;
+    }
+
+    @Override
+    protected void customizeWiremockConfiguration(WireMockConfiguration config) {
+        config.extensions(new ResponseTemplateTransformer(false));
+    }
+
+}

--- a/integration-tests/salesforce/src/test/resources/mappings/bulApi-abortJob.json
+++ b/integration-tests/salesforce/src/test/resources/mappings/bulApi-abortJob.json
@@ -1,0 +1,18 @@
+{
+  "id": "09aa79df-8a19-41df-8655-e414d390d6ed",
+  "name": "salesforce_api_json",
+  "request": {
+    "url": "/services/async/50.0/job/750x0000000005LAAQ",
+    "method": "POST"
+  },
+  "response": {
+    "status": 200,
+    "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<jobInfo\n   xmlns=\"http://www.force.com/2009/06/asyncapi/dataload\">\n  <id>750x0000000005LAAQ</id>\n  <operation>insert</operation>\n  <object>Contact</object>\n  <createdById>005x0000000wPWdAAM</createdById>\n  <createdDate>2009-09-01T16:42:46.000Z</createdDate>\n  <systemModstamp>2009-09-01T16:42:46.000Z</systemModstamp>\n  <state>Aborted</state>\n  <concurrencyMode>Parallel</concurrencyMode>\n  <contentType>CSV</contentType>\n  <numberBatchesQueued>0</numberBatchesQueued>\n  <numberBatchesInProgress>0</numberBatchesInProgress>\n  <numberBatchesCompleted>0</numberBatchesCompleted>\n  <numberBatchesFailed>0</numberBatchesFailed>\n  <numberBatchesTotal>0</numberBatchesTotal>\n  <numberRecordsProcessed>0</numberRecordsProcessed>\n  <numberRetries>0</numberRetries>\n  <apiVersion>52.0</apiVersion>\n  <numberRecordsFailed>0</numberRecordsFailed>\n  <totalProcessingTime>0</totalProcessingTime>\n  <apiActiveProcessingTime>0</apiActiveProcessingTime>\n  <apexProcessingTime>0</apexProcessingTime>\n</jobInfo>",
+    "headers": {
+      "Content-Type": "application/json; charset=UTF-8"
+    }
+  },
+  "uuid": "09aa79df-8a19-41df-8655-e414d390d6ed",
+  "persistent": true,
+  "insertionIndex": 2
+}

--- a/integration-tests/salesforce/src/test/resources/mappings/bulkApi-createJob.json
+++ b/integration-tests/salesforce/src/test/resources/mappings/bulkApi-createJob.json
@@ -1,0 +1,18 @@
+{
+  "id": "09aa79df-8a19-41df-8655-e414d390d6ed",
+  "name": "salesforce_api_json",
+  "request": {
+    "url": "/services/async/50.0/job",
+    "method": "POST"
+  },
+  "response": {
+    "status": 200,
+    "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<jobInfo\n   xmlns=\"http://www.force.com/2009/06/asyncapi/dataload\">\n  <id>750x0000000005LAAQ</id>\n  <operation>insert</operation>\n  <object>Contact</object>\n  <createdById>005x0000000wPWdAAM</createdById>\n  <createdDate>2009-09-01T16:42:46.000Z</createdDate>\n  <systemModstamp>2009-09-01T16:42:46.000Z</systemModstamp>\n  <state>Open</state>\n  <concurrencyMode>Parallel</concurrencyMode>\n  <contentType>CSV</contentType>\n  <numberBatchesQueued>0</numberBatchesQueued>\n  <numberBatchesInProgress>0</numberBatchesInProgress>\n  <numberBatchesCompleted>0</numberBatchesCompleted>\n  <numberBatchesFailed>0</numberBatchesFailed>\n  <numberBatchesTotal>0</numberBatchesTotal>\n  <numberRecordsProcessed>0</numberRecordsProcessed>\n  <numberRetries>0</numberRetries>\n  <apiVersion>52.0</apiVersion>\n  <numberRecordsFailed>0</numberRecordsFailed>\n  <totalProcessingTime>0</totalProcessingTime>\n  <apiActiveProcessingTime>0</apiActiveProcessingTime>\n  <apexProcessingTime>0</apexProcessingTime>\n</jobInfo>",
+    "headers": {
+      "Content-Type": "application/json; charset=UTF-8"
+    }
+  },
+  "uuid": "09aa79df-8a19-41df-8655-e414d390d6ed",
+  "persistent": true,
+  "insertionIndex": 2
+}

--- a/integration-tests/salesforce/src/test/resources/mappings/getAccount.json
+++ b/integration-tests/salesforce/src/test/resources/mappings/getAccount.json
@@ -1,0 +1,18 @@
+{
+  "id": "09aa79df-8a19-41df-8655-e414d390d6ed",
+  "name": "salesforce_api_json",
+  "request": {
+    "url": "/services/data/v50.0/query/?q=SELECT%20Id%2CAccountNumber%20from%20Account%20LIMIT%201",
+    "method": "GET"
+  },
+  "response": {
+    "status": 200,
+    "body" : "{\"records\":[{\"Id\":\"someFakeId\", \"AccountNumber\":\"11233\", \"attributes\": {\"type\" : \"Account\"}}]}",
+    "headers": {
+      "Content-Type": "application/json; charset=UTF-8"
+    }
+  },
+  "uuid": "09aa79df-8a19-41df-8655-e414d390d6ed",
+  "persistent": true,
+  "insertionIndex": 2
+}

--- a/integration-tests/salesforce/src/test/resources/mappings/getDocument.json
+++ b/integration-tests/salesforce/src/test/resources/mappings/getDocument.json
@@ -1,0 +1,18 @@
+{
+  "id": "09aa79df-8a19-41df-8655-e414d390d6ed",
+  "name": "salesforce_api_json",
+  "request": {
+    "url": "/services/data/v50.0/sobjects/Document/Name/test",
+    "method": "GET"
+  },
+  "response": {
+    "status": 200,
+    "body" : "{\"attributes\": {\"type\" : \"Document\"}}",
+    "headers": {
+      "Content-Type": "application/json; charset=UTF-8"
+    }
+},
+  "uuid": "09aa79df-8a19-41df-8655-e414d390d6ed",
+  "persistent": true,
+  "insertionIndex": 2
+}

--- a/integration-tests/salesforce/src/test/resources/mappings/handshake.json
+++ b/integration-tests/salesforce/src/test/resources/mappings/handshake.json
@@ -1,0 +1,19 @@
+{
+  "id": "09aa79df-8a19-41df-8655-e414d390d6ed",
+  "name": "salesforce_api_json",
+  "request": {
+    "url": "/cometd/50.0/handshake",
+    "method": "POST"
+  },
+  "response": {
+    "status": 200,
+    "body": "[\"ext\": {\"replay\": true,\"payload.format\": true}, \"minimumVersion\": \"1.0\", \"clientId\": \"clientId\",\"supportedConnectionTypes\": [ \"long-polling\" ], \"channel\": \"/meta/handshake\", \"id\": \"{{jsonPath request.body '$[0].id'}}\",\"version\": \"1.0\",\"successful\": \"true\" }]",
+    "transformers": ["response-template"],
+    "headers": {
+      "Content-Type": "application/json; charset=UTF-8"
+    }
+  },
+  "uuid": "09aa79df-8a19-41df-8655-e414d390d6ed",
+  "persistent": true,
+  "insertionIndex": 2
+}

--- a/integration-tests/salesforce/src/test/resources/mappings/oauth2.json
+++ b/integration-tests/salesforce/src/test/resources/mappings/oauth2.json
@@ -1,0 +1,19 @@
+{
+  "id": "09aa79df-8a19-41df-8655-e414d390d6ed",
+  "name": "salesforce_api_json",
+  "request": {
+    "url": "/services/oauth2/token",
+    "method": "POST"
+  },
+  "response": {
+    "status": 200,
+    "body": "{\"instance_url\":\"{{request.baseUrl}}\",\"access_token\":\"token\"}",
+    "transformers": ["response-template"],
+    "headers": {
+      "Content-Type": "application/json; charset=UTF-8"
+    }
+    },
+  "uuid": "09aa79df-8a19-41df-8655-e414d390d6ed",
+  "persistent": true,
+  "insertionIndex": 2
+}

--- a/integration-tests/salesforce/src/test/resources/mappings/revokeToken.json
+++ b/integration-tests/salesforce/src/test/resources/mappings/revokeToken.json
@@ -1,0 +1,17 @@
+{
+  "id": "09aa79df-8a19-41df-8655-e414d390d6ed",
+  "name": "salesforce_api_json",
+  "request": {
+    "url": "/services/oauth2/revoke?token=token",
+    "method": "GET"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json; charset=UTF-8"
+    }
+  },
+  "uuid": "09aa79df-8a19-41df-8655-e414d390d6ed",
+  "persistent": true,
+  "insertionIndex": 2
+}


### PR DESCRIPTION
Fixes #2667

This PR covers just one part of the 2667 gitHub issue, which is mocking the existing examples. There will be another PR for more test coverage.
 
The mocking scenario is the same used in some tests in the Camel project, but using wiremock. We can mock if using template, so the Route that starts in this project, is out of the scope, and is loaded only if salesforce credentials are set with environment variables. 