### PR TITLE
Fix doc reference to JUnit 5 component

### DIFF
--- a/docs/modules/ROOT/pages/user-guide/testing.adoc
+++ b/docs/modules/ROOT/pages/user-guide/testing.adoc
@@ -229,7 +229,7 @@ More examples of WireMock usage can be found in the Camel Quarkus integration te
 
 == `CamelTestSupport` style of testing
 
-If you used plain Camel before, you may know https://camel.apache.org/components/latest/others/test-junit5.html[CamelTestSupport] already.
+If you used plain Camel before, you may know xref:components:others:test-junit5.adoc[CamelTestSupport] already.
 Unfortunately the Camel variant won't work on Quarkus and so we prepared a replacement called `CamelQuarkusTestSupport`, which can be used in JVM mode.
 
 Please add following dependency into your module (preferably in the `test` scope), to use `CamelQuarkusTestSupport`.


### PR DESCRIPTION
Attempt to fix the following build error generating the documentation:

```
+ yarn checks
[check:html     ] 
[check:html     ] public/camel-quarkus/next/user-guide/testing.html
[check:html     ]   106:573  error  For links within camel.apache.org use relative links, found: https://camel.apache.org/components/latest/others/test-junit5.html  camel/relative-links
[check:html     ] 
[check:html     ] ✖ 1 problem (1 error, 0 warnings)
```

See: https://ci-builds.apache.org/job/Camel/job/Camel.website/job/main/936/console