### PR TITLE
Exclude maven-artifact from camel-quarkus-debezium-mongodb 

### DIFF
--- a/extensions/debezium-mongodb/runtime/pom.xml
+++ b/extensions/debezium-mongodb/runtime/pom.xml
@@ -62,6 +62,12 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-debezium-mongodb</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.maven</groupId>
+                    <artifactId>maven-artifact</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Fix #3372