### PR TITLE
AWS2 ddb-streams integration tests failures #2860

### DIFF
--- a/integration-test-groups/aws2/aws2-ddb/src/test/java/org/apache/camel/quarkus/component/aws2/ddb/it/Aws2DdbTest.java
+++ b/integration-test-groups/aws2/aws2-ddb/src/test/java/org/apache/camel/quarkus/component/aws2/ddb/it/Aws2DdbTest.java
@@ -16,9 +16,11 @@
  */
 package org.apache.camel.quarkus.component.aws2.ddb.it;
 
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
@@ -40,9 +42,44 @@ class Aws2DdbTest {
 
     @Test
     public void crud() {
-
         final String key = "key" + UUID.randomUUID().toString().replace("-", "");
         final String msg = "val" + UUID.randomUUID().toString().replace("-", "");
+        final String initKeyPrefix = "initKey";
+        final String initMsg = "val";
+
+        /* Wait for the consumer to start. Test event has to be created periodically to ensure consumer reception */
+        RestAssured.given()
+                .contentType(ContentType.TEXT)
+                .body("")
+                .post("/aws2-ddb/item/" + initKeyPrefix + UUID.randomUUID().toString().replace("-", ""))
+                .then()
+                .statusCode(201);
+
+        /* Periodically check that init event is received and if nothing is received, invoke another one  */
+        Awaitility.await().pollInterval(1, TimeUnit.SECONDS).atMost(120, TimeUnit.SECONDS).until(
+                () -> {
+                    ExtractableResponse<Response> result = RestAssured.get("/aws2-ddbstream/change")
+                            .then()
+                            .statusCode(200)
+                            .extract();
+
+                    LOG.info("Expecting at least 1 init event, got " + result.statusCode() + ": " + result.body().asString());
+
+                    List<Map> res = result.jsonPath().getList("$", Map.class);
+
+                    /* If there is no received event, consumer is still not running. Repeat insert. */
+                    if (res.isEmpty()) {
+                        RestAssured.given()
+                                .contentType(ContentType.TEXT)
+                                .body(initMsg)
+                                .post("/aws2-ddb/item/initKey" + UUID.randomUUID().toString().replace("-", ""))
+                                .then()
+                                .statusCode(201);
+                    }
+                    return res;
+                },
+                /* If at least one of the init events is recceived, consumer is working */
+                list -> !list.isEmpty());
 
         /* Ensure initially empty */
         RestAssured.get("/aws2-ddb/item/" + key)
@@ -110,9 +147,12 @@ class Aws2DdbTest {
                             .extract();
 
                     LOG.info("Expecting 3 events got " + result.statusCode() + ": " + result.body().asString());
-                    return result.jsonPath().getList("$", Map.class);
+                    List<Map> retVal = result.jsonPath().getList("$", Map.class);
+                    //remove init events
+                    return retVal.stream().filter(m -> !String.valueOf(m.get("key")).startsWith("initKey"))
+                            .collect(Collectors.toList());
                 },
-                /* The above actions should trigger the following three change events */
+                /* The above actions should trigger the following three change events (initEvent is also present) */
                 list -> list.size() == 3
 
                         && key.equals(list.get(0).get("key"))
@@ -124,7 +164,6 @@ class Aws2DdbTest {
 
                         && key.equals(list.get(2).get("key"))
                         && newMsg.equals(list.get(2).get("old")));
-
     }
 
 }


### PR DESCRIPTION
fixes https://github.com/apache/camel-quarkus/issues/2860

Problem was caused by the fact that on slower machines, route containing consumer is started, but consumer isn't receiving (not started). Then it could easily happen, that some events are ignored because of that.

I added a periodical check, that some random (init event) are received. These init events have to be created periodically to be sure that consumer is running in the moment of event's creation. 

<!-- Uncomment and fill this section if your PR is not trivial
[ ] An issue should be filed for the change unless this is a trivial change (fixing a typo or similar). One issue should ideally be fixed by not more than one commit and the other way round, each commit should fix just one issue, without pulling in other changes.
[ ] Each commit in the pull request should have a meaningful and properly spelled subject line and body. Copying the title of the associated issue is typically enough. Please include the issue number in the commit message prefixed by #.
[ ] The pull request description should explain what the pull request does, how, and why. If the info is available in the associated issue or some other external document, a link is enough.
[ ] Phrases like Fix #<issueNumber> or Fixes #<issueNumber> will auto-close the named issue upon merging the pull request. Using them is typically a good idea.
[ ] Please run mvn process-resources -Pformat (and amend the changes if necessary) before sending the pull request.
[ ] Contributor guide is your good friend: https://camel.apache.org/camel-quarkus/latest/contributor-guide.html
-->