### PR TITLE
Quartz: solve autowired scheduler properly and remove quick workaroun…

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -30,7 +30,7 @@ asciidoc:
     # Project versions
     camel-version: 3.18.2 # replace ${camel.version}
     camel-docs-version: 3.18.x # replace ${camel.docs.components.version}
-    quarkus-version: 2.13.0.Final # replace ${quarkus.version}
+    quarkus-version: 999-SNAPSHOT # replace ${quarkus.version}
     graalvm-version: 22.2.0 # replace ${graalvm.version}
     graalvm-docs-version: 22.2
     min-maven-version: 3.8.2 # replace ${min-maven-version}

--- a/extensions-core/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/ConsumeProcessor.java
+++ b/extensions-core/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/ConsumeProcessor.java
@@ -101,7 +101,7 @@ public class ConsumeProcessor {
                     /* If there is @Consume on a method, make the declaring class a named injectable bean */
                     String beanName = namedValue(classInfo);
                     final Transformation transform = ctx.transform();
-                    if (!classInfo.annotations().keySet().stream().anyMatch(BEAN_DEFINING_ANNOTATIONS::contains)) {
+                    if (!classInfo.annotationsMap().keySet().stream().anyMatch(BEAN_DEFINING_ANNOTATIONS::contains)) {
                         /* Only add @Singleton if there is no other bean defining annotation yet */
                         transform.add(Singleton.class);
                     }

--- a/extensions-core/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/InjectionPointsProcessor.java
+++ b/extensions-core/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/InjectionPointsProcessor.java
@@ -124,7 +124,7 @@ public class InjectionPointsProcessor {
 
             if (injectionPoint.getTarget().kind() == AnnotationTarget.Kind.METHOD) {
                 final MethodInfo target = injectionPoint.getTarget().asMethod();
-                final List<Type> types = target.parameters();
+                final List<Type> types = target.parameterTypes();
 
                 for (int i = 0; i < types.size(); i++) {
                     Type type = types.get(0);

--- a/extensions/grpc/deployment/src/main/java/org/apache/camel/quarkus/component/grpc/deployment/GrpcProcessor.java
+++ b/extensions/grpc/deployment/src/main/java/org/apache/camel/quarkus/component/grpc/deployment/GrpcProcessor.java
@@ -48,6 +48,7 @@ import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
 import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.MethodParameterInfo;
 import org.jboss.jandex.Type;
 
 class GrpcProcessor {
@@ -157,7 +158,9 @@ class GrpcProcessor {
                     if (isCandidateServiceMethod(method)) {
                         String[] params = method.parameters()
                                 .stream()
-                                .map(type -> type.name().toString())
+                                .map(MethodParameterInfo::type)
+                                .map(Type::name)
+                                .map(DotName::toString)
                                 .toArray(String[]::new);
 
                         ClassInfo classInfo = index
@@ -188,11 +191,11 @@ class GrpcProcessor {
     }
 
     private boolean isCandidateServiceMethod(MethodInfo method) {
-        List<Type> parameters = method.parameters();
+        List<MethodParameterInfo> parameters = method.parameters();
         if (parameters.size() == 1) {
-            return parameters.get(0).name().toString().equals(StreamObserver.class.getName());
+            return parameters.get(0).type().name().toString().equals(StreamObserver.class.getName());
         } else if (parameters.size() == 2) {
-            return parameters.get(1).name().toString().equals(StreamObserver.class.getName());
+            return parameters.get(1).type().name().toString().equals(StreamObserver.class.getName());
         }
         return false;
     }

--- a/extensions/quartz/deployment/pom.xml
+++ b/extensions/quartz/deployment/pom.xml
@@ -48,6 +48,12 @@
             <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-quartz</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/quartz/deployment/src/main/java/org/apache/camel/quarkus/component/quartz/deployment/QuartzProcessor.java
+++ b/extensions/quartz/deployment/src/main/java/org/apache/camel/quarkus/component/quartz/deployment/QuartzProcessor.java
@@ -16,9 +16,12 @@
  */
 package org.apache.camel.quarkus.component.quartz.deployment;
 
+import io.quarkus.arc.deployment.BeanContainerBuildItem;
 import io.quarkus.bootstrap.model.ApplicationModel;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.IndexDependencyBuildItem;
@@ -26,6 +29,9 @@ import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageSystemPropertyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
+import org.apache.camel.component.quartz.QuartzComponent;
+import org.apache.camel.quarkus.component.quartz.CamelQuartzRecorder;
+import org.apache.camel.quarkus.core.deployment.spi.CamelRuntimeBeanBuildItem;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
 import org.quartz.impl.jdbcjobstore.StdJDBCDelegate;
@@ -95,6 +101,15 @@ class QuartzProcessor {
     NativeImageSystemPropertyBuildItem disableJMX() {
         return new NativeImageSystemPropertyBuildItem("com.mchange.v2.c3p0.management.ManagementCoordinator",
                 "com.mchange.v2.c3p0.management.NullManagementCoordinator");
+    }
+
+    @Record(ExecutionTime.RUNTIME_INIT)
+    @BuildStep
+    CamelRuntimeBeanBuildItem quartzComponent(CamelQuartzRecorder recorder, BeanContainerBuildItem beanContainer) {
+        return new CamelRuntimeBeanBuildItem(
+                "quartz",
+                QuartzComponent.class.getName(),
+                recorder.createQuartzComponent(beanContainer.getValue()));
     }
 
 }

--- a/extensions/quartz/deployment/src/test/java/org/apache/camel/quarkus/component/quartz/deployment/QuartzNoQuarkusSchedulerAutowiredTest.java
+++ b/extensions/quartz/deployment/src/test/java/org/apache/camel/quarkus/component/quartz/deployment/QuartzNoQuarkusSchedulerAutowiredTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.quartz.deployment;
+
+import javax.inject.Inject;
+
+import io.quarkus.test.QuarkusUnitTest;
+import org.apache.camel.CamelContext;
+import org.apache.camel.component.quartz.QuartzComponent;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class QuartzNoQuarkusSchedulerAutowiredTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest CONFIG = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
+
+    @Inject
+    CamelContext context;
+
+    @Test
+    public void test() throws Exception {
+        QuartzComponent component = context.getComponent("quartz", QuartzComponent.class);
+        assertEquals("DefaultQuartzScheduler-camel-1", component.getScheduler().getSchedulerName());
+    }
+}

--- a/extensions/quartz/deployment/src/test/java/org/apache/camel/quarkus/component/quartz/deployment/QuartzNotAutowiredTest.java
+++ b/extensions/quartz/deployment/src/test/java/org/apache/camel/quarkus/component/quartz/deployment/QuartzNotAutowiredTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.quartz.deployment;
+
+import javax.inject.Inject;
+
+import io.quarkus.test.QuarkusUnitTest;
+import org.apache.camel.CamelContext;
+import org.apache.camel.component.quartz.QuartzComponent;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class QuartzNotAutowiredTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest CONFIG = new QuarkusUnitTest()
+            .withConfigurationResource("application-configuration-not-autowired.properties")
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
+
+    @Inject
+    CamelContext context;
+
+    @Test
+    public void test() throws Exception {
+        QuartzComponent component = context.getComponent("quartz", QuartzComponent.class);
+        assertEquals("DefaultQuartzScheduler-camel-1", component.getScheduler().getSchedulerName());
+    }
+}

--- a/extensions/quartz/deployment/src/test/java/org/apache/camel/quarkus/component/quartz/deployment/QuartzQuarkusCustomSchedulerAutowiredTest.java
+++ b/extensions/quartz/deployment/src/test/java/org/apache/camel/quarkus/component/quartz/deployment/QuartzQuarkusCustomSchedulerAutowiredTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.quartz.deployment;
+
+import java.util.Properties;
+
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+
+import io.quarkus.test.QuarkusUnitTest;
+import org.apache.camel.CamelContext;
+import org.apache.camel.component.quartz.QuartzComponent;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.impl.StdSchedulerFactory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class QuartzQuarkusCustomSchedulerAutowiredTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest CONFIG = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
+
+    @Inject
+    CamelContext context;
+
+    @Test
+    public void test() throws Exception {
+        QuartzComponent component = context.getComponent("quartz", QuartzComponent.class);
+        assertEquals("customScheduler", component.getScheduler().getSchedulerName());
+    }
+
+    @Produces
+    public Scheduler produceScheduler() throws SchedulerException {
+        Properties prop = new Properties();
+        prop.setProperty("org.quartz.scheduler.instanceName", "customScheduler");
+        prop.setProperty("org.quartz.threadPool.threadCount", "2");
+        return new StdSchedulerFactory(prop).getScheduler();
+    }
+}

--- a/extensions/quartz/deployment/src/test/java/org/apache/camel/quarkus/component/quartz/deployment/QuartzQuarkusSchedulerAmbiguousAutowiredTest.java
+++ b/extensions/quartz/deployment/src/test/java/org/apache/camel/quarkus/component/quartz/deployment/QuartzQuarkusSchedulerAmbiguousAutowiredTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.quartz.deployment;
+
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+
+import io.quarkus.test.QuarkusUnitTest;
+import org.apache.camel.CamelContext;
+import org.apache.camel.component.quartz.QuartzComponent;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.impl.StdSchedulerFactory;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class QuartzQuarkusSchedulerAmbiguousAutowiredTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest CONFIG = new QuarkusUnitTest()
+            .withConfigurationResource("application-configuration-quartz-scheduler.properties")
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
+
+    @Inject
+    CamelContext context;
+
+    @Test
+    public void test() {
+        assertThrows(RuntimeException.class, () -> context.getComponent("quartz", QuartzComponent.class));
+    }
+
+    @Produces
+    public Scheduler produceScheduler() throws SchedulerException {
+        return new StdSchedulerFactory().getScheduler();
+    }
+}

--- a/extensions/quartz/deployment/src/test/java/org/apache/camel/quarkus/component/quartz/deployment/QuartzQuarkusSchedulerAutowiredTest.java
+++ b/extensions/quartz/deployment/src/test/java/org/apache/camel/quarkus/component/quartz/deployment/QuartzQuarkusSchedulerAutowiredTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.quartz.deployment;
+
+import javax.inject.Inject;
+
+import io.quarkus.test.QuarkusUnitTest;
+import org.apache.camel.CamelContext;
+import org.apache.camel.component.quartz.QuartzComponent;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class QuartzQuarkusSchedulerAutowiredTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest CONFIG = new QuarkusUnitTest()
+            .withConfigurationResource("application-configuration-quartz-scheduler.properties")
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
+
+    @Inject
+    CamelContext context;
+
+    @Test
+    public void test() throws Exception {
+        QuartzComponent component = context.getComponent("quartz", QuartzComponent.class);
+        assertEquals("QuarkusQuartzScheduler", component.getScheduler().getSchedulerName());
+    }
+}

--- a/extensions/quartz/deployment/src/test/java/org/apache/camel/quarkus/component/quartz/deployment/QuartzQuarkusSchedulerNotAutowiredTest.java
+++ b/extensions/quartz/deployment/src/test/java/org/apache/camel/quarkus/component/quartz/deployment/QuartzQuarkusSchedulerNotAutowiredTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.quartz.deployment;
+
+import javax.inject.Inject;
+
+import io.quarkus.test.QuarkusUnitTest;
+import org.apache.camel.CamelContext;
+import org.apache.camel.component.quartz.QuartzComponent;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class QuartzQuarkusSchedulerNotAutowiredTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest CONFIG = new QuarkusUnitTest()
+            .withConfigurationResource("application-configuration-quarkus-scheduler-not-autowired.properties")
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
+
+    @Inject
+    CamelContext context;
+
+    @Test
+    public void test() throws Exception {
+        QuartzComponent component = context.getComponent("quartz", QuartzComponent.class);
+        assertEquals("DefaultQuartzScheduler-camel-1", component.getScheduler().getSchedulerName());
+    }
+}

--- a/extensions/quartz/deployment/src/test/resources/application-configuration-not-autowired.properties
+++ b/extensions/quartz/deployment/src/test/resources/application-configuration-not-autowired.properties
@@ -1,0 +1,17 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+camel.component.quartz.autowired-enabled = false

--- a/extensions/quartz/deployment/src/test/resources/application-configuration-quarkus-scheduler-not-autowired.properties
+++ b/extensions/quartz/deployment/src/test/resources/application-configuration-quarkus-scheduler-not-autowired.properties
@@ -1,0 +1,18 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+camel.component.quartz.autowired-enabled = false
+quarkus.quartz.start-mode=forced

--- a/extensions/quartz/deployment/src/test/resources/application-configuration-quartz-scheduler.properties
+++ b/extensions/quartz/deployment/src/test/resources/application-configuration-quartz-scheduler.properties
@@ -1,0 +1,17 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+quarkus.quartz.start-mode=forced

--- a/extensions/quartz/runtime/src/main/java/org/apache/camel/quarkus/component/quartz/CamelQuartzRecorder.java
+++ b/extensions/quartz/runtime/src/main/java/org/apache/camel/quarkus/component/quartz/CamelQuartzRecorder.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.quartz;
+
+import java.util.LinkedList;
+import java.util.stream.Collectors;
+
+import javax.enterprise.inject.AmbiguousResolutionException;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.InjectableInstance;
+import io.quarkus.arc.InstanceHandle;
+import io.quarkus.arc.runtime.BeanContainer;
+import io.quarkus.quartz.QuartzScheduler;
+import io.quarkus.quartz.runtime.QuartzSchedulerImpl;
+import io.quarkus.runtime.RuntimeValue;
+import io.quarkus.runtime.annotations.Recorder;
+import org.apache.camel.component.quartz.QuartzComponent;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+
+@Recorder
+public class CamelQuartzRecorder {
+
+    public RuntimeValue<QuartzComponent> createQuartzComponent(BeanContainer beanContainer) {
+        return new RuntimeValue<>(new QuarkusQuartzComponent());
+    }
+
+    @org.apache.camel.spi.annotations.Component("quartz")
+    static class QuarkusQuartzComponent extends QuartzComponent {
+
+        @Override
+        public boolean isAutowiredEnabled() {
+            //autowiring is executed via custom code in doStart method
+            return false;
+        }
+
+        @Override
+        protected void doStart() throws Exception {
+            //autowire scheduler before the start
+
+            //if autowiring is enabled, execute it here, because special approach because of Quarkus has to be applied
+            if (super.isAutowiredEnabled() && getCamelContext().isAutowiredEnabled()) {
+                InjectableInstance<Scheduler> schedulers = Arc.container().select(Scheduler.class);
+
+                LinkedList<Scheduler> foundSchedulers = new LinkedList<>();
+
+                for (InstanceHandle<Scheduler> handle : schedulers.handles()) {
+                    //Scheduler may be null in several cases, which would cause an exception in tradittional autowring
+                    //see https://github.com/quarkusio/quarkus/issues/27929 for more details
+                    if (handle.getBean().getBeanClass().equals(QuartzSchedulerImpl.class)) {
+                        Scheduler scheduler = Arc.container().select(QuartzScheduler.class).getHandle().get().getScheduler();
+                        if (scheduler != null) {
+                            //scheduler is added only if is not null
+                            foundSchedulers.add(scheduler);
+                        }
+                        continue;
+                    }
+                    foundSchedulers.add(handle.get());
+                }
+
+                if (foundSchedulers.size() > 1) {
+                    throw new AmbiguousResolutionException(String.format("Found %d org.quartz.Scheduler beans (%s).",
+                            foundSchedulers.size(), foundSchedulers.stream().map(s -> {
+                                try {
+                                    return s.getSchedulerName();
+                                } catch (SchedulerException e) {
+                                    return "Scheduler name retrieval failed.";
+                                }
+                            }).collect(Collectors.joining(", "))));
+                } else if (!foundSchedulers.isEmpty()) {
+                    setScheduler(foundSchedulers.getFirst());
+                }
+            }
+
+            super.doStart();
+        }
+    }
+}

--- a/integration-tests/http/src/test/java/org/apache/camel/quarkus/component/http/it/HttpTest.java
+++ b/integration-tests/http/src/test/java/org/apache/camel/quarkus/component/http/it/HttpTest.java
@@ -17,6 +17,7 @@
 package org.apache.camel.quarkus.component.http.it;
 
 import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.DisabledOnIntegrationTest;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -157,6 +158,7 @@ class HttpTest {
                 .body(is("Netty Hello World Compressed"));
     }
 
+    @DisabledOnIntegrationTest("https://github.com/apache/camel-quarkus/issues/4148")
     @ParameterizedTest
     @MethodSource("getHttpComponentNames")
     public void transferException(String component) {

--- a/integration-tests/kubernetes/pom.xml
+++ b/integration-tests/kubernetes/pom.xml
@@ -71,6 +71,7 @@
 
 
     <profiles>
+        <!-- TODO: https://github.com/apache/camel-quarkus/issues/4095
         <profile>
             <id>native</id>
             <activation>
@@ -98,6 +99,7 @@
                 </plugins>
             </build>
         </profile>
+        -->
         <profile>
             <id>virtualDependencies</id>
             <activation>

--- a/integration-tests/kubernetes/src/test/java/org/apache/camel/quarkus/component/kubernetes/it/KubernetesIT.java
+++ b/integration-tests/kubernetes/src/test/java/org/apache/camel/quarkus/component/kubernetes/it/KubernetesIT.java
@@ -17,7 +17,9 @@
 package org.apache.camel.quarkus.component.kubernetes.it;
 
 import io.quarkus.test.junit.QuarkusIntegrationTest;
+import org.junit.jupiter.api.Disabled;
 
+@Disabled("https://github.com/apache/camel-quarkus/issues/4095")
 @QuarkusIntegrationTest
 class KubernetesIT extends KubernetesTest {
 

--- a/integration-tests/kubernetes/src/test/java/org/apache/camel/quarkus/component/kubernetes/it/KubernetesTest.java
+++ b/integration-tests/kubernetes/src/test/java/org/apache/camel/quarkus/component/kubernetes/it/KubernetesTest.java
@@ -25,10 +25,12 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.kubernetes.client.KubernetesServerTestResource;
 import io.quarkus.test.kubernetes.client.KubernetesTestServer;
 import io.restassured.RestAssured;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.Matchers.is;
 
+@Disabled("https://github.com/apache/camel-quarkus/issues/4095")
 @QuarkusTest
 @QuarkusTestResource(KubernetesServerTestResource.class)
 public class KubernetesTest {

--- a/integration-tests/master-openshift/pom.xml
+++ b/integration-tests/master-openshift/pom.xml
@@ -145,7 +145,7 @@
                 </plugins>
             </build>
         </profile>
-
+        <!-- TODO: https://github.com/apache/camel-quarkus/issues/4095
         <profile>
             <id>native</id>
             <activation>
@@ -183,6 +183,7 @@
                 </plugins>
             </build>
         </profile>
+        -->
         <profile>
             <id>virtualDependencies</id>
             <activation>

--- a/integration-tests/master-openshift/pom.xml
+++ b/integration-tests/master-openshift/pom.xml
@@ -175,7 +175,7 @@
                                 <quarkus.runner>${quarkus.runner}</quarkus.runner>
                             </systemProperties>
                             <environmentVariables>
-                                <!-- Fake KubernetesClusterService so it assumes being run from a pod named leader  -->
+                                <! Fake KubernetesClusterService so it assumes being run from a pod named leader  >
                                 <HOSTNAME>leader</HOSTNAME>
                             </environmentVariables>
                         </configuration>

--- a/integration-tests/master-openshift/src/test/java/org/apache/camel/quarkus/component/master/it/MasterOpenShiftIT.java
+++ b/integration-tests/master-openshift/src/test/java/org/apache/camel/quarkus/component/master/it/MasterOpenShiftIT.java
@@ -17,7 +17,9 @@
 package org.apache.camel.quarkus.component.master.it;
 
 import io.quarkus.test.junit.QuarkusIntegrationTest;
+import org.junit.jupiter.api.Disabled;
 
+@Disabled("https://github.com/apache/camel-quarkus/issues/4095")
 @QuarkusIntegrationTest
 class MasterOpenShiftIT extends MasterOpenShiftTest {
 

--- a/integration-tests/master-openshift/src/test/java/org/apache/camel/quarkus/component/master/it/MasterOpenShiftTest.java
+++ b/integration-tests/master-openshift/src/test/java/org/apache/camel/quarkus/component/master/it/MasterOpenShiftTest.java
@@ -36,6 +36,7 @@ import org.awaitility.Awaitility;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -45,6 +46,7 @@ import org.zeroturnaround.exec.StartedProcess;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.emptyString;
 
+@Disabled("https://github.com/apache/camel-quarkus/issues/4095")
 @QuarkusTestResource(MasterOpenShiftTestResource.class)
 @QuarkusTest
 class MasterOpenShiftTest {

--- a/integration-tests/messaging/jms/src/test/java/org/apache/camel/quarkus/messaging/jms/AbstractJmsMessagingTest.java
+++ b/integration-tests/messaging/jms/src/test/java/org/apache/camel/quarkus/messaging/jms/AbstractJmsMessagingTest.java
@@ -18,6 +18,7 @@ package org.apache.camel.quarkus.messaging.jms;
 
 import java.util.UUID;
 
+import io.quarkus.test.junit.DisabledOnIntegrationTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import org.apache.camel.quarkus.component.messaging.it.AbstractMessagingTest;
@@ -39,6 +40,7 @@ public class AbstractJmsMessagingTest extends AbstractMessagingTest {
                 .body(is(message));
     }
 
+    @DisabledOnIntegrationTest("https://github.com/apache/camel-quarkus/issues/4148")
     @Test
     public void testJmsTransferException() {
         RestAssured.given()

--- a/integration-tests/optaplanner/pom.xml
+++ b/integration-tests/optaplanner/pom.xml
@@ -70,7 +70,24 @@
         </dependency>
     </dependencies>
 
+    <!-- TODO: Remove this: https://github.com/apache/camel-quarkus/issues/4116 -->
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>quarkus-maven-plugin-disabled</id>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
     <profiles>
+        <!-- TODO: https://github.com/apache/camel-quarkus/issues/4116
         <profile>
             <id>native</id>
             <activation>
@@ -98,6 +115,7 @@
                 </plugins>
             </build>
         </profile>
+        -->
         <profile>
             <id>virtualDependencies</id>
             <activation>

--- a/integration-tests/optaplanner/src/test/java/org/apache/camel/quarkus/component/optaplanner/it/OptaplannerIT.java
+++ b/integration-tests/optaplanner/src/test/java/org/apache/camel/quarkus/component/optaplanner/it/OptaplannerIT.java
@@ -17,7 +17,9 @@
 package org.apache.camel.quarkus.component.optaplanner.it;
 
 import io.quarkus.test.junit.QuarkusIntegrationTest;
+import org.junit.jupiter.api.Disabled;
 
+@Disabled("https://github.com/apache/camel-quarkus/issues/4116")
 @QuarkusIntegrationTest
 class OptaplannerIT extends OptaplannerTest {
 

--- a/integration-tests/optaplanner/src/test/java/org/apache/camel/quarkus/component/optaplanner/it/OptaplannerTest.java
+++ b/integration-tests/optaplanner/src/test/java/org/apache/camel/quarkus/component/optaplanner/it/OptaplannerTest.java
@@ -21,10 +21,12 @@ import java.util.concurrent.TimeUnit;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.path.json.JsonPath;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.awaitility.Awaitility.await;
 
+@Disabled("https://github.com/apache/camel-quarkus/issues/4116")
 @QuarkusTest
 class OptaplannerTest {
 

--- a/integration-tests/xstream/src/test/java/org/apache/camel/quarkus/component/xstream/it/XstreamTest.java
+++ b/integration-tests/xstream/src/test/java/org/apache/camel/quarkus/component/xstream/it/XstreamTest.java
@@ -18,6 +18,7 @@ package org.apache.camel.quarkus.component.xstream.it;
 
 import javax.json.bind.JsonbBuilder;
 
+import io.quarkus.test.junit.DisabledOnIntegrationTest;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -29,6 +30,7 @@ import static org.hamcrest.Matchers.equalTo;
 @QuarkusTest
 class XstreamTest {
 
+    @DisabledOnIntegrationTest("https://github.com/apache/camel-quarkus/issues/4149")
     @Test
     void xstream() {
         final String xml = "<org.apache.camel.quarkus.component.xstream.it.PojoA><name>Joe</name></org.apache.camel.quarkus.component.xstream.it.PojoA>";

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <quarkiverse-minio.version>2.9.2</quarkiverse-minio.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/minio/quarkus-minio-parent/ -->
         <quarkiverse-mybatis.version>1.0.4</quarkiverse-mybatis.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/mybatis/quarkus-mybatis-parent/ -->
         <quarkiverse-tika.version>1.0.3</quarkiverse-tika.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/tika/quarkus-tika-parent/ -->
-        <quarkus.version>2.13.0.Final</quarkus.version><!-- https://repo1.maven.org/maven2/io/quarkus/quarkus-bom/ -->
+        <quarkus.version>999-SNAPSHOT</quarkus.version><!-- https://repo1.maven.org/maven2/io/quarkus/quarkus-bom/ -->
         <quarkus-hazelcast-client.version>3.0.0</quarkus-hazelcast-client.version><!-- https://repo1.maven.org/maven2/com/hazelcast/quarkus-hazelcast-client-bom/ -->
         <quarkus-qpid-jms.version>0.38.0</quarkus-qpid-jms.version><!-- https://repo1.maven.org/maven2/org/amqphub/quarkus/quarkus-qpid-jms-bom/ -->
 
@@ -93,7 +93,7 @@
         <google-auth-library-credentials.version>1.7.0</google-auth-library-credentials.version><!-- TODO: Revert back to using Camel's version when gRPC versions are in sync -->
         <google-oauth-client.version>${google-oauth-client-version}</google-oauth-client.version><!-- TODO: Fix this in Camel https://github.com/apache/camel-quarkus/issues/4139 -->
         <graalvm.version>22.2.0</graalvm.version><!-- @sync io.quarkus:quarkus-bom:${quarkus.version} dep:org.graalvm.sdk:graal-sdk -->
-        <grpc.version>1.49.0</grpc.version><!-- @sync io.quarkus:quarkus-bom:${quarkus.version} dep:io.grpc:grpc-core -->
+        <grpc.version>1.49.1</grpc.version><!-- @sync io.quarkus:quarkus-bom:${quarkus.version} dep:io.grpc:grpc-core -->
         <hapi.version>${hapi-version}</hapi.version>
         <hapi-fhir.version>${hapi-fhir-version}</hapi-fhir.version>
         <hbase.version>${hbase-version}</hbase.version>
@@ -116,7 +116,7 @@
         <jna-platform.version>5.6.0</jna-platform.version><!-- @sync com.azure:azure-identity:${azure-identity-version} dep:net.java.dev.jna:jna-platform -->
         <jnr-ffi.version>2.1.2</jnr-ffi.version><!-- Mess in web3j transitive deps -->
         <json-smart.version>2.4.7</json-smart.version>
-        <kafka.version>3.2.1</kafka.version><!-- @sync io.quarkus:quarkus-bom:${quarkus.version} dep:org.apache.kafka:kafka-clients -->
+        <kafka.version>3.2.3</kafka.version><!-- @sync io.quarkus:quarkus-bom:${quarkus.version} dep:org.apache.kafka:kafka-clients -->
         <kudu.version>${kudu-version}</kudu.version>
         <kotlin.version>1.7.10</kotlin.version><!-- @sync io.quarkus:quarkus-bom:${quarkus.version} dep:org.jetbrains.kotlin:kotlin-stdlib -->
         <kryo.version>2.24.0</kryo.version><!-- @sync org.apache.flink:flink-core:${flink-version} dep:com.esotericsoftware.kryo:kryo -->
@@ -130,9 +130,9 @@
         <reactor-core.version>3.4.14</reactor-core.version><!-- @sync com.azure:azure-core:${azure-core.version} dep:io.projectreactor:reactor-core -->
         <reactor-netty.version>${reactor-netty-version}</reactor-netty.version>
         <retrofit.version>2.5.0</retrofit.version>
-        <smallrye.reactive.messaging.camel.version>3.18.0</smallrye.reactive.messaging.camel.version><!-- @sync io.quarkus:quarkus-bom:${quarkus.version} dep:io.smallrye.reactive:smallrye-reactive-messaging-provider -->
+        <smallrye.reactive.messaging.camel.version>3.20.0</smallrye.reactive.messaging.camel.version><!-- @sync io.quarkus:quarkus-bom:${quarkus.version} dep:io.smallrye.reactive:smallrye-reactive-messaging-provider -->
         <spring.version>${spring5-version}</spring.version>
-        <snakeyaml.version>1.32</snakeyaml.version><!-- @sync io.quarkus:quarkus-bom:${quarkus.version} dep:org.yaml:snakeyaml -->
+        <snakeyaml.version>1.33</snakeyaml.version><!-- @sync io.quarkus:quarkus-bom:${quarkus.version} dep:org.yaml:snakeyaml -->
         <tablesaw.version>0.43.1</tablesaw.version>
         <threetenbp.version>1.6.0</threetenbp.version>
         <xalan.version>${xalan-version}</xalan.version>

--- a/poms/bom/src/main/generated/flattened-full-pom.xml
+++ b/poms/bom/src/main/generated/flattened-full-pom.xml
@@ -9927,7 +9927,7 @@
       <dependency>
         <groupId>io.smallrye.reactive</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>smallrye-reactive-messaging-camel</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <version>3.18.0</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+        <version>3.20.0</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
@@ -10077,7 +10077,7 @@
       <dependency>
         <groupId>org.apache.kafka</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>connect-runtime</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <version>3.2.1</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+        <version>3.2.3</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->

--- a/poms/bom/src/main/generated/flattened-reduced-pom.xml
+++ b/poms/bom/src/main/generated/flattened-reduced-pom.xml
@@ -9927,7 +9927,7 @@
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-reactive-messaging-camel</artifactId>
-        <version>3.18.0</version>
+        <version>3.20.0</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -10072,7 +10072,7 @@
       <dependency>
         <groupId>org.apache.kafka</groupId>
         <artifactId>connect-runtime</artifactId>
-        <version>3.2.1</version>
+        <version>3.2.3</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>

--- a/poms/bom/src/main/generated/flattened-reduced-verbose-pom.xml
+++ b/poms/bom/src/main/generated/flattened-reduced-verbose-pom.xml
@@ -9927,7 +9927,7 @@
       <dependency>
         <groupId>io.smallrye.reactive</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>smallrye-reactive-messaging-camel</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <version>3.18.0</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+        <version>3.20.0</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
@@ -10072,7 +10072,7 @@
       <dependency>
         <groupId>org.apache.kafka</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>connect-runtime</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <version>3.2.1</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+        <version>3.2.3</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->


### PR DESCRIPTION
fixes https://github.com/apache/camel-quarkus/issues/4076

change requires https://github.com/quarkusio/quarkus/pull/28218, therefore based on `quarkus-main`
supersedes https://github.com/apache/camel-quarkus/pull/4119

Problem is caused by the fact, that Quarkus may `@Produce` `null` as a`org.quartz.Scheduler`. Unfortunately feature can not be changed on quarkus side (see [ticket](https://github.com/quarkusio/quarkus/issues/27929))
This PR proposes a fix in camel-qurkus. It is possible to override autowiring mechanism thanks to `@Recorder` .
`Arc` is used directly during autowirng, therefore `null` occurrence can be ignored.

I injected the custom code into `doStart()` method. 

JUnit tests covering different cases are present.

<!-- Uncomment and fill this section if your PR is not trivial
[ ] An issue should be filed for the change unless this is a trivial change (fixing a typo or similar). One issue should ideally be fixed by not more than one commit and the other way round, each commit should fix just one issue, without pulling in other changes.
[ ] Each commit in the pull request should have a meaningful and properly spelled subject line and body. Copying the title of the associated issue is typically enough. Please include the issue number in the commit message prefixed by #.
[ ] The pull request description should explain what the pull request does, how, and why. If the info is available in the associated issue or some other external document, a link is enough.
[ ] Phrases like Fix #<issueNumber> or Fixes #<issueNumber> will auto-close the named issue upon merging the pull request. Using them is typically a good idea.
[ ] Please run mvn process-resources -Pformat (and amend the changes if necessary) before sending the pull request.
[ ] Contributor guide is your good friend: https://camel.apache.org/camel-quarkus/latest/contributor-guide.html
-->