### PR TITLE
Add native support for Azure Identity service principal authentication

### DIFF
--- a/extensions-support/azure-core/deployment/src/main/java/org/apache/camel/quarkus/support/reactor/netty/deployment/AzureCoreSupportProcessor.java
+++ b/extensions-support/azure-core/deployment/src/main/java/org/apache/camel/quarkus/support/reactor/netty/deployment/AzureCoreSupportProcessor.java
@@ -46,6 +46,11 @@ public class AzureCoreSupportProcessor {
         reflectiveClasses.produce(new ReflectiveClassBuildItem(false, false,
                 com.azure.core.util.DateTimeRfc1123.class,
                 com.azure.core.http.rest.StreamResponse.class));
+
+        reflectiveClasses.produce(new ReflectiveClassBuildItem(false, true,
+                "com.microsoft.aad.msal4j.AadInstanceDiscoveryResponse",
+                "com.microsoft.aad.msal4j.InstanceDiscoveryMetadataEntry"));
+
     }
 
     @BuildStep


### PR DESCRIPTION
I will follow up later with a test(s) for this. I need to figure out a good strategy that allows us to test the different Azure authentication mechanisms.

For now, this enables service principal authentication to work in native mode.
