### PR TITLE
Require Maven 3.8.1+ to build Camel Quarkus

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -203,7 +203,7 @@
         <maven.compiler.release>11</maven.compiler.release>
 
         <!-- maven-enforcer-plugin -->
-        <min-maven-version>3.6.2</min-maven-version>
+        <min-maven-version>3.8.1</min-maven-version>
         <target-maven-version>3.8.4</target-maven-version><!-- @sync io.quarkus:quarkus-build-parent:${quarkus.version} prop:proposed-maven-version -->
         <supported-maven-versions>[${min-maven-version},)</supported-maven-versions>
 


### PR DESCRIPTION
This is to make sure that everybody runs Camel Quarkus tests with Maven version recommended by Quarkus https://quarkus.io/guides/getting-started#prerequisites