### PR TITLE
Fixes #3143: Add latest non-prerelease eips

### DIFF
--- a/docs/antora-playbook.yml
+++ b/docs/antora-playbook.yml
@@ -34,6 +34,9 @@ content:
     branches:
       - camel-3.11.x # replace ${camel.docs.branch}
     start_paths:
+      # eip
+      - core/camel-core-engine/src/main/docs
+      # main components doc
       - docs/components
 
   - url: https://github.com/apache/camel.git


### PR DESCRIPTION
Marking components "latest" as pre-release makes eip xrefs in the user manual go to 3.11.x, so this version of eips needs to be included.  Investigating this further reveals a lot more links to wrong versions, but this small change appears to fix the camel-quarkus build for now.