### PR TITLE
testing defaultCredentialProvider with local stack #440

### DIFF
--- a/integration-test-groups/aws2/aws2-cw/src/test/java/org/apache/camel/quarkus/component/aws2/cw/it/Aws2CwTest.java
+++ b/integration-test-groups/aws2/aws2-cw/src/test/java/org/apache/camel/quarkus/component/aws2/cw/it/Aws2CwTest.java
@@ -26,13 +26,16 @@ import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
+import io.restassured.response.ValidatableResponse;
 import org.apache.camel.component.aws2.cw.Cw2Constants;
 import org.apache.camel.quarkus.test.support.aws2.Aws2Client;
+import org.apache.camel.quarkus.test.support.aws2.Aws2DefaultCredentialsProviderAvailabilityCondition;
 import org.apache.camel.quarkus.test.support.aws2.Aws2TestResource;
 import org.apache.camel.util.CollectionHelper;
 import org.awaitility.Awaitility;
 import org.jboss.logging.Logger;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.testcontainers.containers.localstack.LocalStackContainer.Service;
 import software.amazon.awssdk.services.cloudwatch.CloudWatchClient;
 import software.amazon.awssdk.services.cloudwatch.model.Datapoint;
@@ -41,6 +44,7 @@ import software.amazon.awssdk.services.cloudwatch.model.GetMetricStatisticsReque
 import software.amazon.awssdk.services.cloudwatch.model.Statistic;
 
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
 
 @QuarkusTest
 @QuarkusTestResource(Aws2TestResource.class)
@@ -99,7 +103,6 @@ class Aws2CwTest {
 
     @Test
     public void headers() {
-
         final Instant startTime = Instant.ofEpochMilli(System.currentTimeMillis() - 10000);
 
         final String namespace = "cq-metrics-" + java.util.UUID.randomUUID().toString().replace("-", "");
@@ -234,11 +237,51 @@ class Aws2CwTest {
         RestAssured.given()
                 .contentType("application/x-www-form-urlencoded; charset=utf-8")
                 .header("customClientName", "customClient")
+                .header("returnExceptionMessage", true)
                 .formParams(data)
                 .post("/aws2-cw/send-metric-map/" + namespace)
                 .then()
                 .statusCode(200)
                 .body(is("CloudWatchClientMock"));
+    }
+
+    //test can be executed only if mock backend is used and no defaultCredentialsprovider is defined in the system
+    @ExtendWith(Aws2DefaultCredentialsProviderAvailabilityCondition.class)
+    @Test
+    public void defaultCredentialsProviderOnLocalstackTest() {
+        testDefaultCredentialsProvider(false, true).statusCode(200)
+                .body(startsWith(Aws2DefaultCredentialsProviderAvailabilityCondition.UNABLE_TO_LOAD_CREDENTIALS_MSG));
+        ;
+
+        testDefaultCredentialsProvider(true, false).statusCode(201);
+    }
+
+    //called twice from the defaultCredentialsProviderOnLocalstackTest
+    private ValidatableResponse testDefaultCredentialsProvider(boolean setCredenbtials, boolean returnErrorMessage) {
+        final Instant startTime = Instant.ofEpochMilli(System.currentTimeMillis() - 10000);
+
+        final String namespace = "cq-metrics-" + java.util.UUID.randomUUID().toString().replace("-", "");
+        final String metricName = "metricName" + java.util.UUID.randomUUID().toString().replace("-", "");
+
+        List<Map<String, String>> data = new LinkedList<>();
+
+        Map<String, String> item = CollectionHelper.mapOf(
+                Cw2Constants.METRIC_NAMESPACE, namespace,
+                Cw2Constants.METRIC_NAME, metricName,
+                Cw2Constants.METRIC_VALUE, 0,
+                Cw2Constants.METRIC_UNIT, "Count",
+                Cw2Constants.METRIC_DIMENSION_NAME, "type",
+                Cw2Constants.METRIC_DIMENSION_VALUE, "even");
+
+        return RestAssured.given()
+                .contentType("application/x-www-form-urlencoded; charset=utf-8")
+                .formParams(item)
+                .header("defaultCredentialsProvider", true)
+                .header("returnExceptionMessage", returnErrorMessage)
+                .header("setCredentials", setCredenbtials)
+                .post("/aws2-cw/send-metric-map/" + namespace)
+                .then();
+
     }
 
 }

--- a/integration-tests-support/aws2/src/main/java/org/apache/camel/quarkus/test/support/aws2/Aws2DefaultCredentialsProviderAvailabilityCondition.java
+++ b/integration-tests-support/aws2/src/main/java/org/apache/camel/quarkus/test/support/aws2/Aws2DefaultCredentialsProviderAvailabilityCondition.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.test.support.aws2;
+
+import org.apache.camel.quarkus.test.mock.backend.MockBackendUtils;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.core.exception.SdkClientException;
+
+public class Aws2DefaultCredentialsProviderAvailabilityCondition implements ExecutionCondition {
+
+    public static final String UNABLE_TO_LOAD_CREDENTIALS_MSG = "Unable to load credentials";
+
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+        if (!MockBackendUtils.startMockBackend(false)) {
+            return ConditionEvaluationResult.disabled("Test can be executed only with mock backend.");
+        }
+        try {
+            DefaultCredentialsProvider.create().resolveCredentials();
+        } catch (Exception e) {
+            //if message starts with "Unable to load credentials", allow testing
+            if (e instanceof SdkClientException && e.getMessage() != null
+                    && e.getMessage().startsWith(UNABLE_TO_LOAD_CREDENTIALS_MSG)) {
+                return ConditionEvaluationResult
+                        .enabled("DefaultCredentialsProvider is NOT defined in the system, Testing can proceed.");
+            }
+        }
+        return ConditionEvaluationResult.disabled("DefaultCredentialsProvider is already defined in the system.");
+    }
+
+}

--- a/integration-tests-support/aws2/src/main/java/org/apache/camel/quarkus/test/support/aws2/Aws2TestEnvContext.java
+++ b/integration-tests-support/aws2/src/main/java/org/apache/camel/quarkus/test/support/aws2/Aws2TestEnvContext.java
@@ -75,10 +75,7 @@ public class Aws2TestEnvContext {
                     if (credentialsProvider == CredentialsProvider.staticProvider) {
                         properties.put("camel.component.aws2-" + s + ".access-key", accessKey);
                         properties.put("camel.component.aws2-" + s + ".secret-key", secretKey);
-                    } else {
-                        properties.put("camel.component.aws2-" + s + ".useDefaultCredentialsProvider", "true");
                     }
-                    //todo is ot really needed for default provider?
                     properties.put("camel.component.aws2-" + s + ".region", region);
 
                     properties.put("camel.component.aws2-" + s + ".override-endpoint", "true");
@@ -173,7 +170,6 @@ public class Aws2TestEnvContext {
                 .credentialsProvider(
                         credentialsProvider == CredentialsProvider.defaultProvider ? DefaultCredentialsProvider.create()
                                 : StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey)));
-        //todo in default provider might it be null?
         builder.region(Region.of(region));
 
         if (localstack.isPresent()) {

--- a/integration-tests-support/aws2/src/main/java/org/apache/camel/quarkus/test/support/aws2/Aws2TestResource.java
+++ b/integration-tests-support/aws2/src/main/java/org/apache/camel/quarkus/test/support/aws2/Aws2TestResource.java
@@ -52,7 +52,6 @@ public final class Aws2TestResource implements QuarkusTestResourceLifecycleManag
         final boolean useDefaultCredentialsProvider = defaultCredentialsProviderValue != null &&
                 !defaultCredentialsProviderValue.isEmpty() &&
                 Boolean.parseBoolean(defaultCredentialsProviderValue);
-        //todo do we need to have non empty region
         final boolean usingMockBackend = startMockBackend && !realCredentialsProvided && !useDefaultCredentialsProvider;
 
         ServiceLoader<Aws2TestEnvCustomizer> loader = ServiceLoader.load(Aws2TestEnvCustomizer.class);


### PR DESCRIPTION
fixes https://github.com/apache/camel-quarkus/issues/4401

Proposal of testing [STATIC CREDENTIALS VS DEFAULT CREDENTIAL PROVIDER](https://camel.apache.org/components/3.18.x/aws2-cw-component.html#_static_credentials_vs_default_credential_provider)

This PR implements the testing for cw only.

@jamesnetherton @aldettinger  @ppalaga  what do you think about it?

main ideas:

- The test could be executed only with mock backend on system without defaulCredentialsProvider - covered by `Aws2DefaultCredentialsProviderAvailabilityCondition`
- The test set system.properties with localstack authentication and removes them afterwards
- It should be possible to add similar test method for other aws2 extension tests (without duplicated code)

dissadvantage
- if system defines defaultCredentialsProvider (e.g, aiming to real service), test is skipped -> which may hide an error


<!-- Uncomment and fill this section if your PR is not trivial
[ ] An issue should be filed for the change unless this is a trivial change (fixing a typo or similar). One issue should ideally be fixed by not more than one commit and the other way round, each commit should fix just one issue, without pulling in other changes.
[ ] Each commit in the pull request should have a meaningful and properly spelled subject line and body. Copying the title of the associated issue is typically enough. Please include the issue number in the commit message prefixed by #.
[ ] The pull request description should explain what the pull request does, how, and why. If the info is available in the associated issue or some other external document, a link is enough.
[ ] Phrases like Fix #<issueNumber> or Fixes #<issueNumber> will auto-close the named issue upon merging the pull request. Using them is typically a good idea.
[ ] Please run mvn process-resources -Pformat (and amend the changes if necessary) before sending the pull request.
[ ] Contributor guide is your good friend: https://camel.apache.org/camel-quarkus/latest/contributor-guide.html
-->