### PR TITLE
Add test coverage for Quarkus SecurityIdentity & Principal in platform-http routes

### DIFF
--- a/docs/modules/ROOT/pages/reference/extensions/platform-http.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/platform-http.adoc
@@ -110,6 +110,23 @@ from("platform-http:/upload/multipart?fileNameExtWhitelist=adoc,txt&httpMethodRe
     });
 ----
 
+=== Securing `platform-http` endpoints
+
+Quarkus provides a variety of security and authentication mechanisms which can be used to secure `platform-http` endpoints. Refer to the https://quarkus.io/guides/security[Quarkus Security documentation] for further details.
+
+Within a route, it is possible to obtain the authenticated user and its associated `SecurityIdentity` and `Principal`:
+[source,java]
+----
+from("platform-http:/secure")
+    .process(e -> {
+        Message message = e.getMessage();
+        QuarkusHttpUser user = message.getHeader(VertxPlatformHttpConstants.AUTHENTICATED_USER, QuarkusHttpUser.class);
+        SecurityIdentity securityIdentity = user.getSecurityIdentity();
+        Principal principal = securityIdentity.getPrincipal();
+        // Do something useful with SecurityIdentity / Principal. E.g check user roles etc.
+    });
+----
+
 Also check the `quarkus.http.body.*` configuration options in
 https://quarkus.io/guides/all-config#quarkus-vertx-http_quarkus-vertx-http-eclipse-vert.x-http[Quarkus documentation], esp. `quarkus.http.body.handle-file-uploads`, `quarkus.http.body.uploads-directory` and `quarkus.http.body.delete-uploaded-files-on-end`.
 

--- a/extensions/platform-http/runtime/src/main/doc/usage.adoc
+++ b/extensions/platform-http/runtime/src/main/doc/usage.adoc
@@ -64,5 +64,22 @@ from("platform-http:/upload/multipart?fileNameExtWhitelist=adoc,txt&httpMethodRe
     });
 ----
 
+=== Securing `platform-http` endpoints
+
+Quarkus provides a variety of security and authentication mechanisms which can be used to secure `platform-http` endpoints. Refer to the https://quarkus.io/guides/security[Quarkus Security documentation] for further details.
+
+Within a route, it is possible to obtain the authenticated user and its associated `SecurityIdentity` and `Principal`:
+[source,java]
+----
+from("platform-http:/secure")
+    .process(e -> {
+        Message message = e.getMessage();
+        QuarkusHttpUser user = message.getHeader(VertxPlatformHttpConstants.AUTHENTICATED_USER, QuarkusHttpUser.class);
+        SecurityIdentity securityIdentity = user.getSecurityIdentity();
+        Principal principal = securityIdentity.getPrincipal();
+        // Do something useful with SecurityIdentity / Principal. E.g check user roles etc.
+    });
+----
+
 Also check the `quarkus.http.body.*` configuration options in
 https://quarkus.io/guides/all-config#quarkus-vertx-http_quarkus-vertx-http-eclipse-vert.x-http[Quarkus documentation], esp. `quarkus.http.body.handle-file-uploads`, `quarkus.http.body.uploads-directory` and `quarkus.http.body.delete-uploaded-files-on-end`.

--- a/integration-tests/platform-http/pom.xml
+++ b/integration-tests/platform-http/pom.xml
@@ -47,6 +47,10 @@
             <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-support-webhook</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-elytron-security-properties-file</artifactId>
+        </dependency>
 
         <!-- test dependencies -->
         <dependency>

--- a/integration-tests/platform-http/src/main/resources/application.properties
+++ b/integration-tests/platform-http/src/main/resources/application.properties
@@ -21,6 +21,13 @@ quarkus.http.body.uploads-directory=target/uploads
 quarkus.http.ssl.certificate.file=server-cert.pem
 quarkus.http.ssl.certificate.key-file=server-key.pem
 quarkus.http.insecure-requests=disabled
+quarkus.http.auth.basic=true
+quarkus.http.auth.permission.default.paths=/platform-http/secure/basic
+quarkus.http.auth.permission.default.policy=authenticated
+quarkus.security.users.embedded.enabled=true
+quarkus.security.users.embedded.plain-text=true
+quarkus.security.users.embedded.users.camel=p4ssw0rd
+quarkus.security.users.embedded.roles.camel=Admin
 
 # Required by the encoding() test
 quarkus.native.add-all-charsets = true

--- a/integration-tests/platform-http/src/test/java/org/apache/camel/quarkus/component/http/server/it/PlatformHttpTest.java
+++ b/integration-tests/platform-http/src/test/java/org/apache/camel/quarkus/component/http/server/it/PlatformHttpTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
 
 @QuarkusTest
 class PlatformHttpTest {
@@ -316,6 +317,34 @@ class PlatformHttpTest {
                 .then()
                 .statusCode(200)
                 .body(equalTo("Hello Camel Quarkus Webhook"));
+    }
+
+    @Test
+    public void testPathSecuredWithBasicAuth() {
+        // No credentials
+        RestAssured.given()
+                .when()
+                .get("/platform-http/secure/basic")
+                .then()
+                .statusCode(401);
+
+        // Invalid credentials
+        RestAssured.given()
+                .auth()
+                .basic("camel", "s3cr3t")
+                .get("/platform-http/secure/basic")
+                .then()
+                .statusCode(401);
+
+        // Valid credentials
+        RestAssured.given()
+                .auth()
+                .basic("camel", "p4ssw0rd")
+                .get("/platform-http/secure/basic")
+                .then()
+                .statusCode(200)
+                .header("Authorization", notNullValue())
+                .body(equalTo("camel:Admin"));
     }
 
     private static Method[] httpMethods() {

--- a/pom.xml
+++ b/pom.xml
@@ -197,6 +197,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <!-- maven-compiler-plugin -->
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.release>11</maven.compiler.release>
 
         <!-- maven-enforcer-plugin -->


### PR DESCRIPTION
Note - I restored the `maven-compiler-plugin` source / target properties, because without them, I can't seem to get IntelliJ to run / debug tests in the IDE.