### PR TITLE
Improve native support for `org.apache.http.impl.client.BasicAuthCache`

### DIFF
--- a/extensions-support/httpclient/runtime/pom.xml
+++ b/extensions-support/httpclient/runtime/pom.xml
@@ -63,6 +63,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.graalvm.nativeimage</groupId>
+            <artifactId>svm</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions-support/httpclient/runtime/src/main/java/org/apache/camel/quarkus/support/httpclient/graalvm/BasicAuthCacheAlias.java
+++ b/extensions-support/httpclient/runtime/src/main/java/org/apache/camel/quarkus/support/httpclient/graalvm/BasicAuthCacheAlias.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.quarkus.couchdb;
+package org.apache.camel.quarkus.support.httpclient.graalvm;
 
 import java.util.Map;
 

--- a/extensions/couchdb/runtime/pom.xml
+++ b/extensions/couchdb/runtime/pom.xml
@@ -59,11 +59,6 @@
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-couchdb</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
-            <artifactId>svm</artifactId>
-            <scope>provided</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/integration-tests/http/src/main/java/org/apache/camel/quarkus/component/http/it/HttpProducers.java
+++ b/integration-tests/http/src/main/java/org/apache/camel/quarkus/component/http/it/HttpProducers.java
@@ -19,6 +19,15 @@ package org.apache.camel.quarkus.component.http.it;
 import javax.inject.Named;
 
 import org.apache.camel.component.netty.ClientInitializerFactory;
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.impl.auth.BasicScheme;
+import org.apache.http.impl.client.BasicAuthCache;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.protocol.HttpContext;
 import org.asynchttpclient.AsyncHttpClient;
 import org.asynchttpclient.AsyncHttpClientConfig;
 import org.asynchttpclient.DefaultAsyncHttpClient;
@@ -57,5 +66,24 @@ public class HttpProducers {
                 .build();
 
         return new DefaultAsyncHttpClient(config);
+    }
+
+    @Named
+    HttpContext basicAuthContext() {
+        Integer port = ConfigProvider.getConfig().getValue("quarkus.http.test-port", Integer.class);
+
+        UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(USER_ADMIN, USER_ADMIN_PASSWORD);
+        CredentialsProvider provider = new BasicCredentialsProvider();
+        provider.setCredentials(AuthScope.ANY, credentials);
+
+        BasicAuthCache authCache = new BasicAuthCache();
+        BasicScheme basicAuth = new BasicScheme();
+        authCache.put(new HttpHost("localhost", port), basicAuth);
+
+        HttpClientContext context = HttpClientContext.create();
+        context.setAuthCache(authCache);
+        context.setCredentialsProvider(provider);
+
+        return context;
     }
 }

--- a/integration-tests/http/src/main/java/org/apache/camel/quarkus/component/http/it/HttpResource.java
+++ b/integration-tests/http/src/main/java/org/apache/camel/quarkus/component/http/it/HttpResource.java
@@ -245,6 +245,23 @@ public class HttpResource {
         return Response.status(status).entity(body).build();
     }
 
+    @Path("/http/auth/basic/cache")
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public Response httpBasicAuthCache(@QueryParam("test-port") int port) {
+
+        Exchange result = producerTemplate
+                .withHeader(Exchange.HTTP_QUERY, "component=http")
+                .toF("http://localhost:%d/test/client/auth/basic"
+                        + "?throwExceptionOnFailure=false"
+                        + "&httpContext=#basicAuthContext", port)
+                .send();
+
+        Integer status = result.getMessage().getHeader(Exchange.HTTP_RESPONSE_CODE, Integer.class);
+        String body = result.getMessage().getBody(String.class);
+        return Response.status(status).entity(body).build();
+    }
+
     @Path("/http/proxy")
     @GET
     @Produces(MediaType.APPLICATION_XML)

--- a/integration-tests/http/src/test/java/org/apache/camel/quarkus/component/http/it/HttpTest.java
+++ b/integration-tests/http/src/test/java/org/apache/camel/quarkus/component/http/it/HttpTest.java
@@ -118,6 +118,18 @@ class HttpTest {
                 .body(is("Component " + component + " is using basic auth"));
     }
 
+    @Test
+    public void basicAuthCache() {
+        RestAssured
+                .given()
+                .queryParam("test-port", RestAssured.port)
+                .when()
+                .get("/test/client/http/auth/basic/cache")
+                .then()
+                .statusCode(200)
+                .body(is("Component http is using basic auth"));
+    }
+
     @ParameterizedTest
     @MethodSource("getHttpComponentNames")
     public void proxyServer(String component) {


### PR DESCRIPTION
I wasted more time than I care to remember trying to get serialization support for `BasicAuthCache` working. So I opted to reuse the GraalVM substitutions that were originally made for couchdb.