### PR TITLE
Ensure consistent version of `software.amazon.awssdk` dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <animal-sniffer.version>1.18</animal-sniffer.version>
         <antlr3.version>3.5.2</antlr3.version><!-- Spark, Stringtemplate and probably others -->
         <avro.version>1.11.0</avro.version><!-- @sync io.quarkus:quarkus-bom:${quarkus.version} dep:org.apache.avro:avro -->
-        <awssdk.version>2.17.90</awssdk.version><!-- TODO: Remove this https://github.com/apache/camel-quarkus/issues/3366 -->
+        <awssdk.version>2.17.90</awssdk.version><!-- @sync io.quarkiverse.amazonservices:quarkus-amazon-services-parent:${quarkiverse-amazonservices.version} prop:awssdk.version -->
         <aws-java-sdk.version>1.11.714</aws-java-sdk.version>
         <azure-sdk-bom.version>1.0.5</azure-sdk-bom.version><!-- Keep in sync with camel-azure component versions -->
         <bouncycastle.version>1.69</bouncycastle.version><!-- @sync io.quarkus:quarkus-bom:${quarkus.version} dep:org.bouncycastle:bcprov-jdk15on -->

--- a/poms/bom/pom.xml
+++ b/poms/bom/pom.xml
@@ -57,6 +57,13 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>bom</artifactId>
+                <version>${awssdk.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.amqphub.quarkus</groupId>
                 <artifactId>quarkus-qpid-jms-bom</artifactId>
                 <version>${quarkus-qpid-jms.version}</version>


### PR DESCRIPTION
Since the move of Quarkus Amazon Services to Quarkiverse & given the dependency management issues I mentioned [here](https://github.com/apache/camel-quarkus/issues/3302#issuecomment-989648677) and [here](https://camel.zulipchat.com/#narrow/stream/257302-camel-quarkus/topic/BOM.20imports.20for.203rd.20party.20extensions), I don't see a better way of ensuring we are using a consistent & known version of the AWS dependencies.

Alternatively, I could move [this BOM import](https://github.com/apache/camel-quarkus/blob/main/poms/bom-test/pom.xml#L50-L56) into `camel-quarkus-bom`. But `quarkus-amazon-services-bom` also includes the Quarkus AWS extensions, and I don't think we want those being imported into our core BOM. Hence I opted to import the plain `software.amazon.awssdk` BOM.