### PR TITLE
Pass encrypt property to Debezium MS SQL Server JDBC URL

### DIFF
--- a/integration-tests/debezium/src/main/java/org/apache/camel/quarkus/component/debezium/common/it/AbstractDebeziumResource.java
+++ b/integration-tests/debezium/src/main/java/org/apache/camel/quarkus/component/debezium/common/it/AbstractDebeziumResource.java
@@ -61,13 +61,13 @@ public abstract class AbstractDebeziumResource {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public Map<String, String> getAdditionalProperties() {
-        DebeziumEndpoint endpoint = (DebeziumEndpoint) camelContext.getEndpoint(getEndpointUrl()
+        DebeziumEndpoint<?> endpoint = (DebeziumEndpoint<?>) camelContext.getEndpoint(getEndpointUrl()
                 + "&additionalProperties.database.connectionTimeZone=CET");
         return endpoint.getConfiguration().getAdditionalProperties().entrySet().stream()
                 .collect(Collectors.toMap(Map.Entry::getKey, e -> (String) e.getValue()));
     }
 
-    String getEndpoinUrl(String hostname, String port, String username, String password, String databaseServerName,
+    String getEndpointUrl(String hostname, String port, String username, String password, String databaseServerName,
             String offsetStorageFileName) {
         return type.getComponent() + ":localhost?"
                 + "databaseHostname=" + hostname
@@ -117,7 +117,7 @@ public abstract class AbstractDebeziumResource {
     }
 
     protected String getEndpointUrl() {
-        String endpoint = getEndpoinUrl(
+        String endpoint = getEndpointUrl(
                 config.getValue(type.getPropertyHostname(), String.class),
                 config.getValue(type.getPropertyPort(), String.class),
                 config.getValue(type.getPropertyUsername(), String.class),

--- a/integration-tests/debezium/src/main/java/org/apache/camel/quarkus/component/debezium/common/it/DebeziumMongodbResource.java
+++ b/integration-tests/debezium/src/main/java/org/apache/camel/quarkus/component/debezium/common/it/DebeziumMongodbResource.java
@@ -63,7 +63,7 @@ public class DebeziumMongodbResource extends AbstractDebeziumResource {
     }
 
     @Override
-    String getEndpoinUrl(String hostname, String port, String username, String password, String databaseServerName,
+    String getEndpointUrl(String hostname, String port, String username, String password, String databaseServerName,
             String offsetStorageFileName) {
         return Type.mongodb.getComponent() + ":localhost?"
                 + "offsetStorageFileName=" + offsetStorageFileName

--- a/integration-tests/debezium/src/main/java/org/apache/camel/quarkus/component/debezium/common/it/DebeziumMysqlResource.java
+++ b/integration-tests/debezium/src/main/java/org/apache/camel/quarkus/component/debezium/common/it/DebeziumMysqlResource.java
@@ -58,10 +58,10 @@ public class DebeziumMysqlResource extends AbstractDebeziumResource {
     }
 
     @Override
-    String getEndpoinUrl(String hostname, String port, String username, String password, String databaseServerName,
+    String getEndpointUrl(String hostname, String port, String username, String password, String databaseServerName,
             String offsetStorageFileName) {
         //use root user to get all required privileges
-        return super.getEndpoinUrl(hostname, port, DB_ROOT_USERNAME, password, databaseServerName, offsetStorageFileName)
+        return super.getEndpointUrl(hostname, port, DB_ROOT_USERNAME, password, databaseServerName, offsetStorageFileName)
                 //and add specific parameters
                 + "&databaseServerId=223344"
                 + "&databaseHistoryFileFilename=" + config.getValue(PROPERTY_DB_HISTORY_FILE, String.class);

--- a/integration-tests/debezium/src/main/java/org/apache/camel/quarkus/component/debezium/common/it/DebeziumPostgresResource.java
+++ b/integration-tests/debezium/src/main/java/org/apache/camel/quarkus/component/debezium/common/it/DebeziumPostgresResource.java
@@ -47,9 +47,9 @@ public class DebeziumPostgresResource extends AbstractDebeziumResource {
     }
 
     @Override
-    String getEndpoinUrl(String hostname, String port, String username, String password, String databaseServerName,
+    String getEndpointUrl(String hostname, String port, String username, String password, String databaseServerName,
             String offsetStorageFileName) {
-        return super.getEndpoinUrl(hostname, port, username, password, databaseServerName, offsetStorageFileName)
+        return super.getEndpointUrl(hostname, port, username, password, databaseServerName, offsetStorageFileName)
                 + "&databaseDbname=" + DB_NAME;
     }
 }

--- a/integration-tests/debezium/src/main/java/org/apache/camel/quarkus/component/debezium/common/it/DebeziumSqlserverResource.java
+++ b/integration-tests/debezium/src/main/java/org/apache/camel/quarkus/component/debezium/common/it/DebeziumSqlserverResource.java
@@ -24,6 +24,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
 import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 @Path("/debezium-sqlserver")
 @ApplicationScoped
@@ -33,6 +34,9 @@ public class DebeziumSqlserverResource extends AbstractDebeziumResource {
             + "_databaseHistoryFileFilename";
 
     public static final String DB_NAME = "testDB";
+
+    @ConfigProperty(name = "sqlserver.encrypt", defaultValue = "false")
+    Boolean encryptConnection;
 
     @Inject
     Config config;
@@ -65,6 +69,7 @@ public class DebeziumSqlserverResource extends AbstractDebeziumResource {
             String offsetStorageFileName) {
         return super.getEndpoinUrl(hostname, port, username, password, databaseServerName, offsetStorageFileName)
                 + "&databaseDbname=" + DB_NAME
-                + "&databaseHistoryFileFilename=" + config.getValue(PROPERTY_DB_HISTORY_FILE, String.class);
+                + "&databaseHistoryFileFilename=" + config.getValue(PROPERTY_DB_HISTORY_FILE, String.class)
+                + "&additionalProperties.database.encrypt=" + encryptConnection;
     }
 }

--- a/integration-tests/debezium/src/main/java/org/apache/camel/quarkus/component/debezium/common/it/DebeziumSqlserverResource.java
+++ b/integration-tests/debezium/src/main/java/org/apache/camel/quarkus/component/debezium/common/it/DebeziumSqlserverResource.java
@@ -65,9 +65,9 @@ public class DebeziumSqlserverResource extends AbstractDebeziumResource {
     }
 
     @Override
-    String getEndpoinUrl(String hostname, String port, String username, String password, String databaseServerName,
+    String getEndpointUrl(String hostname, String port, String username, String password, String databaseServerName,
             String offsetStorageFileName) {
-        return super.getEndpoinUrl(hostname, port, username, password, databaseServerName, offsetStorageFileName)
+        return super.getEndpointUrl(hostname, port, username, password, databaseServerName, offsetStorageFileName)
                 + "&databaseDbname=" + DB_NAME
                 + "&databaseHistoryFileFilename=" + config.getValue(PROPERTY_DB_HISTORY_FILE, String.class)
                 + "&additionalProperties.database.encrypt=" + encryptConnection;

--- a/integration-tests/debezium/src/test/java/org/apache/camel/quarkus/component/debezium/common/it/AbstractDebeziumTestResource.java
+++ b/integration-tests/debezium/src/test/java/org/apache/camel/quarkus/component/debezium/common/it/AbstractDebeziumTestResource.java
@@ -32,7 +32,8 @@ import org.testcontainers.utility.TestcontainersConfiguration;
  * Abstract parent for debezium test resources.
  * Parent starts using abstract method.
  */
-public abstract class AbstractDebeziumTestResource<T extends GenericContainer> implements QuarkusTestResourceLifecycleManager {
+public abstract class AbstractDebeziumTestResource<T extends GenericContainer<?>>
+        implements QuarkusTestResourceLifecycleManager {
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractDebeziumTestResource.class);
 
     protected T container;
@@ -64,7 +65,7 @@ public abstract class AbstractDebeziumTestResource<T extends GenericContainer> i
             startContainer();
 
             Map<String, String> map = CollectionHelper.mapOf(
-                    type.getPropertyHostname(), container.getContainerIpAddress(),
+                    type.getPropertyHostname(), container.getHost(),
                     type.getPropertyPort(), container.getMappedPort(getPort()) + "",
                     type.getPropertyOffsetFileName(), storeFile.toString(),
                     type.getPropertyJdbc(), getJdbcUrl());

--- a/integration-tests/debezium/src/test/java/org/apache/camel/quarkus/component/debezium/common/it/mongodb/DebeziumMongodbTest.java
+++ b/integration-tests/debezium/src/test/java/org/apache/camel/quarkus/component/debezium/common/it/mongodb/DebeziumMongodbTest.java
@@ -32,7 +32,6 @@ import org.apache.camel.quarkus.component.debezium.common.it.Type;
 import org.bson.Document;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
-import org.jboss.logging.Logger;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -52,11 +51,9 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 @QuarkusTestResource(DebeziumMongodbTestResource.class)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class DebeziumMongodbTest extends AbstractDebeziumTest {
-    private static final Logger LOG = Logger.getLogger(DebeziumMongodbTest.class);
-
     private static MongoClient mongoClient;
 
-    private static MongoCollection companies;
+    private static MongoCollection<Document> companies;
 
     public DebeziumMongodbTest() {
         super(Type.mongodb);

--- a/integration-tests/debezium/src/test/java/org/apache/camel/quarkus/component/debezium/common/it/mysql/DebeziumMysqlTest.java
+++ b/integration-tests/debezium/src/test/java/org/apache/camel/quarkus/component/debezium/common/it/mysql/DebeziumMysqlTest.java
@@ -27,7 +27,6 @@ import org.apache.camel.quarkus.component.debezium.common.it.AbstractDebeziumTes
 import org.apache.camel.quarkus.component.debezium.common.it.Type;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
-import org.jboss.logging.Logger;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
@@ -40,8 +39,6 @@ import org.junit.jupiter.api.TestMethodOrder;
 @QuarkusTestResource(DebeziumMysqlTestResource.class)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class DebeziumMysqlTest extends AbstractDebeziumTest {
-    private static final Logger LOG = Logger.getLogger(DebeziumMysqlTest.class);
-
     private static Connection connection;
 
     public DebeziumMysqlTest() {

--- a/integration-tests/debezium/src/test/java/org/apache/camel/quarkus/component/debezium/common/it/mysql/DebeziumMysqlTestResource.java
+++ b/integration-tests/debezium/src/test/java/org/apache/camel/quarkus/component/debezium/common/it/mysql/DebeziumMysqlTestResource.java
@@ -29,7 +29,7 @@ import org.apache.camel.quarkus.component.debezium.common.it.Type;
 import org.jboss.logging.Logger;
 import org.testcontainers.containers.MySQLContainer;
 
-public class DebeziumMysqlTestResource extends AbstractDebeziumTestResource<MySQLContainer> {
+public class DebeziumMysqlTestResource extends AbstractDebeziumTestResource<MySQLContainer<?>> {
     private static final Logger LOG = Logger.getLogger(DebeziumMysqlTestResource.class);
 
     public static final String DB_NAME = "test";

--- a/integration-tests/debezium/src/test/java/org/apache/camel/quarkus/component/debezium/common/it/postgres/DebeziumPostgresTestResource.java
+++ b/integration-tests/debezium/src/test/java/org/apache/camel/quarkus/component/debezium/common/it/postgres/DebeziumPostgresTestResource.java
@@ -23,7 +23,7 @@ import org.apache.camel.quarkus.component.debezium.common.it.Type;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
-public class DebeziumPostgresTestResource extends AbstractDebeziumTestResource<PostgreSQLContainer> {
+public class DebeziumPostgresTestResource extends AbstractDebeziumTestResource<PostgreSQLContainer<?>> {
 
     public static final String DB_USERNAME = "postgres";
     public static final String DB_PASSWORD = "changeit";
@@ -35,7 +35,7 @@ public class DebeziumPostgresTestResource extends AbstractDebeziumTestResource<P
     }
 
     @Override
-    protected PostgreSQLContainer createContainer() {
+    protected PostgreSQLContainer<?> createContainer() {
         DockerImageName imageName = DockerImageName.parse(POSTGRES_IMAGE)
                 .asCompatibleSubstituteFor("postgres");
         return new PostgreSQLContainer<>(imageName)
@@ -47,11 +47,9 @@ public class DebeziumPostgresTestResource extends AbstractDebeziumTestResource<P
 
     @Override
     protected String getJdbcUrl() {
-        final String jdbcUrl = "jdbc:postgresql://" + container.getContainerIpAddress() + ":"
+        return "jdbc:postgresql://" + container.getHost() + ":"
                 + container.getMappedPort(DB_PORT) + "/" + DebeziumPostgresResource.DB_NAME + "?user="
                 + DB_USERNAME + "&password=" + DB_PASSWORD;
-
-        return jdbcUrl;
     }
 
     @Override

--- a/integration-tests/debezium/src/test/java/org/apache/camel/quarkus/component/debezium/common/it/sqlserver/DebeziumSqlserverTestResource.java
+++ b/integration-tests/debezium/src/test/java/org/apache/camel/quarkus/component/debezium/common/it/sqlserver/DebeziumSqlserverTestResource.java
@@ -30,12 +30,14 @@ import org.apache.camel.quarkus.component.debezium.common.it.Type;
 import org.jboss.logging.Logger;
 import org.testcontainers.containers.MSSQLServerContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
 
-public class DebeziumSqlserverTestResource extends AbstractDebeziumTestResource<MSSQLServerContainer> {
+import static org.testcontainers.containers.MSSQLServerContainer.IMAGE;
+
+public class DebeziumSqlserverTestResource extends AbstractDebeziumTestResource<MSSQLServerContainer<?>> {
     private static final Logger LOG = Logger.getLogger(DebeziumSqlserverTestResource.class);
-
-    private static int DB_PORT = 1433;
-
+    private static final DockerImageName DOCKER_IMAGE_NAME = DockerImageName.parse(IMAGE).withTag("2017-CU12");
+    private static final int DB_PORT = 1433;
     private Path historyFile;
 
     public DebeziumSqlserverTestResource() {
@@ -43,8 +45,9 @@ public class DebeziumSqlserverTestResource extends AbstractDebeziumTestResource<
     }
 
     @Override
-    protected MSSQLServerContainer createContainer() {
-        return new MSSQLServerContainer<>().withEnv(Collections.singletonMap("MSSQL_AGENT_ENABLED", "True"))
+    protected MSSQLServerContainer<?> createContainer() {
+        return new MSSQLServerContainer<>(DOCKER_IMAGE_NAME)
+                .withEnv(Collections.singletonMap("MSSQL_AGENT_ENABLED", "True"))
                 .withInitScript("initSqlserver.sql")
                 .waitingFor(
                         Wait.forLogMessage(".*xp_sqlagent_notify.*", 1));
@@ -96,10 +99,8 @@ public class DebeziumSqlserverTestResource extends AbstractDebeziumTestResource<
 
     @Override
     protected String getJdbcUrl() {
-        final String jdbcUrl = container.getJdbcUrl() + ";databaseName=testDB;user=" + getUsername() + ";password="
+        return container.getJdbcUrl() + ";databaseName=testDB;user=" + getUsername() + ";password="
                 + getPassword();
-
-        return jdbcUrl;
     }
 
     @Override


### PR DESCRIPTION
I took the liberty of adding `acceptLicense()` to the MS SQL Server container setup so that we can always have the SQL Sever tests run by default. Hopefully there's no issues with us doing that.