### PR TITLE
Remove dependency on camel-health from camel-quarkus-core

### DIFF
--- a/extensions-core/core/runtime/pom.xml
+++ b/extensions-core/core/runtime/pom.xml
@@ -85,10 +85,6 @@
             <artifactId>camel-microprofile-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.camel</groupId>
-            <artifactId>camel-health</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.jboss.spec.javax.xml.bind</groupId>
             <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
         </dependency>

--- a/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/FastCamelContext.java
+++ b/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/FastCamelContext.java
@@ -24,13 +24,11 @@ import org.apache.camel.CatalogCamelContext;
 import org.apache.camel.Component;
 import org.apache.camel.TypeConverter;
 import org.apache.camel.component.microprofile.config.CamelMicroProfilePropertiesSource;
-import org.apache.camel.health.HealthCheckRegistry;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.impl.engine.DefaultComponentResolver;
 import org.apache.camel.impl.engine.DefaultDataFormatResolver;
 import org.apache.camel.impl.engine.DefaultLanguageResolver;
 import org.apache.camel.impl.engine.DefaultShutdownStrategy;
-import org.apache.camel.impl.health.DefaultHealthCheckRegistry;
 import org.apache.camel.model.ModelCamelContext;
 import org.apache.camel.quarkus.CamelQuarkusBeanPostProcessor;
 import org.apache.camel.spi.CamelBeanPostProcessor;
@@ -159,11 +157,6 @@ public class FastCamelContext extends DefaultCamelContext implements CatalogCame
     @Override
     protected XMLRoutesDefinitionLoader createXMLRoutesDefinitionLoader() {
         return new DisabledXMLRoutesDefinitionLoader();
-    }
-
-    @Override
-    protected HealthCheckRegistry createHealthCheckRegistry() {
-        return new DefaultHealthCheckRegistry();
     }
 
     @Override


### PR DESCRIPTION
@JiriOndrusek do you recall why the override for `createHealthCheckRegistry` was added to `FastCamelContext` in the 3.20 upgrade? I think it's not needed and enough to inherit the default implementation in `SimpleCamelContext`:

https://github.com/apache/camel/blame/3bcc047dcb54b064df5de3beacc4af57971a47f6/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/SimpleCamelContext.java#L131-L140