### PR TITLE
Enlarge timeout for Keycloak startup

### DIFF
--- a/integration-tests/kafka-oauth/src/test/java/org/apache/camel/quarkus/kafka/oauth/it/KafkaKeycloakTestResource.java
+++ b/integration-tests/kafka-oauth/src/test/java/org/apache/camel/quarkus/kafka/oauth/it/KafkaKeycloakTestResource.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.quarkus.kafka.oauth.it;
 
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -42,6 +43,7 @@ public class KafkaKeycloakTestResource implements QuarkusTestResourceLifecycleMa
 
         //Start keycloak container
         keycloak = new KeycloakContainer();
+        keycloak.withStartupTimeout(Duration.ofMinutes(5));
         keycloak.start();
         log.info(keycloak.getLogs());
         keycloak.createHostsFile();


### PR DESCRIPTION
The test fails on RHEL because of slow Keycloak startup.