### PR TITLE
Verify that the specific log message we're interested in is not present for RouteBuilderWarningWithoutProducedBuilderTest

### DIFF
--- a/test-framework/junit5-extension-tests/pom.xml
+++ b/test-framework/junit5-extension-tests/pom.xml
@@ -65,10 +65,5 @@
             <artifactId>camel-quarkus-direct</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.awaitility</groupId>
-            <artifactId>awaitility</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/test-framework/junit5-extension-tests/src/test/java/org/apache/camel/quarkus/test/extensions/routeBuilder/RouteBuilderWarningWithProducedBuilderTest.java
+++ b/test-framework/junit5-extension-tests/src/test/java/org/apache/camel/quarkus/test/extensions/routeBuilder/RouteBuilderWarningWithProducedBuilderTest.java
@@ -16,12 +16,9 @@
  */
 package org.apache.camel.quarkus.test.extensions.routeBuilder;
 
-import java.util.concurrent.TimeUnit;
-
 import io.quarkus.test.ContinuousTestingTestUtils;
 import io.quarkus.test.QuarkusDevModeTest;
 import org.apache.camel.quarkus.test.extensions.continousDev.HelloResource;
-import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -45,7 +42,7 @@ public class RouteBuilderWarningWithProducedBuilderTest {
         Assertions.assertEquals(1L, ts.getTestsPassed());
         Assertions.assertEquals(0L, ts.getTestsSkipped());
 
-        Awaitility.await().atMost(10, TimeUnit.SECONDS).until(() -> TEST.getLogRecords().stream()
+        Assertions.assertTrue(TEST.getLogRecords().stream()
                 .anyMatch(logRecord -> logRecord.getMessage().contains("`RouteBuilder` detected")));
     }
 }

--- a/test-framework/junit5-extension-tests/src/test/java/org/apache/camel/quarkus/test/extensions/routeBuilder/RouteBuilderWarningWithoutProducedBuilderTest.java
+++ b/test-framework/junit5-extension-tests/src/test/java/org/apache/camel/quarkus/test/extensions/routeBuilder/RouteBuilderWarningWithoutProducedBuilderTest.java
@@ -16,12 +16,9 @@
  */
 package org.apache.camel.quarkus.test.extensions.routeBuilder;
 
-import java.util.concurrent.TimeUnit;
-
 import io.quarkus.test.ContinuousTestingTestUtils;
 import io.quarkus.test.QuarkusDevModeTest;
 import org.apache.camel.quarkus.test.extensions.continousDev.HelloResource;
-import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -45,7 +42,7 @@ public class RouteBuilderWarningWithoutProducedBuilderTest {
         Assertions.assertEquals(1L, ts.getTestsPassed());
         Assertions.assertEquals(0L, ts.getTestsSkipped());
 
-        Awaitility.await().pollDelay(10, TimeUnit.SECONDS).atMost(15, TimeUnit.SECONDS)
-                .until(() -> TEST.getLogRecords().isEmpty());
+        Assertions.assertFalse(TEST.getLogRecords().stream()
+                .anyMatch(logRecord -> logRecord.getMessage().contains("`RouteBuilder` detected")));
     }
 }


### PR DESCRIPTION
Fixes a small issue that was observed on the `quarkus-main` nightly build.

Also - I don't think that polling the log records is required, so I removed it.