### PR TITLE
Fix assertion invocation in core extension tests

### DIFF
--- a/extensions-core/core/deployment/src/test/java/org/apache/camel/quarkus/core/deployment/CamelContextCustomizerTest.java
+++ b/extensions-core/core/deployment/src/test/java/org/apache/camel/quarkus/core/deployment/CamelContextCustomizerTest.java
@@ -69,6 +69,6 @@ public class CamelContextCustomizerTest {
 
     @Test
     public void testRestConfiguration() {
-        assertThat(camelContext.getRestConfiguration().getApiContextPath().equals("/example"));
+        assertThat(camelContext.getRestConfiguration().getApiContextPath()).isEqualTo("/example");
     }
 }

--- a/extensions-core/core/deployment/src/test/java/org/apache/camel/quarkus/core/deployment/CamelContextDefaultStrategyTest.java
+++ b/extensions-core/core/deployment/src/test/java/org/apache/camel/quarkus/core/deployment/CamelContextDefaultStrategyTest.java
@@ -35,6 +35,6 @@ public class CamelContextDefaultStrategyTest {
 
     @Test
     public void testRestConfiguration() {
-        assertThat(camelContext.getShutdownStrategy() instanceof DefaultShutdownStrategy);
+        assertThat(camelContext.getShutdownStrategy() instanceof DefaultShutdownStrategy).isTrue();
     }
 }


### PR DESCRIPTION
It fixes bug in usage of assertThat in core extension's tests. The problem is that the invocation of assertion is missing this means that nothing is actually tested. 

Problem has been discovered by sonarcloud scanner [[1](https://sonarcloud.io/project/issues?issues=AYJn4gD9vQZIYxYYEQIW&open=AYJn4gD9vQZIYxYYEQIW&id=apache_camel_quarkus)][[2](https://sonarcloud.io/project/issues?issues=AYJn4gD3vQZIYxYYEQIT&open=AYJn4gD3vQZIYxYYEQIT&id=apache_camel_quarkus)].