### PR TITLE
Switch from `NativeImageTest` to `QuarkusIntegrationTest`

### DIFF
--- a/docs/modules/ROOT/pages/user-guide/testing.adoc
+++ b/docs/modules/ROOT/pages/user-guide/testing.adoc
@@ -39,14 +39,14 @@ An example implementation can be found https://github.com/apache/camel-quarkus/b
 As long as all extensions your application depends on are supported in native mode,
 you should definitely test that your application really works in native mode.
 The test logic defined in JVM mode can then be reused in native mode thanks to inheriting from the respective JVM mode class.
-`@NativeImageTest` annotation is there to instruct the Quarkus JUnit extension to compile the application under test to native image
+`@QuarkusIntegrationTest` annotation is there to instruct the Quarkus JUnit extension to compile the application under test to native image
 and start it before running the tests.
 
 [source,java]
 ----
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class MyIT extends MyTest {
    ...
 }
@@ -55,13 +55,13 @@ class MyIT extends MyTest {
 An implementation of a native test may help to capture more details https://github.com/apache/camel-quarkus/blob/main/integration-tests/bindy/src/test/java/org/apache/camel/quarkus/component/bindy/it/MessageRecordIT.java[here].
 
 [[jvm-vs-native-tests]]
-== `@QuarkusTest` vs. `@NativeImageTest`
+== `@QuarkusTest` vs. `@QuarkusIntegrationTest`
 
 JVM mode tests annotated with `@QuarkusTest` are executed in the same JVM as the application under test.
 Thanks to that, `@Inject`-ing beans from the application into the test code is possible.
 You can also define new beans or even override the beans from the application using `@javax.enterprise.inject.Alternative` and `@javax.annotation.Priority`.
 
-However all these tricks won't work in native mode tests annotated with `@NativeImageTest`
+However all these tricks won't work in native mode tests annotated with `@QuarkusIntegrationTest`
 because those are executed in a JVM hosted in a process separate from the running native application.
 
 If you ask why, the answer is actually in the previous sentence: a native executable does not need a JVM to run;

--- a/extensions/aws2-lambda/runtime/src/main/org/apache/lambda/it/Aws2LambdaIT.java
+++ b/extensions/aws2-lambda/runtime/src/main/org/apache/lambda/it/Aws2LambdaIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.aws2.lambda.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class Aws2LambdaIT extends Aws2LambdaTest {
 
 }

--- a/integration-test-groups/aws2-quarkus-client/aws2-ddb/src/test/java/org/apache/camel/quarkus/component/aws2/ddb/it/Aws2DdbQuarkusClientIT.java
+++ b/integration-test-groups/aws2-quarkus-client/aws2-ddb/src/test/java/org/apache/camel/quarkus/component/aws2/ddb/it/Aws2DdbQuarkusClientIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.aws2.ddb.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class Aws2DdbQuarkusClientIT extends Aws2DdbQuarkusClientTest {
 
 }

--- a/integration-test-groups/aws2/aws2-cw/src/test/java/org/apache/camel/quarkus/component/aws2/cw/it/Aws2CwIT.java
+++ b/integration-test-groups/aws2/aws2-cw/src/test/java/org/apache/camel/quarkus/component/aws2/cw/it/Aws2CwIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.aws2.cw.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class Aws2CwIT extends Aws2CwTest {
 
 }

--- a/integration-test-groups/aws2/aws2-ddb/src/test/java/org/apache/camel/quarkus/component/aws2/ddb/it/Aws2DdbIT.java
+++ b/integration-test-groups/aws2/aws2-ddb/src/test/java/org/apache/camel/quarkus/component/aws2/ddb/it/Aws2DdbIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.aws2.ddb.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class Aws2DdbIT extends Aws2DdbTest {
 
 }

--- a/integration-test-groups/aws2/aws2-ddb/src/test/java/org/apache/camel/quarkus/component/aws2/ddb/it/Aws2DdbStreamIT.java
+++ b/integration-test-groups/aws2/aws2-ddb/src/test/java/org/apache/camel/quarkus/component/aws2/ddb/it/Aws2DdbStreamIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.aws2.ddb.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class Aws2DdbStreamIT extends Aws2DdbStreamTest {
 
 }

--- a/integration-test-groups/aws2/aws2-kinesis/src/test/java/org/apache/camel/quarkus/component/aws2/kinesis/it/Aws2KinesisIT.java
+++ b/integration-test-groups/aws2/aws2-kinesis/src/test/java/org/apache/camel/quarkus/component/aws2/kinesis/it/Aws2KinesisIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.aws2.kinesis.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class Aws2KinesisIT extends Aws2KinesisTest {
 
 }

--- a/integration-test-groups/aws2/aws2-lambda/src/test/java/org/apache/camel/quarkus/component/aws2/lambda/it/Aws2LambdaIT.java
+++ b/integration-test-groups/aws2/aws2-lambda/src/test/java/org/apache/camel/quarkus/component/aws2/lambda/it/Aws2LambdaIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.aws2.lambda.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class Aws2LambdaIT extends Aws2LambdaTest {
 
 }

--- a/integration-test-groups/aws2/aws2-s3/src/test/java/org/apache/camel/quarkus/component/aws2/s3/it/Aws2S3IT.java
+++ b/integration-test-groups/aws2/aws2-s3/src/test/java/org/apache/camel/quarkus/component/aws2/s3/it/Aws2S3IT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.aws2.s3.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class Aws2S3IT extends Aws2S3Test {
 
 }

--- a/integration-test-groups/aws2/aws2-ses/src/test/java/org/apache/camel/quarkus/component/aws2/ses/it/Aws2SesIT.java
+++ b/integration-test-groups/aws2/aws2-ses/src/test/java/org/apache/camel/quarkus/component/aws2/ses/it/Aws2SesIT.java
@@ -16,14 +16,14 @@
  */
 package org.apache.camel.quarkus.component.aws2.ses.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
 /* Disabled on Localstack because Localstack does not send e-mails which we do assume in our tests
  * See https://github.com/localstack/localstack/issues/339#issuecomment-341727758 */
 @EnabledIfEnvironmentVariable(named = "AWS_ACCESS_KEY", matches = "[a-zA-Z0-9]+")
 @EnabledIfEnvironmentVariable(named = "MAILSLURP_API_KEY", matches = "[a-zA-Z0-9]+")
-@NativeImageTest
+@QuarkusIntegrationTest
 class Aws2SesIT extends Aws2SesTest {
 
 }

--- a/integration-test-groups/aws2/aws2-sqs-sns/src/test/java/org/apache/camel/quarkus/component/aws2/sns/it/Aws2SqsSnsIT.java
+++ b/integration-test-groups/aws2/aws2-sqs-sns/src/test/java/org/apache/camel/quarkus/component/aws2/sns/it/Aws2SqsSnsIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.aws2.sns.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class Aws2SqsSnsIT extends Aws2SqsSnsTest {
 
 }

--- a/integration-test-groups/aws2/aws2-sqs/src/test/java/org/apache/camel/quarkus/component/aws2/sqs/it/Aws2SqsIT.java
+++ b/integration-test-groups/aws2/aws2-sqs/src/test/java/org/apache/camel/quarkus/component/aws2/sqs/it/Aws2SqsIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.aws2.sqs.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class Aws2SqsIT extends Aws2SqsTest {
 
 }

--- a/integration-test-groups/azure/azure-eventhubs/src/test/java/org/apache/camel/quarkus/component/azure/eventhubs/it/AzureEventhubsIT.java
+++ b/integration-test-groups/azure/azure-eventhubs/src/test/java/org/apache/camel/quarkus/component/azure/eventhubs/it/AzureEventhubsIT.java
@@ -16,14 +16,14 @@
  */
 package org.apache.camel.quarkus.component.azure.eventhubs.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
 @EnabledIfEnvironmentVariable(named = "AZURE_STORAGE_ACCOUNT_NAME", matches = ".+")
 @EnabledIfEnvironmentVariable(named = "AZURE_STORAGE_ACCOUNT_KEY", matches = ".+")
 @EnabledIfEnvironmentVariable(named = "AZURE_BLOB_CONTAINER_NAME", matches = ".+")
 @EnabledIfEnvironmentVariable(named = "AZURE_EVENT_HUBS_CONNECTION_STRING", matches = ".+")
-@NativeImageTest
+@QuarkusIntegrationTest
 class AzureEventhubsIT extends AzureEventhubsTest {
 
 }

--- a/integration-test-groups/azure/azure-storage-blob/src/test/java/org/apache/camel/quarkus/component/azure/storage/blob/it/AzureStorageBlobIT.java
+++ b/integration-test-groups/azure/azure-storage-blob/src/test/java/org/apache/camel/quarkus/component/azure/storage/blob/it/AzureStorageBlobIT.java
@@ -17,10 +17,10 @@
 package org.apache.camel.quarkus.component.azure.storage.blob.it;
 
 import io.quarkus.test.common.QuarkusTestResource;
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 import org.apache.camel.quarkus.test.support.azure.AzureStorageTestResource;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 @QuarkusTestResource(AzureStorageTestResource.class)
 class AzureStorageBlobIT extends AzureStorageBlobTest {
 

--- a/integration-test-groups/azure/azure-storage-queue/src/test/java/org/apache/camel/quarkus/component/azure/storage/queue/it/AzureStorageQueueIT.java
+++ b/integration-test-groups/azure/azure-storage-queue/src/test/java/org/apache/camel/quarkus/component/azure/storage/queue/it/AzureStorageQueueIT.java
@@ -17,10 +17,10 @@
 package org.apache.camel.quarkus.component.azure.storage.queue.it;
 
 import io.quarkus.test.common.QuarkusTestResource;
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 import org.apache.camel.quarkus.test.support.azure.AzureStorageTestResource;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 @QuarkusTestResource(AzureStorageTestResource.class)
 class AzureStorageQueueIT extends AzureStorageQueueTest {
 

--- a/integration-test-groups/foundation/bean/src/test/java/org/apache/camel/quarkus/component/bean/BeanITCase.java
+++ b/integration-test-groups/foundation/bean/src/test/java/org/apache/camel/quarkus/component/bean/BeanITCase.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.component.bean;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class BeanITCase extends BeanTest {
 }

--- a/integration-test-groups/foundation/bean/src/test/java/org/apache/camel/quarkus/component/bean/BeanMethodIT.java
+++ b/integration-test-groups/foundation/bean/src/test/java/org/apache/camel/quarkus/component/bean/BeanMethodIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.component.bean;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class BeanMethodIT extends BeanMethodTest {
 }

--- a/integration-test-groups/foundation/bean/src/test/java/org/apache/camel/quarkus/component/bean/ClassIT.java
+++ b/integration-test-groups/foundation/bean/src/test/java/org/apache/camel/quarkus/component/bean/ClassIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.component.bean;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class ClassIT extends ClassTest {
 }

--- a/integration-test-groups/foundation/bean/src/test/java/org/apache/camel/quarkus/component/bean/ConsumeAnnotationIT.java
+++ b/integration-test-groups/foundation/bean/src/test/java/org/apache/camel/quarkus/component/bean/ConsumeAnnotationIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.component.bean;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class ConsumeAnnotationIT extends ConsumeAnnotationTest {
 }

--- a/integration-test-groups/foundation/bean/src/test/java/org/apache/camel/quarkus/component/bean/EipIT.java
+++ b/integration-test-groups/foundation/bean/src/test/java/org/apache/camel/quarkus/component/bean/EipIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.bean;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class EipIT extends EipTest {
 
 }

--- a/integration-test-groups/foundation/browse/src/test/java/org/apache/camel/quarkus/component/browse/it/BrowseIT.java
+++ b/integration-test-groups/foundation/browse/src/test/java/org/apache/camel/quarkus/component/browse/it/BrowseIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.browse.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class BrowseIT extends BrowseTest {
 
 }

--- a/integration-test-groups/foundation/component-name-resolver/src/test/java/org/apache/camel/quarkus/core/component/name/resolver/ComponentNameResolverIT.java
+++ b/integration-test-groups/foundation/component-name-resolver/src/test/java/org/apache/camel/quarkus/core/component/name/resolver/ComponentNameResolverIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.core.component.name.resolver;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class ComponentNameResolverIT extends ComponentNameResolverTest {
 }

--- a/integration-test-groups/foundation/controlbus/src/test/java/org/apache/camel/quarkus/component/controlbus/it/ControlbusIT.java
+++ b/integration-test-groups/foundation/controlbus/src/test/java/org/apache/camel/quarkus/component/controlbus/it/ControlbusIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.controlbus.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class ControlbusIT extends ControlbusTest {
 
 }

--- a/integration-test-groups/foundation/core-annotations/src/test/java/org/apache/camel/quarkus/core/it/annotations/CoreAnnotationsIT.java
+++ b/integration-test-groups/foundation/core-annotations/src/test/java/org/apache/camel/quarkus/core/it/annotations/CoreAnnotationsIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.core.it.annotations;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class CoreAnnotationsIT extends CoreAnnotationsTest {
 
 }

--- a/integration-test-groups/foundation/core-fault-tolerance/src/test/java/org/apache/camel/quarkus/core/faulttolerance/it/CoreFaultToleranceIT.java
+++ b/integration-test-groups/foundation/core-fault-tolerance/src/test/java/org/apache/camel/quarkus/core/faulttolerance/it/CoreFaultToleranceIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.core.faulttolerance.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class CoreFaultToleranceIT extends CoreFaultToleranceTest {
 }

--- a/integration-test-groups/foundation/core-languages/src/test/java/org/apache/camel/quarkus/core/languages/it/ConstantLanguageIT.java
+++ b/integration-test-groups/foundation/core-languages/src/test/java/org/apache/camel/quarkus/core/languages/it/ConstantLanguageIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.core.languages.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class ConstantLanguageIT extends ConstantLanguageTest {
 
 }

--- a/integration-test-groups/foundation/core-languages/src/test/java/org/apache/camel/quarkus/core/languages/it/CustomDataFormatIT.java
+++ b/integration-test-groups/foundation/core-languages/src/test/java/org/apache/camel/quarkus/core/languages/it/CustomDataFormatIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.core.languages.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class CustomDataFormatIT extends CustomDataFormatTest {
 
 }

--- a/integration-test-groups/foundation/core-languages/src/test/java/org/apache/camel/quarkus/core/languages/it/ExchangePropertyLanguageIT.java
+++ b/integration-test-groups/foundation/core-languages/src/test/java/org/apache/camel/quarkus/core/languages/it/ExchangePropertyLanguageIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.core.languages.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class ExchangePropertyLanguageIT extends ExchangePropertyLanguageTest {
 
 }

--- a/integration-test-groups/foundation/core-languages/src/test/java/org/apache/camel/quarkus/core/languages/it/HeaderLanguageIT.java
+++ b/integration-test-groups/foundation/core-languages/src/test/java/org/apache/camel/quarkus/core/languages/it/HeaderLanguageIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.core.languages.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class HeaderLanguageIT extends HeaderLanguageTest {
 
 }

--- a/integration-test-groups/foundation/core-languages/src/test/java/org/apache/camel/quarkus/core/languages/it/RefLanguageIT.java
+++ b/integration-test-groups/foundation/core-languages/src/test/java/org/apache/camel/quarkus/core/languages/it/RefLanguageIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.core.languages.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class RefLanguageIT extends RefLanguageTest {
 
 }

--- a/integration-test-groups/foundation/core-languages/src/test/java/org/apache/camel/quarkus/core/languages/it/SimpleIT.java
+++ b/integration-test-groups/foundation/core-languages/src/test/java/org/apache/camel/quarkus/core/languages/it/SimpleIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.core.languages.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class SimpleIT extends SimpleTest {
 
 }

--- a/integration-test-groups/foundation/core-languages/src/test/java/org/apache/camel/quarkus/core/languages/it/TokenizeLanguageIT.java
+++ b/integration-test-groups/foundation/core-languages/src/test/java/org/apache/camel/quarkus/core/languages/it/TokenizeLanguageIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.core.languages.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class TokenizeLanguageIT extends TokenizeLanguageTest {
 
 }

--- a/integration-test-groups/foundation/core-thread-pools/src/test/java/org/apache/camel/quarkus/core/CoreThreadPoolsIT.java
+++ b/integration-test-groups/foundation/core-thread-pools/src/test/java/org/apache/camel/quarkus/core/CoreThreadPoolsIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.core;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class CoreThreadPoolsIT extends CoreThreadPoolsTest {
 }

--- a/integration-test-groups/foundation/core/src/test/java/org/apache/camel/quarkus/core/CoreIT.java
+++ b/integration-test-groups/foundation/core/src/test/java/org/apache/camel/quarkus/core/CoreIT.java
@@ -16,7 +16,7 @@
  */
 package org.apache.camel.quarkus.core;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.Test;
 
@@ -24,7 +24,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class CoreIT extends CoreTest {
 
     @Test

--- a/integration-test-groups/foundation/customized-log-component/src/test/java/org/apache/camel/quarkus/component/log/it/CustomizedLogComponentIT.java
+++ b/integration-test-groups/foundation/customized-log-component/src/test/java/org/apache/camel/quarkus/component/log/it/CustomizedLogComponentIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.component.log.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class CustomizedLogComponentIT extends CustomizedLogComponentTest {
 }

--- a/integration-test-groups/foundation/direct/src/test/java/org/apache/camel/quarkus/component/direct/it/DirectIT.java
+++ b/integration-test-groups/foundation/direct/src/test/java/org/apache/camel/quarkus/component/direct/it/DirectIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.component.direct.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class DirectIT extends DirectTest {
 }

--- a/integration-test-groups/foundation/eip/src/test/java/org/apache/camel/quarkus/eip/it/EipIT.java
+++ b/integration-test-groups/foundation/eip/src/test/java/org/apache/camel/quarkus/eip/it/EipIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.eip.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class EipIT extends EipTest {
 
 }

--- a/integration-test-groups/foundation/language/src/test/java/org/apache/camel/quarkus/component/language/it/LanguageIT.java
+++ b/integration-test-groups/foundation/language/src/test/java/org/apache/camel/quarkus/component/language/it/LanguageIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.language.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class LanguageIT extends LanguageTest {
 
 }

--- a/integration-test-groups/foundation/log/src/test/java/org/apache/camel/quarkus/component/log/it/LogIT.java
+++ b/integration-test-groups/foundation/log/src/test/java/org/apache/camel/quarkus/component/log/it/LogIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.component.log.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class LogIT extends LogTest {
 }

--- a/integration-test-groups/foundation/mock/src/test/java/org/apache/camel/quarkus/component/mock/it/MockIT.java
+++ b/integration-test-groups/foundation/mock/src/test/java/org/apache/camel/quarkus/component/mock/it/MockIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.mock.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class MockIT extends MockTest {
 
 }

--- a/integration-test-groups/foundation/ref/src/test/java/org/apache/camel/quarkus/component/ref/it/RefIT.java
+++ b/integration-test-groups/foundation/ref/src/test/java/org/apache/camel/quarkus/component/ref/it/RefIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.component.ref.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class RefIT extends RefTest {
 }

--- a/integration-test-groups/foundation/route-configurations/src/test/java/org/apache/camel/quarkus/core/it/routeconfigurations/RouteConfigurationsIT.java
+++ b/integration-test-groups/foundation/route-configurations/src/test/java/org/apache/camel/quarkus/core/it/routeconfigurations/RouteConfigurationsIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.core.it.routeconfigurations;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class RouteConfigurationsIT extends RouteConfigurationsTest {
 }

--- a/integration-test-groups/foundation/scheduler/src/test/java/org/apache/camel/quarkus/component/scheduler/it/SchedulerIT.java
+++ b/integration-test-groups/foundation/scheduler/src/test/java/org/apache/camel/quarkus/component/scheduler/it/SchedulerIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.scheduler.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class SchedulerIT extends SchedulerTest {
 
 }

--- a/integration-test-groups/foundation/seda/src/test/java/org/apache/camel/quarkus/component/seda/it/SedaIT.java
+++ b/integration-test-groups/foundation/seda/src/test/java/org/apache/camel/quarkus/component/seda/it/SedaIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.seda.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class SedaIT extends SedaTest {
 
 }

--- a/integration-test-groups/foundation/stream/src/test/java/org/apache/camel/quarkus/component/stream/it/StreamIT.java
+++ b/integration-test-groups/foundation/stream/src/test/java/org/apache/camel/quarkus/component/stream/it/StreamIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.stream.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class StreamIT extends StreamTest {
 
 }

--- a/integration-test-groups/foundation/timer/src/test/java/org/apache/camel/quarkus/component/timer/it/TimerIT.java
+++ b/integration-test-groups/foundation/timer/src/test/java/org/apache/camel/quarkus/component/timer/it/TimerIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.component.timer.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class TimerIT extends TimerTest {
 }

--- a/integration-test-groups/foundation/type-converter/src/test/java/org/apache/camel/quarkus/core/converter/it/ConverterIT.java
+++ b/integration-test-groups/foundation/type-converter/src/test/java/org/apache/camel/quarkus/core/converter/it/ConverterIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.core.converter.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class ConverterIT extends ConverterTest {
 }

--- a/integration-test-groups/mongodb/mongodb-gridfs/src/test/java/org/apache/camel/quarkus/component/mongodb/gridfs/it/MongodbGridfsIT.java
+++ b/integration-test-groups/mongodb/mongodb-gridfs/src/test/java/org/apache/camel/quarkus/component/mongodb/gridfs/it/MongodbGridfsIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.component.mongodb.gridfs.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class MongodbGridfsIT extends MongodbGridfsTest {
 }

--- a/integration-test-groups/mongodb/mongodb/src/test/java/org/apache/camel/quarkus/component/mongodb/it/MongoDbIT.java
+++ b/integration-test-groups/mongodb/mongodb/src/test/java/org/apache/camel/quarkus/component/mongodb/it/MongoDbIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.mongodb.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class MongoDbIT extends MongoDbTest {
 
 }

--- a/integration-tests/activemq/src/test/java/org/apache/camel/quarkus/component/activemq/it/ActiveMQIT.java
+++ b/integration-tests/activemq/src/test/java/org/apache/camel/quarkus/component/activemq/it/ActiveMQIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.activemq.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class ActiveMQIT extends ActiveMQTest {
 
 }

--- a/integration-tests/amqp/src/test/java/org/apache/camel/quarkus/component/amqp/it/AmqpIT.java
+++ b/integration-tests/amqp/src/test/java/org/apache/camel/quarkus/component/amqp/it/AmqpIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.amqp.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class AmqpIT extends AmqpTest {
 
 }

--- a/integration-tests/arangodb/src/test/java/org/apache/camel/quarkus/component/arangodb/it/ArangodbIT.java
+++ b/integration-tests/arangodb/src/test/java/org/apache/camel/quarkus/component/arangodb/it/ArangodbIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.arangodb.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class ArangodbIT extends ArangodbTest {
 
 }

--- a/integration-tests/as2/src/test/java/org/apache/camel/quarkus/component/as2/it/As2IT.java
+++ b/integration-tests/as2/src/test/java/org/apache/camel/quarkus/component/as2/it/As2IT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.as2.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class As2IT extends As2Test {
 
 }

--- a/integration-tests/atlasmap/src/test/java/org/apache/camel/quarkus/component/atlasmap/it/AtlasmapIT.java
+++ b/integration-tests/atlasmap/src/test/java/org/apache/camel/quarkus/component/atlasmap/it/AtlasmapIT.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.quarkus.component.atlasmap.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 //@DisabledOnNativeImage("https://github.com/apache/camel-quarkus/issues/3189")
-@NativeImageTest
+@QuarkusIntegrationTest
 class AtlasmapIT extends AtlasmapTest {
 
 }

--- a/integration-tests/avro-rpc/src/test/java/org/apache/camel/quarkus/component/avro/rpc/it/AvroRpcHttpIT.java
+++ b/integration-tests/avro-rpc/src/test/java/org/apache/camel/quarkus/component/avro/rpc/it/AvroRpcHttpIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.avro.rpc.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class AvroRpcHttpIT extends AvroRpcHttpTest {
 
 }

--- a/integration-tests/avro-rpc/src/test/java/org/apache/camel/quarkus/component/avro/rpc/it/AvroRpcNettyIT.java
+++ b/integration-tests/avro-rpc/src/test/java/org/apache/camel/quarkus/component/avro/rpc/it/AvroRpcNettyIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.avro.rpc.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class AvroRpcNettyIT extends AvroRpcNettyTest {
 
 }

--- a/integration-tests/avro/src/test/java/org/apache/camel/quarkus/component/avro/it/AvroIT.java
+++ b/integration-tests/avro/src/test/java/org/apache/camel/quarkus/component/avro/it/AvroIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.avro.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class AvroIT extends AvroTest {
 
 }

--- a/integration-tests/base64/src/test/java/org/apache/camel/quarkus/component/base64/it/Base64IT.java
+++ b/integration-tests/base64/src/test/java/org/apache/camel/quarkus/component/base64/it/Base64IT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.base64.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class Base64IT extends Base64Test {
 
 }

--- a/integration-tests/bean-validator/src/test/java/org/apache/camel/quarkus/component/bean/validator/it/BeanValidatorIT.java
+++ b/integration-tests/bean-validator/src/test/java/org/apache/camel/quarkus/component/bean/validator/it/BeanValidatorIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.bean.validator.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class BeanValidatorIT extends BeanValidatorTest {
 
 }

--- a/integration-tests/bindy/src/test/java/org/apache/camel/quarkus/component/bindy/it/CsvRecordIT.java
+++ b/integration-tests/bindy/src/test/java/org/apache/camel/quarkus/component/bindy/it/CsvRecordIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.bindy.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class CsvRecordIT extends CsvRecordTest {
 
 }

--- a/integration-tests/bindy/src/test/java/org/apache/camel/quarkus/component/bindy/it/FixedLengthRecordIT.java
+++ b/integration-tests/bindy/src/test/java/org/apache/camel/quarkus/component/bindy/it/FixedLengthRecordIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.bindy.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class FixedLengthRecordIT extends FixedLengthRecordTest {
 
 }

--- a/integration-tests/bindy/src/test/java/org/apache/camel/quarkus/component/bindy/it/FixedLengthWithLocaleIT.java
+++ b/integration-tests/bindy/src/test/java/org/apache/camel/quarkus/component/bindy/it/FixedLengthWithLocaleIT.java
@@ -16,11 +16,11 @@
  */
 package org.apache.camel.quarkus.component.bindy.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 import org.junit.jupiter.api.Disabled;
 
 @Disabled("https://github.com/apache/camel-quarkus/issues/2407")
-@NativeImageTest
+@QuarkusIntegrationTest
 class FixedLengthWithLocaleIT extends FixedLengthWithLocaleTest {
 
 }

--- a/integration-tests/bindy/src/test/java/org/apache/camel/quarkus/component/bindy/it/MessageRecordIT.java
+++ b/integration-tests/bindy/src/test/java/org/apache/camel/quarkus/component/bindy/it/MessageRecordIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.bindy.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class MessageRecordIT extends MessageTest {
 
 }

--- a/integration-tests/box/src/test/java/org/apache/camel/quarkus/component/box/it/BoxIT.java
+++ b/integration-tests/box/src/test/java/org/apache/camel/quarkus/component/box/it/BoxIT.java
@@ -16,14 +16,14 @@
  */
 package org.apache.camel.quarkus.component.box.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
 @EnabledIfEnvironmentVariable(named = "BOX_USER_NAME", matches = ".+")
 @EnabledIfEnvironmentVariable(named = "BOX_USER_PASSWORD", matches = ".+")
 @EnabledIfEnvironmentVariable(named = "BOX_CLIENT_ID", matches = ".+")
 @EnabledIfEnvironmentVariable(named = "BOX_CLIENT_SECRET", matches = ".+")
-@NativeImageTest
+@QuarkusIntegrationTest
 class BoxIT extends BoxTest {
 
 }

--- a/integration-tests/braintree/src/test/java/org/apache/camel/quarkus/component/braintree/it/BraintreeIT.java
+++ b/integration-tests/braintree/src/test/java/org/apache/camel/quarkus/component/braintree/it/BraintreeIT.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.quarkus.component.braintree.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 @EnabledIfEnvironmentVariable(named = "BRAINTREE_MERCHANT_ID", matches = ".+")
 @EnabledIfEnvironmentVariable(named = "BRAINTREE_PUBLIC_KEY", matches = ".+")
 @EnabledIfEnvironmentVariable(named = "BRAINTREE_PRIVATE_KEY", matches = ".+")

--- a/integration-tests/caffeine/src/test/java/org/apache/camel/quarkus/component/caffeine/it/CaffeineIT.java
+++ b/integration-tests/caffeine/src/test/java/org/apache/camel/quarkus/component/caffeine/it/CaffeineIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.caffeine.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class CaffeineIT extends CaffeineTest {
 
 }

--- a/integration-tests/cassandraql/src/test/java/org/apache/camel/quarkus/component/cassandraql/it/CassandraqlIT.java
+++ b/integration-tests/cassandraql/src/test/java/org/apache/camel/quarkus/component/cassandraql/it/CassandraqlIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.cassandraql.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class CassandraqlIT extends CassandraqlTest {
 
 }

--- a/integration-tests/cbor/src/test/java/org/apache/camel/quarkus/component/cbor/it/CborIT.java
+++ b/integration-tests/cbor/src/test/java/org/apache/camel/quarkus/component/cbor/it/CborIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.cbor.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class CborIT extends CborTest {
 
 }

--- a/integration-tests/compression/src/test/java/org/apache/camel/quarkus/component/compression/it/CompressionIT.java
+++ b/integration-tests/compression/src/test/java/org/apache/camel/quarkus/component/compression/it/CompressionIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.compression.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class CompressionIT extends CompressionTest {
 
 }

--- a/integration-tests/consul/src/test/java/org/apache/camel/quarkus/component/consul/it/ConsulIT.java
+++ b/integration-tests/consul/src/test/java/org/apache/camel/quarkus/component/consul/it/ConsulIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.component.consul.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class ConsulIT extends ConsulTest {
 }

--- a/integration-tests/core-discovery-disabled/src/test/java/org/apache/camel/quarkus/core/CoreDiscoveryDisabledIT.java
+++ b/integration-tests/core-discovery-disabled/src/test/java/org/apache/camel/quarkus/core/CoreDiscoveryDisabledIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.core;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class CoreDiscoveryDisabledIT extends CoreDiscoveryDisabledTest {
 }

--- a/integration-tests/couchdb/src/test/java/org/apache/camel/quarkus/component/couchdb/it/CouchbIT.java
+++ b/integration-tests/couchdb/src/test/java/org/apache/camel/quarkus/component/couchdb/it/CouchbIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.couchdb.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class CouchbIT extends CouchdbTest {
 
 }

--- a/integration-tests/crypto/src/test/java/org/apache/camel/quarkus/component/crypto/it/CryptoIT.java
+++ b/integration-tests/crypto/src/test/java/org/apache/camel/quarkus/component/crypto/it/CryptoIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.crypto.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class CryptoIT extends CryptoTest {
 
 }

--- a/integration-tests/csimple/src/test/java/org/apache/camel/quarkus/component/csimple/it/CSimpleIT.java
+++ b/integration-tests/csimple/src/test/java/org/apache/camel/quarkus/component/csimple/it/CSimpleIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.csimple.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class CSimpleIT extends CSimpleTest {
 
 }

--- a/integration-tests/csv/src/test/java/org/apache/camel/quarkus/component/csv/it/CsvIT.java
+++ b/integration-tests/csv/src/test/java/org/apache/camel/quarkus/component/csv/it/CsvIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.csv.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class CsvIT extends CsvTest {
 
 }

--- a/integration-tests/dataformat/src/test/java/org/apache/camel/quarkus/component/dataformat/it/DataformatIT.java
+++ b/integration-tests/dataformat/src/test/java/org/apache/camel/quarkus/component/dataformat/it/DataformatIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.dataformat.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class DataformatIT extends DataformatTest {
 
 }

--- a/integration-tests/dataformats-json/src/test/java/org/apache/camel/quarkus/component/dataformats/jackson/json/JacksonJsonIT.java
+++ b/integration-tests/dataformats-json/src/test/java/org/apache/camel/quarkus/component/dataformats/jackson/json/JacksonJsonIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.dataformats.jackson.json;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class JacksonJsonIT extends JacksonJsonTest {
 
 }

--- a/integration-tests/dataformats-json/src/test/java/org/apache/camel/quarkus/component/dataformats/jackson/xml/JacksonXmlIT.java
+++ b/integration-tests/dataformats-json/src/test/java/org/apache/camel/quarkus/component/dataformats/jackson/xml/JacksonXmlIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.dataformats.jackson.xml;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class JacksonXmlIT extends JacksonXmlTest {
 
 }

--- a/integration-tests/dataformats-json/src/test/java/org/apache/camel/quarkus/component/dataformats/json/JsonComponentsIT.java
+++ b/integration-tests/dataformats-json/src/test/java/org/apache/camel/quarkus/component/dataformats/json/JsonComponentsIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.component.dataformats.json;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class JsonComponentsIT extends JsonComponentsTest {
 }

--- a/integration-tests/debezium/src/test/java/org/apache/camel/quarkus/component/debezium/common/it/mongodb/DebeziumMongodbIT.java
+++ b/integration-tests/debezium/src/test/java/org/apache/camel/quarkus/component/debezium/common/it/mongodb/DebeziumMongodbIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.debezium.common.it.mongodb;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class DebeziumMongodbIT extends DebeziumMongodbTest {
 
 }

--- a/integration-tests/debezium/src/test/java/org/apache/camel/quarkus/component/debezium/common/it/mysql/DebeziumMysqlIT.java
+++ b/integration-tests/debezium/src/test/java/org/apache/camel/quarkus/component/debezium/common/it/mysql/DebeziumMysqlIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.debezium.common.it.mysql;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class DebeziumMysqlIT extends DebeziumMysqlTest {
 
 }

--- a/integration-tests/debezium/src/test/java/org/apache/camel/quarkus/component/debezium/common/it/postgres/DebeziumPostgresIT.java
+++ b/integration-tests/debezium/src/test/java/org/apache/camel/quarkus/component/debezium/common/it/postgres/DebeziumPostgresIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.debezium.common.it.postgres;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class DebeziumPostgresIT extends DebeziumPostgresTest {
 
 }

--- a/integration-tests/debezium/src/test/java/org/apache/camel/quarkus/component/debezium/common/it/sqlserver/DebeziumSqlserverIT.java
+++ b/integration-tests/debezium/src/test/java/org/apache/camel/quarkus/component/debezium/common/it/sqlserver/DebeziumSqlserverIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.debezium.common.it.sqlserver;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class DebeziumSqlserverIT extends DebeziumSqlserverTest {
 
 }

--- a/integration-tests/digitalocean/src/test/java/org/apache/camel/quarkus/component/digitalocean/it/DigitaloceanDropletIT.java
+++ b/integration-tests/digitalocean/src/test/java/org/apache/camel/quarkus/component/digitalocean/it/DigitaloceanDropletIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.component.digitalocean.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class DigitaloceanDropletIT extends DigitaloceanDropletTest {
 }

--- a/integration-tests/digitalocean/src/test/java/org/apache/camel/quarkus/component/digitalocean/it/DigitaloceanIT.java
+++ b/integration-tests/digitalocean/src/test/java/org/apache/camel/quarkus/component/digitalocean/it/DigitaloceanIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.digitalocean.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class DigitaloceanIT extends DigitaloceanTest {
 
 }

--- a/integration-tests/disruptor/src/test/java/org/apache/camel/quarkus/component/disruptor/it/DisruptorIT.java
+++ b/integration-tests/disruptor/src/test/java/org/apache/camel/quarkus/component/disruptor/it/DisruptorIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.disruptor.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class DisruptorIT extends DisruptorTest {
 
 }

--- a/integration-tests/dozer/src/test/java/org/apache/camel/quarkus/component/dozer/it/DozerIT.java
+++ b/integration-tests/dozer/src/test/java/org/apache/camel/quarkus/component/dozer/it/DozerIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.dozer.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class DozerIT extends DozerTest {
 
 }

--- a/integration-tests/dropbox/src/test/java/org/apache/camel/quarkus/component/dropbox/it/DropboxIT.java
+++ b/integration-tests/dropbox/src/test/java/org/apache/camel/quarkus/component/dropbox/it/DropboxIT.java
@@ -16,12 +16,12 @@
  */
 package org.apache.camel.quarkus.component.dropbox.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
 @EnabledIfEnvironmentVariable(named = "DROPBOX_ACCESS_TOKEN", matches = ".+")
 @EnabledIfEnvironmentVariable(named = "DROPBOX_CLIENT_IDENTIFIER", matches = ".+")
-@NativeImageTest
+@QuarkusIntegrationTest
 class DropboxIT extends DropboxTest {
 
 }

--- a/integration-tests/elasticsearch-rest/src/test/java/org/apache/camel/quarkus/component/elasticsearch/rest/it/ElasticsearchRestIT.java
+++ b/integration-tests/elasticsearch-rest/src/test/java/org/apache/camel/quarkus/component/elasticsearch/rest/it/ElasticsearchRestIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.component.elasticsearch.rest.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class ElasticsearchRestIT extends ElasticsearchRestTest {
 }

--- a/integration-tests/exec/src/test/java/org/apache/camel/quarkus/component/exec/it/ExecIT.java
+++ b/integration-tests/exec/src/test/java/org/apache/camel/quarkus/component/exec/it/ExecIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.exec.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class ExecIT extends ExecTest {
 
 }

--- a/integration-tests/fhir/src/test/java/org/apache/camel/quarkus/component/fhir/it/FhirDstu2Hl7OrgIT.java
+++ b/integration-tests/fhir/src/test/java/org/apache/camel/quarkus/component/fhir/it/FhirDstu2Hl7OrgIT.java
@@ -16,11 +16,11 @@
  */
 package org.apache.camel.quarkus.component.fhir.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 import org.apache.camel.quarkus.component.fhir.it.util.Dstu2Hl7OrgEnabled;
 import org.apache.camel.quarkus.test.EnabledIf;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 @EnabledIf(Dstu2Hl7OrgEnabled.class)
 class FhirDstu2Hl7OrgIT extends FhirDstu2Hl7OrgTest {
 

--- a/integration-tests/fhir/src/test/java/org/apache/camel/quarkus/component/fhir/it/FhirDstu2IT.java
+++ b/integration-tests/fhir/src/test/java/org/apache/camel/quarkus/component/fhir/it/FhirDstu2IT.java
@@ -16,11 +16,11 @@
  */
 package org.apache.camel.quarkus.component.fhir.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 import org.apache.camel.quarkus.component.fhir.it.util.Dstu2Enabled;
 import org.apache.camel.quarkus.test.EnabledIf;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 @EnabledIf(Dstu2Enabled.class)
 class FhirDstu2IT extends FhirDstu2Test {
 

--- a/integration-tests/fhir/src/test/java/org/apache/camel/quarkus/component/fhir/it/FhirDstu2_1IT.java
+++ b/integration-tests/fhir/src/test/java/org/apache/camel/quarkus/component/fhir/it/FhirDstu2_1IT.java
@@ -16,12 +16,12 @@
  */
 package org.apache.camel.quarkus.component.fhir.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 import org.apache.camel.quarkus.component.fhir.it.util.Dstu2_1Enabled;
 import org.apache.camel.quarkus.test.EnabledIf;
 import org.junit.jupiter.api.Disabled;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 @EnabledIf(Dstu2_1Enabled.class)
 @Disabled("https://github.com/hapifhir/hapi-fhir-jpaserver-starter/issues/335")
 class FhirDstu2_1IT extends FhirDstu2_1Test {

--- a/integration-tests/fhir/src/test/java/org/apache/camel/quarkus/component/fhir/it/FhirDstu3IT.java
+++ b/integration-tests/fhir/src/test/java/org/apache/camel/quarkus/component/fhir/it/FhirDstu3IT.java
@@ -16,11 +16,11 @@
  */
 package org.apache.camel.quarkus.component.fhir.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 import org.apache.camel.quarkus.component.fhir.it.util.Dstu3Enabled;
 import org.apache.camel.quarkus.test.EnabledIf;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 @EnabledIf(Dstu3Enabled.class)
 class FhirDstu3IT extends FhirDstu3Test {
 

--- a/integration-tests/fhir/src/test/java/org/apache/camel/quarkus/component/fhir/it/FhirR4IT.java
+++ b/integration-tests/fhir/src/test/java/org/apache/camel/quarkus/component/fhir/it/FhirR4IT.java
@@ -16,11 +16,11 @@
  */
 package org.apache.camel.quarkus.component.fhir.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 import org.apache.camel.quarkus.component.fhir.it.util.R4Enabled;
 import org.apache.camel.quarkus.test.EnabledIf;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 @EnabledIf(R4Enabled.class)
 class FhirR4IT extends FhirR4Test {
 

--- a/integration-tests/fhir/src/test/java/org/apache/camel/quarkus/component/fhir/it/FhirR5IT.java
+++ b/integration-tests/fhir/src/test/java/org/apache/camel/quarkus/component/fhir/it/FhirR5IT.java
@@ -16,11 +16,11 @@
  */
 package org.apache.camel.quarkus.component.fhir.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 import org.apache.camel.quarkus.component.fhir.it.util.R5Enabled;
 import org.apache.camel.quarkus.test.EnabledIf;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 @EnabledIf(R5Enabled.class)
 class FhirR5IT extends FhirR5Test {
 

--- a/integration-tests/file/src/test/java/org/apache/camel/quarkus/component/file/it/FileIT.java
+++ b/integration-tests/file/src/test/java/org/apache/camel/quarkus/component/file/it/FileIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.file.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class FileIT extends FileTest {
 
 }

--- a/integration-tests/file/src/test/java/org/apache/camel/quarkus/component/file/it/FileLanguageIT.java
+++ b/integration-tests/file/src/test/java/org/apache/camel/quarkus/component/file/it/FileLanguageIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.file.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class FileLanguageIT extends FileLanguageTest {
 
 }

--- a/integration-tests/flatpack/src/test/java/org/apache/camel/quarkus/component/flatpack/it/FlatpackIT.java
+++ b/integration-tests/flatpack/src/test/java/org/apache/camel/quarkus/component/flatpack/it/FlatpackIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.flatpack.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class FlatpackIT extends FlatpackTest {
 
 }

--- a/integration-tests/fop/src/test/java/org/apache/camel/quarkus/component/fop/it/FopIT.java
+++ b/integration-tests/fop/src/test/java/org/apache/camel/quarkus/component/fop/it/FopIT.java
@@ -16,11 +16,11 @@
  */
 package org.apache.camel.quarkus.component.fop.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 //https://github.com/apache/camel-quarkus/issues/3280
 @DisabledOnOs(OS.MAC)
 class FopIT extends FopTest {

--- a/integration-tests/freemarker/src/test/java/org/apache/camel/quarkus/component/freemarker/it/FreemarkerIT.java
+++ b/integration-tests/freemarker/src/test/java/org/apache/camel/quarkus/component/freemarker/it/FreemarkerIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.freemarker.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class FreemarkerIT extends FreemarkerTest {
 
 }

--- a/integration-tests/ftp/src/test/java/org/apache/camel/quarkus/component/ftp/it/FtpIT.java
+++ b/integration-tests/ftp/src/test/java/org/apache/camel/quarkus/component/ftp/it/FtpIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.ftp.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class FtpIT extends FtpTest {
 
 }

--- a/integration-tests/ftp/src/test/java/org/apache/camel/quarkus/component/ftps/it/FtpsIT.java
+++ b/integration-tests/ftp/src/test/java/org/apache/camel/quarkus/component/ftps/it/FtpsIT.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.quarkus.component.ftps.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 // https://github.com/apache/camel-quarkus/issues/2317
 @DisabledIfEnvironmentVariable(named = "CI", matches = "true")
 class FtpsIT extends FtpsTest {

--- a/integration-tests/ftp/src/test/java/org/apache/camel/quarkus/component/sftp/it/SftpIT.java
+++ b/integration-tests/ftp/src/test/java/org/apache/camel/quarkus/component/sftp/it/SftpIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.sftp.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class SftpIT extends SftpTest {
 
 }

--- a/integration-tests/geocoder/src/test/java/org/apache/camel/quarkus/component/geocoder/it/GeocoderGoogleIT.java
+++ b/integration-tests/geocoder/src/test/java/org/apache/camel/quarkus/component/geocoder/it/GeocoderGoogleIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.component.geocoder.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class GeocoderGoogleIT extends GeocoderGoogleTest {
 }

--- a/integration-tests/geocoder/src/test/java/org/apache/camel/quarkus/component/geocoder/it/GeocoderNominationIT.java
+++ b/integration-tests/geocoder/src/test/java/org/apache/camel/quarkus/component/geocoder/it/GeocoderNominationIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.component.geocoder.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class GeocoderNominationIT extends GeocoderNominationTest {
 }

--- a/integration-tests/git/src/test/java/org/apache/camel/quarkus/component/git/it/GitIT.java
+++ b/integration-tests/git/src/test/java/org/apache/camel/quarkus/component/git/it/GitIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.git.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class GitIT extends GitTest {
 
 }

--- a/integration-tests/github/src/test/java/org/apache/camel/quarkus/component/github/it/GithubIT.java
+++ b/integration-tests/github/src/test/java/org/apache/camel/quarkus/component/github/it/GithubIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.github.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class GithubIT extends GithubTest {
 
 }

--- a/integration-tests/google-bigquery/src/test/java/org/apache/camel/quarkus/component/google/bigquery/it/GoogleBigqueryIT.java
+++ b/integration-tests/google-bigquery/src/test/java/org/apache/camel/quarkus/component/google/bigquery/it/GoogleBigqueryIT.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.quarkus.component.google.bigquery.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 @EnabledIfEnvironmentVariable(named = "GOOGLE_APPLICATION_CREDENTIALS", matches = ".+")
 class GoogleBigqueryIT extends GoogleBigqueryTest {
 

--- a/integration-tests/google-pubsub/src/test/java/org/apache/camel/quarkus/component/google/pubsub/it/GooglePubsubIT.java
+++ b/integration-tests/google-pubsub/src/test/java/org/apache/camel/quarkus/component/google/pubsub/it/GooglePubsubIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.google.pubsub.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class GooglePubsubIT extends GooglePubsubTest {
 
 }

--- a/integration-tests/google-storage/src/test/java/org/apache/camel/quarkus/component/google/storage/it/GoogleStorageIT.java
+++ b/integration-tests/google-storage/src/test/java/org/apache/camel/quarkus/component/google/storage/it/GoogleStorageIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.google.storage.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class GoogleStorageIT extends GoogleStorageTest {
 
 }

--- a/integration-tests/google/src/test/java/org/apache/camel/quarkus/component/google/it/GoogleComponentsIT.java
+++ b/integration-tests/google/src/test/java/org/apache/camel/quarkus/component/google/it/GoogleComponentsIT.java
@@ -16,14 +16,14 @@
  */
 package org.apache.camel.quarkus.component.google.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
 @EnabledIfEnvironmentVariable(named = "GOOGLE_API_APPLICATION_NAME", matches = ".+")
 @EnabledIfEnvironmentVariable(named = "GOOGLE_API_CLIENT_ID", matches = ".+")
 @EnabledIfEnvironmentVariable(named = "GOOGLE_API_CLIENT_SECRET", matches = ".+")
 @EnabledIfEnvironmentVariable(named = "GOOGLE_API_REFRESH_TOKEN", matches = ".+")
-@NativeImageTest
+@QuarkusIntegrationTest
 class GoogleComponentsIT extends GoogleComponentsTest {
 
 }

--- a/integration-tests/graphql/src/test/java/org/apache/camel/quarkus/component/graphql/it/GraphQLIT.java
+++ b/integration-tests/graphql/src/test/java/org/apache/camel/quarkus/component/graphql/it/GraphQLIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.graphql.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class GraphQLIT extends GraphQLTest {
 
 }

--- a/integration-tests/grok/src/test/java/org/apache/camel/quarkus/component/grok/it/GrokIT.java
+++ b/integration-tests/grok/src/test/java/org/apache/camel/quarkus/component/grok/it/GrokIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.grok.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class GrokIT extends GrokTest {
 
 }

--- a/integration-tests/grpc/src/test/java/org/apache/camel/quarkus/component/grpc/it/GrpcIT.java
+++ b/integration-tests/grpc/src/test/java/org/apache/camel/quarkus/component/grpc/it/GrpcIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.component.grpc.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class GrpcIT extends GrpcTest {
 }

--- a/integration-tests/hazelcast/src/test/java/org/apache/camel/quarkus/component/hazelcast/it/HazelcastAtomicIT.java
+++ b/integration-tests/hazelcast/src/test/java/org/apache/camel/quarkus/component/hazelcast/it/HazelcastAtomicIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.hazelcast.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class HazelcastAtomicIT extends HazelcastAtomicTest {
 
 }

--- a/integration-tests/hazelcast/src/test/java/org/apache/camel/quarkus/component/hazelcast/it/HazelcastIdempotentIT.java
+++ b/integration-tests/hazelcast/src/test/java/org/apache/camel/quarkus/component/hazelcast/it/HazelcastIdempotentIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.component.hazelcast.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class HazelcastIdempotentIT extends HazelcastIdempotentTest {
 }

--- a/integration-tests/hazelcast/src/test/java/org/apache/camel/quarkus/component/hazelcast/it/HazelcastInstanceIT.java
+++ b/integration-tests/hazelcast/src/test/java/org/apache/camel/quarkus/component/hazelcast/it/HazelcastInstanceIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.component.hazelcast.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class HazelcastInstanceIT extends HazelcastInstanceTest {
 }

--- a/integration-tests/hazelcast/src/test/java/org/apache/camel/quarkus/component/hazelcast/it/HazelcastListIT.java
+++ b/integration-tests/hazelcast/src/test/java/org/apache/camel/quarkus/component/hazelcast/it/HazelcastListIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.component.hazelcast.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class HazelcastListIT extends HazelcastListTest {
 }

--- a/integration-tests/hazelcast/src/test/java/org/apache/camel/quarkus/component/hazelcast/it/HazelcastMapIT.java
+++ b/integration-tests/hazelcast/src/test/java/org/apache/camel/quarkus/component/hazelcast/it/HazelcastMapIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.component.hazelcast.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class HazelcastMapIT extends HazelcastMapTest {
 }

--- a/integration-tests/hazelcast/src/test/java/org/apache/camel/quarkus/component/hazelcast/it/HazelcastMultimapIT.java
+++ b/integration-tests/hazelcast/src/test/java/org/apache/camel/quarkus/component/hazelcast/it/HazelcastMultimapIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.component.hazelcast.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class HazelcastMultimapIT extends HazelcastMultimapTest {
 }

--- a/integration-tests/hazelcast/src/test/java/org/apache/camel/quarkus/component/hazelcast/it/HazelcastPolicyIT.java
+++ b/integration-tests/hazelcast/src/test/java/org/apache/camel/quarkus/component/hazelcast/it/HazelcastPolicyIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.component.hazelcast.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class HazelcastPolicyIT extends HazelcastPolicyTest {
 }

--- a/integration-tests/hazelcast/src/test/java/org/apache/camel/quarkus/component/hazelcast/it/HazelcastQueueIT.java
+++ b/integration-tests/hazelcast/src/test/java/org/apache/camel/quarkus/component/hazelcast/it/HazelcastQueueIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.component.hazelcast.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class HazelcastQueueIT extends HazelcastQueueTest {
 }

--- a/integration-tests/hazelcast/src/test/java/org/apache/camel/quarkus/component/hazelcast/it/HazelcastReplicatedmapIT.java
+++ b/integration-tests/hazelcast/src/test/java/org/apache/camel/quarkus/component/hazelcast/it/HazelcastReplicatedmapIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.component.hazelcast.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class HazelcastReplicatedmapIT extends HazelcastReplicatedmapTest {
 }

--- a/integration-tests/hazelcast/src/test/java/org/apache/camel/quarkus/component/hazelcast/it/HazelcastRingbufferIT.java
+++ b/integration-tests/hazelcast/src/test/java/org/apache/camel/quarkus/component/hazelcast/it/HazelcastRingbufferIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.component.hazelcast.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class HazelcastRingbufferIT extends HazelcastRingbufferTest {
 }

--- a/integration-tests/hazelcast/src/test/java/org/apache/camel/quarkus/component/hazelcast/it/HazelcastSedaIT.java
+++ b/integration-tests/hazelcast/src/test/java/org/apache/camel/quarkus/component/hazelcast/it/HazelcastSedaIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.component.hazelcast.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class HazelcastSedaIT extends HazelcastSedaTest {
 }

--- a/integration-tests/hazelcast/src/test/java/org/apache/camel/quarkus/component/hazelcast/it/HazelcastSetIT.java
+++ b/integration-tests/hazelcast/src/test/java/org/apache/camel/quarkus/component/hazelcast/it/HazelcastSetIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.component.hazelcast.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class HazelcastSetIT extends HazelcastSetTest {
 }

--- a/integration-tests/hazelcast/src/test/java/org/apache/camel/quarkus/component/hazelcast/it/HazelcastTopicIT.java
+++ b/integration-tests/hazelcast/src/test/java/org/apache/camel/quarkus/component/hazelcast/it/HazelcastTopicIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.component.hazelcast.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class HazelcastTopicIT extends HazelcastTopicTest {
 }

--- a/integration-tests/headersmap/src/test/java/org/apache/camel/quarkus/component/headersmap/it/HeadersmapIT.java
+++ b/integration-tests/headersmap/src/test/java/org/apache/camel/quarkus/component/headersmap/it/HeadersmapIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.headersmap.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class HeadersmapIT extends HeadersmapTest {
 
 }

--- a/integration-tests/hl7/src/test/java/org/apache/camel/quarkus/component/hl7/it/Hl7IT.java
+++ b/integration-tests/hl7/src/test/java/org/apache/camel/quarkus/component/hl7/it/Hl7IT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.hl7.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class Hl7IT extends Hl7Test {
 
 }

--- a/integration-tests/http/src/test/java/org/apache/camel/quarkus/component/http/it/HttpIT.java
+++ b/integration-tests/http/src/test/java/org/apache/camel/quarkus/component/http/it/HttpIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.component.http.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class HttpIT extends HttpTest {
 }

--- a/integration-tests/hystrix/src/test/java/org/apache/camel/quarkus/component/hystrix/it/HystrixIT.java
+++ b/integration-tests/hystrix/src/test/java/org/apache/camel/quarkus/component/hystrix/it/HystrixIT.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.quarkus.component.hystrix.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 // https://github.com/apache/camel-quarkus/issues/1146
 @DisabledIfEnvironmentVariable(named = "CI", matches = "true")
 class HystrixIT extends HystrixTest {

--- a/integration-tests/infinispan/src/test/java/org/apache/camel/quarkus/component/infinispan/InfinispanIT.java
+++ b/integration-tests/infinispan/src/test/java/org/apache/camel/quarkus/component/infinispan/InfinispanIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.component.infinispan;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class InfinispanIT extends InfinispanTest {
 }

--- a/integration-tests/influxdb/src/test/java/org/apache/camel/quarkus/component/influxdb/it/InfluxdbIT.java
+++ b/integration-tests/influxdb/src/test/java/org/apache/camel/quarkus/component/influxdb/it/InfluxdbIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.component.influxdb.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class InfluxdbIT extends InfluxdbTest {
 }

--- a/integration-tests/jackson-avro/src/test/java/org/apache/camel/quarkus/component/jackson/avro/it/JacksonAvroIT.java
+++ b/integration-tests/jackson-avro/src/test/java/org/apache/camel/quarkus/component/jackson/avro/it/JacksonAvroIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.jackson.avro.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class JacksonAvroIT extends JacksonAvroTest {
 
 }

--- a/integration-tests/jackson-protobuf/src/test/java/org/apache/camel/quarkus/component/jackson/protobuf/it/JacksonProtobufIT.java
+++ b/integration-tests/jackson-protobuf/src/test/java/org/apache/camel/quarkus/component/jackson/protobuf/it/JacksonProtobufIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.jackson.protobuf.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class JacksonProtobufIT extends JacksonProtobufTest {
 
 }

--- a/integration-tests/jaxb/src/test/java/org/apache/camel/quarkus/component/jaxb/it/JaxbIT.java
+++ b/integration-tests/jaxb/src/test/java/org/apache/camel/quarkus/component/jaxb/it/JaxbIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.jaxb.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class JaxbIT extends JaxbTest {
 
 }

--- a/integration-tests/jdbc/src/test/java/org/apache/camel/quarkus/component/jdbc/CamelJdbcIT.java
+++ b/integration-tests/jdbc/src/test/java/org/apache/camel/quarkus/component/jdbc/CamelJdbcIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.jdbc;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class CamelJdbcIT extends CamelJdbcTest {
 
 }

--- a/integration-tests/jfr/src/test/java/org/apache/camel/quarkus/component/jfr/it/JfrIT.java
+++ b/integration-tests/jfr/src/test/java/org/apache/camel/quarkus/component/jfr/it/JfrIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.jfr.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class JfrIT extends JfrTest {
 
 }

--- a/integration-tests/jing/src/test/java/org/apache/camel/quarkus/component/jing/it/JingIT.java
+++ b/integration-tests/jing/src/test/java/org/apache/camel/quarkus/component/jing/it/JingIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.jing.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class JingIT extends JingTest {
 
 }

--- a/integration-tests/jira/src/test/java/org/apache/camel/quarkus/component/jira/it/JiraIT.java
+++ b/integration-tests/jira/src/test/java/org/apache/camel/quarkus/component/jira/it/JiraIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.jira.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class JiraIT extends JiraTest {
 
 }

--- a/integration-tests/jms-artemis-client/src/test/java/org/apache/camel/quarkus/component/jms/artemis/it/JmsArtemisIT.java
+++ b/integration-tests/jms-artemis-client/src/test/java/org/apache/camel/quarkus/component/jms/artemis/it/JmsArtemisIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.component.jms.artemis.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class JmsArtemisIT extends JmsArtemisTest {
 }

--- a/integration-tests/jms-qpid-amqp-client/src/test/java/org/apache/camel/quarkus/component/jms/qpid/it/JmsQpidIT.java
+++ b/integration-tests/jms-qpid-amqp-client/src/test/java/org/apache/camel/quarkus/component/jms/qpid/it/JmsQpidIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.component.jms.qpid.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class JmsQpidIT extends JmsQpidTest {
 }

--- a/integration-tests/jolt/src/test/java/org/apache/camel/quarkus/component/jolt/it/JoltIT.java
+++ b/integration-tests/jolt/src/test/java/org/apache/camel/quarkus/component/jolt/it/JoltIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.jolt.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class JoltIT extends JoltTest {
 
 }

--- a/integration-tests/jpa/src/test/java/org/apache/camel/quarkus/component/jpa/it/JpaIT.java
+++ b/integration-tests/jpa/src/test/java/org/apache/camel/quarkus/component/jpa/it/JpaIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.jpa.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class JpaIT extends JpaTest {
 
 }

--- a/integration-tests/js-dsl/src/test/java/org/apache/camel/quarkus/js/JavaScriptDslIT.java
+++ b/integration-tests/js-dsl/src/test/java/org/apache/camel/quarkus/js/JavaScriptDslIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.js;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class JavaScriptDslIT extends JavaScriptDslTest {
 }

--- a/integration-tests/jsch/src/test/java/org/apache/camel/quarkus/component/jsch/it/JschIT.java
+++ b/integration-tests/jsch/src/test/java/org/apache/camel/quarkus/component/jsch/it/JschIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.jsch.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class JschIT extends JschTest {
 
 }

--- a/integration-tests/jslt/src/test/java/org/apache/camel/quarkus/component/jslt/it/JsltIT.java
+++ b/integration-tests/jslt/src/test/java/org/apache/camel/quarkus/component/jslt/it/JsltIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.jslt.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class JsltIT extends JsltTest {
 
 }

--- a/integration-tests/json-validator/src/test/java/org/apache/camel/quarkus/component/json/validator/it/JsonValidatorIT.java
+++ b/integration-tests/json-validator/src/test/java/org/apache/camel/quarkus/component/json/validator/it/JsonValidatorIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.json.validator.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class JsonValidatorIT extends JsonValidatorTest {
 
 }

--- a/integration-tests/jsonata/src/test/java/org/apache/camel/quarkus/component/jsonata/it/JsonataIT.java
+++ b/integration-tests/jsonata/src/test/java/org/apache/camel/quarkus/component/jsonata/it/JsonataIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.jsonata.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class JsonataIT extends JsonataTest {
 
 }

--- a/integration-tests/jsonpath/src/test/java/org/apache/camel/quarkus/component/json/path/it/JsonPathBeanIT.java
+++ b/integration-tests/jsonpath/src/test/java/org/apache/camel/quarkus/component/json/path/it/JsonPathBeanIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.json.path.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class JsonPathBeanIT extends JsonPathBeanTest {
 
 }

--- a/integration-tests/jsonpath/src/test/java/org/apache/camel/quarkus/component/json/path/it/JsonPathCharsetsIT.java
+++ b/integration-tests/jsonpath/src/test/java/org/apache/camel/quarkus/component/json/path/it/JsonPathCharsetsIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.json.path.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class JsonPathCharsetsIT extends JsonPathCharsetsTest {
 
 }

--- a/integration-tests/jsonpath/src/test/java/org/apache/camel/quarkus/component/json/path/it/JsonPathContentBasedRouterIT.java
+++ b/integration-tests/jsonpath/src/test/java/org/apache/camel/quarkus/component/json/path/it/JsonPathContentBasedRouterIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.json.path.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class JsonPathContentBasedRouterIT extends JsonPathContentBasedRouterTest {
 
 }

--- a/integration-tests/jsonpath/src/test/java/org/apache/camel/quarkus/component/json/path/it/JsonPathSetBodyIT.java
+++ b/integration-tests/jsonpath/src/test/java/org/apache/camel/quarkus/component/json/path/it/JsonPathSetBodyIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.json.path.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class JsonPathSetBodyIT extends JsonPathSetBodyTest {
 
 }

--- a/integration-tests/jsonpath/src/test/java/org/apache/camel/quarkus/component/json/path/it/JsonPathSetHeaderIT.java
+++ b/integration-tests/jsonpath/src/test/java/org/apache/camel/quarkus/component/json/path/it/JsonPathSetHeaderIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.json.path.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class JsonPathSetHeaderIT extends JsonPathSetHeaderTest {
 
 }

--- a/integration-tests/jsonpath/src/test/java/org/apache/camel/quarkus/component/json/path/it/JsonPathSplitIT.java
+++ b/integration-tests/jsonpath/src/test/java/org/apache/camel/quarkus/component/json/path/it/JsonPathSplitIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.json.path.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class JsonPathSplitIT extends JsonPathSplitTest {
 
 }

--- a/integration-tests/jsonpath/src/test/java/org/apache/camel/quarkus/component/json/path/it/JsonPathTransformIT.java
+++ b/integration-tests/jsonpath/src/test/java/org/apache/camel/quarkus/component/json/path/it/JsonPathTransformIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.json.path.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class JsonPathTransformIT extends JsonPathTransformTest {
 
 }

--- a/integration-tests/jsonpath/src/test/java/org/apache/camel/quarkus/component/json/path/it/JsonPathWriteAsStringIT.java
+++ b/integration-tests/jsonpath/src/test/java/org/apache/camel/quarkus/component/json/path/it/JsonPathWriteAsStringIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.json.path.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class JsonPathWriteAsStringIT extends JsonPathWriteAsStringTest {
 
 }

--- a/integration-tests/jta/src/test/java/org/apache/camel/quarkus/component/jta/it/JtaIT.java
+++ b/integration-tests/jta/src/test/java/org/apache/camel/quarkus/component/jta/it/JtaIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.jta.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class JtaIT extends JtaTest {
 
 }

--- a/integration-tests/kafka-oauth/src/test/java/org/apache/camel/quarkus/kafka/oauth/it/KafkaIT.java
+++ b/integration-tests/kafka-oauth/src/test/java/org/apache/camel/quarkus/kafka/oauth/it/KafkaIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.kafka.oauth.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class KafkaIT extends KafkaTest {
 }

--- a/integration-tests/kafka-sasl-ssl/src/test/java/org/apache/camel/quarkus/kafka/sasl/KafkaSaslSslIT.java
+++ b/integration-tests/kafka-sasl-ssl/src/test/java/org/apache/camel/quarkus/kafka/sasl/KafkaSaslSslIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.kafka.sasl;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class KafkaSaslSslIT extends KafkaSaslSslTest {
 }

--- a/integration-tests/kafka-sasl/src/test/java/org/apache/camel/quarkus/kafka/sasl/KafkaSaslIT.java
+++ b/integration-tests/kafka-sasl/src/test/java/org/apache/camel/quarkus/kafka/sasl/KafkaSaslIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.kafka.sasl;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class KafkaSaslIT extends KafkaSaslBindingTest {
 }

--- a/integration-tests/kafka-ssl/src/test/java/org/apache/camel/quarkus/kafka/ssl/KafkaSslIT.java
+++ b/integration-tests/kafka-ssl/src/test/java/org/apache/camel/quarkus/kafka/ssl/KafkaSslIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.kafka.ssl;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class KafkaSslIT extends KafkaSslTest {
 }

--- a/integration-tests/kafka/src/test/java/org/apache/camel/quarkus/component/kafka/it/CamelKafkaIT.java
+++ b/integration-tests/kafka/src/test/java/org/apache/camel/quarkus/component/kafka/it/CamelKafkaIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.component.kafka.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class CamelKafkaIT extends CamelKafkaTest {
 }

--- a/integration-tests/kamelet/src/test/java/org/apache/camel/quarkus/component/kamelet/it/KameletIT.java
+++ b/integration-tests/kamelet/src/test/java/org/apache/camel/quarkus/component/kamelet/it/KameletIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.kamelet.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class KameletIT extends KameletTest {
 
 }

--- a/integration-tests/kotlin/src/test/kotlin/org/apache/camel/quarkus/kotlin/KotlinIT.kt
+++ b/integration-tests/kotlin/src/test/kotlin/org/apache/camel/quarkus/kotlin/KotlinIT.kt
@@ -16,7 +16,7 @@
  */
 package org.apache.camel.quarkus.kotlin
 
-import io.quarkus.test.junit.NativeImageTest
+import io.quarkus.test.junit.QuarkusIntegrationTest
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class KotlinIT : KotlinTest()

--- a/integration-tests/kubernetes/src/test/java/org/apache/camel/quarkus/component/kubernetes/it/KubernetesIT.java
+++ b/integration-tests/kubernetes/src/test/java/org/apache/camel/quarkus/component/kubernetes/it/KubernetesIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.kubernetes.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class KubernetesIT extends KubernetesTest {
 
 }

--- a/integration-tests/kudu/src/test/java/org/apache/camel/quarkus/component/kudu/it/KuduIT.java
+++ b/integration-tests/kudu/src/test/java/org/apache/camel/quarkus/component/kudu/it/KuduIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.kudu.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class KuduIT extends KuduTest {
 
 }

--- a/integration-tests/leveldb/src/test/java/org/apache/camel/quarkus/component/leveldb/it/LeveldbIT.java
+++ b/integration-tests/leveldb/src/test/java/org/apache/camel/quarkus/component/leveldb/it/LeveldbIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.component.leveldb.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class LeveldbIT extends LeveldbTest {
 }

--- a/integration-tests/lra/src/test/java/org/apache/camel/quarkus/component/lra/it/LraIT.java
+++ b/integration-tests/lra/src/test/java/org/apache/camel/quarkus/component/lra/it/LraIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.lra.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class LraIT extends LraTest {
 
 }

--- a/integration-tests/lumberjack/src/test/java/org/apache/camel/quarkus/component/lumberjack/it/LumberjackIT.java
+++ b/integration-tests/lumberjack/src/test/java/org/apache/camel/quarkus/component/lumberjack/it/LumberjackIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.component.lumberjack.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class LumberjackIT extends LumberjackTest {
 }

--- a/integration-tests/mail/src/test/java/org/apache/camel/quarkus/component/mail/MailIT.java
+++ b/integration-tests/mail/src/test/java/org/apache/camel/quarkus/component/mail/MailIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.component.mail;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class MailIT extends MailTest {
 }

--- a/integration-tests/main-caffeine-lrucache/src/test/java/org/apache/camel/quarkus/main/CoreMainCaffeineLRUCacheResourceIT.java
+++ b/integration-tests/main-caffeine-lrucache/src/test/java/org/apache/camel/quarkus/main/CoreMainCaffeineLRUCacheResourceIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.main;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class CoreMainCaffeineLRUCacheResourceIT extends CoreMainCaffeineLRUCacheResourceTest {
 }

--- a/integration-tests/main-discovery-disabled/src/test/java/org/apache/camel/quarkus/main/MainDiscoveryDisabledIT.java
+++ b/integration-tests/main-discovery-disabled/src/test/java/org/apache/camel/quarkus/main/MainDiscoveryDisabledIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.main;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class MainDiscoveryDisabledIT extends MainDiscoveryDisabledTest {
 }

--- a/integration-tests/main-unknown-args-fail/src/test/java/org/apache/camel/quarkus/main/unknown/args/fail/MainUnknownArgumentFailIT.java
+++ b/integration-tests/main-unknown-args-fail/src/test/java/org/apache/camel/quarkus/main/unknown/args/fail/MainUnknownArgumentFailIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.main.unknown.args.fail;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class MainUnknownArgumentFailIT extends MainUnknownArgumentFailTest {
 }

--- a/integration-tests/main-unknown-args-ignore/src/test/java/org/apache/camel/quarkus/main/unknown/args/ignore/MainUnknownArgumentIgnoreIT.java
+++ b/integration-tests/main-unknown-args-ignore/src/test/java/org/apache/camel/quarkus/main/unknown/args/ignore/MainUnknownArgumentIgnoreIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.main.unknown.args.ignore;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class MainUnknownArgumentIgnoreIT extends MainUnknownArgumentIgnoreTest {
 }

--- a/integration-tests/main-xml-io/src/test/java/org/apache/camel/quarkus/main/CoreMainXmlIoIT.java
+++ b/integration-tests/main-xml-io/src/test/java/org/apache/camel/quarkus/main/CoreMainXmlIoIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.main;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class CoreMainXmlIoIT extends CoreMainXmlIoTest {
 }

--- a/integration-tests/main-xml-jaxb/src/test/java/org/apache/camel/quarkus/main/CoreMainXmlJaxbIT.java
+++ b/integration-tests/main-xml-jaxb/src/test/java/org/apache/camel/quarkus/main/CoreMainXmlJaxbIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.main;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class CoreMainXmlJaxbIT extends CoreMainXmlJaxbTest {
 }

--- a/integration-tests/main-yaml/src/test/java/org/apache/camel/quarkus/main/CoreMainYamlIT.java
+++ b/integration-tests/main-yaml/src/test/java/org/apache/camel/quarkus/main/CoreMainYamlIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.main;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class CoreMainYamlIT extends CoreMainYamlTest {
 }

--- a/integration-tests/main/src/test/java/org/apache/camel/quarkus/main/CoreMainIT.java
+++ b/integration-tests/main/src/test/java/org/apache/camel/quarkus/main/CoreMainIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.main;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class CoreMainIT extends CoreMainTest {
 }

--- a/integration-tests/master/src/test/java/org/apache/camel/quarkus/component/master/it/MasterIT.java
+++ b/integration-tests/master/src/test/java/org/apache/camel/quarkus/component/master/it/MasterIT.java
@@ -16,12 +16,12 @@
  */
 package org.apache.camel.quarkus.component.master.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 
 // https://github.com/apache/camel-quarkus/issues/2660
 @DisabledIfEnvironmentVariable(named = "CI", matches = "true")
-@NativeImageTest
+@QuarkusIntegrationTest
 class MasterIT extends MasterTest {
 
 }

--- a/integration-tests/micrometer/src/test/java/org/apache/camel/quarkus/component/micrometer/it/MicrometerIT.java
+++ b/integration-tests/micrometer/src/test/java/org/apache/camel/quarkus/component/micrometer/it/MicrometerIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.micrometer.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class MicrometerIT extends MicrometerTest {
 
 }

--- a/integration-tests/microprofile/src/test/java/org/apache/camel/quarkus/component/microprofile/it/faulttolerance/MicroprofileFaultToleranceIT.java
+++ b/integration-tests/microprofile/src/test/java/org/apache/camel/quarkus/component/microprofile/it/faulttolerance/MicroprofileFaultToleranceIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.microprofile.it.faulttolerance;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class MicroprofileFaultToleranceIT extends MicroprofileFaultToleranceTest {
 
 }

--- a/integration-tests/microprofile/src/test/java/org/apache/camel/quarkus/component/microprofile/it/health/MicroprofileHealthIT.java
+++ b/integration-tests/microprofile/src/test/java/org/apache/camel/quarkus/component/microprofile/it/health/MicroprofileHealthIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.microprofile.it.health;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class MicroprofileHealthIT extends MicroProfileHealthTest {
 
 }

--- a/integration-tests/microprofile/src/test/java/org/apache/camel/quarkus/component/microprofile/it/metrics/MicroprofileMetricsIT.java
+++ b/integration-tests/microprofile/src/test/java/org/apache/camel/quarkus/component/microprofile/it/metrics/MicroprofileMetricsIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.microprofile.it.metrics;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class MicroprofileMetricsIT extends MicroProfileMetricsTest {
 
 }

--- a/integration-tests/minio/src/test/java/org/apache/camel/quarkus/component/minio/it/MinioIT.java
+++ b/integration-tests/minio/src/test/java/org/apache/camel/quarkus/component/minio/it/MinioIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.minio.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class MinioIT extends MinioTest {
 
 }

--- a/integration-tests/mllp/src/test/java/org/apache/camel/quarkus/component/mllp/it/MllpIT.java
+++ b/integration-tests/mllp/src/test/java/org/apache/camel/quarkus/component/mllp/it/MllpIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.mllp.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class MllpIT extends MllpTest {
 
 }

--- a/integration-tests/msv/src/test/java/org/apache/camel/quarkus/component/msv/it/MsvIT.java
+++ b/integration-tests/msv/src/test/java/org/apache/camel/quarkus/component/msv/it/MsvIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.msv.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class MsvIT extends MsvTest {
 
 }

--- a/integration-tests/mustache/src/test/java/org/apache/camel/quarkus/component/mustache/it/MustacheIT.java
+++ b/integration-tests/mustache/src/test/java/org/apache/camel/quarkus/component/mustache/it/MustacheIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.mustache.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class MustacheIT extends MustacheTest {
 
 }

--- a/integration-tests/mybatis/src/test/java/org/apache/camel/quarkus/component/mybatis/it/MyBatisIT.java
+++ b/integration-tests/mybatis/src/test/java/org/apache/camel/quarkus/component/mybatis/it/MyBatisIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.component.mybatis.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class MyBatisIT extends MyBatisTest {
 }

--- a/integration-tests/nagios/src/test/java/org/apache/camel/quarkus/component/nagios/it/NagiosIT.java
+++ b/integration-tests/nagios/src/test/java/org/apache/camel/quarkus/component/nagios/it/NagiosIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.component.nagios.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class NagiosIT extends NagiosTest {
 }

--- a/integration-tests/nats/src/test/java/org/apache/camel/quarkus/component/nats/it/NatsIT.java
+++ b/integration-tests/nats/src/test/java/org/apache/camel/quarkus/component/nats/it/NatsIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.nats.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class NatsIT extends NatsTest {
 
 }

--- a/integration-tests/netty/src/test/java/org/apache/camel/quarkus/component/netty/tcp/NettyTcpIT.java
+++ b/integration-tests/netty/src/test/java/org/apache/camel/quarkus/component/netty/tcp/NettyTcpIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.netty.tcp;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class NettyTcpIT extends NettyTcpTest {
 
 }

--- a/integration-tests/netty/src/test/java/org/apache/camel/quarkus/component/netty/udp/NettyUdpIT.java
+++ b/integration-tests/netty/src/test/java/org/apache/camel/quarkus/component/netty/udp/NettyUdpIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.netty.udp;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class NettyUdpIT extends NettyUdpTest {
 
 }

--- a/integration-tests/nitrite/src/test/java/org/apache/camel/quarkus/component/nitrite/it/NitriteIT.java
+++ b/integration-tests/nitrite/src/test/java/org/apache/camel/quarkus/component/nitrite/it/NitriteIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.nitrite.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class NitriteIT extends NitriteTest {
 
 }

--- a/integration-tests/nsq/src/test/java/org/apache/camel/quarkus/component/nsq/it/NsqIT.java
+++ b/integration-tests/nsq/src/test/java/org/apache/camel/quarkus/component/nsq/it/NsqIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.nsq.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class NsqIT extends NsqTest {
 
 }

--- a/integration-tests/oaipmh/src/test/java/org/apache/camel/quarkus/component/oaipmh/it/OaipmhIT.java
+++ b/integration-tests/oaipmh/src/test/java/org/apache/camel/quarkus/component/oaipmh/it/OaipmhIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.oaipmh.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class OaipmhIT extends OaipmhTest {
 
 }

--- a/integration-tests/olingo4/src/test/java/org/apache/camel/quarkus/component/olingo4/it/Olingo4IT.java
+++ b/integration-tests/olingo4/src/test/java/org/apache/camel/quarkus/component/olingo4/it/Olingo4IT.java
@@ -16,11 +16,11 @@
  */
 package org.apache.camel.quarkus.component.olingo4.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 import org.junit.jupiter.api.Disabled;
 
 @Disabled("https://github.com/apache/camel-quarkus/issues/1972")
-@NativeImageTest
+@QuarkusIntegrationTest
 class Olingo4IT extends Olingo4Test {
 
 }

--- a/integration-tests/openapi-java/src/test/java/org/apache/camel/quarkus/component/openapijava/it/v2/OpenApiV2IT.java
+++ b/integration-tests/openapi-java/src/test/java/org/apache/camel/quarkus/component/openapijava/it/v2/OpenApiV2IT.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.quarkus.component.openapijava.it.v2;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 @EnabledIfSystemProperty(named = "test.profile", matches = "openapi.v2")
 class OpenApiV2IT extends OpenApiV2Test {
 }

--- a/integration-tests/openapi-java/src/test/java/org/apache/camel/quarkus/component/openapijava/it/v3/OpenApiV3IT.java
+++ b/integration-tests/openapi-java/src/test/java/org/apache/camel/quarkus/component/openapijava/it/v3/OpenApiV3IT.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.quarkus.component.openapijava.it.v3;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 @EnabledIfSystemProperty(named = "test.profile", matches = "openapi.v3")
 class OpenApiV3IT extends OpenApiV3Test {
 }

--- a/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenstackCinderSnapshotIT.java
+++ b/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenstackCinderSnapshotIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.openstack.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class OpenstackCinderSnapshotIT extends OpenstackCinderSnapshotTest {
 
 }

--- a/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenstackCinderVolumeIT.java
+++ b/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenstackCinderVolumeIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.openstack.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class OpenstackCinderVolumeIT extends OpenstackCinderVolumeTest {
 
 }

--- a/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenstackGlanceIT.java
+++ b/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenstackGlanceIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.openstack.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class OpenstackGlanceIT extends OpenstackGlanceTest {
 
 }

--- a/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenstackKeystoneDomainIT.java
+++ b/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenstackKeystoneDomainIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.openstack.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class OpenstackKeystoneDomainIT extends OpenstackKeystoneDomainTest {
 
 }

--- a/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenstackKeystoneGroupIT.java
+++ b/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenstackKeystoneGroupIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.openstack.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class OpenstackKeystoneGroupIT extends OpenstackKeystoneGroupTest {
 
 }

--- a/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenstackKeystoneProjectIT.java
+++ b/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenstackKeystoneProjectIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.openstack.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class OpenstackKeystoneProjectIT extends OpenstackKeystoneProjectTest {
 
 }

--- a/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenstackKeystoneRegionIT.java
+++ b/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenstackKeystoneRegionIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.openstack.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class OpenstackKeystoneRegionIT extends OpenstackKeystoneRegionTest {
 
 }

--- a/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenstackKeystoneUserIT.java
+++ b/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenstackKeystoneUserIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.openstack.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class OpenstackKeystoneUserIT extends OpenstackKeystoneUserTest {
 
 }

--- a/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenstackNeutronNetworkIT.java
+++ b/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenstackNeutronNetworkIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.openstack.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class OpenstackNeutronNetworkIT extends OpenstackNeutronNetworkTest {
 
 }

--- a/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenstackNeutronPortIT.java
+++ b/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenstackNeutronPortIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.openstack.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class OpenstackNeutronPortIT extends OpenstackNeutronPortTest {
 
 }

--- a/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenstackNeutronSubnetIT.java
+++ b/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenstackNeutronSubnetIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.openstack.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class OpenstackNeutronSubnetIT extends OpenstackNeutronSubnetTest {
 
 }

--- a/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenstackNovaFlavorIT.java
+++ b/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenstackNovaFlavorIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.openstack.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class OpenstackNovaFlavorIT extends OpenstackNovaFlavorTest {
 
 }

--- a/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenstackNovaServerIT.java
+++ b/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenstackNovaServerIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.openstack.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class OpenstackNovaServerIT extends OpenstackNovaServerTest {
 
 }

--- a/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenstackSwiftContainerIT.java
+++ b/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenstackSwiftContainerIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.openstack.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class OpenstackSwiftContainerIT extends OpenstackSwiftContainerTest {
 
 }

--- a/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenstackSwiftObjectIT.java
+++ b/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenstackSwiftObjectIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.openstack.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class OpenstackSwiftObjectIT extends OpenstackSwiftObjectTest {
 
 }

--- a/integration-tests/opentelemetry/src/test/java/org/apache/camel/quarkus/component/opentelemetry/it/OpenTelemetryIT.java
+++ b/integration-tests/opentelemetry/src/test/java/org/apache/camel/quarkus/component/opentelemetry/it/OpenTelemetryIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.opentelemetry.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class OpenTelemetryIT extends OpenTelemetryTest {
 
 }

--- a/integration-tests/opentracing/src/test/java/org/apache/camel/quarkus/component/opentracing/it/OpenTracingIT.java
+++ b/integration-tests/opentracing/src/test/java/org/apache/camel/quarkus/component/opentracing/it/OpenTracingIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.opentracing.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class OpenTracingIT extends OpenTracingTest {
 
 }

--- a/integration-tests/optaplanner/src/test/java/org/apache/camel/quarkus/component/optaplanner/it/OptaplannerIT.java
+++ b/integration-tests/optaplanner/src/test/java/org/apache/camel/quarkus/component/optaplanner/it/OptaplannerIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.optaplanner.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class OptaplannerIT extends OptaplannerTest {
 
 }

--- a/integration-tests/paho-mqtt5/src/test/java/org/apache/camel/quarkus/component/paho/mqtt5/it/PahoMqtt5IT.java
+++ b/integration-tests/paho-mqtt5/src/test/java/org/apache/camel/quarkus/component/paho/mqtt5/it/PahoMqtt5IT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.paho.mqtt5.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class PahoMqtt5IT extends PahoMqtt5Test {
 
 }

--- a/integration-tests/paho/src/test/java/org/apache/camel/quarkus/component/paho/it/PahoIT.java
+++ b/integration-tests/paho/src/test/java/org/apache/camel/quarkus/component/paho/it/PahoIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.paho.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class PahoIT extends PahoTest {
 
 }

--- a/integration-tests/pdf/src/test/java/org/apache/camel/quarkus/component/pdf/it/PdfIT.java
+++ b/integration-tests/pdf/src/test/java/org/apache/camel/quarkus/component/pdf/it/PdfIT.java
@@ -16,11 +16,11 @@
  */
 package org.apache.camel.quarkus.component.pdf.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 //https://github.com/apache/camel-quarkus/issues/3417
 @DisabledOnOs(OS.MAC)
 class PdfIT extends PdfTest {

--- a/integration-tests/pg-replication-slot/src/test/java/org/apache/camel/quarkus/component/pg/replication/slot/it/PgReplicationSlotIT.java
+++ b/integration-tests/pg-replication-slot/src/test/java/org/apache/camel/quarkus/component/pg/replication/slot/it/PgReplicationSlotIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.pg.replication.slot.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class PgReplicationSlotIT extends PgReplicationSlotTest {
 
 }

--- a/integration-tests/pgevent/src/test/java/org/apache/camel/quarkus/component/pgevent/it/PgeventIT.java
+++ b/integration-tests/pgevent/src/test/java/org/apache/camel/quarkus/component/pgevent/it/PgeventIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.pgevent.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class PgeventIT extends PgeventTest {
 
 }

--- a/integration-tests/platform-http/src/test/java/org/apache/camel/quarkus/component/http/server/it/PlatformHttpIT.java
+++ b/integration-tests/platform-http/src/test/java/org/apache/camel/quarkus/component/http/server/it/PlatformHttpIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.http.server.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class PlatformHttpIT extends PlatformHttpTest {
 
 }

--- a/integration-tests/protobuf/src/test/java/org/apache/camel/quarkus/component/protobuf/it/ProtobufIT.java
+++ b/integration-tests/protobuf/src/test/java/org/apache/camel/quarkus/component/protobuf/it/ProtobufIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.protobuf.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class ProtobufIT extends ProtobufTest {
 
 }

--- a/integration-tests/pubnub/src/test/java/org/apache/camel/quarkus/component/pubnub/it/PubnubIT.java
+++ b/integration-tests/pubnub/src/test/java/org/apache/camel/quarkus/component/pubnub/it/PubnubIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.pubnub.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class PubnubIT extends PubnubTest {
 
 }

--- a/integration-tests/quartz/src/test/java/org/apache/camel/quarkus/component/quartz/it/QuartzIT.java
+++ b/integration-tests/quartz/src/test/java/org/apache/camel/quarkus/component/quartz/it/QuartzIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.quartz.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class QuartzIT extends QuartzTest {
 
 }

--- a/integration-tests/qute/src/test/java/org/apache/camel/quarkus/component/qute/it/QuteIT.java
+++ b/integration-tests/qute/src/test/java/org/apache/camel/quarkus/component/qute/it/QuteIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.qute.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class QuteIT extends QuteTest {
 
 }

--- a/integration-tests/rabbitmq/src/test/java/org/apache/camel/quarkus/component/rabbitmq/it/RabbitmqIT.java
+++ b/integration-tests/rabbitmq/src/test/java/org/apache/camel/quarkus/component/rabbitmq/it/RabbitmqIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.rabbitmq.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class RabbitmqIT extends RabbitmqTest {
 
 }

--- a/integration-tests/reactive-streams/src/test/java/org/apache/camel/quarkus/component/reactive/streams/it/ReactiveStreamsIT.java
+++ b/integration-tests/reactive-streams/src/test/java/org/apache/camel/quarkus/component/reactive/streams/it/ReactiveStreamsIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.reactive.streams.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class ReactiveStreamsIT extends ReactiveStreamsTest {
 
 }

--- a/integration-tests/rest-openapi/src/test/java/org/apache/camel/quarkus/component/rest/openapi/it/RestOpenapiIT.java
+++ b/integration-tests/rest-openapi/src/test/java/org/apache/camel/quarkus/component/rest/openapi/it/RestOpenapiIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.component.rest.openapi.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class RestOpenapiIT extends RestOpenapiTest {
 }

--- a/integration-tests/rest/src/test/java/org/apache/camel/quarkus/component/rest/it/RestIT.java
+++ b/integration-tests/rest/src/test/java/org/apache/camel/quarkus/component/rest/it/RestIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.component.rest.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class RestIT extends RestTest {
 }

--- a/integration-tests/saga/src/test/java/org/apache/camel/quarkus/component/saga/it/SagaTestIT.java
+++ b/integration-tests/saga/src/test/java/org/apache/camel/quarkus/component/saga/it/SagaTestIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.saga.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class SagaTestIT extends SagaTest {
 
 }

--- a/integration-tests/salesforce/src/test/java/org/apache/camel/quarkus/component/salesforce/SalesforceIT.java
+++ b/integration-tests/salesforce/src/test/java/org/apache/camel/quarkus/component/salesforce/SalesforceIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.salesforce;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class SalesforceIT extends SalesforceTest {
 
 }

--- a/integration-tests/salesforce/src/test/java/org/apache/camel/quarkus/component/salesforce/SalesforceIntegrationIT.java
+++ b/integration-tests/salesforce/src/test/java/org/apache/camel/quarkus/component/salesforce/SalesforceIntegrationIT.java
@@ -16,13 +16,13 @@
  */
 package org.apache.camel.quarkus.component.salesforce;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
 @EnabledIfEnvironmentVariable(named = "SALESFORCE_USERNAME", matches = ".+")
 @EnabledIfEnvironmentVariable(named = "SALESFORCE_PASSWORD", matches = ".+")
 @EnabledIfEnvironmentVariable(named = "SALESFORCE_CLIENTID", matches = ".+")
 @EnabledIfEnvironmentVariable(named = "SALESFORCE_CLIENTSECRET", matches = ".+")
-@NativeImageTest
+@QuarkusIntegrationTest
 public class SalesforceIntegrationIT extends SalesforceIntegrationTest {
 }

--- a/integration-tests/saxon/src/test/java/org/apache/camel/quarkus/component/saxon/it/SaxonXPathIT.java
+++ b/integration-tests/saxon/src/test/java/org/apache/camel/quarkus/component/saxon/it/SaxonXPathIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.saxon.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class SaxonXPathIT extends SaxonXPathTest {
 
 }

--- a/integration-tests/saxon/src/test/java/org/apache/camel/quarkus/component/saxon/it/SaxonXQueryIT.java
+++ b/integration-tests/saxon/src/test/java/org/apache/camel/quarkus/component/saxon/it/SaxonXQueryIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.saxon.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class SaxonXQueryIT extends SaxonXQueryTest {
 
 }

--- a/integration-tests/servicenow/src/test/java/org/apache/camel/quarkus/component/servicenow/it/ServicenowIT.java
+++ b/integration-tests/servicenow/src/test/java/org/apache/camel/quarkus/component/servicenow/it/ServicenowIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.servicenow.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class ServicenowIT extends ServicenowTest {
 
 }

--- a/integration-tests/servlet/src/test/java/org/apache/camel/quarkus/component/servlet/CamelServletIT.java
+++ b/integration-tests/servlet/src/test/java/org/apache/camel/quarkus/component/servlet/CamelServletIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.servlet;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class CamelServletIT extends CamelServletTest {
 
 }

--- a/integration-tests/shiro/src/test/java/org/apache/camel/quarkus/component/shiro/it/ShiroIT.java
+++ b/integration-tests/shiro/src/test/java/org/apache/camel/quarkus/component/shiro/it/ShiroIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.shiro.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class ShiroIT extends ShiroTest {
 
 }

--- a/integration-tests/sjms-artemis-client/src/test/java/org/apache/camel/quarkus/component/sjms/artemis/it/SjmsArtemisIT.java
+++ b/integration-tests/sjms-artemis-client/src/test/java/org/apache/camel/quarkus/component/sjms/artemis/it/SjmsArtemisIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.component.sjms.artemis.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class SjmsArtemisIT extends SjmsArtemisTest {
 }

--- a/integration-tests/sjms-qpid-amqp-client/src/test/java/org/apache/camel/quarkus/component/sjms/qpid/it/SjmsQpidIT.java
+++ b/integration-tests/sjms-qpid-amqp-client/src/test/java/org/apache/camel/quarkus/component/sjms/qpid/it/SjmsQpidIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.component.sjms.qpid.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class SjmsQpidIT extends SjmsQpidTest {
 }

--- a/integration-tests/sjms2-artemis-client/src/test/java/org/apache/camel/quarkus/component/sjms2/artemis/it/Sjms2ArtemisIT.java
+++ b/integration-tests/sjms2-artemis-client/src/test/java/org/apache/camel/quarkus/component/sjms2/artemis/it/Sjms2ArtemisIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.component.sjms2.artemis.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class Sjms2ArtemisIT extends Sjms2ArtemisTest {
 }

--- a/integration-tests/sjms2-qpid-amqp-client/src/test/java/org/apache/camel/quarkus/component/sjms2/qpid/it/Sjms2QpidIT.java
+++ b/integration-tests/sjms2-qpid-amqp-client/src/test/java/org/apache/camel/quarkus/component/sjms2/qpid/it/Sjms2QpidIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.component.sjms2.qpid.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class Sjms2QpidIT extends Sjms2QpidTest {
 }

--- a/integration-tests/slack/src/test/java/org/apache/camel/quarkus/component/slack/it/SlackIT.java
+++ b/integration-tests/slack/src/test/java/org/apache/camel/quarkus/component/slack/it/SlackIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.slack.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class SlackIT extends SlackTest {
 
 }

--- a/integration-tests/smallrye-reactive-messaging/src/test/java/org/apache/camel/quarkus/component/smallrye/reactive/messaging/it/SmallRyeReactiveMessagingIT.java
+++ b/integration-tests/smallrye-reactive-messaging/src/test/java/org/apache/camel/quarkus/component/smallrye/reactive/messaging/it/SmallRyeReactiveMessagingIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.smallrye.reactive.messaging.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class SmallRyeReactiveMessagingIT extends SmallRyeReactiveMessagingTest {
 
 }

--- a/integration-tests/soap/src/test/java/org/apache/camel/quarkus/component/soap/it/SoapIT.java
+++ b/integration-tests/soap/src/test/java/org/apache/camel/quarkus/component/soap/it/SoapIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.soap.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class SoapIT extends SoapTest {
 
 }

--- a/integration-tests/solr/src/test/java/org/apache/camel/quarkus/component/solr/it/SolrIT.java
+++ b/integration-tests/solr/src/test/java/org/apache/camel/quarkus/component/solr/it/SolrIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.component.solr.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class SolrIT extends SolrTest {
 }

--- a/integration-tests/splunk/src/test/java/org/apache/camel/quarkus/component/splunk/it/SplunkIT.java
+++ b/integration-tests/splunk/src/test/java/org/apache/camel/quarkus/component/splunk/it/SplunkIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.splunk.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class SplunkIT extends SplunkTest {
 
 }

--- a/integration-tests/spring-rabbitmq/src/test/java/org/apache/camel/quarkus/component/spring/rabbitmq/it/SpringRabbitmqIT.java
+++ b/integration-tests/spring-rabbitmq/src/test/java/org/apache/camel/quarkus/component/spring/rabbitmq/it/SpringRabbitmqIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.spring.rabbitmq.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class SpringRabbitmqIT extends SpringRabbitmqTest {
 
 }

--- a/integration-tests/sql/src/test/java/org/apache/camel/quarkus/component/sql/it/SqlIT.java
+++ b/integration-tests/sql/src/test/java/org/apache/camel/quarkus/component/sql/it/SqlIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.sql.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class SqlIT extends SqlTest {
 
 }

--- a/integration-tests/ssh/src/test/java/org/apache/camel/quarkus/component/ssh/it/SshIT.java
+++ b/integration-tests/ssh/src/test/java/org/apache/camel/quarkus/component/ssh/it/SshIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.ssh.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class SshIT extends SshTest {
 
 }

--- a/integration-tests/stax/src/test/java/org/apache/camel/quarkus/component/stax/it/StaxIT.java
+++ b/integration-tests/stax/src/test/java/org/apache/camel/quarkus/component/stax/it/StaxIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.stax.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class StaxIT extends StaxTest {
 
 }

--- a/integration-tests/stringtemplate/src/test/java/org/apache/camel/quarkus/component/stringtemplate/it/StringtemplateIT.java
+++ b/integration-tests/stringtemplate/src/test/java/org/apache/camel/quarkus/component/stringtemplate/it/StringtemplateIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.stringtemplate.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class StringtemplateIT extends StringtemplateTest {
 
 }

--- a/integration-tests/syndication/src/test/java/org/apache/camel/quarkus/component/atom/it/AtomIT.java
+++ b/integration-tests/syndication/src/test/java/org/apache/camel/quarkus/component/atom/it/AtomIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.atom.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class AtomIT extends AtomTest {
 
 }

--- a/integration-tests/syndication/src/test/java/org/apache/camel/quarkus/component/rss/it/RssIT.java
+++ b/integration-tests/syndication/src/test/java/org/apache/camel/quarkus/component/rss/it/RssIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.rss.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class RssIT extends RssTest {
 
 }

--- a/integration-tests/syslog/src/test/java/org/apache/camel/quarkus/component/syslog/it/SyslogIT.java
+++ b/integration-tests/syslog/src/test/java/org/apache/camel/quarkus/component/syslog/it/SyslogIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.syslog.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class SyslogIT extends SyslogTest {
 
 }

--- a/integration-tests/tarfile/src/test/java/org/apache/camel/quarkus/component/tarfile/it/TarfileIT.java
+++ b/integration-tests/tarfile/src/test/java/org/apache/camel/quarkus/component/tarfile/it/TarfileIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.tarfile.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class TarfileIT extends TarfileTest {
 
 }

--- a/integration-tests/telegram/src/test/java/org/apache/camel/quarkus/component/telegram/it/TelegramIT.java
+++ b/integration-tests/telegram/src/test/java/org/apache/camel/quarkus/component/telegram/it/TelegramIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.telegram.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class TelegramIT extends TelegramTest {
 
 }

--- a/integration-tests/tika/src/test/java/org/apache/camel/quarkus/component/tika/it/TikaIT.java
+++ b/integration-tests/tika/src/test/java/org/apache/camel/quarkus/component/tika/it/TikaIT.java
@@ -16,11 +16,11 @@
  */
 package org.apache.camel.quarkus.component.tika.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 //https://github.com/apache/camel-quarkus/issues/3417
 @DisabledOnOs(OS.MAC)
 class TikaIT extends TikaTest {

--- a/integration-tests/twilio/src/test/java/org/apache/camel/quarkus/component/twilio/it/TwilioIT.java
+++ b/integration-tests/twilio/src/test/java/org/apache/camel/quarkus/component/twilio/it/TwilioIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.twilio.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class TwilioIT extends TwilioTest {
 
 }

--- a/integration-tests/twitter/src/test/java/org/apache/camel/quarkus/component/twitter/CamelTwitterIT.java
+++ b/integration-tests/twitter/src/test/java/org/apache/camel/quarkus/component/twitter/CamelTwitterIT.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.quarkus.component.twitter;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 @EnabledIfEnvironmentVariable(named = "TWITTER_CONSUMER_KEY", matches = "[a-zA-Z0-9]+")
 public class CamelTwitterIT extends CamelTwitterTest {
 

--- a/integration-tests/univocity-parsers/src/test/java/org/apache/camel/quarkus/component/univocity/parsers/it/UniVocityCsvDataFormatMarshalIT.java
+++ b/integration-tests/univocity-parsers/src/test/java/org/apache/camel/quarkus/component/univocity/parsers/it/UniVocityCsvDataFormatMarshalIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.univocity.parsers.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class UniVocityCsvDataFormatMarshalIT extends UniVocityCsvDataFormatMarshalTest {
 
 }

--- a/integration-tests/univocity-parsers/src/test/java/org/apache/camel/quarkus/component/univocity/parsers/it/UniVocityCsvDataFormatUnmarshalIT.java
+++ b/integration-tests/univocity-parsers/src/test/java/org/apache/camel/quarkus/component/univocity/parsers/it/UniVocityCsvDataFormatUnmarshalIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.univocity.parsers.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class UniVocityCsvDataFormatUnmarshalIT extends UniVocityCsvDataFormatUnmarshalTest {
 
 }

--- a/integration-tests/univocity-parsers/src/test/java/org/apache/camel/quarkus/component/univocity/parsers/it/UniVocityFixedWidthDataFormatMarshalIT.java
+++ b/integration-tests/univocity-parsers/src/test/java/org/apache/camel/quarkus/component/univocity/parsers/it/UniVocityFixedWidthDataFormatMarshalIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.univocity.parsers.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class UniVocityFixedWidthDataFormatMarshalIT extends UniVocityFixedWidthDataFormatMarshalTest {
 
 }

--- a/integration-tests/univocity-parsers/src/test/java/org/apache/camel/quarkus/component/univocity/parsers/it/UniVocityFixedWidthDataFormatUnmarshalIT.java
+++ b/integration-tests/univocity-parsers/src/test/java/org/apache/camel/quarkus/component/univocity/parsers/it/UniVocityFixedWidthDataFormatUnmarshalIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.univocity.parsers.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class UniVocityFixedWidthDataFormatUnmarshalIT extends UniVocityFixedWidthDataFormatUnmarshalTest {
 
 }

--- a/integration-tests/univocity-parsers/src/test/java/org/apache/camel/quarkus/component/univocity/parsers/it/UniVocityTsvDataFormatMarshalIT.java
+++ b/integration-tests/univocity-parsers/src/test/java/org/apache/camel/quarkus/component/univocity/parsers/it/UniVocityTsvDataFormatMarshalIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.univocity.parsers.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class UniVocityTsvDataFormatMarshalIT extends UniVocityTsvDataFormatMarshalTest {
 
 }

--- a/integration-tests/univocity-parsers/src/test/java/org/apache/camel/quarkus/component/univocity/parsers/it/UniVocityTsvDataFormatUnmarshalIT.java
+++ b/integration-tests/univocity-parsers/src/test/java/org/apache/camel/quarkus/component/univocity/parsers/it/UniVocityTsvDataFormatUnmarshalIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.univocity.parsers.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class UniVocityTsvDataFormatUnmarshalIT extends UniVocityTsvDataFormatUnmarshalTest {
 
 }

--- a/integration-tests/validator/src/test/java/org/apache/camel/quarkus/component/validator/it/ValidatorIT.java
+++ b/integration-tests/validator/src/test/java/org/apache/camel/quarkus/component/validator/it/ValidatorIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.validator.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class ValidatorIT extends ValidatorTest {
 
 }

--- a/integration-tests/velocity/src/test/java/org/apache/camel/quarkus/component/velocity/it/VelocityIT.java
+++ b/integration-tests/velocity/src/test/java/org/apache/camel/quarkus/component/velocity/it/VelocityIT.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.component.velocity.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class VelocityIT extends VelocityTest {
 }

--- a/integration-tests/vertx-websocket/src/test/java/org/apache/camel/quarkus/component/vertx/websocket/it/VertxWebsocketIT.java
+++ b/integration-tests/vertx-websocket/src/test/java/org/apache/camel/quarkus/component/vertx/websocket/it/VertxWebsocketIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.vertx.websocket.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class VertxWebsocketIT extends VertxWebsocketTest {
 
 }

--- a/integration-tests/vertx/src/test/java/org/apache/camel/quarkus/component/vertx/it/VertxIT.java
+++ b/integration-tests/vertx/src/test/java/org/apache/camel/quarkus/component/vertx/it/VertxIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.vertx.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class VertxIT extends VertxTest {
 
 }

--- a/integration-tests/weather/src/test/java/org/apache/camel/quarkus/component/weather/it/WeatherIT.java
+++ b/integration-tests/weather/src/test/java/org/apache/camel/quarkus/component/weather/it/WeatherIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.weather.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class WeatherIT extends WeatherTest {
 
 }

--- a/integration-tests/xchange/src/test/java/org/apache/camel/quarkus/component/xchange/it/XchangeIT.java
+++ b/integration-tests/xchange/src/test/java/org/apache/camel/quarkus/component/xchange/it/XchangeIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.xchange.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class XchangeIT extends XchangeTest {
 
 }

--- a/integration-tests/xml/src/test/java/org/apache/camel/quarkus/component/xml/it/XmlIT.java
+++ b/integration-tests/xml/src/test/java/org/apache/camel/quarkus/component/xml/it/XmlIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.xml.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class XmlIT extends XmlTest {
 
 }

--- a/integration-tests/xmlsecurity/src/test/java/org/apache/camel/quarkus/component/xmlsecurity/it/XmlsecurityIT.java
+++ b/integration-tests/xmlsecurity/src/test/java/org/apache/camel/quarkus/component/xmlsecurity/it/XmlsecurityIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.xmlsecurity.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class XmlsecurityIT extends XmlsecurityTest {
 
 }

--- a/integration-tests/xpath/src/test/java/org/apache/camel/quarkus/language/xpath/XPathIT.java
+++ b/integration-tests/xpath/src/test/java/org/apache/camel/quarkus/language/xpath/XPathIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.language.xpath;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class XPathIT extends XPathTest {
 
 }

--- a/integration-tests/xstream/src/test/java/org/apache/camel/quarkus/component/xstream/it/XstreamIT.java
+++ b/integration-tests/xstream/src/test/java/org/apache/camel/quarkus/component/xstream/it/XstreamIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.xstream.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class XstreamIT extends XstreamTest {
 
 }

--- a/integration-tests/zendesk/src/test/java/org/apache/camel/quarkus/component/zendesk/it/ZendeskIT.java
+++ b/integration-tests/zendesk/src/test/java/org/apache/camel/quarkus/component/zendesk/it/ZendeskIT.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.quarkus.component.zendesk.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class ZendeskIT extends ZendeskTest {
 
 }

--- a/tooling/create-extension-templates/IT.java
+++ b/tooling/create-extension-templates/IT.java
@@ -16,9 +16,9 @@
  */
 package [=javaPackageBase].it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class [=toCapCamelCase(artifactIdBase)]IT extends [=toCapCamelCase(artifactIdBase)]Test {
 
 }


### PR DESCRIPTION
In anticipation of `@NativeImageTest` deprecation in Quarkus 2.8.x.