### PR TITLE
Add test coverage for OpenTelemetry `@WithSpan` annotation

### DIFF
--- a/integration-tests/opentelemetry/pom.xml
+++ b/integration-tests/opentelemetry/pom.xml
@@ -33,6 +33,10 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-bean</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-direct</artifactId>
         </dependency>
         <dependency>
@@ -110,6 +114,19 @@
             </activation>
             <dependencies>
                 <!-- The following dependencies guarantee that this module is built after them. You can update them by running `mvn process-resources -Pformat -N` from the source tree root directory -->
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-bean-deployment</artifactId>
+                    <version>${project.version}</version>
+                    <type>pom</type>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
                 <dependency>
                     <groupId>org.apache.camel.quarkus</groupId>
                     <artifactId>camel-quarkus-direct-deployment</artifactId>

--- a/integration-tests/opentelemetry/src/main/java/org/apache/camel/quarkus/component/opentelemetry/it/GreetingsBean.java
+++ b/integration-tests/opentelemetry/src/main/java/org/apache/camel/quarkus/component/opentelemetry/it/GreetingsBean.java
@@ -17,33 +17,16 @@
 package org.apache.camel.quarkus.component.opentelemetry.it;
 
 import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
+import javax.inject.Named;
 
-import org.apache.camel.ProducerTemplate;
+import io.opentelemetry.extension.annotations.WithSpan;
 
-@Path("/opentelemetry")
 @ApplicationScoped
-public class OpenTelemetryResource {
+@Named("greetingsBean")
+public class GreetingsBean {
 
-    @Inject
-    ProducerTemplate producerTemplate;
-
-    @Path("/trace")
-    @GET
-    @Produces(MediaType.TEXT_PLAIN)
-    public String traceRoute() {
-        return producerTemplate.requestBody("direct:start", null, String.class);
-    }
-
-    @Path("/greet/{name}")
-    @GET
-    @Produces(MediaType.TEXT_PLAIN)
-    public String traceRoute(@PathParam("name") String name) {
-        return producerTemplate.requestBody("direct:greet", name, String.class);
+    @WithSpan
+    public String greet(String name) {
+        return "Hello " + name;
     }
 }

--- a/integration-tests/opentelemetry/src/main/java/org/apache/camel/quarkus/component/opentelemetry/it/OpenTelemetryRouteBuilder.java
+++ b/integration-tests/opentelemetry/src/main/java/org/apache/camel/quarkus/component/opentelemetry/it/OpenTelemetryRouteBuilder.java
@@ -33,6 +33,9 @@ public class OpenTelemetryRouteBuilder extends RouteBuilder {
         from("direct:start")
                 .setBody().constant("Traced direct:start");
 
+        from("direct:greet")
+                .bean("greetingsBean");
+
         from("timer:filtered?repeatCount=5&delay=-1")
                 .setBody().constant("Route filtered from tracing");
     }

--- a/integration-tests/opentelemetry/src/test/java/org/apache/camel/quarkus/component/opentelemetry/it/OpenTelemetryTest.java
+++ b/integration-tests/opentelemetry/src/test/java/org/apache/camel/quarkus/component/opentelemetry/it/OpenTelemetryTest.java
@@ -81,6 +81,21 @@ class OpenTelemetryTest {
         assertEquals(spans.get(0).get("parentId"), spans.get(1).get("spanId"));
     }
 
+    @Test
+    public void testTracedBean() {
+        String name = "Camel Quarkus OpenTelemetry";
+        RestAssured.get("/opentelemetry/greet/" + name)
+                .then()
+                .statusCode(200)
+                .body(equalTo("Hello " + name));
+
+        // Verify the span hierarchy is JAX-RS Service -> Direct Endpoint -> Bean Method
+        List<Map<String, String>> spans = getSpans();
+        assertEquals(3, spans.size());
+        assertEquals(spans.get(0).get("parentId"), spans.get(1).get("parentId"));
+        assertEquals(spans.get(1).get("parentId"), spans.get(2).get("spanId"));
+    }
+
     private List<Map<String, String>> getSpans() {
         return RestAssured.given()
                 .get("/opentelemetry/exporter/spans")


### PR DESCRIPTION
CDI support for OpenTelemetry `@WithSpan` was added in Quarkus 2.6.0. So I figured we should have some coverage for it with Camel.