### PR TITLE
Fix #3432 add a build step to support source location

### DIFF
--- a/extensions-core/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/CamelContextProcessor.java
+++ b/extensions-core/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/CamelContextProcessor.java
@@ -111,6 +111,20 @@ public class CamelContextProcessor {
     }
 
     /**
+     * Enable source location if camel.quarkus.source-location-enabled=true
+     *
+     * @param recorder the recorder
+     * @param producer producer of context customizer build item
+     */
+    @Record(ExecutionTime.STATIC_INIT)
+    @BuildStep(onlyIf = SourceLocationEnabled.class)
+    public void enableSourceLocation(
+            CamelContextRecorder recorder,
+            BuildProducer<CamelContextCustomizerBuildItem> producer) {
+        producer.produce(new CamelContextCustomizerBuildItem(recorder.createSourceLocationEnabledCustomizer()));
+    }
+
+    /**
      * Registers Camel CDI event bridges if quarkus.camel.event-bridge.enabled=true and if
      * the relevant events have CDI observers configured for them.
      *
@@ -157,6 +171,13 @@ public class CamelContextProcessor {
         @Override
         public boolean getAsBoolean() {
             return config.eventBridge.enabled;
+        }
+    }
+
+    public static final class SourceLocationEnabled implements BooleanSupplier {
+        @Override
+        public boolean getAsBoolean() {
+            return CamelSupport.getOptionalConfigValue("camel.quarkus.source-location-enabled", Boolean.class, false);
         }
     }
 }

--- a/extensions-core/core/deployment/src/test/java/org/apache/camel/quarkus/core/deployment/CamelSourceLocationTest.java
+++ b/extensions-core/core/deployment/src/test/java/org/apache/camel/quarkus/core/deployment/CamelSourceLocationTest.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.core.deployment;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.Properties;
+
+import javax.inject.Inject;
+
+import io.quarkus.test.QuarkusUnitTest;
+import org.apache.camel.CamelContext;
+import org.apache.camel.Exchange;
+import org.apache.camel.LineNumberAware;
+import org.apache.camel.Processor;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.RouteBuilder;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class CamelSourceLocationTest {
+    @RegisterExtension
+    static final QuarkusUnitTest CONFIG = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource(applicationProperties(), "application.properties")
+                    .addClasses(MyProcessor.class));
+
+    public static Asset applicationProperties() {
+        Writer writer = new StringWriter();
+
+        Properties props = new Properties();
+        props.setProperty("camel.quarkus.source-location-enabled", "true");
+
+        try {
+            props.store(writer, "");
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        return new StringAsset(writer.toString());
+    }
+
+    @Inject
+    CamelContext context;
+
+    @Inject
+    ProducerTemplate producer;
+
+    @Test
+    public void test() throws Exception {
+        context.addRoutes(
+                new RouteBuilder() {
+                    @Override
+                    public void configure() throws Exception {
+                        from("direct:start")
+                                .process(new MyProcessor());
+                    }
+                });
+        Object out = producer.requestBody("direct:start", "Hello World");
+        Assertions.assertEquals("org.apache.camel.quarkus.core.deployment.CamelSourceLocationTest$1:76", out);
+    }
+
+    private static class MyProcessor implements Processor, LineNumberAware {
+
+        private int lineNumber;
+        private String location;
+
+        @Override
+        public int getLineNumber() {
+            return lineNumber;
+        }
+
+        @Override
+        public void setLineNumber(int lineNumber) {
+            this.lineNumber = lineNumber;
+        }
+
+        @Override
+        public String getLocation() {
+            return location;
+        }
+
+        @Override
+        public void setLocation(String location) {
+            this.location = location;
+        }
+
+        @Override
+        public void process(Exchange exchange) throws Exception {
+            exchange.getMessage().setBody(location + ":" + lineNumber);
+        }
+    }
+}

--- a/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/CamelContextRecorder.java
+++ b/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/CamelContextRecorder.java
@@ -89,6 +89,10 @@ public class CamelContextRecorder {
         return new RuntimeValue((CamelContextCustomizer) context -> context.setShutdownStrategy(new NoShutdownStrategy()));
     }
 
+    public RuntimeValue<CamelContextCustomizer> createSourceLocationEnabledCustomizer() {
+        return new RuntimeValue((CamelContextCustomizer) context -> context.setSourceLocationEnabled(true));
+    }
+
     public void addRoutes(RuntimeValue<CamelContext> context, List<String> nonCdiRoutesBuilderClassNames) {
         List<RoutesBuilder> allRoutesBuilders = new ArrayList<>();
 


### PR DESCRIPTION
I assume that the config should be ```camel.quarkus.source-location-enabled = true``` according to

https://camel.apache.org/components/3.15.x/eips/message-history.html#_enabling_source_location_information