### PR TITLE
Fix conflict in property name with OS env variable

### DIFF
--- a/integration-tests/quartz-clustered/src/main/java/org/apache/camel/quarkus/component/quartz/it/QuartzClusteredResource.java
+++ b/integration-tests/quartz-clustered/src/main/java/org/apache/camel/quarkus/component/quartz/it/QuartzClusteredResource.java
@@ -49,7 +49,7 @@ public class QuartzClusteredResource {
             @Override
             public void configure() {
                 from("quartz:camel-quarkus/1 * * * *")
-                        .log("Hello from {{node.name}}");
+                        .log("Hello from {{quartz.node.name}}");
             }
         });
     }

--- a/integration-tests/quartz-clustered/src/main/java/org/apache/camel/quarkus/component/quartz/it/QuartzClusteredRoutes.java
+++ b/integration-tests/quartz-clustered/src/main/java/org/apache/camel/quarkus/component/quartz/it/QuartzClusteredRoutes.java
@@ -23,14 +23,14 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 @ApplicationScoped
 public class QuartzClusteredRoutes extends RouteBuilder {
-    @ConfigProperty(name = "node.name")
+    @ConfigProperty(name = "quartz.node.name")
     String nodeName;
 
     @Override
     public void configure() {
         if (nodeName.equals("NodeB")) {
             from("quartz:camel-quarkus/1 * * * *").routeId("clustered")
-                    .log("Hello from {{node.name}}");
+                    .log("Hello from {{quartz.node.name}}");
         }
     }
 }

--- a/integration-tests/quartz-clustered/src/main/resources/application.properties
+++ b/integration-tests/quartz-clustered/src/main/resources/application.properties
@@ -36,4 +36,4 @@ quarkus.flyway.baseline-on-migrate = true
 quarkus.flyway.baseline-version = 1.0
 quarkus.flyway.baseline-description = Quartz
 
-node.name = NodeA
+quartz.node.name = NodeA

--- a/integration-tests/quartz-clustered/src/test/java/org/apache/camel/quarkus/component/quartz/it/QuartzClusteredTest.java
+++ b/integration-tests/quartz-clustered/src/test/java/org/apache/camel/quarkus/component/quartz/it/QuartzClusteredTest.java
@@ -57,7 +57,7 @@ class QuartzClusteredTest {
 
         // Start secondary application process
         QuarkusProcessExecutor quarkusProcessExecutor = new QuarkusProcessExecutor(
-                "-Dnode.name=NodeB",
+                "-Dquartz.node.name=NodeB",
                 "-Dnode.autostart=true",
                 "-Dquarkus.log.file.path=" + QUARKUS_LOG,
                 "-Dquarkus.datasource.jdbc.url=" + jdbcUrl,


### PR DESCRIPTION
Previous property `node.name` clash with Jenkins ENV variable.