### PR TITLE
Fix bash syntax error in CI integration tests step

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -159,17 +159,17 @@ jobs:
       - name: Integration Tests
         run: |
           for MODULE in $(cat tooling/scripts/test-categories.yaml | yq r - "${{ matrix.category }}.*"); do
-            if [ "${MODULE}" == "-" ]; then
+            if [[ "${MODULE}" == "-" ]]; then
               continue
             fi
             MODULE="integration-tests/$(echo ${MODULE} | sed 's/^[ \t]*//;s/[ \t]*$//')"
-            if [ "x$(mvn org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=ci.native.tests.skip -DforceStdout -q -f ${MODULE})" == "xtrue" ]; then
+            if [[ "x$(mvn org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=ci.native.tests.skip -DforceStdout -q -f ${MODULE})" == "xtrue" ]]; then
               JVM_MODULES+=("${MODULE}")
             else
               NATIVE_MODULES+=("${MODULE}")
             fi
           done
-          if [ ${#JVM_MODULES[@]} -eq 0 && ${#NATIVE_MODULES[@]} -eq 0 ]; then
+          if [[ ${#JVM_MODULES[@]} -eq 0 ]] && [[ ${#NATIVE_MODULES[@]} -eq 0 ]]; then
             echo "No test modules were found for category ${{ matrix.category }}"
             exit 1
           fi


### PR DESCRIPTION
Fixes a minor syntax error I spotted in the CI build on the integration tests step:

```
/home/runner/work/_temp/80d28131-e250-4105-b3b0-fdf3d970e64d.sh: line 12: [: missing `]'
```