### PR TITLE
DoBeforeEach does not work with Advice #4362

### DIFF
--- a/docs/modules/ROOT/pages/user-guide/testing.adoc
+++ b/docs/modules/ROOT/pages/user-guide/testing.adoc
@@ -258,9 +258,9 @@ Be aware that execution of method `doAfterConstruct` differs from the execution 
 * To force Quarkus JUnit Extension to restart the application (and thus also `CamelContext`) for a given test class, you need to assign a unique `@io.quarkus.test.junit.TestProfile` to that class. Check the https://quarkus.io/guides/getting-started-testing#testing_different_profiles[Quarkus documentation] for how you can do that. (Note that `https://quarkus.io/guides/getting-started-testing#quarkus-test-resource[@io.quarkus.test.common.QuarkusTestResource]` has a similar effect.)
 * Camel Quarkus executes the production of beans during the build phase. Because all the tests are
 build together, exclusion behavior is implemented into `CamelQuarkusTestSupport`. If a producer of the specific type and name is used in one tests, the instance will be the same for the rest of the tests.
-* JUnit Jupiter callbacks (`BeforeEachCallback`, `AfterEachCallback`, `AfterAllCallback`, `BeforeAllCallback`, `BeforeTestExecutionCallback` and `AfterTestExecutionCallback`) might not work correctly. See the https://quarkus.io/guides/getting-started-testing#enrichment-via-quarkustestcallback[documentation].
+* JUnit Jupiter callbacks (`BeforeEachCallback`, `AfterEachCallback`, `AfterAllCallback`, `BeforeAllCallback`, `BeforeTestExecutionCallback` and `AfterTestExecutionCallback`) and JUnit Jupiter annotations (`@BeforeEach`, `@AfterEach`, `@AfterAll` and `@BeforeAll`) might not work correctly. See the https://quarkus.io/guides/getting-started-testing#enrichment-via-quarkustestcallback[documentation].
 * If there is an unaffected route, when using advice with, it's important to execute method `CamelQuarkusTestSupport.startRouteDefinitions()` manually from the unit test after you are done doing all the advice with
-
+* Do not use `@Produces` with `RouteBuilder` use the overridden method `createRouteBuilder()` instead. `@Produces` with `RouteBuilder` might not work correctly.
 
 [source,java]
 ----

--- a/test-framework/junit5-extension-tests/src/test/java/org/apache/camel/quarkus/test/extensions/producedRouteBuilder/ProducedRouteBuilderET.java
+++ b/test-framework/junit5-extension-tests/src/test/java/org/apache/camel/quarkus/test/extensions/producedRouteBuilder/ProducedRouteBuilderET.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.test.extensions.producedRouteBuilder;
+
+import javax.enterprise.inject.Produces;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.apache.camel.builder.AdviceWith;
+import org.apache.camel.builder.AdviceWithRouteBuilder;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.quarkus.test.CamelQuarkusTestSupport;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+public class ProducedRouteBuilderET extends CamelQuarkusTestSupport {
+
+    @BeforeEach
+    public void doSomethingBefore() throws Exception {
+        AdviceWith.adviceWith(this.context, "sampleRoute",
+                ProducedRouteBuilderET::enhanceRoute);
+    }
+
+    @Produces
+    public RouteBuilder routes() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+                from("direct:in").routeId("sampleRoute").to("file:target/data/RouteBuilderET?filename=hello_true.txt");
+            }
+        };
+    }
+
+    @Test
+    public void firstTest() throws Exception {
+        Assertions.assertTrue(true);
+    }
+
+    @Test
+    public void secondTest() throws Exception {
+        Assertions.assertTrue(true);
+    }
+
+    private static void enhanceRoute(AdviceWithRouteBuilder route) {
+        route.replaceFromWith("direct:ftp");
+        route.interceptSendToEndpoint("file:.*samples.*")
+                .skipSendToOriginalEndpoint()
+                .to("mock:file:sample_requests");
+    }
+
+}

--- a/test-framework/junit5-extension-tests/src/test/java/org/apache/camel/quarkus/test/extensions/producedRouteBuilder/ProducedRouteBuilderTest.java
+++ b/test-framework/junit5-extension-tests/src/test/java/org/apache/camel/quarkus/test/extensions/producedRouteBuilder/ProducedRouteBuilderTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.test.extensions.producedRouteBuilder;
+
+import java.util.function.Supplier;
+
+import io.quarkus.test.ContinuousTestingTestUtils;
+import io.quarkus.test.QuarkusDevModeTest;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+/**
+ * Test for https://github.com/apache/camel-quarkus/issues/4362
+ */
+public class ProducedRouteBuilderTest {
+
+    @RegisterExtension
+    static final QuarkusDevModeTest TEST = new QuarkusDevModeTest()
+            .setArchiveProducer(new Supplier<>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .add(new StringAsset(
+                                    ContinuousTestingTestUtils.appProperties("camel-quarkus.junit5.message=Sheldon")),
+                                    "application.properties");
+                }
+            })
+            .setTestArchiveProducer(new Supplier<>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class).addClasses(ProducedRouteBuilderET.class);
+                }
+            });
+
+    @Test
+    public void checkTests() {
+        ContinuousTestingTestUtils utils = new ContinuousTestingTestUtils();
+        ContinuousTestingTestUtils.TestStatus ts = utils.waitForNextCompletion();
+
+        Assertions.assertEquals(1L, ts.getTestsFailed());
+        Assertions.assertEquals(1L, ts.getTestsPassed());
+    }
+}

--- a/test-framework/junit5/src/main/java/org/apache/camel/quarkus/test/AfterAllCallback.java
+++ b/test-framework/junit5/src/main/java/org/apache/camel/quarkus/test/AfterAllCallback.java
@@ -27,8 +27,8 @@ public class AfterAllCallback implements QuarkusTestAfterAllCallback {
             CamelQuarkusTestSupport testInstance = (CamelQuarkusTestSupport) context.getTestInstance();
 
             if (CallbackUtil.isPerClass(testInstance)) {
-                CallbackUtil.resetContext(testInstance);
                 testInstance.internalAfterAll(context);
+                CallbackUtil.resetContext(testInstance);
             }
 
             try {

--- a/test-framework/junit5/src/main/java/org/apache/camel/quarkus/test/AfterEachCallback.java
+++ b/test-framework/junit5/src/main/java/org/apache/camel/quarkus/test/AfterEachCallback.java
@@ -26,15 +26,15 @@ public class AfterEachCallback implements QuarkusTestAfterEachCallback {
         if (context.getTestInstance() instanceof CamelQuarkusTestSupport) {
             CamelQuarkusTestSupport testInstance = (CamelQuarkusTestSupport) context.getTestInstance();
 
-            if (!CallbackUtil.isPerClass(testInstance)) {
-                CallbackUtil.resetContext(testInstance);
-            }
-
             try {
+                testInstance.tearDown();
                 testInstance.doAfterEach(context);
             } catch (Exception e) {
                 throw new RuntimeException(e);
+            }
 
+            if (!CallbackUtil.isPerClass(testInstance)) {
+                CallbackUtil.resetContext(testInstance);
             }
         }
     }

--- a/test-framework/junit5/src/main/java/org/apache/camel/quarkus/test/BeforeEachCallback.java
+++ b/test-framework/junit5/src/main/java/org/apache/camel/quarkus/test/BeforeEachCallback.java
@@ -36,6 +36,7 @@ public class BeforeEachCallback implements QuarkusTestBeforeEachCallback {
             try {
                 testInstance.internalBeforeEach(mockContext);
                 testInstance.internalBeforeAll(mockContext);
+                testInstance.setUp();
                 testInstance.doBeforeEach(context);
             } catch (Exception e) {
                 throw new RuntimeException(e);

--- a/test-framework/junit5/src/main/java/org/apache/camel/quarkus/test/CamelQuarkusTestSupport.java
+++ b/test-framework/junit5/src/main/java/org/apache/camel/quarkus/test/CamelQuarkusTestSupport.java
@@ -220,6 +220,27 @@ public class CamelQuarkusTestSupport extends CamelTestSupport
     }
 
     /**
+     * Method {@link CamelTestSupport#setUp()} is triggered via annotation {@link org.junit.jupiter.api.BeforeEach}.
+     * Its execution is disabled (by using overriding method without any annotation) and is executed from
+     * {@link BeforeEachCallback}
+     */
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+    }
+
+    /**
+     * Method {@link CamelTestSupport#tearDown()} is triggered via annotation
+     * {@link org.junit.jupiter.api.AfterEach}.
+     * Its execution is disabled (by using overriding method without any annotation) and is executed from
+     * {@link AfterEachCallback}
+     */
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+    /**
      * This method stops the Camel context. Be aware that on of the limitation that Quarkus brings is that context
      * can not be started (lifecycle f the context is bound to the application) .
      *

--- a/test-framework/junit5/src/test/java/org/apache/camel/quarkus/test/junit5/CamelTestSupportTest.java
+++ b/test-framework/junit5/src/test/java/org/apache/camel/quarkus/test/junit5/CamelTestSupportTest.java
@@ -22,7 +22,6 @@ import org.apache.camel.NoSuchEndpointException;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.quarkus.test.CamelQuarkusTestSupport;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -33,7 +32,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class CamelTestSupportTest extends CamelQuarkusTestSupport {
 
     @Override
-    @BeforeEach
     public void setUp() throws Exception {
         replaceRouteFromWith("routeId", "direct:start");
         super.setUp();

--- a/test-framework/junit5/src/test/java/org/apache/camel/quarkus/test/junit5/patterns/IsMockEndpointsFileTest.java
+++ b/test-framework/junit5/src/test/java/org/apache/camel/quarkus/test/junit5/patterns/IsMockEndpointsFileTest.java
@@ -21,7 +21,6 @@ import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.quarkus.test.CamelQuarkusTestSupport;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.camel.test.junit5.TestSupport.deleteDirectory;
@@ -30,7 +29,6 @@ import static org.apache.camel.test.junit5.TestSupport.deleteDirectory;
 public class IsMockEndpointsFileTest extends CamelQuarkusTestSupport {
 
     @Override
-    @BeforeEach
     public void setUp() throws Exception {
         deleteDirectory("target/input");
         deleteDirectory("target/messages");

--- a/test-framework/junit5/src/test/java/org/apache/camel/quarkus/test/junit5/patterns/RouteBuilderConfigureExceptionTest.java
+++ b/test-framework/junit5/src/test/java/org/apache/camel/quarkus/test/junit5/patterns/RouteBuilderConfigureExceptionTest.java
@@ -20,7 +20,6 @@ import io.quarkus.test.junit.QuarkusTest;
 import org.apache.camel.Predicate;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.quarkus.test.CamelQuarkusTestSupport;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.fail;
@@ -31,7 +30,6 @@ public class RouteBuilderConfigureExceptionTest extends CamelQuarkusTestSupport 
     private Predicate iAmNull;
 
     @Override
-    @BeforeEach
     public void setUp() {
         try {
             super.setUp();

--- a/test-framework/junit5/src/test/java/org/apache/camel/quarkus/test/userTestCases/AdviceInDoBeforeEachMethodsTest.java
+++ b/test-framework/junit5/src/test/java/org/apache/camel/quarkus/test/userTestCases/AdviceInDoBeforeEachMethodsTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.test.userTestCases;
+
+import javax.inject.Inject;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.junit.callback.QuarkusTestMethodContext;
+import org.apache.camel.CamelContext;
+import org.apache.camel.EndpointInject;
+import org.apache.camel.Produce;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.AdviceWith;
+import org.apache.camel.builder.AdviceWithRouteBuilder;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.quarkus.test.CamelQuarkusTestSupport;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test for https://github.com/apache/camel-quarkus/issues/4362
+ */
+@QuarkusTest
+@TestProfile(AdviceInDoBeforeEachMethodsTest.class)
+public class AdviceInDoBeforeEachMethodsTest extends CamelQuarkusTestSupport {
+
+    @Produce("direct:ftp")
+    protected ProducerTemplate template;
+
+    @Inject
+    protected CamelContext context;
+
+    @EndpointInject("mock:file:sample_requests")
+    protected MockEndpoint fileMock;
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            public void configure() {
+                from("direct:start")
+                        .routeId("sampleRoute")
+                        .to("file:samples/");
+            }
+        };
+    }
+
+    @Override
+    protected void doBeforeEach(QuarkusTestMethodContext context) throws Exception {
+        AdviceWith.adviceWith(this.context, "sampleRoute",
+                AdviceInDoBeforeEachMethodsTest::enhanceRoute);
+    }
+
+    @Test
+    void testConsumeFtpWriteToFileOne() throws Exception {
+        fileMock.message(0).body().isEqualTo("Hello World");
+        template.sendBody("direct:ftp", "Hello World");
+        fileMock.assertIsSatisfied();
+    }
+
+    @Test
+    void testConsumeFtpWriteToFileTwo() throws Exception {
+        fileMock.message(0).body().isEqualTo("Hello World");
+        template.sendBody("direct:ftp", "Hello World");
+        fileMock.assertIsSatisfied();
+    }
+
+    private static void enhanceRoute(AdviceWithRouteBuilder route) {
+        route.replaceFromWith("direct:ftp");
+        route.interceptSendToEndpoint("file:.*samples.*")
+                .skipSendToOriginalEndpoint()
+                .to("mock:file:sample_requests");
+    }
+}


### PR DESCRIPTION
fixes https://github.com/apache/camel-quarkus/issues/4362

Originally reported issue problem is not a bug -> this is intentional (forced) behaviour.
Second problem -> Advice not working in @BeforeEach method is na issue, which is fixed in this PR.

Tests covering both cases  and a small change in the documentation are added.

<!-- Uncomment and fill this section if your PR is not trivial
[ ] An issue should be filed for the change unless this is a trivial change (fixing a typo or similar). One issue should ideally be fixed by not more than one commit and the other way round, each commit should fix just one issue, without pulling in other changes.
[ ] Each commit in the pull request should have a meaningful and properly spelled subject line and body. Copying the title of the associated issue is typically enough. Please include the issue number in the commit message prefixed by #.
[ ] The pull request description should explain what the pull request does, how, and why. If the info is available in the associated issue or some other external document, a link is enough.
[ ] Phrases like Fix #<issueNumber> or Fixes #<issueNumber> will auto-close the named issue upon merging the pull request. Using them is typically a good idea.
[ ] Please run mvn process-resources -Pformat (and amend the changes if necessary) before sending the pull request.
[ ] Contributor guide is your good friend: https://camel.apache.org/camel-quarkus/latest/contributor-guide.html
-->