### PR TITLE
fix line ending

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,7 @@
 * text=auto eol=lf
 *.cmd text eol=crlf
-
+*.jar binary
+*.jks binary
+*.png binary
+*.ttf binary
+*.zip binary


### PR DESCRIPTION
On my local machine I ended up with message like:
```
warning: CRLF will be replaced by LF in integration-test-groups/cxf-soap/cxf-soap-mtom-awt/src/test/resources/linux-image.png.
The file will have its original line endings in your working directory.
warning: CRLF will be replaced by LF in integration-test-groups/cxf-soap/cxf-soap-mtom/src/test/resources/linux-image.png.
The file will have its original line endings in your working directory.
diff --git a/integration-test-groups/cxf-soap/cxf-soap-mtom-awt/src/test/resources/linux-image.png b/integration-test-groups/cxf-soap/cxf-soap-mtom-awt/src/test/resources/linux-image.png
index 17d7bfe..4dc8fda 100644
Binary files a/integration-test-groups/cxf-soap/cxf-soap-mtom-awt/src/test/resources/linux-image.png and b/integration-test-groups/cxf-soap/cxf-soap-mtom-awt/src/test/resources/linux-image.png differ
diff --git a/integration-test-groups/cxf-soap/cxf-soap-mtom/src/test/resources/linux-image.png b/integration-test-groups/cxf-soap/cxf-soap-mtom/src/test/resources/linux-image.png
index 17d7bfe..4dc8fda 100644
Binary files a/integration-test-groups/cxf-soap/cxf-soap-mtom/src/test/resources/linux-image.png and b/integration-test-groups/cxf-soap/cxf-soap-mtom/src/test/resources/linux-image.png differ
[main_upstream @ camel-quarkus-upstream]$ git commit -am 'fix line ending'
warning: CRLF will be replaced by LF in integration-test-groups/cxf-soap/cxf-soap-mtom-awt/src/test/resources/linux-image.png.
The file will have its original line endings in your working directory.
warning: CRLF will be replaced by LF in integration-test-groups/cxf-soap/cxf-soap-mtom/src/test/resources/linux-image.png.
The file will have its original line endings in your working directory.
warning: CRLF will be replaced by LF in integration-test-groups/cxf-soap/cxf-soap-mtom-awt/src/test/resources/linux-image.png.
The file will have its original line endings in your working directory.
warning: CRLF will be replaced by LF in integration-test-groups/cxf-soap/cxf-soap-mtom/src/test/resources/linux-image.png.
The file will have its original line endings in your working directory.
```

Should we fix it ?