### PR TITLE
Update CamelRoute.java

### DIFF
--- a/integration-tests/main-command-mode/src/main/java/org/apache/camel/quarkus/main/cmd/CamelRoute.java
+++ b/integration-tests/main-command-mode/src/main/java/org/apache/camel/quarkus/main/cmd/CamelRoute.java
@@ -29,7 +29,7 @@ public class CamelRoute extends RouteBuilder {
 
     @Override
     public void configure() {
-        from("timer:hello?delay=-1&repeatCount=1")
+        from("timer:hello?delay=-20000&repeatCount=1")
                 .setBody().constant("Hello " + greetedSubject + "!")
                 .to("log:hello");
     }


### PR DESCRIPTION
Change delay to 20000 (20 seconds) to allow the application.properties camel.main.durationMaxSeconds (set at 10 seconds) to stop the JVM before the timer kicks in

A reproducer for https://github.com/apache/camel-quarkus/issues/3394