### PR TITLE
Add KeyStoreParameters for reflection

### DIFF
--- a/extensions/salesforce/deployment/src/main/java/org/apache/camel/quarkus/component/salesforce/deployment/SalesforceProcessor.java
+++ b/extensions/salesforce/deployment/src/main/java/org/apache/camel/quarkus/component/salesforce/deployment/SalesforceProcessor.java
@@ -71,6 +71,6 @@ class SalesforceProcessor {
         reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, userDtoClasses));
         
         // Register KeyStoreParameters for reflection
-        new ReflectiveClassBuildItem(true, true, KeyStoreParameters.class);
+        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, KeyStoreParameters.class));
     }
 }

--- a/extensions/salesforce/deployment/src/main/java/org/apache/camel/quarkus/component/salesforce/deployment/SalesforceProcessor.java
+++ b/extensions/salesforce/deployment/src/main/java/org/apache/camel/quarkus/component/salesforce/deployment/SalesforceProcessor.java
@@ -23,6 +23,7 @@ import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import org.apache.camel.component.salesforce.api.dto.AbstractDTOBase;
+import org.apache.camel.support.jsse.KeyStoreParameters;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
 
@@ -68,5 +69,8 @@ class SalesforceProcessor {
                 .toArray(String[]::new);
 
         reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, userDtoClasses));
+        
+        // Register KeyStoreParameters for reflection
+        new ReflectiveClassBuildItem(true, true, KeyStoreParameters.class);
     }
 }

--- a/extensions/salesforce/deployment/src/main/java/org/apache/camel/quarkus/component/salesforce/deployment/SalesforceProcessor.java
+++ b/extensions/salesforce/deployment/src/main/java/org/apache/camel/quarkus/component/salesforce/deployment/SalesforceProcessor.java
@@ -69,7 +69,6 @@ class SalesforceProcessor {
                 .toArray(String[]::new);
 
         reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, userDtoClasses));
-        
         // Register KeyStoreParameters for reflection
         reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, KeyStoreParameters.class));
     }


### PR DESCRIPTION
Camel salesforce component uses KeyStoreParameters for OAuth JWT flow which is recommended way for production. [camel.component.salesforce.keystore](https://camel.apache.org/components/3.16.x/salesforce-component.html#_sb_option_camel_component_salesforce_keystore)

The problem is `org.apache.camel.support.jsse.KeyStoreParameters` is not in reflection list. So, if you want to use camel-salesforce with  OAuth JWT authantication, `KeyStoreParameters` class needs to be added [reflection-config.json](https://quarkus.io/guides/writing-native-applications-tips#including-resources).

Currently, SalesforceProcessor assumes every classes related about camel-salesforce starts with `org.apache.camel.component.salesforce` . But the `KeyStoreParameters` class is an exception and it has to be registered too.

Fixes #3754 