### PR TITLE
Use parametrized groupId for quarkus-maven-plugin so that it is possible to run our tests with io.quarkus.platform:quarkus-maven-plugin

### DIFF
--- a/extensions/jira/runtime/pom.xml
+++ b/extensions/jira/runtime/pom.xml
@@ -68,10 +68,6 @@
             <artifactId>camel-quarkus-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-jira</artifactId>
         </dependency>

--- a/extensions/minio/runtime/pom.xml
+++ b/extensions/minio/runtime/pom.xml
@@ -59,6 +59,12 @@
         <dependency>
             <groupId>io.quarkiverse.minio</groupId>
             <artifactId>quarkus-minio</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>jsr305</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/extensions/protobuf/deployment/pom.xml
+++ b/extensions/protobuf/deployment/pom.xml
@@ -42,6 +42,12 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-grpc-codegen</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>jsr305</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
     </dependencies>

--- a/integration-tests/avro/pom.xml
+++ b/integration-tests/avro/pom.xml
@@ -60,7 +60,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>io.quarkus</groupId>
+                <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
                 <extensions>true</extensions><!-- Workaround for https://github.com/quarkusio/quarkus/issues/21718 -->
                 <executions>

--- a/integration-tests/cassandraql/pom.xml
+++ b/integration-tests/cassandraql/pom.xml
@@ -61,6 +61,10 @@
             <scope>test</scope>
             <exclusions>
                 <exclusion>
+                    <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>jsr305</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>com.github.jnr</groupId>
                     <artifactId>jnr-posix</artifactId>
                 </exclusion>

--- a/integration-tests/messaging/pom.xml
+++ b/integration-tests/messaging/pom.xml
@@ -40,7 +40,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>io.quarkus</groupId>
+                <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
                 <executions>
                     <execution>

--- a/integration-tests/protobuf/pom.xml
+++ b/integration-tests/protobuf/pom.xml
@@ -60,7 +60,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>io.quarkus</groupId>
+                <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
                 <extensions>true</extensions><!-- Workaround for https://github.com/quarkusio/quarkus/issues/21718 -->
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,6 @@
         <google-auth-library-credentials.version>0.22.2</google-auth-library-credentials.version><!-- @sync io.grpc:grpc-auth:${grpc.version} dep:com.google.auth:google-auth-library-credentials -->
         <graalvm.version>21.3.0</graalvm.version><!-- @sync io.quarkus:quarkus-bom:${quarkus.version} dep:org.graalvm.nativeimage:svm -->
         <grpc.version>1.43.2</grpc.version><!-- @sync io.quarkus:quarkus-bom:${quarkus.version} dep:io.grpc:grpc-core -->
-        <gson.version>2.8.6</gson.version><!-- @sync com.ibm.jsonata4java:JSONata4Java:${jsonata4java-version} dep:com.google.code.gson:gson -->
         <guice-servlet.version>4.0</guice-servlet.version><!-- Spark -->
         <hadoop3.version>${hadoop3-version}</hadoop3.version><!-- Spark -->
         <hapi.version>${hapi-version}</hapi.version>
@@ -103,7 +102,6 @@
         <jcodings.version>1.0.55</jcodings.version><!-- used by hbase -->
         <jodatime.version>2.10.6</jodatime.version><!-- Mess in transitive dependencies of Spark and Splunk -->
         <joni.version>2.1.31</joni.version><!-- used by json-validator -->
-        <jsoup.version>1.12.1</jsoup.version><!-- used by oaipmh -->
         <jaxen.version>1.2.0</jaxen.version>
         <javassist.version>3.22.0-CR2</javassist.version><!-- debezium -->
         <jersey-sun.version>1.19.4</jersey-sun.version><!-- Spark -->
@@ -118,7 +116,6 @@
         <libthrift.version>${libthrift-version}</libthrift.version> <!-- Spark -->
         <metrics.version>${metrics-version}</metrics.version><!-- Spark -->
         <mvel2.version>${mvel-version}</mvel2.version>
-        <okhttp.version>${squareup-okhttp-version}</okhttp.version>
         <okio.version>${squareup-okio-version}</okio.version>
         <protobuf.version>3.19.3</protobuf.version><!-- @sync io.quarkus:quarkus-bom:${quarkus.version} dep:com.google.protobuf:protobuf-java -->
         <retrofit.version>2.5.0</retrofit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -402,11 +402,6 @@
                 </plugin>
 
                 <plugin>
-                    <groupId>io.quarkus</groupId>
-                    <artifactId>quarkus-maven-plugin</artifactId>
-                    <version>${quarkus.version}</version>
-                </plugin>
-                <plugin>
                     <groupId>org.l2x6.cq</groupId>
                     <artifactId>cq-maven-plugin</artifactId>
                     <version>${cq-plugin.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,6 @@
         <github-api.version>1.111</github-api.version><!-- Used in a Groovy script bellow -->
         <google-native-image-support.version>0.8.0</google-native-image-support.version>
         <google-auth-library-credentials.version>0.22.2</google-auth-library-credentials.version><!-- @sync io.grpc:grpc-auth:${grpc.version} dep:com.google.auth:google-auth-library-credentials -->
-        <guava.version>30.1.1-jre</guava.version><!-- @sync io.quarkus:quarkus-bootstrap-parent:${quarkus.version} prop:guava.version -->
         <graalvm.version>21.3.0</graalvm.version><!-- @sync io.quarkus:quarkus-bom:${quarkus.version} dep:org.graalvm.nativeimage:svm -->
         <grpc.version>1.43.2</grpc.version><!-- @sync io.quarkus:quarkus-bom:${quarkus.version} dep:io.grpc:grpc-core -->
         <gson.version>2.8.6</gson.version><!-- @sync com.ibm.jsonata4java:JSONata4Java:${jsonata4java-version} dep:com.google.code.gson:gson -->

--- a/poms/bom-test/pom.xml
+++ b/poms/bom-test/pom.xml
@@ -265,6 +265,10 @@
                 <version>${htmlunit-driver.version}</version>
                 <exclusions>
                     <exclusion>
+                        <groupId>com.google.code.findbugs</groupId>
+                        <artifactId>jsr305</artifactId>
+                    </exclusion>
+                    <exclusion>
                         <groupId>org.apache.httpcomponents</groupId>
                         <artifactId>httpmime</artifactId>
                     </exclusion>

--- a/poms/bom/pom.xml
+++ b/poms/bom/pom.xml
@@ -197,6 +197,12 @@
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-asterisk</artifactId>
                 <version>${camel.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.google.code.findbugs</groupId>
+                        <artifactId>jsr305</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
@@ -600,6 +606,12 @@
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-cassandraql</artifactId>
                 <version>${camel.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.google.code.findbugs</groupId>
+                        <artifactId>jsr305</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
@@ -1268,6 +1280,12 @@
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-iec60870</artifactId>
                 <version>${camel.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.google.code.findbugs</groupId>
+                        <artifactId>jsr305</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
@@ -1360,6 +1378,10 @@
                 <artifactId>camel-jclouds</artifactId>
                 <version>${camel.version}</version>
                 <exclusions>
+                    <exclusion>
+                        <groupId>com.google.code.findbugs</groupId>
+                        <artifactId>jsr305</artifactId>
+                    </exclusion>
                     <exclusion>
                         <groupId>javax.ws.rs</groupId>
                         <artifactId>javax.ws.rs-api</artifactId>
@@ -1736,6 +1758,10 @@
                 <version>${camel.version}</version>
                 <exclusions>
                     <exclusion>
+                        <groupId>com.google.code.findbugs</groupId>
+                        <artifactId>jsr305</artifactId>
+                    </exclusion>
+                    <exclusion>
                         <groupId>io.minio</groupId>
                         <artifactId>minio</artifactId>
                     </exclusion>
@@ -1828,6 +1854,12 @@
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-nsq</artifactId>
                 <version>${camel.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.google.code.findbugs</groupId>
+                        <artifactId>jsr305</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
@@ -1952,6 +1984,12 @@
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-protobuf</artifactId>
                 <version>${camel.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.google.code.findbugs</groupId>
+                        <artifactId>jsr305</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
@@ -1963,6 +2001,10 @@
                 <artifactId>camel-pulsar</artifactId>
                 <version>${camel.version}</version>
                 <exclusions>
+                    <exclusion>
+                        <groupId>com.google.code.findbugs</groupId>
+                        <artifactId>jsr305</artifactId>
+                    </exclusion>
                     <exclusion>
                         <groupId>com.google.j2objc</groupId>
                         <artifactId>j2objc-annotations</artifactId>
@@ -2309,6 +2351,12 @@
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-twilio</artifactId>
                 <version>${camel.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.google.code.findbugs</groupId>
+                        <artifactId>jsr305</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
@@ -5970,17 +6018,6 @@
                 <groupId>com.google.code.gson</groupId>
                 <artifactId>gson</artifactId>
                 <version>${gson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>${guava.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>com.google.code.findbugs</groupId>
-                        <artifactId>jsr305</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <groupId>com.google.protobuf</groupId>

--- a/poms/bom/pom.xml
+++ b/poms/bom/pom.xml
@@ -6015,27 +6015,6 @@
                 <version>${google-native-image-support.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.google.code.gson</groupId>
-                <artifactId>gson</artifactId>
-                <version>${gson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.protobuf</groupId>
-                <artifactId>protobuf-java</artifactId>
-                <version>${protobuf.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.protobuf</groupId>
-                <artifactId>protobuf-java-util</artifactId>
-                <version>${protobuf.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>com.google.code.findbugs</groupId>
-                        <artifactId>jsr305</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
                 <groupId>com.google.zxing</groupId>
                 <artifactId>core</artifactId>
                 <version>${zxing.version}</version>
@@ -6044,16 +6023,6 @@
                 <groupId>com.orbitz.consul</groupId>
                 <artifactId>consul-client</artifactId>
                 <version>${consul-client.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.squareup.okhttp3</groupId>
-                <artifactId>logging-interceptor</artifactId>
-                <version>${okhttp.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.squareup.okhttp3</groupId>
-                <artifactId>okhttp</artifactId>
-                <version>${okhttp.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.squareup.okio</groupId>
@@ -6397,11 +6366,6 @@
                 <version>${joni.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.jsoup</groupId>
-                <artifactId>jsoup</artifactId>
-                <version>${jsoup.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.mvel</groupId>
                 <artifactId>mvel2</artifactId>
                 <version>${mvel2.version}</version>
@@ -6491,11 +6455,6 @@
                 <groupId>org.web3j</groupId>
                 <artifactId>quorum</artifactId>
                 <version>${web3j.quorum.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.yaml</groupId>
-                <artifactId>snakeyaml</artifactId>
-                <version>${snakeyaml.version}</version>
             </dependency>
             <dependency>
                 <groupId>xalan</groupId>

--- a/poms/build-parent-it/pom.xml
+++ b/poms/build-parent-it/pom.xml
@@ -36,13 +36,12 @@
 
     <properties>
         <!-- Allow running our tests against alternative BOMs, such as io.quarkus.platform:quarkus-camel-bom https://repo1.maven.org/maven2/io/quarkus/platform/quarkus-camel-bom/ -->
-        <!-- The BOM GAVs below are swapped as a workaround for https://github.com/quarkusio/quarkus/issues/20461 -->
-        <quarkus.platform.group-id>org.apache.camel.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.artifact-id>camel-quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.version>2.7.0-SNAPSHOT</quarkus.platform.version>
-        <camel-quarkus.platform.group-id>io.quarkus</camel-quarkus.platform.group-id>
-        <camel-quarkus.platform.artifact-id>quarkus-bom</camel-quarkus.platform.artifact-id>
-        <camel-quarkus.platform.version>${quarkus.version}</camel-quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
+        <quarkus.platform.version>${quarkus.version}</quarkus.platform.version>
+        <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+        <camel-quarkus.platform.version>2.7.0-SNAPSHOT</camel-quarkus.platform.version>
         <camel-quarkus.version>2.7.0-SNAPSHOT</camel-quarkus.version><!-- This needs to be set to the underlying CQ version from command line when testing against Platform BOMs -->
 
         <quarkus.banner.enabled>false</quarkus.banner.enabled>

--- a/poms/build-parent-it/pom.xml
+++ b/poms/build-parent-it/pom.xml
@@ -77,6 +77,11 @@
         <pluginManagement>
             <plugins>
                 <plugin>
+                    <groupId>${quarkus.platform.group-id}</groupId>
+                    <artifactId>quarkus-maven-plugin</artifactId>
+                    <version>${quarkus.platform.version}</version>
+                </plugin>
+                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
                     <executions>
@@ -152,7 +157,7 @@
                     </plugin>
 
                     <plugin>
-                        <groupId>io.quarkus</groupId>
+                        <groupId>${quarkus.platform.group-id}</groupId>
                         <artifactId>quarkus-maven-plugin</artifactId>
                         <executions>
                             <execution>

--- a/tooling/maven-plugin/pom.xml
+++ b/tooling/maven-plugin/pom.xml
@@ -88,6 +88,10 @@
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
+                    <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>jsr305</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>org.codehaus.plexus</groupId>
                     <artifactId>plexus-classworlds</artifactId>
                 </exclusion>


### PR DESCRIPTION
Fix #3222
Fix #3115