### PR TITLE
CamelQuarkusTestSupport: Alow to use AdiceWith with another route #4104

### DIFF
--- a/docs/modules/ROOT/pages/user-guide/testing.adoc
+++ b/docs/modules/ROOT/pages/user-guide/testing.adoc
@@ -259,6 +259,7 @@ Be aware that execution of method `doAfterConstruct` differs from the execution 
 * Camel Quarkus executes the production of beans during the build phase. Because all the tests are
 build together, exclusion behavior is implemented into `CamelQuarkusTestSupport`. If a producer of the specific type and name is used in one tests, the instance will be the same for the rest of the tests.
 * JUnit Jupiter callbacks (`BeforeEachCallback`, `AfterEachCallback`, `AfterAllCallback`, `BeforeAllCallback`, `BeforeTestExecutionCallback` and `AfterTestExecutionCallback`) might not work correctly. See the https://quarkus.io/guides/getting-started-testing#enrichment-via-quarkustestcallback[documentation].
+* If there is an unaffected route, when using advice with, it's important to execute method `CamelQuarkusTestSupport.startRouteDefinitions()` manually from the unit test after you are done doing all the advice with
 
 
 [source,java]

--- a/test-framework/junit5/src/main/java/org/apache/camel/quarkus/test/CamelQuarkusTestSupport.java
+++ b/test-framework/junit5/src/main/java/org/apache/camel/quarkus/test/CamelQuarkusTestSupport.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.quarkus.test;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import javax.inject.Inject;
@@ -24,6 +25,7 @@ import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.callback.QuarkusTestContext;
 import io.quarkus.test.junit.callback.QuarkusTestMethodContext;
 import org.apache.camel.CamelContext;
+import org.apache.camel.Route;
 import org.apache.camel.Service;
 import org.apache.camel.model.ModelCamelContext;
 import org.apache.camel.model.RouteDefinition;
@@ -306,4 +308,31 @@ public class CamelQuarkusTestSupport extends CamelTestSupport
     protected final void startCamelContext() {
         //context has already started
     }
+
+    /**
+     * Override when using <a href="http://camel.apache.org/advicewith.html">advice with</a> and return <tt>true</tt>.
+     * This helps knowing advice with is to be used.
+     * <p/>
+     * <b>Important:</b> Its important to execute method {@link #startRouteDefinitions()}} manually from the unit test
+     * after you are done doing all the advice with.
+     *
+     * @return <tt>true</tt> if you use advice with in your unit tests.
+     */
+    @Override
+    public boolean isUseAdviceWith() {
+        return false;
+    }
+
+    /**
+     * Helper method to start routeDefinitions (to be used with `adviceWith`).
+     */
+    protected void startRouteDefinitions() throws Exception {
+        List<RouteDefinition> definitions = new ArrayList<>(context.adapt(ModelCamelContext.class).getRouteDefinitions());
+        for (Route r : context.getRoutes()) {
+            //existing route does not need to be started
+            definitions.remove(r.getRoute());
+        }
+        context.adapt(ModelCamelContext.class).startRouteDefinitions(definitions);
+    }
+
 }

--- a/test-framework/junit5/src/test/java/org/apache/camel/quarkus/test/junit5/patterns/AdviceWithAnotherRouteTest.java
+++ b/test-framework/junit5/src/test/java/org/apache/camel/quarkus/test/junit5/patterns/AdviceWithAnotherRouteTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.test.junit5.patterns;
+
+import java.util.Properties;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import org.apache.camel.Endpoint;
+import org.apache.camel.builder.AdviceWith;
+import org.apache.camel.builder.AdviceWithRouteBuilder;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.model.ModelCamelContext;
+import org.apache.camel.quarkus.test.CamelQuarkusTestSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@TestProfile(AdviceWithAnotherRouteTest.class)
+public class AdviceWithAnotherRouteTest extends CamelQuarkusTestSupport {
+
+    @Override
+    public boolean isUseAdviceWith() {
+        return true;
+    }
+
+    @BeforeEach
+    public void doSomethingBefore() throws Exception {
+        AdviceWithRouteBuilder mocker = new AdviceWithRouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                replaceFromWith("direct:sftp");
+
+                interceptSendToEndpoint("file:*").skipSendToOriginalEndpoint().to("mock:file");
+            }
+        };
+        AdviceWith.adviceWith(this.context.adapt(ModelCamelContext.class).getRouteDefinition("myRoute"), this.context, mocker);
+
+        startRouteDefinitions();
+    }
+
+    @Override
+    protected Properties useOverridePropertiesWithPropertiesComponent() {
+        Properties pc = new Properties();
+        pc.put("ftp.username", "scott");
+        pc.put("ftp.password", "tiger");
+        return pc;
+    }
+
+    @Test
+    public void testOverride() throws Exception {
+
+        getMockEndpoint("mock:file").expectedMessageCount(1);
+        getMockEndpoint("mock:result").expectedMessageCount(1);
+        template.sendBody("direct:start", "Haha");
+        template.sendBody("direct:sftp", "Hello World");
+        Endpoint endpoint = getMockEndpoint("mock:start", true);
+        System.out.println(endpoint);
+
+        assertMockEndpointsSatisfied();
+    }
+
+    @Override
+    protected RouteBuilder[] createRouteBuilders() {
+        return new RouteBuilder[] { new RouteBuilder() {
+            public void configure() {
+                from("direct:start").to("mock:result");
+            }
+        }, new RouteBuilder() {
+            public void configure() {
+                from("ftp:somepath?username={{ftp.username}}&password={{ftp.password}}").routeId("myRoute")
+                        .log("{{ftp.username}} is hahah")
+                        .to("file:target/out");
+            }
+        } };
+    }
+}


### PR DESCRIPTION
fixes https://github.com/apache/camel-quarkus/issues/4104

New helper method `startRouteDefinitions` was added into `CamelQuarkusTestSupport` to enable this usecase. Use of the method is described in the javadoc.


<!-- Uncomment and fill this section if your PR is not trivial
[ ] An issue should be filed for the change unless this is a trivial change (fixing a typo or similar). One issue should ideally be fixed by not more than one commit and the other way round, each commit should fix just one issue, without pulling in other changes.
[ ] Each commit in the pull request should have a meaningful and properly spelled subject line and body. Copying the title of the associated issue is typically enough. Please include the issue number in the commit message prefixed by #.
[ ] The pull request description should explain what the pull request does, how, and why. If the info is available in the associated issue or some other external document, a link is enough.
[ ] Phrases like Fix #<issueNumber> or Fixes #<issueNumber> will auto-close the named issue upon merging the pull request. Using them is typically a good idea.
[ ] Please run mvn process-resources -Pformat (and amend the changes if necessary) before sending the pull request.
[ ] Contributor guide is your good friend: https://camel.apache.org/camel-quarkus/latest/contributor-guide.html
-->