### PR TITLE
Use default timer delay for main-unknown-args itest application

### DIFF
--- a/integration-tests/main-unknown-args-fail/src/main/java/org/apache/camel/quarkus/main/unknown/args/fail/Routes.java
+++ b/integration-tests/main-unknown-args-fail/src/main/java/org/apache/camel/quarkus/main/unknown/args/fail/Routes.java
@@ -22,7 +22,7 @@ public class Routes extends RouteBuilder {
 
     @Override
     public void configure() throws Exception {
-        from("timer:tick?repeatCount=1&delay=-1")
+        from("timer:tick?repeatCount=1")
                 .log("Timer tick!");
     }
 }

--- a/integration-tests/main-unknown-args-ignore/src/main/java/org/apache/camel/quarkus/main/unknown/args/ignore/Routes.java
+++ b/integration-tests/main-unknown-args-ignore/src/main/java/org/apache/camel/quarkus/main/unknown/args/ignore/Routes.java
@@ -22,7 +22,7 @@ public class Routes extends RouteBuilder {
 
     @Override
     public void configure() throws Exception {
-        from("timer:tick?repeatCount=1&delay=-1")
+        from("timer:tick?repeatCount=1")
                 .log("Timer tick!");
     }
 }


### PR DESCRIPTION
Relates to failures I observed on the nightly `quarkus-main` build. I think with `delay=-1`, the app exists before the Quarkus process listener has a chance to observe the state of things. Hence switching to using the default delay.