### PR TITLE
Pass Object class type to BeanManager.getReferece to avoid bean resolution issues #4444

### DIFF
--- a/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/RuntimeBeanRepository.java
+++ b/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/RuntimeBeanRepository.java
@@ -76,7 +76,7 @@ public final class RuntimeBeanRepository implements BeanRepository {
     }
 
     private static <T> T getReference(BeanManager manager, Class<T> type, Bean<?> bean) {
-        return type.cast(manager.getReference(bean, type, manager.createCreationalContext(bean)));
+        return type.cast(manager.getReference(bean, Object.class, manager.createCreationalContext(bean)));
     }
 
     private static <T> Map<String, T> getReferencesByTypeWithName(BeanManager manager, Class<T> type,


### PR DESCRIPTION
Should fix two of the three cases in #4444.