### PR TITLE
Fix intermittent native mode failures of JacksonJsonTest

### DIFF
--- a/integration-tests/dataformats-json/src/main/java/org/apache/camel/quarkus/component/dataformats/json/model/Person.java
+++ b/integration-tests/dataformats-json/src/main/java/org/apache/camel/quarkus/component/dataformats/json/model/Person.java
@@ -21,7 +21,7 @@ import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
-@RegisterForReflection(fields = false)
+@RegisterForReflection
 public class Person {
 
     @JsonProperty


### PR DESCRIPTION
Otherwise the JSON key ordering is non-deterministic, thus making assertions on the JSON string fail.