### PR TITLE
Exclude main-unknown-args-ignore test from the list of tests for the platform again

### DIFF
--- a/tooling/test-list/pom.xml
+++ b/tooling/test-list/pom.xml
@@ -59,7 +59,7 @@
                                 <exclude>master/pom.xml</exclude>
                                 <exclude>main-command-mode/pom.xml</exclude>
                                 <exclude>main-unknown-args-fail/pom.xml</exclude>
-                                <exclude>main-unknown-args-fail/pom.xml</exclude>
+                                <exclude>main-unknown-args-ignore/pom.xml</exclude>
                                 <exclude>messaging/pom.xml</exclude>
                             </excludes>
                         </fileSet>


### PR DESCRIPTION
Correcting a mistake done in https://github.com/apache/camel-quarkus/commit/01719a219a0669e3262cc70e93021cd8af04b177#diff-35f534541c2edd9b14c25d705d2c5227a0ae51e29a0aa348ffe534ed1795272cL62-R62