### PR TITLE
Disable MasterOpenShiftIT due to #4387

### DIFF
--- a/integration-tests/master-openshift/src/test/java/org/apache/camel/quarkus/component/master/it/MasterOpenShiftIT.java
+++ b/integration-tests/master-openshift/src/test/java/org/apache/camel/quarkus/component/master/it/MasterOpenShiftIT.java
@@ -17,8 +17,10 @@
 package org.apache.camel.quarkus.component.master.it;
 
 import io.quarkus.test.junit.QuarkusIntegrationTest;
+import org.junit.jupiter.api.Disabled;
 
 @QuarkusIntegrationTest
+@Disabled("https://github.com/apache/camel-quarkus/issues/4387")
 class MasterOpenShiftIT extends MasterOpenShiftTest {
 
 }

--- a/integration-tests/master-openshift/src/test/java/org/apache/camel/quarkus/component/master/it/MasterOpenShiftTest.java
+++ b/integration-tests/master-openshift/src/test/java/org/apache/camel/quarkus/component/master/it/MasterOpenShiftTest.java
@@ -48,7 +48,7 @@ import static org.hamcrest.Matchers.emptyString;
 
 @QuarkusTestResource(MasterOpenShiftTestResource.class)
 @QuarkusTest
-@Disabled //https://github.com/apache/camel-quarkus/issues/4095
+@Disabled("https://github.com/apache/camel-quarkus/issues/4387")
 class MasterOpenShiftTest {
 
     @OpenShiftTestServer


### PR DESCRIPTION
I forgot to disable the test when I did the upgrade to Quarkus 2.16.0.CR1.