### PR TITLE
Workaround for NoSuchFileException: .../target/classes when executing a

### DIFF
--- a/integration-tests/avro/pom.xml
+++ b/integration-tests/avro/pom.xml
@@ -62,6 +62,7 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
+                <extensions>true</extensions><!-- Workaround for https://github.com/quarkusio/quarkus/issues/21718 -->
                 <executions>
                     <execution>
                         <id>generate-code</id>

--- a/integration-tests/protobuf/pom.xml
+++ b/integration-tests/protobuf/pom.xml
@@ -62,6 +62,7 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
+                <extensions>true</extensions><!-- Workaround for https://github.com/quarkusio/quarkus/issues/21718 -->
                 <executions>
                     <execution>
                         <id>quarkus-generate-code</id>


### PR DESCRIPTION
codegen task https://github.com/quarkusio/quarkus/issues/21718

