### PR TITLE
[2.13.x] Backports and test against GraalVM 22.3

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -72,7 +72,6 @@ jobs:
         run: |
           echo "BRANCH_OPTIONS=-Papache-snapshots" >> $GITHUB_ENV
       - name: Setup oss-snapshots profile
-        if: github.ref == 'refs/heads/quarkus-main' || github.base_ref == 'quarkus-main'
         run: |
           echo "BRANCH_OPTIONS=-Poss-snapshots -Dquarkus.version=999-SNAPSHOT" >> $GITHUB_ENV
       - name: Set up JDK 11
@@ -81,9 +80,8 @@ jobs:
           distribution: 'temurin'
           java-version: '11'
       - name: Build Quarkus
-        if: github.ref == 'refs/heads/quarkus-main' || github.base_ref == 'quarkus-main'
         run: |
-          git clone --depth 1 --branch main https://github.com/quarkusio/quarkus.git \
+          git clone --depth 1 --branch 2.13 https://github.com/quarkusio/quarkus.git \
             && cd quarkus \
             && echo "Current Quarkus commit:" $(git rev-parse HEAD) \
             && ./mvnw ${MAVEN_ARGS} clean install -Dquickly
@@ -95,10 +93,6 @@ jobs:
       - name: Sync Maven properties
         run: |
           ./mvnw cq:sync-versions ${MAVEN_ARGS} -N
-      - name: Fail if there are uncommitted changes
-        shell: bash
-        run: |
-          [[ -z $(git status --porcelain | grep -v antora.yml) ]] || { echo 'There are uncommitted changes'; git status; exit 1; }
       - name: Tar Maven Repo
         shell: bash
         run: |
@@ -131,7 +125,6 @@ jobs:
         run: |
           echo "BRANCH_OPTIONS=-Papache-snapshots" >> $GITHUB_ENV
       - name: Setup oss-snapshots profile
-        if: github.ref == 'refs/heads/quarkus-main' || github.base_ref == 'quarkus-main'
         run: |
           echo "BRANCH_OPTIONS=-Poss-snapshots -Dquarkus.version=999-SNAPSHOT" >> $GITHUB_ENV
       - name: Checkout
@@ -188,10 +181,6 @@ jobs:
               --fail-at-end \
               -pl "${NATIVE_MODULES[*]}"
           fi
-      - name: Fail if there are uncommitted changes
-        shell: bash
-        run: |
-          [[ -z $(git status --porcelain) ]] || { echo 'There are uncommitted changes'; git status; exit 1; }
 
   functional-extension-tests:
     runs-on: ubuntu-latest
@@ -205,7 +194,6 @@ jobs:
         run: |
           echo "BRANCH_OPTIONS=-Papache-snapshots" >> $GITHUB_ENV
       - name: Setup oss-snapshots profile
-        if: github.ref == 'refs/heads/quarkus-main' || github.base_ref == 'quarkus-main'
         run: |
           echo "BRANCH_OPTIONS=-Poss-snapshots -Dquarkus.version=999-SNAPSHOT" >> $GITHUB_ENV
       - uses: actions/checkout@v2
@@ -271,7 +259,6 @@ jobs:
         run: |
           echo "BRANCH_OPTIONS=-Papache-snapshots" >> $GITHUB_ENV
       - name: Setup oss-snapshots profile
-        if: github.ref == 'refs/heads/quarkus-main' || github.base_ref == 'quarkus-main'
         run: |
           echo "BRANCH_OPTIONS=-Poss-snapshots -Dquarkus.version=999-SNAPSHOT" >> $GITHUB_ENV
       - uses: actions/checkout@v2
@@ -318,7 +305,6 @@ jobs:
         run: |
           echo "BRANCH_OPTIONS=-Papache-snapshots" >> $GITHUB_ENV
       - name: Setup oss-snapshots profile
-        if: github.ref == 'refs/heads/quarkus-main' || github.base_ref == 'quarkus-main'
         run: |
           echo "BRANCH_OPTIONS=-Poss-snapshots -Dquarkus.version=999-SNAPSHOT" >> $GITHUB_ENV
       - uses: actions/checkout@v2
@@ -372,7 +358,6 @@ jobs:
           echo "BRANCH_OPTIONS=-Papache-snapshots" >> $GITHUB_ENV
       - name: Setup oss-snapshots profile
         shell: bash
-        if: github.ref == 'refs/heads/quarkus-main' || github.base_ref == 'quarkus-main'
         run: |
           echo "BRANCH_OPTIONS=-Poss-snapshots -Dquarkus.version=999-SNAPSHOT" >> $GITHUB_ENV
       - uses: actions/checkout@v2
@@ -409,7 +394,6 @@ jobs:
         run: |
           echo "BRANCH_OPTIONS=-Papache-snapshots" >> $GITHUB_ENV
       - name: Setup oss-snapshots profile
-        if: github.ref == 'refs/heads/quarkus-main' || github.base_ref == 'quarkus-main'
         run: |
           echo "BRANCH_OPTIONS=-Poss-snapshots -Dquarkus.version=999-SNAPSHOT" >> $GITHUB_ENV
       - name: Checkout

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -28,7 +28,7 @@ asciidoc:
     camel-version: 3.18.3 # replace ${camel.version}
     camel-docs-version: 3.18.x # replace ${camel.docs.components.version}
     quarkus-version: 2.13.3.Final # replace ${quarkus.version}
-    graalvm-version: 22.2.0 # replace ${graalvm.version}
+    graalvm-version: 22.3.0 # replace ${graalvm.version}
     graalvm-docs-version: 22.2
     min-maven-version: 3.8.2 # replace ${min-maven-version}
     target-maven-version: 3.8.6 # replace ${target-maven-version}

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -27,7 +27,7 @@ asciidoc:
     # Project versions
     camel-version: 3.18.3 # replace ${camel.version}
     camel-docs-version: 3.18.x # replace ${camel.docs.components.version}
-    quarkus-version: 2.13.3.Final # replace ${quarkus.version}
+    quarkus-version: 999-SNAPSHOT # replace ${quarkus.version}
     graalvm-version: 22.3.0 # replace ${graalvm.version}
     graalvm-docs-version: 22.2
     min-maven-version: 3.8.2 # replace ${min-maven-version}

--- a/extensions/xchange/deployment/src/main/java/org/apache/camel/quarkus/component/xchange/deployment/XchangeProcessor.java
+++ b/extensions/xchange/deployment/src/main/java/org/apache/camel/quarkus/component/xchange/deployment/XchangeProcessor.java
@@ -137,7 +137,7 @@ class XchangeProcessor {
 
     @BuildStep
     void registerResourceBundles(BuildProducer<NativeImageResourceBundleBuildItem> producer) {
-        producer.produce(new NativeImageResourceBundleBuildItem("sun.util.resources.CurrencyNames"));
+        producer.produce(new NativeImageResourceBundleBuildItem("sun.util.resources.CurrencyNames", "java.base"));
     }
 
 }

--- a/integration-test-groups/foundation/scheduler/src/main/java/org/apache/camel/quarkus/component/scheduler/it/SchedulerResource.java
+++ b/integration-test-groups/foundation/scheduler/src/main/java/org/apache/camel/quarkus/component/scheduler/it/SchedulerResource.java
@@ -22,13 +22,20 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+
+import org.apache.camel.CamelContext;
 
 @Path("/scheduler")
 @ApplicationScoped
 public class SchedulerResource {
+
+    @Inject
+    CamelContext context;
 
     @Inject
     @Named("withDelayCounter")
@@ -117,6 +124,16 @@ public class SchedulerResource {
     @Named("greedyCounter")
     AtomicInteger greedyCounter() {
         return new AtomicInteger();
+    }
+
+    @POST
+    @Path("route/{route}/{enable}")
+    public void mangeRoutes(@PathParam("route") String route, @PathParam("enable") boolean enable) throws Exception {
+        if (enable) {
+            context.getRouteController().startRoute(route);
+        } else {
+            context.getRouteController().stopRoute(route);
+        }
     }
 
 }

--- a/integration-test-groups/foundation/scheduler/src/main/java/org/apache/camel/quarkus/component/scheduler/it/SchedulerRoute.java
+++ b/integration-test-groups/foundation/scheduler/src/main/java/org/apache/camel/quarkus/component/scheduler/it/SchedulerRoute.java
@@ -49,19 +49,19 @@ public class SchedulerRoute extends RouteBuilder {
 
     @Override
     public void configure() throws Exception {
-        from("scheduler:withInitialDelay?initialDelay=1")
+        from("scheduler:withInitialDelay?initialDelay=1").routeId("withInitialDelay").noAutoStartup()
                 .process(e -> schedulerCounter.incrementAndGet());
 
-        from("scheduler:withDelay?delay=100")
+        from("scheduler:withDelay?delay=100").routeId("withDelay").noAutoStartup()
                 .process(e -> withDelayCounter.incrementAndGet());
 
-        from("scheduler:useFixedDelay?initialDelay=200&useFixedDelay=true")
+        from("scheduler:useFixedDelay?initialDelay=200&useFixedDelay=true").routeId("useFixedDelay").noAutoStartup()
                 .process(e -> useFixedDelayCounter.incrementAndGet());
 
-        from("scheduler:withDelayRepeat?delay=1&repeatCount=5")
+        from("scheduler:withDelayRepeat?delay=1&repeatCount=5").routeId("withDelayRepeat").noAutoStartup()
                 .process(e -> withDelayRepeatCounter.incrementAndGet());
 
-        from("scheduler:greedy?delay=100&greedy=true")
+        from("scheduler:greedy?delay=100&greedy=true").routeId("greedy").noAutoStartup()
                 .process(e -> greedyCounter.incrementAndGet());
     }
 }

--- a/integration-test-groups/foundation/scheduler/src/test/java/org/apache/camel/quarkus/component/scheduler/it/SchedulerTest.java
+++ b/integration-test-groups/foundation/scheduler/src/test/java/org/apache/camel/quarkus/component/scheduler/it/SchedulerTest.java
@@ -29,47 +29,103 @@ class SchedulerTest {
 
     @Test
     public void testInitialDelay() throws Exception {
-        await().atMost(5, TimeUnit.SECONDS).until(() -> {
-            String body = RestAssured.get("/scheduler/get").then().statusCode(200).extract().body().asString();
-            return !body.equals("0");
-        });
+        try {
+            RestAssured.given()
+                    .post("/scheduler/route/withInitialDelay/true")
+                    .then()
+                    .statusCode(204);
+            await().atMost(5, TimeUnit.SECONDS).until(() -> {
+                String body = RestAssured.get("/scheduler/get").then().statusCode(200).extract().body().asString();
+                return !body.equals("0");
+            });
+        } finally {
+            RestAssured.given()
+                    .post("/scheduler/route/withInitialDelay/false")
+                    .then()
+                    .statusCode(204);
+        }
     }
 
     @Test
     public void testDelay() throws Exception {
-        await().atMost(2, TimeUnit.SECONDS).until(() -> {
-            String body = RestAssured.get("/scheduler/get-delay-count").then().statusCode(200).extract().body()
-                    .asString();
-            return Integer.parseInt(body) > 2;
-        });
+        try {
+            RestAssured.given()
+                    .post("/scheduler/route/withDelay/true")
+                    .then()
+                    .statusCode(204);
+            await().atMost(10, TimeUnit.SECONDS).until(() -> {
+                String body = RestAssured.get("/scheduler/get-delay-count").then().statusCode(200).extract().body()
+                        .asString();
+                return Integer.parseInt(body) > 2;
+            });
+        } finally {
+            RestAssured.given()
+                    .post("/scheduler/route/withDelay/false")
+                    .then()
+                    .statusCode(204);
+        }
 
     }
 
     @Test
     public void testFixedDelay() throws Exception {
-        await().atMost(2, TimeUnit.SECONDS).until(() -> {
-            String body = RestAssured.get("/scheduler/get-fixed-delay-count").then().statusCode(200).extract().body()
-                    .asString();
-            return Integer.parseInt(body) > 2;
-        });
+        try {
+            RestAssured.given()
+                    .post("/scheduler/route/useFixedDelay/true")
+                    .then()
+                    .statusCode(204);
+            await().atMost(2, TimeUnit.SECONDS).until(() -> {
+                String body = RestAssured.get("/scheduler/get-fixed-delay-count").then().statusCode(200).extract()
+                        .body()
+                        .asString();
+                return Integer.parseInt(body) > 2;
+            });
+        } finally {
+            RestAssured.given()
+                    .post("/scheduler/route/useFixedDelay/flase")
+                    .then()
+                    .statusCode(204);
+        }
     }
 
     @Test
     public void testDelayWithRepeat() throws Exception {
-        await().atMost(4, TimeUnit.SECONDS).until(() -> {
-            String body = RestAssured.get("/scheduler/get-repeat-count").then().statusCode(200).extract().body()
-                    .asString();
-            return Integer.parseInt(body) >= 4;
-        });
+        try {
+            RestAssured.given()
+                    .post("/scheduler/route/withDelayRepeat/true")
+                    .then()
+                    .statusCode(204);
+            await().atMost(4, TimeUnit.SECONDS).until(() -> {
+                String body = RestAssured.get("/scheduler/get-repeat-count").then().statusCode(200).extract().body()
+                        .asString();
+                return Integer.parseInt(body) >= 4;
+            });
+        } finally {
+            RestAssured.given()
+                    .post("/scheduler/route/withDelayRepeat/false")
+                    .then()
+                    .statusCode(204);
+        }
     }
 
     @Test
     public void testGreedyScheduler() throws Exception {
-        await().atMost(1, TimeUnit.SECONDS).until(() -> {
-            String body = RestAssured.get("/scheduler/get-greedy-count").then().statusCode(200).extract().body()
-                    .asString();
-            return Integer.parseInt(body) > 10;
-        });
-    }
+        try {
+            RestAssured.given()
+                    .post("/scheduler/route/greedy/true")
+                    .then()
+                    .statusCode(204);
+            await().atMost(2, TimeUnit.SECONDS).until(() -> {
+                String body = RestAssured.get("/scheduler/get-greedy-count").then().statusCode(200).extract().body()
+                        .asString();
+                return Integer.parseInt(body) > 10;
+            });
+        } finally {
+            RestAssured.given()
+                    .post("/scheduler/route/greedy/false")
+                    .then()
+                    .statusCode(204);
+        }
 
+    }
 }

--- a/integration-tests/jms-artemis-client/pom.xml
+++ b/integration-tests/jms-artemis-client/pom.xml
@@ -49,6 +49,12 @@
             <artifactId>quarkus-artemis-jms</artifactId>
         </dependency>
 
+        <!-- Messaging Pooled JMS -->
+        <dependency>
+            <groupId>io.quarkiverse.messaginghub</groupId>
+            <artifactId>quarkus-pooled-jms</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>jakarta.jms</groupId>
             <artifactId>jakarta.jms-api</artifactId>
@@ -69,6 +75,12 @@
             <groupId>io.quarkiverse.artemis</groupId>
             <artifactId>quarkus-test-artemis</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-pool2</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Inherit base messaging tests -->

--- a/integration-tests/jms-artemis-client/pom.xml
+++ b/integration-tests/jms-artemis-client/pom.xml
@@ -65,6 +65,11 @@
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.artemis</groupId>
+            <artifactId>quarkus-test-artemis</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <!-- Inherit base messaging tests -->
         <dependency>

--- a/integration-tests/jms-artemis-client/src/main/java/org/apache/camel/quarkus/component/jms/artemis/it/CustomConnectionFactory.java
+++ b/integration-tests/jms-artemis-client/src/main/java/org/apache/camel/quarkus/component/jms/artemis/it/CustomConnectionFactory.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.jms.artemis.it;
+
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Produces;
+import javax.jms.ConnectionFactory;
+
+import io.quarkus.arc.properties.UnlessBuildProperty;
+import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
+import org.eclipse.microprofile.config.ConfigProvider;
+
+@Dependent
+public class CustomConnectionFactory {
+    @Produces
+    @UnlessBuildProperty(name = "quarkus.artemis.enabled", stringValue = "true")
+    ConnectionFactory createConnectionFactory() {
+        String url = ConfigProvider.getConfig().getValue("artemis.custom.url", String.class);
+        ActiveMQConnectionFactory cf = new ActiveMQConnectionFactory(url);
+        return cf;
+    }
+}

--- a/integration-tests/jms-artemis-client/src/main/resources/application.properties
+++ b/integration-tests/jms-artemis-client/src/main/resources/application.properties
@@ -14,14 +14,7 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 ## ---------------------------------------------------------------------------
-
 #
-# Quarkus :: DS
-#
-quarkus.datasource.camel-ds.jdbc.url=jdbc:h2:tcp://localhost/mem:test
-quarkus.datasource.camel-ds.db-kind=h2
-quarkus.datasource.camel-ds.jdbc.max-size=8
-quarkus.datasource.camel-ds.jdbc.transactions=xa
-
-# Quarkus :: Artemis
-quarkus.artemis.xa-enabled=true
+# Overridden to false via @TestProfile(JmsArtemisDisable.class) for some tests
+# When false, we produce a custom ConnectionFactory via CustomConnectionFactory producer bean
+quarkus.artemis.enabled=true

--- a/integration-tests/jms-artemis-client/src/main/resources/application.properties
+++ b/integration-tests/jms-artemis-client/src/main/resources/application.properties
@@ -18,3 +18,6 @@
 # Overridden to false via @TestProfile(JmsArtemisDisable.class) for some tests
 # When false, we produce a custom ConnectionFactory via CustomConnectionFactory producer bean
 quarkus.artemis.enabled=true
+#
+# Only enabled with JmsArtemisPoolingTest
+quarkus.pooled-jms.pooling.enabled=false

--- a/integration-tests/jms-artemis-client/src/test/java/org/apache/camel/quarkus/component/jms/artemis/it/CustomArtemisTestResource.java
+++ b/integration-tests/jms-artemis-client/src/test/java/org/apache/camel/quarkus/component/jms/artemis/it/CustomArtemisTestResource.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.jms.artemis.it;
+
+import io.quarkus.artemis.test.ArtemisTestResource;
+
+public class CustomArtemisTestResource extends ArtemisTestResource {
+    public CustomArtemisTestResource() {
+        super("artemis", "custom");
+    }
+
+}

--- a/integration-tests/jms-artemis-client/src/test/java/org/apache/camel/quarkus/component/jms/artemis/it/JmsArtemisCustomTest.java
+++ b/integration-tests/jms-artemis-client/src/test/java/org/apache/camel/quarkus/component/jms/artemis/it/JmsArtemisCustomTest.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.jms.artemis.it;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import org.apache.camel.quarkus.messaging.jms.AbstractJmsMessagingTest;
+
+@QuarkusTest
+@TestProfile(JmsArtemisDisable.class)
+@QuarkusTestResource(CustomArtemisTestResource.class)
+public class JmsArtemisCustomTest extends AbstractJmsMessagingTest {
+}

--- a/integration-tests/jms-artemis-client/src/test/java/org/apache/camel/quarkus/component/jms/artemis/it/JmsArtemisDisable.java
+++ b/integration-tests/jms-artemis-client/src/test/java/org/apache/camel/quarkus/component/jms/artemis/it/JmsArtemisDisable.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.quarkus.component.jms.artemis.it;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+public class JmsArtemisDisable implements QuarkusTestProfile {
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        Map<String, String> props = new HashMap<>();
+        props.put("quarkus.artemis.enabled", "false");
+        return props;
+    }
+
+}

--- a/integration-tests/jms-artemis-client/src/test/java/org/apache/camel/quarkus/component/jms/artemis/it/JmsArtemisPoolingIT.java
+++ b/integration-tests/jms-artemis-client/src/test/java/org/apache/camel/quarkus/component/jms/artemis/it/JmsArtemisPoolingIT.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.jms.artemis.it;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class JmsArtemisPoolingIT extends JmsArtemisPoolingTest {
+}

--- a/integration-tests/jms-artemis-client/src/test/java/org/apache/camel/quarkus/component/jms/artemis/it/JmsArtemisPoolingTest.java
+++ b/integration-tests/jms-artemis-client/src/test/java/org/apache/camel/quarkus/component/jms/artemis/it/JmsArtemisPoolingTest.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.jms.artemis.it;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import org.apache.camel.quarkus.messaging.jms.AbstractJmsMessagingTest;
+
+@QuarkusTest
+@TestProfile(JmsPoolingEnabled.class)
+public class JmsArtemisPoolingTest extends AbstractJmsMessagingTest {
+    @Override
+    public void testJmsTopic() {
+        // Ignore testJmsTopic since it can't use setClientId in a pool connection.
+    }
+}

--- a/integration-tests/jms-artemis-client/src/test/java/org/apache/camel/quarkus/component/jms/artemis/it/JmsPoolingEnabled.java
+++ b/integration-tests/jms-artemis-client/src/test/java/org/apache/camel/quarkus/component/jms/artemis/it/JmsPoolingEnabled.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.quarkus.component.jms.artemis.it;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+public class JmsPoolingEnabled implements QuarkusTestProfile {
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        Map<String, String> props = new HashMap<>();
+        props.put("quarkus.pooled-jms.pooling.enabled", "true");
+        props.put("quarkus.pooled-jms.max-connections", "8");
+        return props;
+    }
+}

--- a/integration-tests/jms-artemis-client/src/test/resources/broker-custom.xml
+++ b/integration-tests/jms-artemis-client/src/test/resources/broker-custom.xml
@@ -1,0 +1,44 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<configuration xmlns="urn:activemq" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:activemq /schema/artemis-configuration.xsd">
+    <core xmlns="urn:activemq:core">
+        <paging-directory>./target/artemis/default/paging</paging-directory>
+        <bindings-directory>./target/artemis/default/bindings</bindings-directory>
+        <journal-directory>./target/artemis/default/journal</journal-directory>
+        <large-messages-directory>./target/artemis/default/large-messages</large-messages-directory>
+
+        <connectors>
+            <connector name="activemq">tcp://localhost:61616</connector>
+        </connectors>
+        <acceptors>
+            <acceptor name="activemq">tcp://localhost:61616</acceptor>
+        </acceptors>
+
+        <max-disk-usage>-1</max-disk-usage>
+        <security-enabled>false</security-enabled>
+
+        <addresses>
+            <address name="test-jms-default">
+                <anycast>
+                    <queue name="test-jms-default"/>
+                </anycast>
+            </address>
+        </addresses>
+    </core>
+</configuration>

--- a/integration-tests/sjms-artemis-client/src/main/resources/application.properties
+++ b/integration-tests/sjms-artemis-client/src/main/resources/application.properties
@@ -14,14 +14,6 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 ## ---------------------------------------------------------------------------
-
 #
-# Quarkus :: DS
-#
-quarkus.datasource.camel-ds.jdbc.url=jdbc:h2:tcp://localhost/mem:test
-quarkus.datasource.camel-ds.db-kind=h2
-quarkus.datasource.camel-ds.jdbc.max-size=8
-quarkus.datasource.camel-ds.jdbc.transactions=xa
-
-# Quarkus :: Artemis
-quarkus.artemis.xa-enabled=true
+# Let Quarkus Artemis extension produce the ConnectionFactory
+quarkus.artemis.enabled=true

--- a/integration-tests/sjms2-artemis-client/src/main/resources/application.properties
+++ b/integration-tests/sjms2-artemis-client/src/main/resources/application.properties
@@ -14,14 +14,6 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 ## ---------------------------------------------------------------------------
-
 #
-# Quarkus :: DS
-#
-quarkus.datasource.camel-ds.jdbc.url=jdbc:h2:tcp://localhost/mem:test
-quarkus.datasource.camel-ds.db-kind=h2
-quarkus.datasource.camel-ds.jdbc.max-size=8
-quarkus.datasource.camel-ds.jdbc.transactions=xa
-
-# Quarkus :: Artemis
-quarkus.artemis.xa-enabled=true
+# Let Quarkus Artemis extension produce the ConnectionFactory
+quarkus.artemis.enabled=true

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <quarkiverse-mybatis.version>1.0.4</quarkiverse-mybatis.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/mybatis/quarkus-mybatis-parent/ -->
         <quarkiverse-pooled-jms.version>1.0.5</quarkiverse-pooled-jms.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/messaginghub/quarkus-pooled-jms-parent/ -->
         <quarkiverse-tika.version>1.0.3</quarkiverse-tika.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/tika/quarkus-tika-parent/ -->
-        <quarkus.version>2.13.3.Final</quarkus.version><!-- https://repo1.maven.org/maven2/io/quarkus/quarkus-bom/ -->
+        <quarkus.version>999-SNAPSHOT</quarkus.version><!-- https://repo1.maven.org/maven2/io/quarkus/quarkus-bom/ -->
         <quarkus-hazelcast-client.version>3.0.0</quarkus-hazelcast-client.version><!-- https://repo1.maven.org/maven2/com/hazelcast/quarkus-hazelcast-client-bom/ -->
         <quarkus-qpid-jms.version>0.38.0</quarkus-qpid-jms.version><!-- https://repo1.maven.org/maven2/org/amqphub/quarkus/quarkus-qpid-jms-bom/ -->
 

--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,7 @@
         <graalvm.version>22.2.0</graalvm.version><!-- @sync io.quarkus:quarkus-bom:${quarkus.version} dep:org.graalvm.sdk:graal-sdk -->
         <grpc.version>1.49.0</grpc.version><!-- @sync io.quarkus:quarkus-bom:${quarkus.version} dep:io.grpc:grpc-core -->
         <hapi.version>${hapi-version}</hapi.version>
+        <hapi-base.version>${hapi-base-version}</hapi-base.version>
         <hapi-fhir.version>${hapi-fhir-version}</hapi-fhir.version>
         <hbase.version>${hbase-version}</hbase.version>
         <htrace.version>4.2.0-incubating</htrace.version><!-- Mess in hbase transitive deps -->

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <github-api.version>1.111</github-api.version><!-- Used in a Groovy script bellow -->
         <google-auth-library-credentials.version>1.7.0</google-auth-library-credentials.version><!-- TODO: Revert back to using Camel's version when gRPC versions are in sync -->
         <google-oauth-client.version>${google-oauth-client-version}</google-oauth-client.version><!-- TODO: Fix this in Camel https://github.com/apache/camel-quarkus/issues/4139 -->
-        <graalvm.version>22.2.0</graalvm.version><!-- @sync io.quarkus:quarkus-bom:${quarkus.version} dep:org.graalvm.sdk:graal-sdk -->
+        <graalvm.version>22.3.0</graalvm.version><!-- @sync io.quarkus:quarkus-bom:${quarkus.version} dep:org.graalvm.sdk:graal-sdk -->
         <grpc.version>1.49.0</grpc.version><!-- @sync io.quarkus:quarkus-bom:${quarkus.version} dep:io.grpc:grpc-core -->
         <hapi.version>${hapi-version}</hapi.version>
         <hapi-base.version>${hapi-base-version}</hapi-base.version>

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
         <quarkiverse-jsch.version>2.0.1</quarkiverse-jsch.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/jsch/quarkus-jsch-parent/ -->
         <quarkiverse-minio.version>2.9.2</quarkiverse-minio.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/minio/quarkus-minio-parent/ -->
         <quarkiverse-mybatis.version>1.0.4</quarkiverse-mybatis.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/mybatis/quarkus-mybatis-parent/ -->
+        <quarkiverse-pooled-jms.version>1.0.5</quarkiverse-pooled-jms.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/messaginghub/quarkus-pooled-jms-parent/ -->
         <quarkiverse-tika.version>1.0.3</quarkiverse-tika.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/tika/quarkus-tika-parent/ -->
         <quarkus.version>2.13.3.Final</quarkus.version><!-- https://repo1.maven.org/maven2/io/quarkus/quarkus-bom/ -->
         <quarkus-hazelcast-client.version>3.0.0</quarkus-hazelcast-client.version><!-- https://repo1.maven.org/maven2/com/hazelcast/quarkus-hazelcast-client-bom/ -->

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <debezium.version>1.9.6.Final</debezium.version><!-- May go back to Camel's ${debezium-version} when they are in sync https://repo1.maven.org/maven2/io/debezium/debezium-bom/ -->
         <optaplanner.version>8.29.0.Final</optaplanner.version><!-- May go back to Camel's ${optaplanner-version} when they are in sync https://repo1.maven.org/maven2/org/optaplanner/optaplanner-quarkus/ -->
         <quarkiverse-amazonservices.version>1.3.1</quarkiverse-amazonservices.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/amazonservices/quarkus-amazon-services-parent/ -->
-        <quarkiverse-artemis.version>1.2.0</quarkiverse-artemis.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/artemis/quarkus-artemis-parent/ -->
+        <quarkiverse-artemis.version>2.0.0</quarkiverse-artemis.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/artemis/quarkus-artemis-parent/ -->
         <quarkiverse-cxf.version>1.5.5</quarkiverse-cxf.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/cxf/quarkus-cxf-parent/ -->
         <quarkiverse-freemarker.version>0.3.0</quarkiverse-freemarker.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/freemarker/quarkus-freemarker-parent/ -->
         <quarkiverse-jackson-jq.version>1.1.0</quarkiverse-jackson-jq.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/jackson-jq/quarkus-jackson-jq-parent/ -->

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <optaplanner.version>8.29.0.Final</optaplanner.version><!-- May go back to Camel's ${optaplanner-version} when they are in sync https://repo1.maven.org/maven2/org/optaplanner/optaplanner-quarkus/ -->
         <quarkiverse-amazonservices.version>1.3.1</quarkiverse-amazonservices.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/amazonservices/quarkus-amazon-services-parent/ -->
         <quarkiverse-artemis.version>2.0.0</quarkiverse-artemis.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/artemis/quarkus-artemis-parent/ -->
-        <quarkiverse-cxf.version>1.5.5</quarkiverse-cxf.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/cxf/quarkus-cxf-parent/ -->
+        <quarkiverse-cxf.version>1.5.6</quarkiverse-cxf.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/cxf/quarkus-cxf-parent/ -->
         <quarkiverse-freemarker.version>0.3.0</quarkiverse-freemarker.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/freemarker/quarkus-freemarker-parent/ -->
         <quarkiverse-jackson-jq.version>1.1.0</quarkiverse-jackson-jq.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/jackson-jq/quarkus-jackson-jq-parent/ -->
         <quarkiverse-jgit.version>2.2.0</quarkiverse-jgit.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/jgit/quarkus-jgit-parent/ -->

--- a/poms/bom/pom.xml
+++ b/poms/bom/pom.xml
@@ -9407,7 +9407,7 @@
             <dependency>
                 <groupId>ca.uhn.hapi</groupId>
                 <artifactId>hapi-base</artifactId>
-                <version>${hapi.version}</version>
+                <version>${hapi-base.version}</version>
             </dependency>
             <dependency>
                 <groupId>ca.uhn.hapi</groupId>

--- a/poms/bom/pom.xml
+++ b/poms/bom/pom.xml
@@ -9999,6 +9999,17 @@
                 <version>${quarkiverse-jsch.version}</version>
             </dependency>
             <dependency>
+                <groupId>io.quarkiverse.messaginghub</groupId>
+                <artifactId>quarkus-pooled-jms</artifactId>
+                <version>${quarkiverse-pooled-jms.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>jakarta.jms</groupId>
+                        <artifactId>jakarta.jms-api</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
                 <groupId>io.quarkiverse.minio</groupId>
                 <artifactId>quarkus-minio</artifactId>
                 <version>${quarkiverse-minio.version}</version>
@@ -10510,6 +10521,7 @@
                                 <resolutionEntryPointInclude>org.apache.camel.quarkus:*</resolutionEntryPointInclude>
                                 <resolutionEntryPointInclude>ca.uhn.hapi:*</resolutionEntryPointInclude>
                                 <resolutionEntryPointInclude>io.quarkiverse.cxf:*</resolutionEntryPointInclude>
+                                <resolutionEntryPointInclude>io.quarkiverse.messaginghub:*</resolutionEntryPointInclude>
                                 <resolutionEntryPointInclude>net.openhft:affinity</resolutionEntryPointInclude><!-- https://github.com/apache/camel-quarkus/issues/3788 -->
                                 <resolutionEntryPointInclude>org.apache.cxf.xjc-utils:cxf-xjc-runtime</resolutionEntryPointInclude>
                             </resolutionEntryPointIncludes>

--- a/poms/bom/src/main/generated/flattened-full-pom.xml
+++ b/poms/bom/src/main/generated/flattened-full-pom.xml
@@ -10244,12 +10244,12 @@
       <dependency>
         <groupId>org.graalvm.js</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>js</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <version>22.2.0</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+        <version>22.3.0</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
       </dependency>
       <dependency>
         <groupId>org.graalvm.js</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>js-scriptengine</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <version>22.2.0</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+        <version>22.3.0</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
       </dependency>
       <dependency>
         <groupId>org.influxdb</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->

--- a/poms/bom/src/main/generated/flattened-full-pom.xml
+++ b/poms/bom/src/main/generated/flattened-full-pom.xml
@@ -9933,6 +9933,17 @@
         <version>2.0.1</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
       </dependency>
       <dependency>
+        <groupId>io.quarkiverse.messaginghub</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+        <artifactId>quarkus-pooled-jms</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+        <version>1.0.5</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+        <exclusions>
+          <exclusion>
+            <groupId>jakarta.jms</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+            <artifactId>jakarta.jms-api</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
         <groupId>io.quarkiverse.minio</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>quarkus-minio</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <version>2.9.2</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->

--- a/poms/bom/src/main/generated/flattened-full-pom.xml
+++ b/poms/bom/src/main/generated/flattened-full-pom.xml
@@ -10444,434 +10444,434 @@
         <version>2.12.2</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>cxf-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>cxf-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
         <exclusions>
           <exclusion>
-            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
           <exclusion>
-            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>cxf-rt-features-logging</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>cxf-rt-features-logging</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
         <exclusions>
           <exclusion>
-            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
           <exclusion>
-            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>cxf-rt-features-metrics</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>cxf-rt-features-metrics</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
         <exclusions>
           <exclusion>
-            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
           <exclusion>
-            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>cxf-rt-frontend-jaxws</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>cxf-rt-frontend-jaxws</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
         <exclusions>
           <exclusion>
-            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
           <exclusion>
-            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
           <exclusion>
-            <groupId>org.glassfish.jaxb</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>jaxb-runtime</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>org.glassfish.jaxb</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>jaxb-runtime</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
           <exclusion>
-            <groupId>org.ow2.asm</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>asm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>org.ow2.asm</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>asm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>cxf-rt-transports-http</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>cxf-rt-transports-http</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
         <exclusions>
           <exclusion>
-            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
           <exclusion>
-            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>cxf-rt-transports-http-hc5</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>cxf-rt-transports-http-hc5</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
         <exclusions>
           <exclusion>
-            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
           <exclusion>
-            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
           <exclusion>
-            <groupId>org.slf4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>jcl-over-slf4j</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>org.slf4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>jcl-over-slf4j</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>cxf-rt-ws-mex</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>cxf-rt-ws-mex</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
         <exclusions>
           <exclusion>
-            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
           <exclusion>
-            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
           <exclusion>
-            <groupId>org.ow2.asm</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>asm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>org.ow2.asm</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>asm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>cxf-rt-ws-security</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>cxf-rt-ws-security</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
         <exclusions>
           <exclusion>
-            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
           <exclusion>
-            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
           <exclusion>
-            <groupId>org.ow2.asm</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>asm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>org.ow2.asm</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>asm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>cxf-rt-ws-rm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>cxf-rt-ws-rm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
         <exclusions>
           <exclusion>
-            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
           <exclusion>
-            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
           <exclusion>
-            <groupId>org.ow2.asm</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>asm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>org.ow2.asm</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>asm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.services.sts</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>cxf-services-sts-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>org.apache.cxf.services.sts</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>cxf-services-sts-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
         <exclusions>
           <exclusion>
-            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
           <exclusion>
-            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
           <exclusion>
-            <groupId>org.springframework</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>*</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>org.springframework</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>*</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.xjc-utils</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>cxf-xjc-runtime</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>3.3.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>org.apache.cxf.xjc-utils</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>cxf-xjc-runtime</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>3.3.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
         <exclusions>
           <exclusion>
-            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
           <exclusion>
-            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>quarkus-cxf</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>1.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>quarkus-cxf</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>1.5.6</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>quarkus-cxf-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>1.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>quarkus-cxf-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>1.5.6</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>quarkus-cxf-rt-features-logging</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>1.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>quarkus-cxf-rt-features-logging</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>1.5.6</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>quarkus-cxf-rt-features-logging-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>1.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>quarkus-cxf-rt-features-logging-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>1.5.6</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>quarkus-cxf-rt-features-metrics</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>1.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>quarkus-cxf-rt-features-metrics</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>1.5.6</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>quarkus-cxf-rt-features-metrics-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>1.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>quarkus-cxf-rt-features-metrics-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>1.5.6</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>quarkus-cxf-rt-transports-http-hc5</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>1.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>quarkus-cxf-rt-transports-http-hc5</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>1.5.6</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>quarkus-cxf-rt-transports-http-hc5-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>1.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>quarkus-cxf-rt-transports-http-hc5-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>1.5.6</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>quarkus-cxf-rt-ws-security</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>1.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>quarkus-cxf-rt-ws-security</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>1.5.6</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>quarkus-cxf-rt-ws-security-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>1.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>quarkus-cxf-rt-ws-security-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>1.5.6</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>quarkus-cxf-rt-ws-rm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>1.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>quarkus-cxf-rt-ws-rm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>1.5.6</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>quarkus-cxf-rt-ws-rm-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>1.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>quarkus-cxf-rt-ws-rm-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>1.5.6</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>quarkus-cxf-saaj</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>1.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>quarkus-cxf-saaj</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>1.5.6</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>quarkus-cxf-saaj-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>1.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>quarkus-cxf-saaj-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>1.5.6</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>quarkus-cxf-services-sts</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>1.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>quarkus-cxf-services-sts</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>1.5.6</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>quarkus-cxf-services-sts-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>1.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>quarkus-cxf-services-sts-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>1.5.6</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>quarkus-cxf-woodstox</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>1.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>quarkus-cxf-woodstox</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>1.5.6</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>quarkus-cxf-woodstox-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>1.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>quarkus-cxf-woodstox-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>1.5.6</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>com.fasterxml.woodstox</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>woodstox-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>6.4.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>com.fasterxml.woodstox</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>woodstox-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>6.4.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>com.sun.xml.messaging.saaj</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>saaj-impl</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>1.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>com.sun.xml.messaging.saaj</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>saaj-impl</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>1.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.neethi</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>neethi</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>3.2.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>org.apache.neethi</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>neethi</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>3.2.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>org.ehcache</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>ehcache</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>3.10.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>org.ehcache</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>ehcache</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>3.10.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
         <exclusions>
           <exclusion>
-            <groupId>org.glassfish.jaxb</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>jaxb-runtime</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>org.glassfish.jaxb</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>jaxb-runtime</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.jvnet.mimepull</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>mimepull</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>1.9.14</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>org.jvnet.mimepull</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>mimepull</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>1.9.14</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.santuario</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>xmlsec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>2.3.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>org.apache.santuario</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>xmlsec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>2.3.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
         <exclusions>
           <exclusion>
-            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
           <exclusion>
-            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.xmlsec</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>quarkus-xmlsec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>1.1.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>io.quarkiverse.xmlsec</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>quarkus-xmlsec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>1.1.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.xmlsec</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>quarkus-xmlsec-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>1.1.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>io.quarkiverse.xmlsec</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>quarkus-xmlsec-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>1.1.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>cxf-rt-bindings-soap</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>cxf-rt-bindings-soap</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>cxf-rt-bindings-xml</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>cxf-rt-bindings-xml</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>cxf-rt-databinding-jaxb</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>cxf-rt-databinding-jaxb</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>cxf-rt-frontend-simple</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>cxf-rt-frontend-simple</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>cxf-rt-management</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>cxf-rt-management</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>cxf-rt-rs-json-basic</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>cxf-rt-rs-json-basic</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>cxf-rt-rs-security-jose</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>cxf-rt-rs-security-jose</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>cxf-rt-security-saml</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>cxf-rt-security-saml</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>cxf-rt-wsdl</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>cxf-rt-wsdl</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>cxf-rt-ws-addr</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>cxf-rt-ws-addr</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>cxf-rt-security</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>cxf-rt-security</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
         <groupId>org.codehaus.groovy</groupId><!-- org.codehaus.groovy:groovy-bom:3.0.8 -->

--- a/poms/bom/src/main/generated/flattened-reduced-pom.xml
+++ b/poms/bom/src/main/generated/flattened-reduced-pom.xml
@@ -10239,7 +10239,7 @@
       <dependency>
         <groupId>org.graalvm.js</groupId>
         <artifactId>js</artifactId>
-        <version>22.2.0</version>
+        <version>22.3.0</version>
       </dependency>
       <dependency>
         <groupId>org.influxdb</groupId>

--- a/poms/bom/src/main/generated/flattened-reduced-pom.xml
+++ b/poms/bom/src/main/generated/flattened-reduced-pom.xml
@@ -9933,6 +9933,17 @@
         <version>2.0.1</version>
       </dependency>
       <dependency>
+        <groupId>io.quarkiverse.messaginghub</groupId>
+        <artifactId>quarkus-pooled-jms</artifactId>
+        <version>1.0.5</version>
+        <exclusions>
+          <exclusion>
+            <groupId>jakarta.jms</groupId>
+            <artifactId>jakarta.jms-api</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
         <groupId>io.quarkiverse.minio</groupId>
         <artifactId>quarkus-minio</artifactId>
         <version>2.9.2</version>

--- a/poms/bom/src/main/generated/flattened-reduced-pom.xml
+++ b/poms/bom/src/main/generated/flattened-reduced-pom.xml
@@ -10655,92 +10655,92 @@
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf</artifactId>
-        <version>1.5.5</version>
+        <version>1.5.6</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-deployment</artifactId>
-        <version>1.5.5</version>
+        <version>1.5.6</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-features-logging</artifactId>
-        <version>1.5.5</version>
+        <version>1.5.6</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-features-logging-deployment</artifactId>
-        <version>1.5.5</version>
+        <version>1.5.6</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-features-metrics</artifactId>
-        <version>1.5.5</version>
+        <version>1.5.6</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-features-metrics-deployment</artifactId>
-        <version>1.5.5</version>
+        <version>1.5.6</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-transports-http-hc5</artifactId>
-        <version>1.5.5</version>
+        <version>1.5.6</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-transports-http-hc5-deployment</artifactId>
-        <version>1.5.5</version>
+        <version>1.5.6</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-ws-security</artifactId>
-        <version>1.5.5</version>
+        <version>1.5.6</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-ws-security-deployment</artifactId>
-        <version>1.5.5</version>
+        <version>1.5.6</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-ws-rm</artifactId>
-        <version>1.5.5</version>
+        <version>1.5.6</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-ws-rm-deployment</artifactId>
-        <version>1.5.5</version>
+        <version>1.5.6</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-saaj</artifactId>
-        <version>1.5.5</version>
+        <version>1.5.6</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-saaj-deployment</artifactId>
-        <version>1.5.5</version>
+        <version>1.5.6</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-services-sts</artifactId>
-        <version>1.5.5</version>
+        <version>1.5.6</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-services-sts-deployment</artifactId>
-        <version>1.5.5</version>
+        <version>1.5.6</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-woodstox</artifactId>
-        <version>1.5.5</version>
+        <version>1.5.6</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-woodstox-deployment</artifactId>
-        <version>1.5.5</version>
+        <version>1.5.6</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.woodstox</groupId>

--- a/poms/bom/src/main/generated/flattened-reduced-verbose-pom.xml
+++ b/poms/bom/src/main/generated/flattened-reduced-verbose-pom.xml
@@ -9933,6 +9933,17 @@
         <version>2.0.1</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
       </dependency>
       <dependency>
+        <groupId>io.quarkiverse.messaginghub</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+        <artifactId>quarkus-pooled-jms</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+        <version>1.0.5</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+        <exclusions>
+          <exclusion>
+            <groupId>jakarta.jms</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+            <artifactId>jakarta.jms-api</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
         <groupId>io.quarkiverse.minio</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>quarkus-minio</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <version>2.9.2</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->

--- a/poms/bom/src/main/generated/flattened-reduced-verbose-pom.xml
+++ b/poms/bom/src/main/generated/flattened-reduced-verbose-pom.xml
@@ -10424,434 +10424,434 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>cxf-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>cxf-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
         <exclusions>
           <exclusion>
-            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
           <exclusion>
-            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>cxf-rt-features-logging</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>cxf-rt-features-logging</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
         <exclusions>
           <exclusion>
-            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
           <exclusion>
-            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>cxf-rt-features-metrics</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>cxf-rt-features-metrics</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
         <exclusions>
           <exclusion>
-            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
           <exclusion>
-            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>cxf-rt-frontend-jaxws</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>cxf-rt-frontend-jaxws</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
         <exclusions>
           <exclusion>
-            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
           <exclusion>
-            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
           <exclusion>
-            <groupId>org.glassfish.jaxb</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>jaxb-runtime</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>org.glassfish.jaxb</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>jaxb-runtime</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
           <exclusion>
-            <groupId>org.ow2.asm</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>asm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>org.ow2.asm</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>asm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>cxf-rt-transports-http</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>cxf-rt-transports-http</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
         <exclusions>
           <exclusion>
-            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
           <exclusion>
-            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>cxf-rt-transports-http-hc5</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>cxf-rt-transports-http-hc5</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
         <exclusions>
           <exclusion>
-            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
           <exclusion>
-            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
           <exclusion>
-            <groupId>org.slf4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>jcl-over-slf4j</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>org.slf4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>jcl-over-slf4j</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>cxf-rt-ws-mex</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>cxf-rt-ws-mex</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
         <exclusions>
           <exclusion>
-            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
           <exclusion>
-            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
           <exclusion>
-            <groupId>org.ow2.asm</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>asm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>org.ow2.asm</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>asm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>cxf-rt-ws-security</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>cxf-rt-ws-security</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
         <exclusions>
           <exclusion>
-            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
           <exclusion>
-            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
           <exclusion>
-            <groupId>org.ow2.asm</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>asm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>org.ow2.asm</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>asm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>cxf-rt-ws-rm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>cxf-rt-ws-rm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
         <exclusions>
           <exclusion>
-            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
           <exclusion>
-            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
           <exclusion>
-            <groupId>org.ow2.asm</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>asm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>org.ow2.asm</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>asm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.services.sts</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>cxf-services-sts-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>org.apache.cxf.services.sts</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>cxf-services-sts-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
         <exclusions>
           <exclusion>
-            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
           <exclusion>
-            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
           <exclusion>
-            <groupId>org.springframework</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>*</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>org.springframework</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>*</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.xjc-utils</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>cxf-xjc-runtime</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>3.3.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>org.apache.cxf.xjc-utils</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>cxf-xjc-runtime</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>3.3.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
         <exclusions>
           <exclusion>
-            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
           <exclusion>
-            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>quarkus-cxf</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>1.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>quarkus-cxf</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>1.5.6</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>quarkus-cxf-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>1.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>quarkus-cxf-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>1.5.6</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>quarkus-cxf-rt-features-logging</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>1.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>quarkus-cxf-rt-features-logging</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>1.5.6</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>quarkus-cxf-rt-features-logging-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>1.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>quarkus-cxf-rt-features-logging-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>1.5.6</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>quarkus-cxf-rt-features-metrics</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>1.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>quarkus-cxf-rt-features-metrics</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>1.5.6</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>quarkus-cxf-rt-features-metrics-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>1.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>quarkus-cxf-rt-features-metrics-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>1.5.6</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>quarkus-cxf-rt-transports-http-hc5</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>1.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>quarkus-cxf-rt-transports-http-hc5</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>1.5.6</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>quarkus-cxf-rt-transports-http-hc5-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>1.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>quarkus-cxf-rt-transports-http-hc5-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>1.5.6</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>quarkus-cxf-rt-ws-security</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>1.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>quarkus-cxf-rt-ws-security</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>1.5.6</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>quarkus-cxf-rt-ws-security-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>1.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>quarkus-cxf-rt-ws-security-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>1.5.6</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>quarkus-cxf-rt-ws-rm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>1.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>quarkus-cxf-rt-ws-rm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>1.5.6</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>quarkus-cxf-rt-ws-rm-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>1.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>quarkus-cxf-rt-ws-rm-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>1.5.6</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>quarkus-cxf-saaj</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>1.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>quarkus-cxf-saaj</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>1.5.6</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>quarkus-cxf-saaj-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>1.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>quarkus-cxf-saaj-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>1.5.6</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>quarkus-cxf-services-sts</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>1.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>quarkus-cxf-services-sts</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>1.5.6</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>quarkus-cxf-services-sts-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>1.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>quarkus-cxf-services-sts-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>1.5.6</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>quarkus-cxf-woodstox</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>1.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>quarkus-cxf-woodstox</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>1.5.6</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>quarkus-cxf-woodstox-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>1.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>quarkus-cxf-woodstox-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>1.5.6</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>com.fasterxml.woodstox</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>woodstox-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>6.4.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>com.fasterxml.woodstox</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>woodstox-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>6.4.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>com.sun.xml.messaging.saaj</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>saaj-impl</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>1.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>com.sun.xml.messaging.saaj</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>saaj-impl</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>1.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.neethi</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>neethi</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>3.2.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>org.apache.neethi</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>neethi</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>3.2.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>org.ehcache</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>ehcache</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>3.10.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>org.ehcache</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>ehcache</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>3.10.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
         <exclusions>
           <exclusion>
-            <groupId>org.glassfish.jaxb</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>jaxb-runtime</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>org.glassfish.jaxb</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>jaxb-runtime</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.jvnet.mimepull</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>mimepull</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>1.9.14</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>org.jvnet.mimepull</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>mimepull</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>1.9.14</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.santuario</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>xmlsec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>2.3.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>org.apache.santuario</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>xmlsec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>2.3.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
         <exclusions>
           <exclusion>
-            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
           <exclusion>
-            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.xmlsec</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>quarkus-xmlsec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>1.1.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>io.quarkiverse.xmlsec</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>quarkus-xmlsec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>1.1.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.xmlsec</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>quarkus-xmlsec-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>1.1.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>io.quarkiverse.xmlsec</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>quarkus-xmlsec-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>1.1.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>cxf-rt-bindings-soap</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>cxf-rt-bindings-soap</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>cxf-rt-bindings-xml</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>cxf-rt-bindings-xml</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>cxf-rt-databinding-jaxb</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>cxf-rt-databinding-jaxb</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>cxf-rt-frontend-simple</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>cxf-rt-frontend-simple</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>cxf-rt-management</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>cxf-rt-management</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>cxf-rt-rs-json-basic</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>cxf-rt-rs-json-basic</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>cxf-rt-rs-security-jose</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>cxf-rt-rs-security-jose</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>cxf-rt-security-saml</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>cxf-rt-security-saml</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>cxf-rt-wsdl</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>cxf-rt-wsdl</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>cxf-rt-ws-addr</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>cxf-rt-ws-addr</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <artifactId>cxf-rt-security</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
-        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.5 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <artifactId>cxf-rt-security</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
+        <version>3.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.6 -->
       </dependency>
       <dependency>
         <groupId>org.codehaus.groovy</groupId><!-- org.codehaus.groovy:groovy-bom:3.0.8 -->

--- a/poms/bom/src/main/generated/flattened-reduced-verbose-pom.xml
+++ b/poms/bom/src/main/generated/flattened-reduced-verbose-pom.xml
@@ -10239,7 +10239,7 @@
       <dependency>
         <groupId>org.graalvm.js</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>js</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <version>22.2.0</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+        <version>22.3.0</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
       </dependency>
       <dependency>
         <groupId>org.influxdb</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->


### PR DESCRIPTION
GraalVM 22.3 will come with Quarkus 2.13.4