### PR TITLE
Sql test using derby doesn't start dev service and stored procedure is not working on derby db

### DIFF
--- a/integration-tests/sql/pom.xml
+++ b/integration-tests/sql/pom.xml
@@ -156,5 +156,22 @@
                 </dependency>
             </dependencies>
         </profile>
+        <profile>
+            <id>derbyDevServiceWorkaround</id>
+            <activation>
+                <property>
+                    <name>cq.sqlJdbcKind</name>
+                    <value>derby</value>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.derby</groupId>
+                    <artifactId>derbynet</artifactId>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+
+        </profile>
     </profiles>
 </project>

--- a/integration-tests/sql/src/main/java/org/apache/camel/quarkus/component/sql/it/storedproc/DerbyNumberAddStoredProcedure.java
+++ b/integration-tests/sql/src/main/java/org/apache/camel/quarkus/component/sql/it/storedproc/DerbyNumberAddStoredProcedure.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.sql.it.storedproc;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class DerbyNumberAddStoredProcedure {
+
+    public static void testProc(int a, int b, String fileName) throws Exception {
+        Path path = Paths.get("target", fileName);
+        byte[] strToBytes = String.valueOf(a + b).getBytes(StandardCharsets.UTF_8);
+
+        Files.write(path, strToBytes);
+    }
+}

--- a/integration-tests/sql/src/main/resources/sql/derby/initDb.sql
+++ b/integration-tests/sql/src/main/resources/sql/derby/initDb.sql
@@ -35,3 +35,5 @@ DROP TABLE aggregation
 CREATE TABLE aggregation (id VARCHAR(255) NOT NULL, exchange BLOB NOT NULL, version BIGINT NOT NULL, constraint aggregation_pk PRIMARY KEY (id))
 DROP TABLE aggregation_completed
 CREATE TABLE aggregation_completed (id VARCHAR(255) NOT NULL, exchange BLOB NOT NULL, version BIGINT NOT NULL, constraint aggregation_completed_pk PRIMARY KEY (id))
+
+CREATE PROCEDURE ADD_NUMS(IN a INTEGER, IN b INTEGER, IN fileName VARCHAR(50)) PARAMETER STYLE JAVA READS SQL DATA LANGUAGE JAVA EXTERNAL NAME 'org.apache.camel.quarkus.component.sql.it.storedproc.DerbyNumberAddStoredProcedure.testProc'

--- a/integration-tests/sql/src/test/java/org/apache/camel/quarkus/component/sql/it/SqlTest.java
+++ b/integration-tests/sql/src/test/java/org/apache/camel/quarkus/component/sql/it/SqlTest.java
@@ -31,7 +31,7 @@ import org.hamcrest.Matcher;
 import org.hamcrest.collection.IsMapContaining;
 import org.hamcrest.text.IsEqualIgnoringCase;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.api.condition.DisabledIf;
 
 import static io.restassured.RestAssured.given;
 import static org.awaitility.Awaitility.await;
@@ -70,8 +70,12 @@ class SqlTest {
                 .body(is("Dromedarius 1"));
     }
 
+    public boolean storedProcedureDisabled() {
+        return "derby".equals(System.getProperty("cq.sqlJdbcKind")) && System.getenv().containsKey("SQL_JDBC_URL");
+    }
+
     @Test
-    @DisabledIfSystemProperty(named = "cq.sqlJdbcKind", matches = "derby", disabledReason = "https://github.com/apache/camel-quarkus/issues/3260")
+    @DisabledIf("storedProcedureDisabled")
     public void testSqlStoredComponent() {
         // Invoke ADD_NUMS stored procedure
         RestAssured.given()


### PR DESCRIPTION
fixes https://github.com/apache/camel-quarkus/issues/3260

- I used a workaround for an issue in quarkus - https://github.com/quarkusio/quarkus/issues/21639
- Test still can't be executed with external derby db (hance the condition on the stored procedure test). Problem is caused by the fact, that stored procedure is a java class, which has to be uploaded to the external derby  instance. With devServices (which uses in-memory db) this is not a problem.
- I used different approach for the stored procedure test - creation of temp file. Which is sufficient for the test.

<!-- Uncomment and fill this section if your PR is not trivial
[ ] An issue should be filed for the change unless this is a trivial change (fixing a typo or similar). One issue should ideally be fixed by not more than one commit and the other way round, each commit should fix just one issue, without pulling in other changes.
[ ] Each commit in the pull request should have a meaningful and properly spelled subject line and body. Copying the title of the associated issue is typically enough. Please include the issue number in the commit message prefixed by #.
[ ] The pull request description should explain what the pull request does, how, and why. If the info is available in the associated issue or some other external document, a link is enough.
[ ] Phrases like Fix #<issueNumber> or Fixes #<issueNumber> will auto-close the named issue upon merging the pull request. Using them is typically a good idea.
[ ] Please run mvn process-resources -Pformat (and amend the changes if necessary) before sending the pull request.
[ ] Contributor guide is your good friend: https://camel.apache.org/camel-quarkus/latest/contributor-guide.html
-->