### PR TITLE
Sql test using derby doesn't start dev service and shows class loadin…

### DIFF
--- a/integration-tests-support/pom.xml
+++ b/integration-tests-support/pom.xml
@@ -48,6 +48,7 @@
         <module>kafka</module>
         <module>mongodb</module>
         <module>process-executor-support</module>
+        <module>sql-derby-support</module>
         <module>test-support</module>
         <module>mock-backend</module>
         <module>wiremock</module>

--- a/integration-tests-support/sql-derby-support/README.adoc
+++ b/integration-tests-support/sql-derby-support/README.adoc
@@ -1,0 +1,3 @@
+== SQL integration tests
+
+This module creates jar with stored procedure used in test from `sql` module (for derby database).

--- a/integration-tests-support/sql-derby-support/pom.xml
+++ b/integration-tests-support/sql-derby-support/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">    
+    <parent>
+        <groupId>org.apache.camel.quarkus</groupId>
+        <artifactId>camel-quarkus-integration-tests-support</artifactId>
+        <version>2.17.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>camel-quarkus-integration-tests-support-sql-derby</artifactId>
+    <name>Camel Quarkus :: Integration Tests :: Support :: Sql Derby</name>
+
+    <properties>
+        <cq.sqlJdbcKind>h2</cq.sqlJdbcKind>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-sql</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/integration-tests-support/sql-derby-support/src/main/java/test/AddNumsProcedure.java
+++ b/integration-tests-support/sql-derby-support/src/main/java/test/AddNumsProcedure.java
@@ -14,19 +14,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.quarkus.component.sql.it.storedproc;
+package test;
 
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
 
-public class DerbyNumberAddStoredProcedure {
+public class AddNumsProcedure {
 
-    public static void testProc(int a, int b, String fileName) throws Exception {
-        Path path = Paths.get("target", fileName);
-        byte[] strToBytes = String.valueOf(a + b).getBytes(StandardCharsets.UTF_8);
+    public static void testProc(int a, int b) throws SQLException {
+        String sql = "insert into ADD_NUMS_RESULTS (id, value) VALUES (1, " + (a + b) + ")";
 
-        Files.write(path, strToBytes);
+        try (Connection con = DriverManager.getConnection("jdbc:default:connection");
+                PreparedStatement ps = con.prepareStatement(sql)) {
+            ps.execute();
+        }
     }
 }

--- a/integration-tests/sql/README.adoc
+++ b/integration-tests/sql/README.adoc
@@ -43,3 +43,28 @@ $Env:SQL_JDBC_PASSWORD="#password"
 ```
 
 Oracle database could be used as external db. In that case use parameter `-Dcq.sqlJdbcKind=oracle`.
+
+=== External Derby database
+
+To execute tests against external Derby database, stored procedure has to be uploaded into the database classpath.
+Jar with stored procedure for the derby database is creaed by module `sql-derby`.
+Jar could be uploaded via following commands through `ij`:
+```
+CALL sqlj.install_jar('/PATH_TO_JAR/camel-quarkus-integration-test-sql-derby-stored-procedure-*.jar', 'AddNumsProcedure' , 0)
+
+CALL syscs_util.syscs_set_database_property('derby.database.classpath', 'APP.ADDNUMSPROCEDURE')
+```
+
+=== External Derby database via Docker
+
+To avoid manual upload of the jar, test can automatically use external derby database created via docker.
+To execute the tests against external derby database, set the environment variable `SQL_USE_DERBY_DOCKER` to value `true`:
+
+```
+export SQL_USE_DERBY_DOCKER=true
+```
+
+or for windows:
+
+```
+$Env:SQL_USE_DERBY_DOCKER = "true"

--- a/integration-tests/sql/pom.xml
+++ b/integration-tests/sql/pom.xml
@@ -75,6 +75,32 @@
             <artifactId>awaitility</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-integration-tests-support-sql-derby</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit4-mock</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-integration-test-support</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 
@@ -164,14 +190,32 @@
                     <value>derby</value>
                 </property>
             </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>process-sources</phase>
+                                <goals>
+                                    <goal>copy-dependencies</goal>
+                                </goals>
+                                <configuration>
+                                    <includeArtifactIds>camel-quarkus-integration-tests-support-sql-derby</includeArtifactIds>
+                                    <outputDirectory>target/test-classes/derby/</outputDirectory>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
             <dependencies>
                 <dependency>
-                    <groupId>org.apache.derby</groupId>
-                    <artifactId>derbynet</artifactId>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-test-derby</artifactId>
                     <scope>test</scope>
                 </dependency>
             </dependencies>
-
         </profile>
     </profiles>
 </project>

--- a/integration-tests/sql/src/main/java/org/apache/camel/quarkus/component/sql/it/SqlDbInitializer.java
+++ b/integration-tests/sql/src/main/java/org/apache/camel/quarkus/component/sql/it/SqlDbInitializer.java
@@ -45,10 +45,19 @@ public class SqlDbInitializer {
 
     public void initDb() throws SQLException, IOException {
 
+        runScripts("initDb.sql");
+
+        if (SqlHelper.useDocker()) {
+            //docker execution may require more sql scripts
+            runScripts("initDb_docker.sql");
+        }
+    }
+
+    private void runScripts(String fileName) throws SQLException, IOException {
         try (Connection conn = dataSource.getConnection()) {
             try (Statement statement = conn.createStatement()) {
                 try (InputStream is = Thread.currentThread().getContextClassLoader()
-                        .getResourceAsStream("sql/" + dbKind + "/initDb.sql");
+                        .getResourceAsStream("sql/" + dbKind + "/" + fileName);
                         InputStreamReader isr = new InputStreamReader(is);
                         BufferedReader reader = new BufferedReader(isr)) {
 
@@ -66,6 +75,5 @@ public class SqlDbInitializer {
                 }
             }
         }
-
     }
 }

--- a/integration-tests/sql/src/main/java/org/apache/camel/quarkus/component/sql/it/SqlHelper.java
+++ b/integration-tests/sql/src/main/java/org/apache/camel/quarkus/component/sql/it/SqlHelper.java
@@ -20,6 +20,8 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.eclipse.microprofile.config.ConfigProvider;
+
 public class SqlHelper {
 
     private static Set<String> BOOLEAN_AS_NUMBER = new HashSet<>(Arrays.asList("db2", "mssql", "oracle"));
@@ -39,4 +41,12 @@ public class SqlHelper {
     static String getSelectProjectsScriptName(String dbKind) {
         return BOOLEAN_AS_NUMBER.contains(dbKind) ? "selectProjectsAsNumber.sql" : "selectProjectsAsBoolean.sql";
     }
+
+    public static boolean useDocker() {
+        return Boolean.parseBoolean(System.getenv("SQL_USE_DERBY_DOCKER")) &&
+                "derby".equals(ConfigProvider.getConfig().getOptionalValue("quarkus.datasource.db-kind", String.class)
+                        .orElse(System.getProperty("cq.sqlJdbcKind")))
+                && System.getenv("SQL_JDBC_URL") == null;
+    }
+
 }

--- a/integration-tests/sql/src/main/java/org/apache/camel/quarkus/component/sql/it/SqlRoutes.java
+++ b/integration-tests/sql/src/main/java/org/apache/camel/quarkus/component/sql/it/SqlRoutes.java
@@ -64,9 +64,11 @@ public class SqlRoutes extends RouteBuilder {
     SqlDbInitializer sqlDbInitializer;
 
     @Override
-    public void configure() throws IOException, SQLException {
+    public void configure() throws SQLException, IOException {
         //db has to be initialized before routes are started
         sqlDbInitializer.initDb();
+
+        String dbKind = System.getProperty("cq.sqlJdbcKind");
 
         String representationOfTrue = SqlHelper.convertBooleanToSqlDialect(dbKind, true);
         String representationOfFalse = SqlHelper.convertBooleanToSqlDialect(dbKind, false);

--- a/integration-tests/sql/src/main/resources/sql/derby/initDb.sql
+++ b/integration-tests/sql/src/main/resources/sql/derby/initDb.sql
@@ -36,4 +36,8 @@ CREATE TABLE aggregation (id VARCHAR(255) NOT NULL, exchange BLOB NOT NULL, vers
 DROP TABLE aggregation_completed
 CREATE TABLE aggregation_completed (id VARCHAR(255) NOT NULL, exchange BLOB NOT NULL, version BIGINT NOT NULL, constraint aggregation_completed_pk PRIMARY KEY (id))
 
-CREATE PROCEDURE ADD_NUMS(IN a INTEGER, IN b INTEGER, IN fileName VARCHAR(50)) PARAMETER STYLE JAVA READS SQL DATA LANGUAGE JAVA EXTERNAL NAME 'org.apache.camel.quarkus.component.sql.it.storedproc.DerbyNumberAddStoredProcedure.testProc'
+-- stored procedure
+DROP TABLE ADD_NUMS_RESULTS
+CREATE TABLE ADD_NUMS_RESULTS (id INT PRIMARY KEY, value INT NOT NULL)
+
+CREATE PROCEDURE ADD_NUMS(IN a INTEGER, IN b INTEGER) PARAMETER STYLE JAVA LANGUAGE JAVA EXTERNAL NAME 'test.AddNumsProcedure.testProc'

--- a/integration-tests/sql/src/main/resources/sql/derby/initDb_docker.sql
+++ b/integration-tests/sql/src/main/resources/sql/derby/initDb_docker.sql
@@ -1,0 +1,20 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one or more
+-- contributor license agreements.  See the NOTICE file distributed with
+-- this work for additional information regarding copyright ownership.
+-- The ASF licenses this file to You under the Apache License, Version 2.0
+-- (the "License"); you may not use this file except in compliance with
+-- the License.  You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+CALL sqlj.install_jar('/dbs/storedProcedure.jar', 'AddNumsProcedure' , 0)
+
+CALL syscs_util.syscs_set_database_property('derby.database.classpath', 'APP.ADDNUMSPROCEDURE')

--- a/integration-tests/sql/src/test/java/org/apache/camel/quarkus/component/sql/it/DerbyTestResource.java
+++ b/integration-tests/sql/src/test/java/org/apache/camel/quarkus/component/sql/it/DerbyTestResource.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.quarkus.component.sql.it;
+
+import java.io.File;
+import java.net.URL;
+import java.util.Collections;
+import java.util.Map;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import org.apache.camel.util.CollectionHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.MountableFile;
+import org.testcontainers.utility.TestcontainersConfiguration;
+
+/**
+ * Derby test resource starts derby container in case that SQL_USE_DERBY_DOCKER is set to true.
+ * It uses fixed port number obtained from SQL_USE_DERBY_PORT.
+ */
+public class DerbyTestResource<T extends GenericContainer> implements QuarkusTestResourceLifecycleManager {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DerbyTestResource.class);
+
+    private GenericContainer container;
+
+    @Override
+    public Map<String, String> start() {
+        //should be started only for derby in docker
+        // derby dev service does not work - it is still in process, see https://quarkus.io/guides/databases-dev-services
+        if (!SqlHelper.useDocker()) {
+            return Collections.emptyMap();
+        }
+
+        LOGGER.info(TestcontainersConfiguration.getInstance().toString());
+
+        try {
+            URL derby = Thread.currentThread().getContextClassLoader().getResource("derby");
+            File[] jars = new File(derby.toURI())
+                    .listFiles((d, n) -> n.startsWith("camel-quarkus-integration-tests-support-sql-derby"));
+            if (jars.length != 1) {
+                String msg = "There has to be one jar in target/test-classes with the name \"camel-quarkus-integration-test-sql-derby-stored-procedure-*.jar\", which contains stored procedure for the derby db.";
+                LOGGER.error(msg);
+                throw new IllegalStateException(msg);
+            }
+
+            container = new GenericContainer("az82/docker-derby")
+                    .withExposedPorts(1527)
+                    .withCopyFileToContainer(
+                            MountableFile.forClasspathResource("derby/" + jars[0].getName()),
+                            "/dbs/storedProcedure.jar")
+                    .waitingFor(Wait.forListeningPort());
+
+            container.start();
+
+            return CollectionHelper.mapOf("quarkus.datasource.jdbc.url",
+                    "jdbc:derby://localhost:" + container.getMappedPort(1527) + "/DOCKERDB;create=true");
+
+        } catch (Exception e) {
+            LOGGER.error("Container does not start", e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    protected void startContainer() throws Exception {
+        container.start();
+    }
+
+    @Override
+    public void stop() {
+        try {
+            if (container != null) {
+                container.stop();
+            }
+        } catch (Exception e) {
+            // ignored
+        }
+    }
+}

--- a/integration-tests/sql/src/test/java/org/apache/camel/quarkus/component/sql/it/SqlIT.java
+++ b/integration-tests/sql/src/test/java/org/apache/camel/quarkus/component/sql/it/SqlIT.java
@@ -20,5 +20,4 @@ import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest
 class SqlIT extends SqlTest {
-
 }

--- a/integration-tests/sql/src/test/java/org/apache/camel/quarkus/component/sql/it/SqlTest.java
+++ b/integration-tests/sql/src/test/java/org/apache/camel/quarkus/component/sql/it/SqlTest.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -31,13 +32,13 @@ import org.hamcrest.Matcher;
 import org.hamcrest.collection.IsMapContaining;
 import org.hamcrest.text.IsEqualIgnoringCase;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIf;
 
 import static io.restassured.RestAssured.given;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.*;
 
 @QuarkusTest
+@QuarkusTestResource(DerbyTestResource.class)
 class SqlTest {
 
     @Test
@@ -70,13 +71,9 @@ class SqlTest {
                 .body(is("Dromedarius 1"));
     }
 
-    public boolean storedProcedureDisabled() {
-        return "derby".equals(System.getProperty("cq.sqlJdbcKind")) && System.getenv().containsKey("SQL_JDBC_URL");
-    }
-
     @Test
-    @DisabledIf("storedProcedureDisabled")
     public void testSqlStoredComponent() {
+
         // Invoke ADD_NUMS stored procedure
         RestAssured.given()
                 .queryParam("numA", 10)

--- a/poms/bom-test/pom.xml
+++ b/poms/bom-test/pom.xml
@@ -142,6 +142,11 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
+                <artifactId>camel-quarkus-integration-tests-support-sql-derby</artifactId>
+                <version>${camel-quarkus.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel.quarkus</groupId>
                 <artifactId>camel-quarkus-integration-wiremock-support</artifactId>
                 <version>${camel-quarkus.version}</version>
             </dependency>


### PR DESCRIPTION
…g issue if stored procedure is called #3260

fixes https://github.com/apache/camel-quarkus/issues/3327

Needs https://github.com/quarkusio/quarkus/issues/22058 to work correctly.

I introduced an option to start sql test with derby started by docker. - to simulate external database (and not dev service).
There are 2 things which may need some changes:

1. To run stored procedure on external derby db, there has to be a jar which is uploaded there. I created module `sql-derby` for that purpose and I put it on the same hierarchy level as `sql` test module. I'm not sure if this is the right approach, another option is to put both `sql` and `sql-derby` in one module.
2. I'm facing a problem with generated port number for docker container. If I let docker to generate its own random port, I'm not able propagate it back to datasource definition. Therefore there are 2 properties, which forces usage of docker derby db:
```
export SQL_USE_DERBY_DOCKER=true
export SQL_USE_DERBY_PORT="#port"
```
On the other hand in current moment, when there is no CI automation for derby (see https://github.com/apache/camel-quarkus/issues/3083) it could stay in that way.

WDYT? @aldettinger 

<!-- Uncomment and fill this section if your PR is not trivial
[ ] An issue should be filed for the change unless this is a trivial change (fixing a typo or similar). One issue should ideally be fixed by not more than one commit and the other way round, each commit should fix just one issue, without pulling in other changes.
[ ] Each commit in the pull request should have a meaningful and properly spelled subject line and body. Copying the title of the associated issue is typically enough. Please include the issue number in the commit message prefixed by #.
[ ] The pull request description should explain what the pull request does, how, and why. If the info is available in the associated issue or some other external document, a link is enough.
[ ] Phrases like Fix #<issueNumber> or Fixes #<issueNumber> will auto-close the named issue upon merging the pull request. Using them is typically a good idea.
[ ] Please run mvn process-resources -Pformat (and amend the changes if necessary) before sending the pull request.
[ ] Contributor guide is your good friend: https://camel.apache.org/camel-quarkus/latest/contributor-guide.html
-->