### PR TITLE
Make the creation of a GitHub release a part of the release process

### DIFF
--- a/docs/modules/ROOT/pages/contributor-guide/release-guide.adoc
+++ b/docs/modules/ROOT/pages/contributor-guide/release-guide.adoc
@@ -137,6 +137,27 @@ $ svn add --force .
 $ svn commit -m "Apache Camel Quarkus $VERSION released artifacts"
 ----
 
+== Create a GitHub release
+
+This will trigger sending a notification to folks watching the Camel Quarkus github repository,
+so it should ideally happen once the newly released artifacts are available on https://repo1.maven.org/maven2/org/apache/camel/quarkus/camel-quarkus-bom/[Maven Central].
+
+The following needs to be done:
+
+* Go to https://github.com/apache/camel-quarkus/releases[https://github.com/apache/camel-quarkus/releases].
+* Click the tag you want to promote to a GitHub release
+* Click "Edit Tag" button
+* In the "New release" form:
+  * Leave "Release title" empty
+  * Add something meaningful to the description, e.g. something like
++
+[source,markdown]
+----
+Check the full [release announcement](https://camel.apache.org/blog/2021/06/camel-quarkus-release-2.0.0/)
+----
++
+  * Click the green "Publish release" button at the bottom
+
 == Further steps
 
 In addition to the above, the following is needed:


### PR DESCRIPTION
fix #2864
