### PR TITLE
Fixup e72113e send optaplanner test messages asynchronously

### DIFF
--- a/integration-tests/optaplanner/src/main/java/org/apache/camel/quarkus/component/optaplanner/it/OptaplannerResource.java
+++ b/integration-tests/optaplanner/src/main/java/org/apache/camel/quarkus/component/optaplanner/it/OptaplannerResource.java
@@ -63,7 +63,9 @@ public class OptaplannerResource {
     @Path("solveSync")
     public void solveSync() {
         if (SolverStatus.NOT_SOLVING == solverManager.getSolverStatus(SINGLETON_TIME_TABLE_ID)) {
-            producerTemplate.sendBodyAndHeader("direct:solveSync", DataGenerator.timeTable, OptaPlannerConstants.SOLVER_MANAGER,
+            // The message payload is sent asynchronously, but the optaplanner route is configured to solve the problem synchronously
+            producerTemplate.asyncRequestBodyAndHeader("direct:solveSync", DataGenerator.timeTable,
+                    OptaPlannerConstants.SOLVER_MANAGER,
                     solverManager);
         }
     }
@@ -72,7 +74,7 @@ public class OptaplannerResource {
     @Path("solveAsync")
     public void solveAsync() throws ExecutionException, InterruptedException {
         if (SolverStatus.NOT_SOLVING == solverManager.getSolverStatus(SINGLETON_TIME_TABLE_ID)) {
-            producerTemplate.sendBodyAndHeader("direct:solveAsync", DataGenerator.timeTable,
+            producerTemplate.asyncRequestBodyAndHeader("direct:solveAsync", DataGenerator.timeTable,
                     OptaPlannerConstants.SOLVER_MANAGER, solverManager);
         }
     }


### PR DESCRIPTION
Minor amendment to the optaplanner rework in e72113e8e67347d057b23dd918ef3a2f9731527e. Since we're polling for results, the sending of message payloads can be async 'fire and forget'.