### PR TITLE
Enable Kubernetes extension native tests on CI

### DIFF
--- a/integration-tests/kubernetes/pom.xml
+++ b/integration-tests/kubernetes/pom.xml
@@ -29,11 +29,6 @@
     <name>Camel Quarkus :: Integration Tests :: Kubernetes</name>
     <description>Integration tests for Camel Quarkus Kubernetes extension</description>
 
-    <properties>
-        <!-- Takes too long or spends too much memory on GH actions -->
-        <ci.native.tests.skip>true</ci.native.tests.skip>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>


### PR DESCRIPTION
Curious to see if https://github.com/quarkusio/quarkus/commit/758e8cb38a8d3d35181681a9b1fe7d1428d1ce97 helps to build & run the Kubernetes extension native tests on CI.

I managed to do a sucessful build on an underpowered machine in 6 minutes, so it should work on GitHub actions.