### PR TITLE
Use static issues to report nightly sync workflow failures

### DIFF
--- a/.github/workflows/camel-master-cron.yaml
+++ b/.github/workflows/camel-master-cron.yaml
@@ -27,6 +27,7 @@ env:
   MAVEN_OPTS: -Xmx3000m
   MAVEN_ARGS: -V -ntp -Dhttp.keepAlive=false -e
   TESTCONTAINERS_RYUK_DISABLED: true
+  ISSUE_ID: 2927
 
 jobs:
   initial-mvn-install:
@@ -95,7 +96,7 @@ jobs:
             git rebase --abort
           fi
 
-          ./mvnw ${MAVEN_ARGS} verify -N -Pbuild-notification -Dstatus=${{ job.status }} -Dtoken=${{ secrets.GITHUB_TOKEN }} -DbuildId=$(cat ~/build-data/build-id.txt) -Drepo=${GITHUB_REPOSITORY} -Dbranch=camel-main -Dbranch-commit=$(cat ~/build-data/main-sha.txt)
+          ./mvnw ${MAVEN_ARGS} verify -N -Pbuild-notification -Dstatus=${{ job.status }} -DissueId=${{ env.ISSUE_ID }} -Dtoken=${{ secrets.GITHUB_TOKEN }} -DbuildId=$(cat ~/build-data/build-id.txt) -Drepo=${GITHUB_REPOSITORY} -Dbranch=camel-main -Dbranch-commit=$(cat ~/build-data/main-sha.txt)
 
   native-tests:
     name: Native Tests - ${{matrix.category}}
@@ -169,7 +170,7 @@ jobs:
       - name: Report Build Failure
         if: failure()
         run: |
-          ./mvnw ${MAVEN_ARGS} verify -N -Pbuild-notification -Dstatus=${{ job.status }} -Dtoken=${{ secrets.GITHUB_TOKEN }} -DbuildId=$(cat ~/build-data/build-id.txt) -Drepo=${GITHUB_REPOSITORY} -Dbranch=camel-main -Dbranch-commit=$(cat ~/build-data/main-sha.txt)
+          ./mvnw ${MAVEN_ARGS} verify -N -Pbuild-notification -Dstatus=${{ job.status }} -DissueId=${{ env.ISSUE_ID }} -Dtoken=${{ secrets.GITHUB_TOKEN }} -DbuildId=$(cat ~/build-data/build-id.txt) -Drepo=${GITHUB_REPOSITORY} -Dbranch=camel-main -Dbranch-commit=$(cat ~/build-data/main-sha.txt)
 
   handle-build-status:
     needs: native-tests
@@ -201,7 +202,7 @@ jobs:
       - name: Report build status
         id: report
         run: |
-          ./mvnw ${MAVEN_ARGS} verify -N -Pbuild-notification -Dstatus=verify -Dtoken=${{ secrets.GITHUB_TOKEN }} -DbuildId=$(cat ~/build-data/build-id.txt) -Drepo=${GITHUB_REPOSITORY} -Dbranch=camel-main -Dbranch-commit=$(cat ~/build-data/main-sha.txt)
+          ./mvnw ${MAVEN_ARGS} verify -N -Pbuild-notification -Dstatus=verify -DissueId=${{ env.ISSUE_ID }} -Dtoken=${{ secrets.GITHUB_TOKEN }} -DbuildId=$(cat ~/build-data/build-id.txt) -Drepo=${GITHUB_REPOSITORY} -Dbranch=camel-main -Dbranch-commit=$(cat ~/build-data/main-sha.txt)
       - name: Sync branch Main to Camel Main
         if: steps.report.outputs.overall_build_status == 'success'
         run: |

--- a/.github/workflows/quarkus-master-cron.yaml
+++ b/.github/workflows/quarkus-master-cron.yaml
@@ -27,6 +27,7 @@ env:
   MAVEN_OPTS: -Xmx3000m
   MAVEN_ARGS: -V -ntp -Dhttp.keepAlive=false -e
   TESTCONTAINERS_RYUK_DISABLED: true
+  ISSUE_ID: 2926
 
 jobs:
   initial-mvn-install:
@@ -104,7 +105,7 @@ jobs:
             git rebase --abort
           fi
 
-          ./mvnw ${MAVEN_ARGS} verify -N -Pbuild-notification -Dstatus=${{ job.status }} -Dtoken=${{ secrets.GITHUB_TOKEN }} -DbuildId=$(cat ~/build-data/build-id.txt) -Drepo=${GITHUB_REPOSITORY} -Dbranch=quarkus-main -Dbranch-commit=$(cat ~/build-data/main-sha.txt)
+          ./mvnw ${MAVEN_ARGS} verify -N -Pbuild-notification -Dstatus=${{ job.status }} -DissueId=${{ env.ISSUE_ID }} -Dtoken=${{ secrets.GITHUB_TOKEN }} -DbuildId=$(cat ~/build-data/build-id.txt) -Drepo=${GITHUB_REPOSITORY} -Dbranch=quarkus-main -Dbranch-commit=$(cat ~/build-data/main-sha.txt)
 
   native-tests:
     name: Native Tests - ${{matrix.category}}
@@ -178,7 +179,7 @@ jobs:
       - name: Report Build Failure
         if: failure()
         run: |
-          ./mvnw ${MAVEN_ARGS} verify -N -Pbuild-notification -Dstatus=${{ job.status }} -Dtoken=${{ secrets.GITHUB_TOKEN }} -DbuildId=$(cat ~/build-data/build-id.txt) -Drepo=${GITHUB_REPOSITORY} -Dbranch=quarkus-main -Dbranch-commit=$(cat ~/build-data/main-sha.txt)
+          ./mvnw ${MAVEN_ARGS} verify -N -Pbuild-notification -Dstatus=${{ job.status }} -DissueId=${{ env.ISSUE_ID }} -Dtoken=${{ secrets.GITHUB_TOKEN }} -DbuildId=$(cat ~/build-data/build-id.txt) -Drepo=${GITHUB_REPOSITORY} -Dbranch=quarkus-main -Dbranch-commit=$(cat ~/build-data/main-sha.txt)
 
   handle-build-status:
     needs: native-tests
@@ -210,7 +211,7 @@ jobs:
       - name: Report build status
         id: report
         run: |
-          ./mvnw ${MAVEN_ARGS} verify -N -Pbuild-notification -Dstatus=verify -Dtoken=${{ secrets.GITHUB_TOKEN }} -DbuildId=$(cat ~/build-data/build-id.txt) -Drepo=${GITHUB_REPOSITORY} -Dbranch=quarkus-main -Dbranch-commit=$(cat ~/build-data/main-sha.txt)
+          ./mvnw ${MAVEN_ARGS} verify -N -Pbuild-notification -Dstatus=verify -DissueId=${{ env.ISSUE_ID }} -Dtoken=${{ secrets.GITHUB_TOKEN }} -DbuildId=$(cat ~/build-data/build-id.txt) -Drepo=${GITHUB_REPOSITORY} -Dbranch=quarkus-main -Dbranch-commit=$(cat ~/build-data/main-sha.txt)
       - name: Sync branch main to quarkus-main
         if: steps.report.outputs.overall_build_status == 'success'
         run: |

--- a/tooling/scripts/report-build-status.groovy
+++ b/tooling/scripts/report-build-status.groovy
@@ -20,11 +20,13 @@ import org.kohsuke.github.*
 /**
  * A script to report on the build status of synchronization for branches camel-main and quarkus-main.
  *
- * If failures were encountered in the build, a new GitHub issue is opened labeled with build/quarkus-main or build/camel-main, with the body containing
- * information about the commit SHA and a link to the build. If an existing open issue with the appropriate label exists, then
- * a new comment about the build failure is added.
+ * A GitHub issue ID is passed to this script from the GitHub workflow. The issue is inteded to be repeatedly closed / reopened
+ * whenever a build workflow run is successful / unsuccessful.
  *
- * If the build was successful, any open GitHub issue relating to the branch build will be closed.
+ * If failures were encountered in the build, a comment is appended to a specified GitHub issue, with the body containing
+ * information about the commit SHA and a link to the build.
+ *
+ * If the build was successful, the open GitHub issue relating to the branch build will be closed.
  *
  * The script also outputs a GitHub action step variable named 'overall_build_status', this is used by the build to determine whether it
  * should automatically merge the latest changes from the main branch, to the target branch.
@@ -40,6 +42,7 @@ final String BRANCH_COMMIT = properties['branch-commit'] ?: 'Unknown'
 final String ACTIONS_URL = "https://github.com/${REPO}/actions/runs/${BUILD_ID.split("-")[0]}"
 final String BRANCH_URL = "https://github.com/${REPO}/tree/${BRANCH}"
 final String ISSUE_LABEL = "build/${BRANCH}"
+final Integer ISSUE_ID = properties['issueId'] as Integer
 
 class Utils {
     static boolean workflowHasPreviousFailures(GHIssue issue, String buildId) {
@@ -61,67 +64,47 @@ final GitHub github = new GitHubBuilder().withOAuthToken(TOKEN, "github-actions"
 final GHRepository repository = github.getRepository(REPO)
 final String camelQuarkusCommit = "git rev-parse HEAD".execute().text
 
-GHIssue issue = null
-def issues = repository.getIssues(GHIssueState.OPEN)
-issues.each { i ->
-    i.getLabels().each { label ->
-        if (label.getName() == ISSUE_LABEL) {
-            issue = i
-            return
-        }
-    }
-}
+GHIssue issue = repository.getIssue(ISSUE_ID)
 
 if (issue == null) {
-    println("Unable to find the issue labeled ${ISSUE_LABEL} in project ${REPO}")
+    println("Unable to find the issue with id ${ISSUE_ID} in project ${REPO}")
+    System.exit(1)
 } else {
     println("Report issue found: ${issue.getTitle()} - ${issue.getHtmlUrl()}")
 }
 
 if (STATUS == "failure") {
-    if (issue == null) {
-        final String issueBody = """The [${BRANCH}](${BRANCH_URL}) branch build is failing:
-
-* Build ID: ${BUILD_ID}
-* Camel Quarkus Commit: ${camelQuarkusCommit}
-* ${BRANCH_NAME} Commit: ${BRANCH_COMMIT}
-* Link to build: ${ACTIONS_URL}
-"""
-
-        issue = repository.createIssue("[CI] - ${BRANCH_NAME} Branch Build Failure")
-                .body(issueBody)
-                .label(ISSUE_LABEL)
-                .create();
-
-        println("Created new issue ${issue.getHtmlUrl()}")
+    if (Utils.workflowHasPreviousFailures(issue, BUILD_ID)) {
+        println("Workflow for Build ID ${BUILD_ID} has already reported failures - exiting")
     } else {
-        if (Utils.workflowHasPreviousFailures(issue, BUILD_ID)) {
-            println("Workflow for Build ID ${BUILD_ID} has already reported failures - exiting")
-        } else {
-            issue.comment("""The [${BRANCH}](${BRANCH_URL}) branch build is still failing:
+        if (issue.getState() == GHIssueState.CLOSED) {
+            issue.reopen()
+        }
+
+        issue.comment("""The [${BRANCH}](${BRANCH_URL}) branch build has failed:
 
 * Build ID: ${BUILD_ID}
 * Camel Quarkus Commit: ${camelQuarkusCommit}
 * ${BRANCH_NAME} Commit: ${BRANCH_COMMIT}
 * Link to build: ${ACTIONS_URL}""")
 
-            println("Commented on issue ${issue.getHtmlUrl()}")
-        }
+        println("Commented on issue ${issue.getHtmlUrl()}")
     }
 }
 
 if (STATUS == "verify") {
-    if (issue != null) {
-        if (Utils.workflowHasPreviousFailures(issue, BUILD_ID)) {
-            println("Overall build status is: failure")
-            println "::set-output name=overall_build_status::failure"
-            return
-        } else {
+    if (Utils.workflowHasPreviousFailures(issue, BUILD_ID)) {
+        println("Overall build status is: failure")
+        println "::set-output name=overall_build_status::failure"
+        return
+    } else {
+        if (issue.getState() == GHIssueState.OPEN) {
             final GHIssueComment comment = issue.comment("""Build fixed with:
 
 * Camel Quarkus Commit: ${camelQuarkusCommit}
 * ${BRANCH_NAME} Commit: ${BRANCH_COMMIT}
 * Link to build: ${ACTIONS_URL}""")
+
             issue.close()
             println("Comment added on issue ${issue.getHtmlUrl()} - ${comment.getHtmlUrl()}, the issue has also been closed")
         }


### PR DESCRIPTION
I think this should be enough for the sync jobs to reuse a single issue for failure reporting. Lets see how things go over the next few days.