### PR TITLE
Manage camel-quarkus-catalog in camel-quarkus-bom to allow Camel K to

### DIFF
--- a/poms/bom/pom.xml
+++ b/poms/bom/pom.xml
@@ -3070,6 +3070,11 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
+                <artifactId>camel-quarkus-catalog</artifactId>
+                <version>${camel-quarkus.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel.quarkus</groupId>
                 <artifactId>camel-quarkus-cbor</artifactId>
                 <version>${camel-quarkus.version}</version>
             </dependency>


### PR DESCRIPTION
use Quarkus Platform BOMs 

Fix #3347
