### PR TITLE
Revert "Fixup 218bef4 Special fix for JMS extensions depending on"

### DIFF
--- a/integration-tests/jms-qpid-amqp-client/pom.xml
+++ b/integration-tests/jms-qpid-amqp-client/pom.xml
@@ -134,25 +134,6 @@
                 </dependency>
             </dependencies>
         </profile>
-        <profile>
-            <id>quarkus-platform</id>
-            <activation>
-                <property>
-                    <name>quarkus.platform.version</name>
-                </property>
-            </activation>
-            <dependencyManagement>
-                <dependencies>
-                    <dependency>
-                        <groupId>com.redhat.quarkus</groupId>
-                        <artifactId>quarkus-universe-bom</artifactId>
-                        <version>${quarkus.platform.version}</version>
-                        <type>pom</type>
-                        <scope>import</scope>
-                    </dependency>
-                </dependencies>
-            </dependencyManagement>
-        </profile>
     </profiles>
 
 </project>

--- a/integration-tests/sjms-qpid-amqp-client/pom.xml
+++ b/integration-tests/sjms-qpid-amqp-client/pom.xml
@@ -134,25 +134,6 @@
                 </dependency>
             </dependencies>
         </profile>
-        <profile>
-            <id>quarkus-platform</id>
-            <activation>
-                <property>
-                    <name>quarkus.platform.version</name>
-                </property>
-            </activation>
-            <dependencyManagement>
-                <dependencies>
-                    <dependency>
-                        <groupId>com.redhat.quarkus</groupId>
-                        <artifactId>quarkus-universe-bom</artifactId>
-                        <version>${quarkus.platform.version}</version>
-                        <type>pom</type>
-                        <scope>import</scope>
-                    </dependency>
-                </dependencies>
-            </dependencyManagement>
-        </profile>
     </profiles>
 
 </project>

--- a/integration-tests/sjms2-qpid-amqp-client/pom.xml
+++ b/integration-tests/sjms2-qpid-amqp-client/pom.xml
@@ -134,25 +134,6 @@
                 </dependency>
             </dependencies>
         </profile>
-        <profile>
-            <id>quarkus-platform</id>
-            <activation>
-                <property>
-                    <name>quarkus.platform.version</name>
-                </property>
-            </activation>
-            <dependencyManagement>
-                <dependencies>
-                    <dependency>
-                        <groupId>com.redhat.quarkus</groupId>
-                        <artifactId>quarkus-universe-bom</artifactId>
-                        <version>${quarkus.platform.version}</version>
-                        <type>pom</type>
-                        <scope>import</scope>
-                    </dependency>
-                </dependencies>
-            </dependencyManagement>
-        </profile>
     </profiles>
 
 </project>


### PR DESCRIPTION
This reverts commit 000d5e1add0af0f7683c5ba8258e3b90bb3b2ad7.

This was properly fixed in Platform BOM generator 0.0.35, see
https://github.com/quarkusio/quarkus-platform-bom-generator/issues/86
