### PR TITLE
Fix #3904 increase xslt extension test coverage

### DIFF
--- a/docs/modules/ROOT/pages/reference/extensions/xslt.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/xslt.adoc
@@ -59,7 +59,22 @@ quarkus.camel.xslt.sources = transform.xsl, classpath:path/to/my/file.xsl
 
 Scheme-less URIs are interpreted as `classpath:` URIs.
 
-Only `classpath:` URIs are supported on Quarkus. `file:`, `http:` and other kinds of URIs do not work by design.
+Only `classpath:` URIs are supported on Quarkus native mode. `file:`, `http:` and other kinds of URIs can be used on JVM mode only.
+
+`<xsl:include>` and `<xsl:messaging>` XSLT elements are also supported in JVM mode only right now.
+
+If `aggregate` DSL is used, `XsltSaxonAggregationStrategy` has to be used such as
+[source,java]
+----
+from("file:src/test/resources?noop=true&sortBy=file:name&antInclude=*.xml")
+   .routeId("aggregate").noAutoStartup()
+   .aggregate(new XsltSaxonAggregationStrategy("xslt/aggregate.xsl"))
+   .constant(true)
+   .completionFromBatchConsumer()
+   .log("after aggregate body: ${body}")
+   .to("mock:transformed");
+----
+Also, it's only supported on JVM mode.
 
 [id="extensions-xslt-configuration-configuration"]
 === Configuration
@@ -87,11 +102,6 @@ public class FunctionsConfiguration {
 ====
 The content of the XSLT source URIs is parsed and compiled into Java classes at build time. These Java classes are the
 only source of XSLT information at runtime. The XSLT source files may not be included in the application archive at all.
-====
-
-[WARNING]
-====
-the extension does not yet support Java 11.
 ====
 
 

--- a/extensions/xslt/runtime/src/main/doc/configuration.adoc
+++ b/extensions/xslt/runtime/src/main/doc/configuration.adoc
@@ -9,7 +9,22 @@ quarkus.camel.xslt.sources = transform.xsl, classpath:path/to/my/file.xsl
 
 Scheme-less URIs are interpreted as `classpath:` URIs.
 
-Only `classpath:` URIs are supported on Quarkus. `file:`, `http:` and other kinds of URIs do not work by design.
+Only `classpath:` URIs are supported on Quarkus native mode. `file:`, `http:` and other kinds of URIs can be used on JVM mode only.
+
+`<xsl:include>` and `<xsl:messaging>` XSLT elements are also supported in JVM mode only right now.
+
+If `aggregate` DSL is used, `XsltSaxonAggregationStrategy` has to be used such as
+[source,java]
+----
+from("file:src/test/resources?noop=true&sortBy=file:name&antInclude=*.xml")
+   .routeId("aggregate").noAutoStartup()
+   .aggregate(new XsltSaxonAggregationStrategy("xslt/aggregate.xsl"))
+   .constant(true)
+   .completionFromBatchConsumer()
+   .log("after aggregate body: ${body}")
+   .to("mock:transformed");
+----
+Also, it's only supported on JVM mode.
 
 === Configuration
 TransformerFactory features can be configured using following property:
@@ -35,9 +50,4 @@ public class FunctionsConfiguration {
 ====
 The content of the XSLT source URIs is parsed and compiled into Java classes at build time. These Java classes are the
 only source of XSLT information at runtime. The XSLT source files may not be included in the application archive at all.
-====
-
-[WARNING]
-====
-the extension does not yet support Java 11.
 ====

--- a/extensions/xslt/runtime/src/main/java/org/apache/camel/quarkus/component/xslt/RuntimeUriResolver.java
+++ b/extensions/xslt/runtime/src/main/java/org/apache/camel/quarkus/component/xslt/RuntimeUriResolver.java
@@ -57,14 +57,11 @@ public class RuntimeUriResolver implements URIResolver {
 
     /**
      * @param  uri the URI whose translet is seeked
-     * @return     the unqualified translet name associated with the given {@code uri}
+     * @return     the unqualified translet name associated with the given {@code uri} or
+     *             {@code null} if the given XSLT resource was not compiled to a translet at build time.
      */
     public String getTransletClassName(String uri) {
-        final String transletClassName = uriToTransletName.get(uri);
-        if (transletClassName == null) {
-            throw new RuntimeException("Could not resolve " + uri);
-        }
-        return transletClassName;
+        return uriToTransletName.get(uri);
     }
 
     /**

--- a/integration-tests/xml/pom.xml
+++ b/integration-tests/xml/pom.xml
@@ -37,6 +37,10 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-xslt-saxon</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-xpath</artifactId>
         </dependency>
         <dependency>
@@ -45,7 +49,19 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-bean</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-direct</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-file</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-mock</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
@@ -73,6 +89,11 @@
         <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-integration-wiremock-support</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/integration-tests/xml/src/main/java/org/apache/camel/quarkus/component/xml/it/XmlResource.java
+++ b/integration-tests/xml/src/main/java/org/apache/camel/quarkus/component/xml/it/XmlResource.java
@@ -21,13 +21,20 @@ import java.util.StringJoiner;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
+import org.apache.camel.CamelContext;
 import org.apache.camel.ConsumerTemplate;
+import org.apache.camel.Exchange;
 import org.apache.camel.ProducerTemplate;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.logging.Logger;
 
 @Path("/xml")
@@ -42,11 +49,34 @@ public class XmlResource {
     @Inject
     ConsumerTemplate consumerTemplate;
 
+    @Inject
+    CamelContext camelContext;
+
     @Path("/xslt")
     @POST
     @Produces(MediaType.TEXT_PLAIN)
-    public String classpath(String body) {
-        return producerTemplate.requestBody("xslt:xslt/classpath-transform.xsl", body, String.class);
+    public String classpath(@QueryParam("output") @DefaultValue("string") String output, String body) {
+        if (output.equals("file")) {
+            return producerTemplate.requestBodyAndHeader("xslt:xslt/classpath-transform.xsl?output=file",
+                    body, Exchange.XSLT_FILE_NAME, "target/xsltme.xml", String.class);
+        }
+        return producerTemplate.requestBody("xslt:xslt/classpath-transform.xsl?output=" + output, body, String.class);
+    }
+
+    @Path("/xslt_include")
+    @POST
+    @Produces(MediaType.TEXT_PLAIN)
+    public String xsltInclude(String body) {
+        return producerTemplate.requestBody("xslt:xslt/include.xsl", body, String.class);
+    }
+
+    @Path("/xslt_terminate")
+    @POST
+    @Produces(MediaType.TEXT_PLAIN)
+    public String xsltTerminate(String body) {
+        Exchange out = producerTemplate.request("xslt:xslt/terminate.xsl", exchange -> exchange.getIn().setBody(body));
+        Exception warning = out.getProperty(Exchange.XSLT_WARNING, Exception.class);
+        return warning.getMessage();
     }
 
     @Path("/xslt-extension-function")
@@ -54,6 +84,58 @@ public class XmlResource {
     @Produces(MediaType.TEXT_PLAIN)
     public String extensionFunction(String body) {
         return producerTemplate.requestBody("xslt:xslt/extension-function.xsl", body, String.class);
+    }
+
+    @Path("/xslt-custom-uri-resolver")
+    @POST
+    @Produces(MediaType.TEXT_PLAIN)
+    public String customURIResolver(String body) {
+        return producerTemplate.requestBody("xslt:xslt/include_not_existing_resource.xsl?uriResolver=#customURIResolver", body,
+                String.class);
+    }
+
+    @Path("/xslt-ref")
+    @POST
+    @Produces(MediaType.TEXT_PLAIN)
+    public String xsltRef(String body) {
+        return producerTemplate.requestBody("xslt:ref:xslt_resource", body, String.class);
+    }
+
+    @Path("/xslt-bean")
+    @POST
+    @Produces(MediaType.TEXT_PLAIN)
+    public String xsltBean(String body) {
+        return producerTemplate.requestBody("xslt:bean:xslt_bean.getXsltResource", body, String.class);
+    }
+
+    @Path("/xslt-file")
+    @POST
+    @Produces(MediaType.TEXT_PLAIN)
+    public String xsltFile(String body) {
+        return producerTemplate.requestBody("xslt:file:src/main/resources/xslt/classpath-transform.xsl", body, String.class);
+    }
+
+    @Path("/xslt-http")
+    @POST
+    @Produces(MediaType.TEXT_PLAIN)
+    public String xsltHttp(String body) {
+        String serverURL = ConfigProvider.getConfig()
+                .getConfigValue("xslt.server-url")
+                .getRawValue();
+        return producerTemplate.requestBody("xslt:" + serverURL + "/xslt", body, String.class);
+    }
+
+    @Path("/aggregate")
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String aggregate() throws Exception {
+        MockEndpoint mock = camelContext.getEndpoint("mock:transformed", MockEndpoint.class);
+        mock.expectedMessageCount(1);
+        camelContext.getRouteController().startRoute("aggregate");
+
+        mock.assertIsSatisfied();
+        return mock.getExchanges().get(0).getIn().getBody(String.class);
+
     }
 
     @Path("/html-transform")

--- a/integration-tests/xml/src/main/java/org/apache/camel/quarkus/component/xml/it/XsltProducers.java
+++ b/integration-tests/xml/src/main/java/org/apache/camel/quarkus/component/xml/it/XsltProducers.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.quarkus.component.xml.it;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.xml.transform.Source;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.URIResolver;
+import javax.xml.transform.stream.StreamSource;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.support.ResourceHelper;
+
+@Dependent
+public class XsltProducers {
+    public static final String EXPECTED_XML_CONSTANT = "<data>FOO DATA</data>";
+    @Inject
+    CamelContext context;
+
+    @Named("customURIResolver")
+    public URIResolver getCustomURIResolver() {
+        return new URIResolver() {
+
+            @Override
+            public Source resolve(String href, String base) throws TransformerException {
+                if (href.equals("xslt/include_not_existing_resource.xsl")) {
+                    try {
+                        InputStream is = ResourceHelper.resolveMandatoryResourceAsInputStream(context, href);
+                        return new StreamSource(is);
+                    } catch (Exception e) {
+                        throw new TransformerException(e);
+                    }
+                }
+
+                Source constantResult = new StreamSource(new ByteArrayInputStream(EXPECTED_XML_CONSTANT.getBytes()));
+                return constantResult;
+            }
+        };
+    }
+
+    @Named("xslt_resource")
+    public String getXsltResource() throws Exception {
+        return getXsltContent();
+    }
+
+    @Named("xslt_bean")
+    public XsltBean getXsltBean() {
+        return new XsltBean();
+    }
+
+    public static class XsltBean {
+        public String getXsltResource() throws Exception {
+            return getXsltContent();
+        }
+    }
+
+    private static String getXsltContent() throws Exception {
+        try (InputStream in = Thread.currentThread().getContextClassLoader()
+                .getResourceAsStream("xslt/classpath-transform.xsl")) {
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+}

--- a/integration-tests/xml/src/main/resources/application.properties
+++ b/integration-tests/xml/src/main/resources/application.properties
@@ -23,5 +23,5 @@ quarkus.log.category."org.apache.camel.quarkus.core.deployment".level = INFO
 #
 # Quarkus - Camel
 #
-quarkus.camel.xslt.sources = xslt/classpath-transform.xsl,xslt/html-transform.xsl,xslt/html-to-text.xsl,xslt/extension-function.xsl
+quarkus.camel.xslt.sources = xslt/classpath-transform.xsl,xslt/html-transform.xsl,xslt/html-to-text.xsl,xslt/extension-function.xsl,xslt/include_not_existing_resource.xsl,xslt/aggregate.xsl,xslt/terminate.xsl
 quarkus.camel.xslt.features."http\://javax.xml.XMLConstants/feature/secure-processing" = false

--- a/integration-tests/xml/src/main/resources/xslt/aggregate.xsl
+++ b/integration-tests/xml/src/main/resources/xslt/aggregate.xsl
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+    <xsl:output method="xml" indent="no"/>
+    <xsl:strip-space elements="*"/>
+
+    <xsl:param name="new-exchange" />
+
+    <xsl:template match="/">
+        <item>
+            <xsl:value-of select="."/>
+            <xsl:value-of select="$new-exchange/item"/>
+        </item>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/integration-tests/xml/src/main/resources/xslt/include.xsl
+++ b/integration-tests/xml/src/main/resources/xslt/include.xsl
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<xsl:stylesheet
+        xmlns:xsl='http://www.w3.org/1999/XSL/Transform'
+        version='1.0'>
+
+    <xsl:include href="classpath-transform.xsl"/>
+
+</xsl:stylesheet>

--- a/integration-tests/xml/src/main/resources/xslt/include_not_existing_resource.xsl
+++ b/integration-tests/xml/src/main/resources/xslt/include_not_existing_resource.xsl
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<xsl:stylesheet
+        xmlns:xsl='http://www.w3.org/1999/XSL/Transform'
+        version='1.0'>
+
+    <xsl:output method="xml" indent="yes" encoding="ISO-8859-1"/>
+
+    <xsl:template match="/">
+        <xsl:copy-of select="document('notExistingExternalFile.xml')"/>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/integration-tests/xml/src/main/resources/xslt/terminate.xsl
+++ b/integration-tests/xml/src/main/resources/xslt/terminate.xsl
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+  <xsl:template match="/">
+    <html>
+      <body>
+        <xsl:for-each select="staff/programmer">
+          <p>Name: <xsl:value-of select="name"/><br />
+            <xsl:if test="dob=''">
+              <xsl:message terminate="yes">Error: DOB is an empty string!</xsl:message>
+            </xsl:if>
+          </p>
+        </xsl:for-each>
+      </body>
+    </html>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/integration-tests/xml/src/test/java/org/apache/camel/quarkus/component/xml/it/XmlTestResource.java
+++ b/integration-tests/xml/src/test/java/org/apache/camel/quarkus/component/xml/it/XmlTestResource.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.xml.it;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+
+public class XmlTestResource implements QuarkusTestResourceLifecycleManager {
+    private WireMockServer server;
+
+    @Override
+    public Map<String, String> start() {
+        try (InputStream in = Thread.currentThread().getContextClassLoader()
+                .getResourceAsStream("xslt/classpath-transform.xsl")) {
+            server = new WireMockServer(WireMockConfiguration.DYNAMIC_PORT);
+            server.start();
+            server.stubFor(
+                    get(urlEqualTo("/xslt"))
+                            .willReturn(aResponse()
+                                    .withHeader("Content-Type", "application/XML")
+                                    .withBody(new String(in.readAllBytes(), StandardCharsets.UTF_8))));
+            Map<String, String> conf = new HashMap<>();
+            conf.put("xslt.server-url", server.baseUrl());
+            return conf;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void stop() {
+        if (server != null) {
+            server.stop();
+        }
+    }
+}

--- a/integration-tests/xml/src/test/resources/data1.xml
+++ b/integration-tests/xml/src/test/resources/data1.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<item>A</item>

--- a/integration-tests/xml/src/test/resources/data2.xml
+++ b/integration-tests/xml/src/test/resources/data2.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<item>B</item>

--- a/integration-tests/xml/src/test/resources/data3.xml
+++ b/integration-tests/xml/src/test/resources/data3.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<item>C</item>


### PR DESCRIPTION
- [x] Add `ref`, `bean`, `http`, `file` schemas which could only work in jvm mode since generating xslt template classes dynamically does not be supported in native mode.
- [x] Different outputs (string, bytes, dom, file)
- [x] Using xsl:include to include files
- [x] Add aggergate test
- [x] Add custom URIResolver 
- [ ] Caching
- [x] Being able to raise errors with xsl:message and messages getting into `Exchange.XSLT_ERROR`, `Exchange.XSLT_FATAL_ERROR`, or `Exchange.XSLT_WARNING`
- [x] Update the documents