### PR TITLE
Use log await strategy for RabbitMQ container

### DIFF
--- a/integration-tests/rabbitmq/src/test/java/org/apache/camel/quarkus/component/rabbitmq/it/RabbitmqTestResource.java
+++ b/integration-tests/rabbitmq/src/test/java/org/apache/camel/quarkus/component/rabbitmq/it/RabbitmqTestResource.java
@@ -45,7 +45,7 @@ public class RabbitmqTestResource implements QuarkusTestResourceLifecycleManager
             container = new GenericContainer<>(RABBITMQ_IMAGE)
                     .withExposedPorts(RABBITMQ_PORT)
                     .withLogConsumer(new Slf4jLogConsumer(LOGGER))
-                    .waitingFor(Wait.forListeningPort());
+                    .waitingFor(Wait.forLogMessage(".*Server startup complete.*", 1));
 
             container.start();
 


### PR DESCRIPTION
Should hopefully fix some random failures I was seeing on the `quarkus-main` branch.