### PR TITLE
Remove redundant CI workflow steps

### DIFF
--- a/.github/workflows/camel-master-cron.yaml
+++ b/.github/workflows/camel-master-cron.yaml
@@ -304,55 +304,6 @@ jobs:
         run: |
           ./mvnw ${MAVEN_ARGS} verify -N -Pbuild-notification -Dstatus=${{ job.status }} -DissueId=${{ env.ISSUE_ID }} -Dtoken=${{ secrets.GITHUB_TOKEN }} -DbuildId=$(cat ~/build-data/build-id.txt) -Drepo=${GITHUB_REPOSITORY} -Dbranch=camel-main -Dbranch-commit=$(cat ~/build-data/main-sha.txt)
 
-  integration-tests-alternative-jdk:
-    runs-on: ubuntu-latest
-    needs: initial-mvn-install
-    env:
-      MAVEN_OPTS: -Xmx3000m
-    steps:
-      - name: Download Maven Repo
-        uses: actions/download-artifact@v2
-        with:
-          name: maven-repo
-          path: ..
-      - name: Extract Maven Repo
-        shell: bash
-        run: |
-          df -h /
-          tar -xzf ../maven-repo.tgz -C ~
-          df -h /
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          ref: camel-main
-          fetch-depth: 0
-      - name: Rebase branch main onto camel-main
-        run: |
-          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-          git fetch origin main
-          git rebase $(cat ~/build-data/main-sha.txt)
-      - name: Clean VM
-        run: |
-          echo "Removing unwanted SDKs"
-          sudo rm -rf /usr/local/lib/android \
-               rm -rf /usr/local/share/boost \
-               rm -rf /usr/local/go \
-               rm -rf /usr/share/dotnet \
-               rm -rf /usr/share/rust
-      - name: Set up JDK 17
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-      - name: cd integration-tests && mvn clean verify
-        run: |
-          cd integration-tests
-          ../mvnw ${MAVEN_ARGS} ${BRANCH_OPTIONS} \
-            -Dformatter.skip -Dimpsort.skip -Denforcer.skip \
-            --fail-at-end \
-            clean verify
-
   integration-tests-alternative-platform:
     runs-on: ${{ matrix.os }}
     needs: initial-mvn-install

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -263,7 +263,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ '17', '17' ]
+        java: [ '17' ]
     env:
       MAVEN_OPTS: -Xmx3000m
     steps:
@@ -306,54 +306,6 @@ jobs:
             -Dformatter.skip -Dimpsort.skip -Denforcer.skip \
             --fail-at-end \
             clean test
-
-  integration-tests-alternative-jdk:
-    runs-on: ubuntu-latest
-    needs: initial-mvn-install
-    if: github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'JVM')
-    env:
-      MAVEN_OPTS: -Xmx3000m
-    steps:
-      - name: Setup apache-snapshots profile
-        if: github.ref == 'refs/heads/camel-main' || github.base_ref == 'camel-main'
-        run: |
-          echo "BRANCH_OPTIONS=-Papache-snapshots" >> $GITHUB_ENV
-      - name: Setup oss-snapshots profile
-        if: github.ref == 'refs/heads/quarkus-main' || github.base_ref == 'quarkus-main'
-        run: |
-          echo "BRANCH_OPTIONS=-Poss-snapshots -Dquarkus.version=999-SNAPSHOT" >> $GITHUB_ENV
-      - uses: actions/checkout@v2
-      - name: Clean VM
-        run: |
-          echo "Removing unwanted SDKs"
-          sudo rm -rf /usr/local/lib/android \
-               rm -rf /usr/local/share/boost \
-               rm -rf /usr/local/go \
-               rm -rf /usr/share/dotnet \
-               rm -rf /usr/share/rust
-      - name: Set up JDK 17
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-      - name: Download Maven Repo
-        uses: actions/download-artifact@v2
-        with:
-          name: maven-repo
-          path: ..
-      - name: Extract Maven Repo
-        shell: bash
-        run: |
-          df -h /
-          tar -xzf ../maven-repo.tgz -C ~
-          df -h /
-      - name: cd integration-tests && mvn clean verify
-        run: |
-          cd integration-tests
-          ../mvnw ${MAVEN_ARGS} ${BRANCH_OPTIONS} \
-            -Dformatter.skip -Dimpsort.skip -Denforcer.skip \
-            --fail-at-end \
-            clean verify
 
   integration-tests-alternative-platform:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/quarkus-master-cron.yaml
+++ b/.github/workflows/quarkus-master-cron.yaml
@@ -310,55 +310,6 @@ jobs:
         run: |
           ./mvnw ${MAVEN_ARGS} verify -N -Pbuild-notification -Dstatus=${{ job.status }} -DissueId=${{ env.ISSUE_ID }} -Dtoken=${{ secrets.GITHUB_TOKEN }} -DbuildId=$(cat ~/build-data/build-id.txt) -Drepo=${GITHUB_REPOSITORY} -Dbranch=quarkus-main -Dbranch-commit=$(cat ~/build-data/main-sha.txt)
 
-  integration-tests-alternative-jdk:
-    runs-on: ubuntu-latest
-    needs: initial-mvn-install
-    env:
-      MAVEN_OPTS: -Xmx3000m
-    steps:
-      - name: Download Maven Repo
-        uses: actions/download-artifact@v2
-        with:
-          name: maven-repo
-          path: ..
-      - name: Extract Maven Repo
-        shell: bash
-        run: |
-          df -h /
-          tar -xzf ../maven-repo.tgz -C ~
-          df -h /
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          ref: quarkus-main
-          fetch-depth: 0
-      - name: Rebase branch main onto quarkus-main
-        run: |
-          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-          git fetch origin main
-          git rebase $(cat ~/build-data/main-sha.txt)
-      - name: Clean VM
-        run: |
-          echo "Removing unwanted SDKs"
-          sudo rm -rf /usr/local/lib/android \
-               rm -rf /usr/local/share/boost \
-               rm -rf /usr/local/go \
-               rm -rf /usr/share/dotnet \
-               rm -rf /usr/share/rust
-      - name: Set up JDK 17
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-      - name: cd integration-tests && mvn clean verify
-        run: |
-          cd integration-tests
-          ../mvnw ${MAVEN_ARGS} ${BRANCH_OPTIONS} \
-            -Dformatter.skip -Dimpsort.skip -Denforcer.skip \
-            --fail-at-end \
-            clean verify
-
   integration-tests-alternative-platform:
     runs-on: ${{ matrix.os }}
     needs: initial-mvn-install


### PR DESCRIPTION
Not sure if we want to preserve the 'alternate JDK' testing?

Thinking at the moment we have enough to contend with for the Jakarta / Camel / Quarkus upgrade. Introducing another JDK into the test matrix at this stage just adds to the workload.
 