### PR TITLE
Avoid release:prepare failure "The version could not be updated:

### DIFF
--- a/catalog/pom.xml
+++ b/catalog/pom.xml
@@ -35,7 +35,7 @@
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
                 <artifactId>camel-quarkus-bom</artifactId>
-                <version>${camel-quarkus.version}</version>
+                <version>${project.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/extensions-core/pom.xml
+++ b/extensions-core/pom.xml
@@ -50,7 +50,7 @@
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
                 <artifactId>camel-quarkus-bom</artifactId>
-                <version>${camel-quarkus.version}</version>
+                <version>${project.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/extensions-jvm/pom.xml
+++ b/extensions-jvm/pom.xml
@@ -134,7 +134,7 @@
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
                 <artifactId>camel-quarkus-bom</artifactId>
-                <version>${camel-quarkus.version}</version>
+                <version>${project.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/extensions-support/pom.xml
+++ b/extensions-support/pom.xml
@@ -63,7 +63,7 @@
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
                 <artifactId>camel-quarkus-bom</artifactId>
-                <version>${camel-quarkus.version}</version>
+                <version>${project.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/extensions-support/spring/integration-test/pom.xml
+++ b/extensions-support/spring/integration-test/pom.xml
@@ -30,32 +30,6 @@
   <name>Camel Quarkus :: Support Spring :: Integration Test</name>
   <description>Integration tests for Camel Quarkus Support Spring extension</description>
 
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>${quarkus.platform.group-id}</groupId>
-        <artifactId>${quarkus.platform.artifact-id}</artifactId>
-        <version>${quarkus.platform.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>${camel-quarkus.platform.group-id}</groupId>
-        <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-        <version>${camel-quarkus.platform.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-bom-test</artifactId>
-        <version>${camel-quarkus.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
   <dependencies>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -254,7 +254,7 @@
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
                 <artifactId>camel-quarkus-bom</artifactId>
-                <version>${camel-quarkus.version}</version>
+                <version>${project.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/integration-test-groups/aws2-quarkus-client/aws2-ddb/pom.xml
+++ b/integration-test-groups/aws2-quarkus-client/aws2-ddb/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: AWS 2 DynamoDB Quarkus Client</name>
     <description>Integration tests for Camel Quarkus AWS 2 DynamoDB extension with the Quarkus AWS DynamoDB client</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-test-groups/aws2-quarkus-client/aws2-s3/pom.xml
+++ b/integration-test-groups/aws2-quarkus-client/aws2-s3/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: AWS 2 S3 Quarkus Client</name>
     <description>Integration tests for Camel Quarkus AWS 2 S3 extension with the Quarkus AWS S3 client</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-test-groups/aws2/aws2-cw/pom.xml
+++ b/integration-test-groups/aws2/aws2-cw/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: AWS 2 CloudWatch</name>
     <description>Integration tests for Camel Quarkus AWS 2 CloudWatch extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-test-groups/aws2/aws2-ddb/pom.xml
+++ b/integration-test-groups/aws2/aws2-ddb/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: AWS 2 DynamoDB</name>
     <description>Integration tests for Camel Quarkus AWS 2 DynamoDB extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-test-groups/aws2/aws2-kinesis/pom.xml
+++ b/integration-test-groups/aws2/aws2-kinesis/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: AWS 2 Kinesis</name>
     <description>Integration tests for Camel Quarkus AWS 2 Kinesis extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-test-groups/aws2/aws2-lambda/pom.xml
+++ b/integration-test-groups/aws2/aws2-lambda/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: AWS 2 Lambda</name>
     <description>Integration tests for Camel Quarkus AWS 2 Lambda extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-test-groups/aws2/aws2-s3/pom.xml
+++ b/integration-test-groups/aws2/aws2-s3/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: AWS2 S3</name>
     <description>The camel integration tests</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-test-groups/aws2/aws2-ses/pom.xml
+++ b/integration-test-groups/aws2/aws2-ses/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: AWS 2 Simple Email Service (SES)</name>
     <description>Integration tests for Camel Quarkus AWS 2 Simple Email Service (SES) extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-test-groups/aws2/aws2-sqs-sns/pom.xml
+++ b/integration-test-groups/aws2/aws2-sqs-sns/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: AWS 2 SQS and SNS</name>
     <description>Integration tests for SQS and SNS extensions</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-test-groups/azure/azure-eventhubs/pom.xml
+++ b/integration-test-groups/azure/azure-eventhubs/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Azure Event Hubs</name>
     <description>Integration tests for Camel Quarkus Azure Event Hubs extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-test-groups/azure/azure-storage-blob/pom.xml
+++ b/integration-test-groups/azure/azure-storage-blob/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Azure Storage Blob Service</name>
     <description>Integration tests for Camel Quarkus Azure Storage Blob Service extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-test-groups/azure/azure-storage-queue/pom.xml
+++ b/integration-test-groups/azure/azure-storage-queue/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Azure Storage Queue Service</name>
     <description>Integration tests for Camel Quarkus Azure Storage Queue Service extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-test-groups/foundation/bean/pom.xml
+++ b/integration-test-groups/foundation/bean/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Bean</name>
     <description>Integration tests for Camel Bean extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-test-groups/foundation/browse/pom.xml
+++ b/integration-test-groups/foundation/browse/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Browse</name>
     <description>Integration tests for Camel Quarkus Browse extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-test-groups/foundation/component-name-resolver/pom.xml
+++ b/integration-test-groups/foundation/component-name-resolver/pom.xml
@@ -29,32 +29,6 @@
     <artifactId>camel-quarkus-integration-test-component-name-resolver</artifactId>
     <name>Camel Quarkus :: Integration Tests :: Component Name Resolver :: Tests</name>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-test-groups/foundation/controlbus/pom.xml
+++ b/integration-test-groups/foundation/controlbus/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Control Bus</name>
     <description>Integration tests for Camel Quarkus Control Bus extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-test-groups/foundation/core-annotations/pom.xml
+++ b/integration-test-groups/foundation/core-annotations/pom.xml
@@ -29,32 +29,6 @@
     <artifactId>camel-quarkus-integration-test-core-annotations</artifactId>
     <name>Camel Quarkus :: Integration Tests :: Core Annotations :: Tests</name>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-test-groups/foundation/core-fault-tolerance/pom.xml
+++ b/integration-test-groups/foundation/core-fault-tolerance/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Core Fault Tolerance :: Tests</name>
     <description>The camel quarkus integration tests for camel.faulttolerance.* properties</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-test-groups/foundation/core-languages/pom.xml
+++ b/integration-test-groups/foundation/core-languages/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Core Languages :: Tests</name>
     <description>The camel quarkus integration tests for Camel Core languages: Constant, ExchangeProperty, Header, Ref, Simple</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-test-groups/foundation/core-thread-pools/pom.xml
+++ b/integration-test-groups/foundation/core-thread-pools/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Core Thread Pools :: Tests</name>
     <description>The camel quarkus integration tests for camel.threadpool.* properties</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-test-groups/foundation/core/pom.xml
+++ b/integration-test-groups/foundation/core/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Core :: Tests</name>
     <description>The camel integration tests</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-test-groups/foundation/customized-log-component/pom.xml
+++ b/integration-test-groups/foundation/customized-log-component/pom.xml
@@ -29,32 +29,6 @@
     <artifactId>camel-quarkus-integration-test-customized-log-component</artifactId>
     <name>Camel Quarkus :: Integration Tests :: Customize Log component :: Tests</name>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-test-groups/foundation/direct/pom.xml
+++ b/integration-test-groups/foundation/direct/pom.xml
@@ -29,32 +29,6 @@
     <artifactId>camel-quarkus-integration-test-direct</artifactId>
     <name>Camel Quarkus :: Integration Tests :: Direct :: Tests</name>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-test-groups/foundation/eip/pom.xml
+++ b/integration-test-groups/foundation/eip/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: EIP</name>
     <description>Integration tests for Camel Enterprise Integration Patterns</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-test-groups/foundation/language/pom.xml
+++ b/integration-test-groups/foundation/language/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Language</name>
     <description>Integration tests for Camel Quarkus Language extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-test-groups/foundation/log/pom.xml
+++ b/integration-test-groups/foundation/log/pom.xml
@@ -29,32 +29,6 @@
     <artifactId>camel-quarkus-integration-test-log</artifactId>
     <name>Camel Quarkus :: Integration Tests :: Log :: Tests</name>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-test-groups/foundation/mock/pom.xml
+++ b/integration-test-groups/foundation/mock/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Mock</name>
     <description>Integration tests for Camel Quarkus Mock extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-test-groups/foundation/ref/pom.xml
+++ b/integration-test-groups/foundation/ref/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Ref</name>
     <description>Integration tests for Camel Quarkus Ref extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-test-groups/foundation/scheduler/pom.xml
+++ b/integration-test-groups/foundation/scheduler/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Scheduler</name>
     <description>Integration tests for Camel Quarkus Scheduler extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-test-groups/foundation/seda/pom.xml
+++ b/integration-test-groups/foundation/seda/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: SEDA</name>
     <description>Integration tests for Camel Quarkus SEDA extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-test-groups/foundation/stream/pom.xml
+++ b/integration-test-groups/foundation/stream/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Stream</name>
     <description>Integration tests for Camel Quarkus Stream extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-test-groups/foundation/timer/pom.xml
+++ b/integration-test-groups/foundation/timer/pom.xml
@@ -29,32 +29,6 @@
     <artifactId>camel-quarkus-integration-test-timer</artifactId>
     <name>Camel Quarkus :: Integration Tests :: Timer :: Tests</name>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-test-groups/foundation/type-converter/pom.xml
+++ b/integration-test-groups/foundation/type-converter/pom.xml
@@ -29,32 +29,6 @@
     <artifactId>camel-quarkus-integration-test-type-converter</artifactId>
     <name>Camel Quarkus :: Integration Tests :: Type Converter :: Tests</name>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-test-groups/mongodb/mongodb-gridfs/pom.xml
+++ b/integration-test-groups/mongodb/mongodb-gridfs/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: MongoDB GridFS</name>
     <description>Integration tests for Camel Quarkus MongoDB GridFS extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-test-groups/mongodb/mongodb/pom.xml
+++ b/integration-test-groups/mongodb/mongodb/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: MongoDB</name>
     <description>Integration tests for Camel Quarkus MongoDB extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/asn1/pom.xml
+++ b/integration-tests-jvm/asn1/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: ASN.1 File</name>
     <description>Integration tests for Camel Quarkus ASN.1 File extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/asterisk/pom.xml
+++ b/integration-tests-jvm/asterisk/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Asterisk</name>
     <description>Integration tests for Camel Quarkus Asterisk extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/atmos/pom.xml
+++ b/integration-tests-jvm/atmos/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Atmos</name>
     <description>Integration tests for Camel Quarkus Atmos extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/atomix/pom.xml
+++ b/integration-tests-jvm/atomix/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Atomix Map</name>
     <description>Integration tests for Camel Quarkus Atomix Map extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/aws-secrets-manager/pom.xml
+++ b/integration-tests-jvm/aws-secrets-manager/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: AWS Secrets Manager</name>
     <description>Integration tests for Camel Quarkus AWS Secrets Manager extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/aws-xray/pom.xml
+++ b/integration-tests-jvm/aws-xray/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: AWS XRay</name>
     <description>Integration tests for Camel Quarkus AWS XRay extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/azure-cosmosdb/pom.xml
+++ b/integration-tests-jvm/azure-cosmosdb/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Azure CosmosDB</name>
     <description>Integration tests for Camel Quarkus Azure CosmosDB extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/azure-storage-datalake/pom.xml
+++ b/integration-tests-jvm/azure-storage-datalake/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Azure storage datalake service</name>
     <description>Integration tests for Camel Quarkus Azure storage datalake service extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/barcode/pom.xml
+++ b/integration-tests-jvm/barcode/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Barcode</name>
     <description>Integration tests for Camel Quarkus Barcode extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/beanio/pom.xml
+++ b/integration-tests-jvm/beanio/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: BeanIO</name>
     <description>Integration tests for Camel Quarkus BeanIO extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/beanstalk/pom.xml
+++ b/integration-tests-jvm/beanstalk/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Beanstalk</name>
     <description>Integration tests for Camel Quarkus Beanstalk extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/bonita/pom.xml
+++ b/integration-tests-jvm/bonita/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Bonita</name>
     <description>Integration tests for Camel Quarkus Bonita extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/chatscript/pom.xml
+++ b/integration-tests-jvm/chatscript/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: ChatScript</name>
     <description>Integration tests for Camel Quarkus ChatScript extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/chunk/pom.xml
+++ b/integration-tests-jvm/chunk/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Chunk</name>
     <description>Integration tests for Camel Quarkus Chunk extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/cm-sms/pom.xml
+++ b/integration-tests-jvm/cm-sms/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: CM SMS Gateway</name>
     <description>Integration tests for Camel Quarkus CM SMS Gateway extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/cmis/pom.xml
+++ b/integration-tests-jvm/cmis/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: CMIS</name>
     <description>Integration tests for Camel Quarkus CMIS extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/coap/pom.xml
+++ b/integration-tests-jvm/coap/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: CoAP</name>
     <description>Integration tests for Camel Quarkus CoAP extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/cometd/pom.xml
+++ b/integration-tests-jvm/cometd/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: CometD</name>
     <description>Integration tests for Camel Quarkus CometD extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/corda/pom.xml
+++ b/integration-tests-jvm/corda/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Corda</name>
     <description>Integration tests for Camel Quarkus Corda extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/couchbase/pom.xml
+++ b/integration-tests-jvm/couchbase/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Couchbase</name>
     <description>Integration tests for Camel Quarkus Couchbase extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/djl/pom.xml
+++ b/integration-tests-jvm/djl/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Deep Java Library</name>
     <description>Integration tests for Camel Quarkus Deep Java Library extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/dns/pom.xml
+++ b/integration-tests-jvm/dns/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: DNS</name>
     <description>Integration tests for Camel Quarkus DNS extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/drill/pom.xml
+++ b/integration-tests-jvm/drill/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Drill</name>
     <description>Integration tests for Camel Quarkus Drill extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/ehcache/pom.xml
+++ b/integration-tests-jvm/ehcache/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Ehcache</name>
     <description>Integration tests for Camel Quarkus Ehcache extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/elsql/pom.xml
+++ b/integration-tests-jvm/elsql/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: ElSQL</name>
     <description>Integration tests for Camel Quarkus ElSQL extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/etcd/pom.xml
+++ b/integration-tests-jvm/etcd/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Etcd Keys</name>
     <description>Integration tests for Camel Quarkus Etcd Keys extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/etcd3/pom.xml
+++ b/integration-tests-jvm/etcd3/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Etcd3</name>
     <description>Integration tests for Camel Quarkus Etcd3 extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/facebook/pom.xml
+++ b/integration-tests-jvm/facebook/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Facebook</name>
     <description>Integration tests for Camel Quarkus Facebook extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/fastjson/pom.xml
+++ b/integration-tests-jvm/fastjson/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: JSON Fastjson</name>
     <description>Integration tests for Camel Quarkus JSON Fastjson extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/flink/pom.xml
+++ b/integration-tests-jvm/flink/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Flink</name>
     <description>Integration tests for Camel Quarkus Flink extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/ganglia/pom.xml
+++ b/integration-tests-jvm/ganglia/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Ganglia</name>
     <description>Integration tests for Camel Quarkus Ganglia extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/google-functions/pom.xml
+++ b/integration-tests-jvm/google-functions/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: GoogleCloudFunctions</name>
     <description>Integration tests for Camel Quarkus GoogleCloudFunctions extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/groovy-dsl/pom.xml
+++ b/integration-tests-jvm/groovy-dsl/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Groovy DSL</name>
     <description>Integration tests for Camel Groovy DSL extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/groovy/pom.xml
+++ b/integration-tests-jvm/groovy/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Groovy</name>
     <description>Integration tests for Camel Quarkus Groovy extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/guava-eventbus/pom.xml
+++ b/integration-tests-jvm/guava-eventbus/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Guava EventBus</name>
     <description>Integration tests for Camel Quarkus Guava EventBus extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/hbase/pom.xml
+++ b/integration-tests-jvm/hbase/pom.xml
@@ -50,27 +50,6 @@
                 <artifactId>guava</artifactId>
                 <version>20.0</version><!-- The last version that contains com.google.common.util.concurrent.Futures.addCallback(com.google.common.util.concurrent.ListenableFuture, com.google.common.util.concurrent.FutureCallback) required by hbase-test-util -->
             </dependency>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/integration-tests-jvm/hdfs/pom.xml
+++ b/integration-tests-jvm/hdfs/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: HDFS</name>
     <description>Integration tests for Camel Quarkus HDFS extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/huaweicloud-smn/pom.xml
+++ b/integration-tests-jvm/huaweicloud-smn/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: SimpleNotification</name>
     <description>Integration tests for Camel Quarkus SimpleNotification extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/iec60870/pom.xml
+++ b/integration-tests-jvm/iec60870/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: IEC 60870 Client</name>
     <description>Integration tests for Camel Quarkus IEC 60870 Client extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/ignite/pom.xml
+++ b/integration-tests-jvm/ignite/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Ignite Cache</name>
     <description>Integration tests for Camel Quarkus Ignite Cache extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/iota/pom.xml
+++ b/integration-tests-jvm/iota/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: IOTA</name>
     <description>Integration tests for Camel Quarkus IOTA extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/irc/pom.xml
+++ b/integration-tests-jvm/irc/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: IRC</name>
     <description>Integration tests for Camel Quarkus IRC extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/jasypt/pom.xml
+++ b/integration-tests-jvm/jasypt/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Jasypt</name>
     <description>Integration tests for Camel Quarkus Jasypt extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/java-joor-dsl/pom.xml
+++ b/integration-tests-jvm/java-joor-dsl/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Java jOOR DSL</name>
     <description>Integration tests for Camel Java jOOR DSL extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/jbpm/pom.xml
+++ b/integration-tests-jvm/jbpm/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: JBPM</name>
     <description>Integration tests for Camel Quarkus JBPM extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/jcache/pom.xml
+++ b/integration-tests-jvm/jcache/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: JCache</name>
     <description>Integration tests for Camel Quarkus JCache extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/jclouds/pom.xml
+++ b/integration-tests-jvm/jclouds/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: JClouds</name>
     <description>Integration tests for Camel Quarkus JClouds extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/jcr/pom.xml
+++ b/integration-tests-jvm/jcr/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: JCR</name>
     <description>Integration tests for Camel Quarkus JCR extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/jfr/pom.xml
+++ b/integration-tests-jvm/jfr/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Jfr</name>
     <description>Integration tests for Camel Quarkus Jfr extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/jgroups-raft/pom.xml
+++ b/integration-tests-jvm/jgroups-raft/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: JGroups raft</name>
     <description>Integration tests for Camel Quarkus JGroups raft extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/jgroups/pom.xml
+++ b/integration-tests-jvm/jgroups/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: JGroups</name>
     <description>Integration tests for Camel Quarkus JGroups extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/jooq/pom.xml
+++ b/integration-tests-jvm/jooq/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: JOOQ</name>
     <description>Integration tests for Camel Quarkus JOOQ extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/joor/pom.xml
+++ b/integration-tests-jvm/joor/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: jOOR</name>
     <description>Integration tests for Camel Quarkus jOOR extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/jsonapi/pom.xml
+++ b/integration-tests-jvm/jsonapi/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: JSonApi</name>
     <description>Integration tests for Camel Quarkus JSonApi extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/jt400/pom.xml
+++ b/integration-tests-jvm/jt400/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: JT400</name>
     <description>Integration tests for Camel Quarkus JT400 extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/kamelet-reify/pom.xml
+++ b/integration-tests-jvm/kamelet-reify/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Kamelet Reify</name>
     <description>Integration tests for Camel Quarkus Kamelet Reify extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/kotlin-dsl/pom.xml
+++ b/integration-tests-jvm/kotlin-dsl/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Kotlin DSL</name>
     <description>Integration tests for Camel Kotlin DSL extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/ldap/pom.xml
+++ b/integration-tests-jvm/ldap/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: LDAP</name>
     <description>Integration tests for Camel Quarkus LDAP extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/ldif/pom.xml
+++ b/integration-tests-jvm/ldif/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: LDIF</name>
     <description>Integration tests for Camel Quarkus LDIF extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/lucene/pom.xml
+++ b/integration-tests-jvm/lucene/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Lucene</name>
     <description>Integration tests for Camel Quarkus Lucene extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/management/pom.xml
+++ b/integration-tests-jvm/management/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Management</name>
     <description>Integration tests for Camel Quarkus Management extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/milo/pom.xml
+++ b/integration-tests-jvm/milo/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: OPC UA Client</name>
     <description>Integration tests for Camel Quarkus OPC UA Client extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/mvel/pom.xml
+++ b/integration-tests-jvm/mvel/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: MVEL</name>
     <description>Integration tests for Camel Quarkus MVEL extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/mybatis/pom.xml
+++ b/integration-tests-jvm/mybatis/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: MyBatis</name>
     <description>Integration tests for Camel Quarkus MyBatis extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/ognl/pom.xml
+++ b/integration-tests-jvm/ognl/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: OGNL</name>
     <description>Integration tests for Camel Quarkus OGNL extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/printer/pom.xml
+++ b/integration-tests-jvm/printer/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Printer</name>
     <description>Integration tests for Camel Quarkus Printer extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/pulsar/pom.xml
+++ b/integration-tests-jvm/pulsar/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Pulsar</name>
     <description>Integration tests for Camel Quarkus Pulsar extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/quickfix/pom.xml
+++ b/integration-tests-jvm/quickfix/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: QuickFix</name>
     <description>Integration tests for Camel Quarkus QuickFix extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/redis/pom.xml
+++ b/integration-tests-jvm/redis/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Redis</name>
     <description>Integration tests for Camel Quarkus Redis extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/ribbon/pom.xml
+++ b/integration-tests-jvm/ribbon/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Ribbon</name>
     <description>Integration tests for Camel Quarkus Ribbon extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/robotframework/pom.xml
+++ b/integration-tests-jvm/robotframework/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Robot Framework</name>
     <description>Integration tests for Camel Quarkus Robot Framework extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/schematron/pom.xml
+++ b/integration-tests-jvm/schematron/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Schematron</name>
     <description>Integration tests for Camel Quarkus Schematron extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/sip/pom.xml
+++ b/integration-tests-jvm/sip/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: SIP</name>
     <description>Integration tests for Camel Quarkus SIP extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/smpp/pom.xml
+++ b/integration-tests-jvm/smpp/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: SMPP</name>
     <description>Integration tests for Camel Quarkus SMPP extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/snmp/pom.xml
+++ b/integration-tests-jvm/snmp/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: SNMP</name>
     <description>Integration tests for Camel Quarkus SNMP extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/soroush/pom.xml
+++ b/integration-tests-jvm/soroush/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Soroush</name>
     <description>Integration tests for Camel Quarkus Soroush extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/spark/pom.xml
+++ b/integration-tests-jvm/spark/pom.xml
@@ -39,27 +39,6 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/integration-tests-jvm/splunk-hec/pom.xml
+++ b/integration-tests-jvm/splunk-hec/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Splunk HEC</name>
     <description>Integration tests for Camel Quarkus Splunk HEC extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/stitch/pom.xml
+++ b/integration-tests-jvm/stitch/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Stitch</name>
     <description>Integration tests for Camel Quarkus Stitch extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/stomp/pom.xml
+++ b/integration-tests-jvm/stomp/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Stomp</name>
     <description>Integration tests for Camel Quarkus Stomp extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/stub/pom.xml
+++ b/integration-tests-jvm/stub/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Stub</name>
     <description>Integration tests for Camel Quarkus Stub extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/thrift/pom.xml
+++ b/integration-tests-jvm/thrift/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Thrift</name>
     <description>Integration tests for Camel Quarkus Thrift extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/web3j/pom.xml
+++ b/integration-tests-jvm/web3j/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Web3j Ethereum Blockchain</name>
     <description>Integration tests for Camel Quarkus Web3j Ethereum Blockchain extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/weka/pom.xml
+++ b/integration-tests-jvm/weka/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Weka</name>
     <description>Integration tests for Camel Quarkus Weka extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/wordpress/pom.xml
+++ b/integration-tests-jvm/wordpress/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Wordpress</name>
     <description>Integration tests for Camel Quarkus Wordpress extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/workday/pom.xml
+++ b/integration-tests-jvm/workday/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Workday</name>
     <description>Integration tests for Camel Quarkus Workday extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/xj/pom.xml
+++ b/integration-tests-jvm/xj/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: XJ</name>
     <description>Integration tests for Camel Quarkus XJ extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/xmpp/pom.xml
+++ b/integration-tests-jvm/xmpp/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: XMPP</name>
     <description>Integration tests for Camel Quarkus XMPP extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/xslt-saxon/pom.xml
+++ b/integration-tests-jvm/xslt-saxon/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: XSLT Saxon</name>
     <description>Integration tests for Camel Quarkus XSLT Saxon extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/yammer/pom.xml
+++ b/integration-tests-jvm/yammer/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Yammer</name>
     <description>Integration tests for Camel Quarkus Yammer extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/zookeeper-master/pom.xml
+++ b/integration-tests-jvm/zookeeper-master/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: ZooKeeper Master</name>
     <description>Integration tests for Camel Quarkus ZooKeeper Master extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-jvm/zookeeper/pom.xml
+++ b/integration-tests-jvm/zookeeper/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: ZooKeeper</name>
     <description>Integration tests for Camel Quarkus ZooKeeper extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests-support/pom.xml
+++ b/integration-tests-support/pom.xml
@@ -57,14 +57,14 @@
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
                 <artifactId>camel-quarkus-bom</artifactId>
-                <version>${camel-quarkus.version}</version>
+                <version>${project.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
                 <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
+                <version>${project.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/integration-tests/activemq/pom.xml
+++ b/integration-tests/activemq/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: ActiveMQ</name>
     <description>Integration tests for Camel Quarkus ActiveMQ extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <!-- Messaging extension to test -->
         <dependency>

--- a/integration-tests/amqp/pom.xml
+++ b/integration-tests/amqp/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Amqp</name>
     <description>Integration tests for Camel Quarkus Amqp extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/arangodb/pom.xml
+++ b/integration-tests/arangodb/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: ArangoDb</name>
     <description>Integration tests for Camel Quarkus ArangoDb extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/as2/pom.xml
+++ b/integration-tests/as2/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: AS2</name>
     <description>Integration tests for Camel Quarkus AS2 extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/atlasmap/pom.xml
+++ b/integration-tests/atlasmap/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: AtlasMap</name>
     <description>Integration tests for Camel Quarkus AtlasMap extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/avro-rpc/pom.xml
+++ b/integration-tests/avro-rpc/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Avro RPC</name>
     <description>Integration tests for Camel Quarkus Avro RPC extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/avro/pom.xml
+++ b/integration-tests/avro/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Avro</name>
     <description>Integration tests for Camel Quarkus Avro extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/aws2-grouped/pom.xml
+++ b/integration-tests/aws2-grouped/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: AWS2 Grouped</name>
     <description>AWS 2 tests from ../integration-test-groups/aws2 merged together</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <!-- Regenerate the dependencies via `mvn process-resources -Pformat -N` from the source tree root directory -->
     <dependencies>
         <dependency>

--- a/integration-tests/aws2-quarkus-client-grouped/pom.xml
+++ b/integration-tests/aws2-quarkus-client-grouped/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: AWS2 Quarkus Client Grouped</name>
     <description>AWS 2 tests from ../integration-test-groups/aws2-quarkus-client merged together</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <!-- Regenerate the dependencies via `mvn process-resources -Pformat -N` from the source tree root directory -->
     <dependencies>
         <dependency>

--- a/integration-tests/aws2/pom.xml
+++ b/integration-tests/aws2/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: AWS2</name>
     <description>The camel integration tests</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/azure-grouped/pom.xml
+++ b/integration-tests/azure-grouped/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Azure Grouped</name>
     <description>Azure tests from ../integration-test-groups/azure merged together</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <!-- Regenerate the dependencies via `mvn process-resources -Pformat -N` from the source tree root directory -->
     <dependencies>
         <dependency>

--- a/integration-tests/base64/pom.xml
+++ b/integration-tests/base64/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Base64</name>
     <description>Integration tests for Camel Quarkus Base64 extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/bean-validator/pom.xml
+++ b/integration-tests/bean-validator/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Bean Validator</name>
     <description>Integration tests for Camel Quarkus Bean Validator extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/bindy/pom.xml
+++ b/integration-tests/bindy/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Bindy</name>
     <description>Integration tests for Camel Quarkus Bindy extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/box/pom.xml
+++ b/integration-tests/box/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Box</name>
     <description>Integration tests for Camel Quarkus Box extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/braintree/pom.xml
+++ b/integration-tests/braintree/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Braintree</name>
     <description>Integration tests for Camel Quarkus Braintree extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/caffeine/pom.xml
+++ b/integration-tests/caffeine/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Caffeine Cache</name>
     <description>Integration tests for Camel Quarkus Caffeine Cache extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/cassandraql/pom.xml
+++ b/integration-tests/cassandraql/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Cassandra CQL</name>
     <description>Integration tests for Camel Quarkus Cassandra CQL extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/cbor/pom.xml
+++ b/integration-tests/cbor/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: CBOR</name>
     <description>Integration tests for Camel Quarkus CBOR extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/compression/pom.xml
+++ b/integration-tests/compression/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Compression</name>
     <description>Integration tests for various compression related extensions</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/consul/pom.xml
+++ b/integration-tests/consul/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Consul</name>
     <description>Integration tests for Camel Quarkus Consul extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/core-discovery-disabled/pom.xml
+++ b/integration-tests/core-discovery-disabled/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Core Discovery Disabled :: Tests</name>
     <description>The camel integration tests</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/couchdb/pom.xml
+++ b/integration-tests/couchdb/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: CouchDB</name>
     <description>Integration tests for Camel Quarkus CouchDB extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/crypto/pom.xml
+++ b/integration-tests/crypto/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Crypto (JCE)</name>
     <description>Integration tests for Camel Quarkus Crypto (JCE) extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/csimple/pom.xml
+++ b/integration-tests/csimple/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: CSimple</name>
     <description>Integration tests for Camel Quarkus CSimple extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/csv/pom.xml
+++ b/integration-tests/csv/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: CSV</name>
     <description>Integration tests for Camel Quarkus CSV extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/dataformat/pom.xml
+++ b/integration-tests/dataformat/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Data Format</name>
     <description>Integration tests for Camel Quarkus Data Format extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/dataformats-json/pom.xml
+++ b/integration-tests/dataformats-json/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: DataFormats JSON</name>
     <description>Integration tests for Camel Quarkus extension providing JSON related data formats</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/debezium/pom.xml
+++ b/integration-tests/debezium/pom.xml
@@ -40,32 +40,6 @@
         <sqlserver.EULA>src/test/resources/container-license-acceptance.txt</sqlserver.EULA>
     </properties>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/digitalocean/pom.xml
+++ b/integration-tests/digitalocean/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: DigitalOcean</name>
     <description>Integration tests for Camel Quarkus DigitalOcean extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/disruptor/pom.xml
+++ b/integration-tests/disruptor/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Disruptor</name>
     <description>Integration tests for Camel Quarkus Disruptor extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/dozer/pom.xml
+++ b/integration-tests/dozer/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Dozer</name>
     <description>Integration tests for Camel Quarkus Dozer extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/dropbox/pom.xml
+++ b/integration-tests/dropbox/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Dropbox</name>
     <description>Integration tests for Camel Quarkus Dropbox extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/elasticsearch-rest/pom.xml
+++ b/integration-tests/elasticsearch-rest/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Elasticsearch Rest</name>
     <description>Integration tests for Camel Quarkus Elasticsearch Rest extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/exec/pom.xml
+++ b/integration-tests/exec/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Exec</name>
     <description>Integration tests for Camel Quarkus Exec extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/fhir/pom.xml
+++ b/integration-tests/fhir/pom.xml
@@ -35,32 +35,6 @@
         <ci.native.tests.skip>true</ci.native.tests.skip>
     </properties>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/file/pom.xml
+++ b/integration-tests/file/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: File</name>
     <description>Integration tests for Camel Quarkus File extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/flatpack/pom.xml
+++ b/integration-tests/flatpack/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Flatpack</name>
     <description>Integration tests for Camel Quarkus Flatpack extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/fop/pom.xml
+++ b/integration-tests/fop/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: FOP</name>
     <description>Integration tests for Camel Quarkus FOP extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/foundation-grouped/pom.xml
+++ b/integration-tests/foundation-grouped/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Foundation Grouped</name>
     <description>Foundation tests from ../integration-test-groups/foundation merged together</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <!-- Regenerate the dependencies via `mvn process-resources -Pformat -N` from the source tree root directory -->
     <dependencies>
         <dependency>

--- a/integration-tests/freemarker/pom.xml
+++ b/integration-tests/freemarker/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Freemarker</name>
     <description>Integration tests for Camel Quarkus Freemarker extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/ftp/pom.xml
+++ b/integration-tests/ftp/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: FTP</name>
     <description>Integration tests for Camel Quarkus FTP extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/geocoder/pom.xml
+++ b/integration-tests/geocoder/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Geocoder</name>
     <description>Integration tests for Camel Quarkus Geocoder extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/git/pom.xml
+++ b/integration-tests/git/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Git</name>
     <description>Integration tests for Camel Quarkus Git extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/github/pom.xml
+++ b/integration-tests/github/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: GitHub</name>
     <description>Integration tests for Camel Quarkus GitHub extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/google-bigquery/pom.xml
+++ b/integration-tests/google-bigquery/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Google BigQuery</name>
     <description>Integration tests for Camel Quarkus Google BigQuery extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/google-pubsub/pom.xml
+++ b/integration-tests/google-pubsub/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Google Pubsub</name>
     <description>Integration tests for Camel Quarkus Google Pubsub extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/google-storage/pom.xml
+++ b/integration-tests/google-storage/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Google Storage</name>
     <description>Integration tests for Camel Quarkus Google Storage extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/google/pom.xml
+++ b/integration-tests/google/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Google APIs</name>
     <description>Integration tests for Camel Quarkus Google APIs</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/graphql/pom.xml
+++ b/integration-tests/graphql/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: GraphQL</name>
     <description>Integration tests for Camel Quarkus GraphQL extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/grok/pom.xml
+++ b/integration-tests/grok/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Grok</name>
     <description>Integration tests for Camel Quarkus Grok extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/grpc/pom.xml
+++ b/integration-tests/grpc/pom.xml
@@ -34,32 +34,6 @@
         <cq.skip.protobuf>false</cq.skip.protobuf><!-- set to true via groovy below on unsupported platforms or if -Dquickly is available -->
     </properties>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel</groupId>

--- a/integration-tests/hazelcast/pom.xml
+++ b/integration-tests/hazelcast/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Hazelcast</name>
     <description>Integration tests for Camel Quarkus Hazelcast extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/headersmap/pom.xml
+++ b/integration-tests/headersmap/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Headersmap</name>
     <description>Integration tests for Camel Quarkus Headersmap extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/hl7/pom.xml
+++ b/integration-tests/hl7/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: HL7</name>
     <description>Integration tests for Camel Quarkus HL7 extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/http/pom.xml
+++ b/integration-tests/http/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: HTTP</name>
     <description>Integration tests for Camel Quarkus HTTP extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/hystrix/pom.xml
+++ b/integration-tests/hystrix/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Hystrix</name>
     <description>Integration tests for Camel Quarkus Hystrix extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/infinispan/pom.xml
+++ b/integration-tests/infinispan/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Infinispan</name>
     <description>Integration tests for Camel Infinispan component</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/influxdb/pom.xml
+++ b/integration-tests/influxdb/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: InfluxDB</name>
     <description>Integration tests for Camel Quarkus InfluxDB extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/ipfs/pom.xml
+++ b/integration-tests/ipfs/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: IPFS</name>
     <description>Integration tests for Camel Quarkus IPFS extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/jackson-avro/pom.xml
+++ b/integration-tests/jackson-avro/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Avro Jackson</name>
     <description>Integration tests for Camel Quarkus Avro Jackson extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/jackson-protobuf/pom.xml
+++ b/integration-tests/jackson-protobuf/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Protobuf Jackson</name>
     <description>Integration tests for Camel Quarkus Protobuf Jackson extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/jaxb/pom.xml
+++ b/integration-tests/jaxb/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: JAXB</name>
     <description>Integration tests for Camel Quarkus JAXB extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/jdbc/pom.xml
+++ b/integration-tests/jdbc/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: JDBC</name>
     <description>Integration tests for Camel JDBC extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/jing/pom.xml
+++ b/integration-tests/jing/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Jing</name>
     <description>Integration tests for Camel Quarkus Jing extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/jira/pom.xml
+++ b/integration-tests/jira/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Jira</name>
     <description>Integration tests for Camel Quarkus Jira extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/jms-artemis-client/pom.xml
+++ b/integration-tests/jms-artemis-client/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: JMS Artemis Client</name>
     <description>Integration tests for Camel Quarkus JMS extension with the Apache ActiveMQ Artemis Client</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <!-- Messaging extension to test -->
         <dependency>

--- a/integration-tests/jms-qpid-amqp-client/pom.xml
+++ b/integration-tests/jms-qpid-amqp-client/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: JMS QPID AMQP Client</name>
     <description>Integration tests for Camel Quarkus JMS extension with the Quarkus Qpid JMS Client</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <!-- Messaging extension to test -->
         <dependency>

--- a/integration-tests/jolt/pom.xml
+++ b/integration-tests/jolt/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: JOLT</name>
     <description>Integration tests for Camel Quarkus JOLT extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/jpa/pom.xml
+++ b/integration-tests/jpa/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: JPA</name>
     <description>Integration tests for Camel Quarkus JPA extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/js-dsl/pom.xml
+++ b/integration-tests/js-dsl/pom.xml
@@ -35,32 +35,6 @@
         <ci.native.tests.skip>true</ci.native.tests.skip>
     </properties>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/jsch/pom.xml
+++ b/integration-tests/jsch/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: SCP</name>
     <description>Integration tests for Camel Quarkus SCP extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/jslt/pom.xml
+++ b/integration-tests/jslt/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: JSLT</name>
     <description>Integration tests for Camel Quarkus JSLT extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/json-validator/pom.xml
+++ b/integration-tests/json-validator/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: JSON Schema Validator</name>
     <description>Integration tests for Camel Quarkus JSON Schema Validator extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/jsonata/pom.xml
+++ b/integration-tests/jsonata/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: JSONATA</name>
     <description>Integration tests for Camel Quarkus JSONATA extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/jsonpath/pom.xml
+++ b/integration-tests/jsonpath/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: JSON Path</name>
     <description>Integration tests for Camel Quarkus JSON Path extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/jta/pom.xml
+++ b/integration-tests/jta/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: JTA</name>
     <description>Integration tests for Camel Quarkus JTA extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/kafka-sasl-ssl/pom.xml
+++ b/integration-tests/kafka-sasl-ssl/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Kafka SASL SSL</name>
     <description>Integration tests for Camel Quarkus Kafka SASL SSL</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/kafka-sasl/pom.xml
+++ b/integration-tests/kafka-sasl/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Kafka SASL</name>
     <description>Integration tests for Camel Quarkus Kafka SASL</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/kafka-ssl/pom.xml
+++ b/integration-tests/kafka-ssl/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Kafka SSL</name>
     <description>Integration tests for Camel Quarkus Kafka SSL</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/kafka/pom.xml
+++ b/integration-tests/kafka/pom.xml
@@ -34,32 +34,6 @@
         <surefire.rerunFailingTestsCount>2</surefire.rerunFailingTestsCount>
     </properties>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/kamelet/pom.xml
+++ b/integration-tests/kamelet/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Kamelet</name>
     <description>Integration tests for Camel Quarkus Kamelet extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/kotlin/pom.xml
+++ b/integration-tests/kotlin/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Kotlin :: Tests</name>
     <description>The camel integration tests</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/kubernetes/pom.xml
+++ b/integration-tests/kubernetes/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Kubernetes</name>
     <description>Integration tests for Camel Quarkus Kubernetes extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/kudu/pom.xml
+++ b/integration-tests/kudu/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Kudu</name>
     <description>Integration tests for Camel Quarkus Kudu extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
          <dependency>
             <groupId>io.quarkus</groupId>

--- a/integration-tests/leveldb/pom.xml
+++ b/integration-tests/leveldb/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: LevelDB</name>
     <description>Integration tests for Camel Quarkus LevelDB extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/lra/pom.xml
+++ b/integration-tests/lra/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: LRA</name>
     <description>Integration tests for Camel Quarkus LRA extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/lumberjack/pom.xml
+++ b/integration-tests/lumberjack/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Lumberjack</name>
     <description>Integration tests for Camel Quarkus Lumberjack extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/mail/pom.xml
+++ b/integration-tests/mail/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Mail</name>
     <description>Integration tests for Camel Mail extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/main-caffeine-lrucache/pom.xml
+++ b/integration-tests/main-caffeine-lrucache/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Main Caffeine LRUCache :: Tests</name>
     <description>The camel integration tests</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/main-collector/pom.xml
+++ b/integration-tests/main-collector/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Main Collector :: Tests</name>
     <description>The camel integration tests</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/main-command-mode/pom.xml
+++ b/integration-tests/main-command-mode/pom.xml
@@ -33,32 +33,6 @@
         <quarkus.runner.jar>${project.build.directory}/quarkus-app/quarkus-run.jar</quarkus.runner.jar>
     </properties>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/main-devmode/pom.xml
+++ b/integration-tests/main-devmode/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Main DevMode :: Tests</name>
     <description>The camel integration tests</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/main-discovery-disabled/pom.xml
+++ b/integration-tests/main-discovery-disabled/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Main Discovery Disabled :: Tests</name>
     <description>The camel integration tests</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/main-unknown-args-fail/pom.xml
+++ b/integration-tests/main-unknown-args-fail/pom.xml
@@ -33,32 +33,6 @@
         <quarkus.runner.jar>${project.build.directory}/quarkus-app/quarkus-run.jar</quarkus.runner.jar>
     </properties>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/main-unknown-args-ignore/pom.xml
+++ b/integration-tests/main-unknown-args-ignore/pom.xml
@@ -33,32 +33,6 @@
         <quarkus.runner.jar>${project.build.directory}/quarkus-app/quarkus-run.jar</quarkus.runner.jar>
     </properties>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/main-xml-io/pom.xml
+++ b/integration-tests/main-xml-io/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Main XML Io :: Tests</name>
     <description>The camel integration tests</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/main-xml-jaxb/pom.xml
+++ b/integration-tests/main-xml-jaxb/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Main XML Jaxb :: Tests</name>
     <description>The camel integration tests</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/main-yaml/pom.xml
+++ b/integration-tests/main-yaml/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Main YAML :: Tests</name>
     <description>The camel integration tests</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/main/pom.xml
+++ b/integration-tests/main/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Main :: Tests</name>
     <description>The camel integration tests</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/master/pom.xml
+++ b/integration-tests/master/pom.xml
@@ -34,32 +34,6 @@
         <quarkus.runner>${project.build.directory}/quarkus-app/quarkus-run.jar</quarkus.runner>
     </properties>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/messaging/pom.xml
+++ b/integration-tests/messaging/pom.xml
@@ -37,32 +37,6 @@
         <module>sjms</module>
     </modules>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <build>
         <plugins>
             <plugin>

--- a/integration-tests/micrometer/pom.xml
+++ b/integration-tests/micrometer/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Micrometer</name>
     <description>Integration tests for Camel Quarkus Micrometer extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/microprofile/pom.xml
+++ b/integration-tests/microprofile/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: MicroProfile</name>
     <description>Integration tests for Camel Quarkus MicroProfile extensions</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/minio/pom.xml
+++ b/integration-tests/minio/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Minio</name>
     <description>Integration tests for Camel Quarkus Minio extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/mllp/pom.xml
+++ b/integration-tests/mllp/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: MLLP</name>
     <description>Integration tests for Camel Quarkus MLLP extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/mongodb-grouped/pom.xml
+++ b/integration-tests/mongodb-grouped/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: MongoDB Grouped</name>
     <description>MongoDB tests from ../integration-test-groups/mongodb merged together</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <!-- Regenerate the dependencies via `mvn process-resources -Pformat -N` from the source tree root directory -->
     <dependencies>
         <dependency>

--- a/integration-tests/msv/pom.xml
+++ b/integration-tests/msv/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: MSV</name>
     <description>Integration tests for Camel Quarkus MSV extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/mustache/pom.xml
+++ b/integration-tests/mustache/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Mustache</name>
     <description>Integration tests for Camel Quarkus Mustache extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/nagios/pom.xml
+++ b/integration-tests/nagios/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Nagios</name>
     <description>Integration tests for Camel Quarkus Nagios extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/nats/pom.xml
+++ b/integration-tests/nats/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Nats</name>
     <description>Integration tests for Camel Quarkus Nats extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/netty/pom.xml
+++ b/integration-tests/netty/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Netty</name>
     <description>Integration tests for Camel Quarkus Netty extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/nitrite/pom.xml
+++ b/integration-tests/nitrite/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Nitrite</name>
     <description>Integration tests for Camel Quarkus Nitrite extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/nsq/pom.xml
+++ b/integration-tests/nsq/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: NSQ</name>
     <description>Integration tests for Camel Quarkus NSQ extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/oaipmh/pom.xml
+++ b/integration-tests/oaipmh/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: OAI-PMH</name>
     <description>Integration tests for Camel Quarkus OAI-PMH extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/integration-tests/olingo4/pom.xml
+++ b/integration-tests/olingo4/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Olingo4</name>
     <description>Integration tests for Camel Quarkus Olingo4 extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/openapi-java/pom.xml
+++ b/integration-tests/openapi-java/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: OpenApi Java</name>
     <description>Integration tests for Camel Quarkus OpenApi Java extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/openstack/pom.xml
+++ b/integration-tests/openstack/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: OpenStack</name>
     <description>Integration tests for Camel Quarkus OpenStack extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/opentelemetry/pom.xml
+++ b/integration-tests/opentelemetry/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: OpenTelemetry</name>
     <description>Integration tests for Camel Quarkus OpenTelemetry extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/opentracing/pom.xml
+++ b/integration-tests/opentracing/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: OpenTracing</name>
     <description>Integration tests for Camel Quarkus OpenTracing extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/optaplanner/pom.xml
+++ b/integration-tests/optaplanner/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: OptaPlanner</name>
     <description>Integration tests for Camel Quarkus OptaPlanner extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/paho-mqtt5/pom.xml
+++ b/integration-tests/paho-mqtt5/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Paho MQTT 5</name>
     <description>Integration tests for Camel Quarkus Paho MQTT 5 extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/paho/pom.xml
+++ b/integration-tests/paho/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Paho</name>
     <description>Integration tests for Camel Quarkus Paho extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/pdf/pom.xml
+++ b/integration-tests/pdf/pom.xml
@@ -29,32 +29,6 @@
     <name>Camel Quarkus :: Integration Tests :: PDF</name>
     <description>Integration tests for Camel Quarkus PDF extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/pg-replication-slot/pom.xml
+++ b/integration-tests/pg-replication-slot/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: PostgresSQL Replication Slot</name>
     <description>Integration tests for Camel Quarkus PostgresSQL Replication Slot extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/pgevent/pom.xml
+++ b/integration-tests/pgevent/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: PostgresSQL Event</name>
     <description>Integration tests for Camel Quarkus PostgresSQL Event extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/platform-http-engine/pom.xml
+++ b/integration-tests/platform-http-engine/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Platform HTTP Engine</name>
     <description>Integration tests for Camel Quarkus platform-http engine extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/platform-http/pom.xml
+++ b/integration-tests/platform-http/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Platform HTTP</name>
     <description>Integration tests for Camel Quarkus platform-http extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/protobuf/pom.xml
+++ b/integration-tests/protobuf/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Protobuf</name>
     <description>Integration tests for Camel Quarkus Protobuf extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/pubnub/pom.xml
+++ b/integration-tests/pubnub/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: PubNub</name>
     <description>Integration tests for Camel Quarkus PubNub extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/quartz/pom.xml
+++ b/integration-tests/quartz/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Quartz</name>
     <description>Integration tests for Camel Quarkus Quartz extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/qute/pom.xml
+++ b/integration-tests/qute/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Camel Quarkus Qute</name>
     <description>Integration tests for Camel Quarkus Camel Quarkus Qute extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/rabbitmq/pom.xml
+++ b/integration-tests/rabbitmq/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: RabbitMQ</name>
     <description>Integration tests for Camel Quarkus RabbitMQ extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/reactive-streams/pom.xml
+++ b/integration-tests/reactive-streams/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Reactive Streams</name>
     <description>Integration tests for Camel Quarkus Reactive Streams extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/rest-openapi/pom.xml
+++ b/integration-tests/rest-openapi/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: REST OpenApi</name>
     <description>Integration tests for Camel Quarkus REST OpenApi extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/rest/pom.xml
+++ b/integration-tests/rest/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Rest</name>
     <description>Integration tests for Camel Quarkus Rest extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/saga/pom.xml
+++ b/integration-tests/saga/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Saga</name>
     <description>Integration tests for Camel Quarkus Saga extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/salesforce/pom.xml
+++ b/integration-tests/salesforce/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Salesforce</name>
     <description>The camel integration tests</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/sap-netweaver/pom.xml
+++ b/integration-tests/sap-netweaver/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: SAP NetWeaver</name>
     <description>Integration tests for Camel Quarkus SAP NetWeaver extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/saxon/pom.xml
+++ b/integration-tests/saxon/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: XQuery</name>
     <description>Integration tests for Camel Quarkus XQuery extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/servicenow/pom.xml
+++ b/integration-tests/servicenow/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: ServiceNow</name>
     <description>Integration tests for Camel Quarkus ServiceNow extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/servlet/pom.xml
+++ b/integration-tests/servlet/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Servlet</name>
     <description>Integration tests for Camel Servlet component</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/shiro/pom.xml
+++ b/integration-tests/shiro/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Shiro</name>
     <description>Integration tests for Camel Quarkus Shiro extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/sjms-artemis-client/pom.xml
+++ b/integration-tests/sjms-artemis-client/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: SJMS Artemis Client</name>
     <description>Integration tests for Camel Quarkus SJMS extension with the Apache ActiveMQ Artemis Client</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <!-- Messaging extension to test -->
         <dependency>

--- a/integration-tests/sjms-qpid-amqp-client/pom.xml
+++ b/integration-tests/sjms-qpid-amqp-client/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: SJMS QPID AMQP Client</name>
     <description>Integration tests for Camel Quarkus SJMS extension with the Quarkus Qpid JMS Client</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <!-- Messaging extension to test -->
         <dependency>

--- a/integration-tests/sjms2-artemis-client/pom.xml
+++ b/integration-tests/sjms2-artemis-client/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: SJMS2 Artemis Client</name>
     <description>Integration tests for Camel Quarkus SJMS2 extension with the Apache ActiveMQ Artemis Client</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <!-- Messaging extension to test -->
         <dependency>

--- a/integration-tests/sjms2-qpid-amqp-client/pom.xml
+++ b/integration-tests/sjms2-qpid-amqp-client/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: SJMS2 QPID AMQP Client</name>
     <description>Integration tests for Camel Quarkus SJMS2 extension with the Quarkus Qpid JMS Client</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <!-- Messaging extension to test -->
         <dependency>

--- a/integration-tests/slack/pom.xml
+++ b/integration-tests/slack/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Slack</name>
     <description>Integration tests for Camel Quarkus Slack extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <!-- Mongo dependency exists as a test for https://github.com/apache/camel-quarkus/issues/2489 -->
         <dependency>

--- a/integration-tests/smallrye-reactive-messaging/pom.xml
+++ b/integration-tests/smallrye-reactive-messaging/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: SmallRye Reactive Messaging</name>
     <description>Integration tests for Camel Quarkus SmallRye Reactive Messaging extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/soap/pom.xml
+++ b/integration-tests/soap/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Soap dataformat</name>
     <description>Integration tests for Camel Quarkus Soap dataformat extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/solr/pom.xml
+++ b/integration-tests/solr/pom.xml
@@ -34,32 +34,6 @@
         <solr.trust-store>${project.basedir}/target/ssl/trust-store.jks</solr.trust-store>
     </properties>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/splunk/pom.xml
+++ b/integration-tests/splunk/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Splunk</name>
     <description>Integration tests for Camel Quarkus Splunk extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/spring-rabbitmq/pom.xml
+++ b/integration-tests/spring-rabbitmq/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Spring RabbitMQ</name>
     <description>Integration tests for Camel Quarkus Spring RabbitMQ extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/sql/pom.xml
+++ b/integration-tests/sql/pom.xml
@@ -33,32 +33,6 @@
         <cq.sqlJdbcKind>h2</cq.sqlJdbcKind>
     </properties>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/ssh/pom.xml
+++ b/integration-tests/ssh/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: SSH</name>
     <description>Integration tests for Camel Quarkus SSH extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/stax/pom.xml
+++ b/integration-tests/stax/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: StAX</name>
     <description>Integration tests for Camel Quarkus StAX extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/stringtemplate/pom.xml
+++ b/integration-tests/stringtemplate/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: String Template</name>
     <description>Integration tests for Camel Quarkus String Template extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/syndication/pom.xml
+++ b/integration-tests/syndication/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Syndication</name>
     <description>Integration tests for Camel Quarkus Syndication</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/syslog/pom.xml
+++ b/integration-tests/syslog/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Syslog</name>
     <description>Integration tests for Camel Quarkus Syslog extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/tarfile/pom.xml
+++ b/integration-tests/tarfile/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Tarfile</name>
     <description>Integration tests for Camel Quarkus tarfile extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/telegram/pom.xml
+++ b/integration-tests/telegram/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Telegram</name>
     <description>Integration tests for Camel Quarkus Telegram extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/tika/pom.xml
+++ b/integration-tests/tika/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Tika</name>
     <description>Integration tests for Camel Quarkus Tika extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/twilio/pom.xml
+++ b/integration-tests/twilio/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Twilio</name>
     <description>Integration tests for Camel Quarkus Twilio extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/twitter/pom.xml
+++ b/integration-tests/twitter/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Twitter</name>
     <description>The camel twitter integration tests</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/univocity-parsers/pom.xml
+++ b/integration-tests/univocity-parsers/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: uniVocity CSV</name>
     <description>Integration tests for Camel Quarkus uniVocity CSV extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/validator/pom.xml
+++ b/integration-tests/validator/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Validator</name>
     <description>Integration tests for Camel Quarkus Validator extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/velocity/pom.xml
+++ b/integration-tests/velocity/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Velocity</name>
     <description>Integration tests for Camel Quarkus Velocity extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/vertx-kafka/pom.xml
+++ b/integration-tests/vertx-kafka/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Vert.x Kafka</name>
     <description>Integration tests for Camel Quarkus Vert.x Kafka extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/vertx-websocket/pom.xml
+++ b/integration-tests/vertx-websocket/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Vert.x WebSocket</name>
     <description>Integration tests for Camel Quarkus Vert.x WebSocket extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/vertx/pom.xml
+++ b/integration-tests/vertx/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Vert.x</name>
     <description>Integration tests for Camel Quarkus Vert.x extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/weather/pom.xml
+++ b/integration-tests/weather/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Weather</name>
     <description>Integration tests for Camel Quarkus Weather extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/xchange/pom.xml
+++ b/integration-tests/xchange/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: XChange</name>
     <description>Integration tests for Camel Quarkus XChange extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/xml/pom.xml
+++ b/integration-tests/xml/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: XML</name>
     <description>Integration tests for various XML related extensions</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/xmlsecurity/pom.xml
+++ b/integration-tests/xmlsecurity/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: XML Security Sign</name>
     <description>Integration tests for Camel Quarkus XML Security Sign extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/xpath/pom.xml
+++ b/integration-tests/xpath/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: XPath</name>
     <description>The camel quarkus integration tests for the XPath language</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/xstream/pom.xml
+++ b/integration-tests/xstream/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: XStream</name>
     <description>Integration tests for Camel Quarkus XStream extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/integration-tests/zendesk/pom.xml
+++ b/integration-tests/zendesk/pom.xml
@@ -30,32 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: Zendesk</name>
     <description>Integration tests for Camel Quarkus Zendesk extension</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>${camel-quarkus.platform.group-id}</groupId>
-                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
-                <version>${camel-quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-test</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -37,9 +37,6 @@
     <inceptionYear>2019</inceptionYear>
 
     <properties>
-        <!-- This property is kept in sync with project.version by the release plugin -->
-        <!-- Do not change to project.version because otherwise the end user apps having our BOM as parent (rather than importing it) will stop working -->
-        <camel-quarkus.version>2.3.0-SNAPSHOT</camel-quarkus.version>
 
         <!-- Primary dependencies - maintained manually -->
         <camel.major.minor>3.11</camel.major.minor> <!-- run after each change: cd docs && mvnd validate -->
@@ -57,15 +54,6 @@
         <quarkus-google-cloud.version>0.10.0</quarkus-google-cloud.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/googlecloudservices/quarkus-google-cloud-services-bom/ -->
         <quarkus-hazelcast-client.version>2.0.0</quarkus-hazelcast-client.version><!-- https://repo1.maven.org/maven2/com/hazelcast/quarkus-hazelcast-client-bom/ -->
         <quarkus-qpid-jms.version>0.28.0</quarkus-qpid-jms.version><!-- https://repo1.maven.org/maven2/org/amqphub/quarkus/quarkus-qpid-jms-bom/ -->
-
-        <!-- Allow running our tests against alternative BOMs, such as io.quarkus.platform:quarkus-camel-bom https://repo1.maven.org/maven2/io/quarkus/platform/quarkus-camel-bom/ -->
-        <!-- The BOM GAVs below are swapped as a workaround for https://github.com/quarkusio/quarkus/issues/20461 -->
-        <quarkus.platform.group-id>org.apache.camel.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.artifact-id>camel-quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.version>${camel-quarkus.version}</quarkus.platform.version>
-        <camel-quarkus.platform.group-id>io.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>quarkus-bom</camel-quarkus.platform.artifact-id>
-        <camel-quarkus.platform.version>${quarkus.version}</camel-quarkus.platform.version>
 
         <!-- Compile dependency versions (keep sorted alphabetically) -->
         <!-- Items annotated with @sync can be updated by running mvn cq:sync-versions -N -e -->

--- a/poms/bom-test/pom.xml
+++ b/poms/bom-test/pom.xml
@@ -32,6 +32,12 @@
 
     <name>Camel Quarkus :: Test BOM</name>
 
+    <properties>
+        <!-- This property is kept in sync with project.version by the release plugin -->
+        <!-- Do not change to project.version because otherwise the end user apps having our BOM as parent (rather than importing it) will stop working -->
+        <camel-quarkus.version>2.3.0-SNAPSHOT</camel-quarkus.version>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/poms/bom/pom.xml
+++ b/poms/bom/pom.xml
@@ -32,6 +32,12 @@
 
     <name>Camel Quarkus :: BOM</name>
 
+    <properties>
+        <!-- This property is kept in sync with project.version by the release plugin -->
+        <!-- Do not change to project.version because otherwise the end user apps having our BOM as parent (rather than importing it) will stop working -->
+        <camel-quarkus.version>2.3.0-SNAPSHOT</camel-quarkus.version>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
 

--- a/poms/build-parent-it/pom.xml
+++ b/poms/build-parent-it/pom.xml
@@ -35,8 +35,43 @@
     <description>Maven plugins configuration for Integration Tests</description>
 
     <properties>
+        <!-- Allow running our tests against alternative BOMs, such as io.quarkus.platform:quarkus-camel-bom https://repo1.maven.org/maven2/io/quarkus/platform/quarkus-camel-bom/ -->
+        <!-- The BOM GAVs below are swapped as a workaround for https://github.com/quarkusio/quarkus/issues/20461 -->
+        <quarkus.platform.group-id>org.apache.camel.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.artifact-id>camel-quarkus-bom</quarkus.platform.artifact-id>
+        <quarkus.platform.version>2.3.0-SNAPSHOT</quarkus.platform.version>
+        <camel-quarkus.platform.group-id>io.quarkus</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.version>${quarkus.version}</camel-quarkus.platform.version>
+
         <quarkus.banner.enabled>false</quarkus.banner.enabled>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>${quarkus.platform.group-id}</groupId>
+                <artifactId>${quarkus.platform.artifact-id}</artifactId>
+                <version>${quarkus.platform.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>${camel-quarkus.platform.group-id}</groupId>
+                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
+                <version>${camel-quarkus.platform.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel.quarkus</groupId>
+                <artifactId>camel-quarkus-bom-test</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <build>
         <pluginManagement>

--- a/tooling/maven-plugin/pom.xml
+++ b/tooling/maven-plugin/pom.xml
@@ -39,7 +39,7 @@
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
                 <artifactId>camel-quarkus-bom</artifactId>
-                <version>${camel-quarkus.version}</version>
+                <version>${project.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
${quarkus.platform.version}"

The problem is that the release plugin does not like if version props of currently released dependencies are not defined in the same file.  Originally, we had

```
    <properties>
        <camel-quarkus.version>2.3.0-SNAPSHOT</camel-quarkus.version><!-- kept in sync with project.version by the release plugin -->
    </properties>
```
 in the BOMs and that worked as long as `${camel-quarkus.version}` was used only in the BOMs.

I moved `<camel-quarkus.version>2.3.0-SNAPSHOT</camel-quarkus.version>` to the top pom in https://github.com/apache/camel-quarkus/pull/3134 and it does not work any more.

`quarkus.platform.version` is the same case.

To solve that, I did the following: 
* I moved `camel-quarkus.version` back to the BOMs. 
* I replaced `${camel-quarkus.version}` with `${project.version}` where the app BOM is imported in extension modules
* I moved the parametrized BOM imports from test modules to `build-parent-it` where also the definition of `<quarkus.platform.version>2.3.0-SNAPSHOT</quarkus.platform.version>` have to be moved.

The above fixes the issue with `release:prepare` and it still alows to run the tests against alternative BOMs
