### PR TITLE
Upgrade to Optaplanner 8.8.0 & fix removeProperty tests

### DIFF
--- a/integration-test-groups/foundation/eip/src/test/java/org/apache/camel/quarkus/eip/it/EipTest.java
+++ b/integration-test-groups/foundation/eip/src/test/java/org/apache/camel/quarkus/eip/it/EipTest.java
@@ -222,7 +222,7 @@ class EipTest {
                 .then()
                 .statusCode(200);
 
-        RestAssured.get("/eip/mock/removeProperty/1/5000/header")
+        RestAssured.get("/eip/mock/removeProperty/1/5000/property")
                 .then()
                 .statusCode(200)
                 .body(
@@ -244,7 +244,7 @@ class EipTest {
                 .then()
                 .statusCode(200);
 
-        RestAssured.get("/eip/mock/removeProperties/1/5000/header")
+        RestAssured.get("/eip/mock/removeProperties/1/5000/property")
                 .then()
                 .statusCode(200)
                 .body(

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
 
         <cassandra-quarkus.version>1.1.0</cassandra-quarkus.version><!-- https://repo1.maven.org/maven2/com/datastax/oss/quarkus/cassandra-quarkus-bom/ -->
         <debezium.version>1.6.0.Final</debezium.version><!-- May go back to Camel's ${debezium-version} when they are in sync https://repo1.maven.org/maven2/io/debezium/debezium-bom/ -->
-        <optaplanner.version>8.0.0.Final</optaplanner.version><!-- May go back to Camel's ${optaplanner-version} when they are in sync https://repo1.maven.org/maven2/org/optaplanner/optaplanner-quarkus/ -->
+        <optaplanner.version>8.8.0.Final</optaplanner.version><!-- May go back to Camel's ${optaplanner-version} when they are in sync https://repo1.maven.org/maven2/org/optaplanner/optaplanner-quarkus/ -->
         <quarkiverse.freemarker.version>0.3.0</quarkiverse.freemarker.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/freemarker/quarkus-freemarker-parent/ -->
         <quarkiverse-minio.version>2.0.0</quarkiverse-minio.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/minio/quarkus-minio-parent/ -->
         <quarkus.version>2.1.0.CR1</quarkus.version><!-- https://repo1.maven.org/maven2/io/quarkus/quarkus-bom/ -->


### PR DESCRIPTION
My previous downgrade from Optaplanner 8.7.0 to 8.0.0 was a typo. It should have been 8.8.0 at that time already. 

The second fix corrects the removeProperty tests that were in reality testing removing headers (my copy and paste mistake).

2x sorry for the confusion.