### PR TITLE
Ref #4527: Make twilio extension Jakarta compatible

### DIFF
--- a/extensions/twilio/deployment/src/main/java/org/apache/camel/quarkus/component/twilio/deployment/TwilioProcessor.java
+++ b/extensions/twilio/deployment/src/main/java/org/apache/camel/quarkus/component/twilio/deployment/TwilioProcessor.java
@@ -16,8 +16,6 @@
  */
 package org.apache.camel.quarkus.component.twilio.deployment;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.stream.Stream;
 
 import com.twilio.base.Creator;
@@ -32,11 +30,9 @@ import io.quarkus.deployment.builditem.AdditionalApplicationArchiveMarkerBuildIt
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
-import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
-import org.joda.time.DateTimeZone;
 
 class TwilioProcessor {
 
@@ -63,7 +59,7 @@ class TwilioProcessor {
 
         // Register Twilio API CRUD generator classes for reflection
         String[] reflectiveClasses = Stream.of(Creator.class, Deleter.class, Fetcher.class, Reader.class, Updater.class)
-                .map(aClass -> aClass.getName())
+                .map(Class::getName)
                 .map(DotName::createSimple)
                 .flatMap(dotName -> index.getAllKnownSubclasses(dotName).stream())
                 .map(classInfo -> classInfo.name().toString())
@@ -78,18 +74,5 @@ class TwilioProcessor {
                 .toArray(String[]::new);
 
         reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, endpointImplementors));
-    }
-
-    @BuildStep
-    NativeImageResourceBuildItem nativeImageResources() {
-        // Add Joda timezone resources into the native image as it is required by com.twilio.converter.DateConverter
-        List<String> timezones = new ArrayList<>();
-        for (String timezone : DateTimeZone.getAvailableIDs()) {
-            String[] zoneParts = timezone.split("/");
-            if (zoneParts.length == 2) {
-                timezones.add(String.format("org/joda/time/tz/data/%s/%s", zoneParts[0], zoneParts[1]));
-            }
-        }
-        return new NativeImageResourceBuildItem(timezones);
     }
 }

--- a/poms/bom/pom.xml
+++ b/poms/bom/pom.xml
@@ -2439,14 +2439,6 @@
                         <artifactId>commons-logging</artifactId>
                     </exclusion>
                     <exclusion>
-                        <groupId>javax.activation</groupId>
-                        <artifactId>javax.activation-api</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>javax.xml.bind</groupId>
-                        <artifactId>jaxb-api</artifactId>
-                    </exclusion>
-                    <exclusion>
                         <groupId>org.checkerframework</groupId>
                         <artifactId>checker-qual</artifactId>
                     </exclusion>

--- a/poms/bom/src/main/generated/flattened-full-pom.xml
+++ b/poms/bom/src/main/generated/flattened-full-pom.xml
@@ -2343,14 +2343,6 @@
             <artifactId>commons-logging</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
           </exclusion>
           <exclusion>
-            <groupId>javax.activation</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-            <artifactId>javax.activation-api</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-          </exclusion>
-          <exclusion>
-            <groupId>javax.xml.bind</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-            <artifactId>jaxb-api</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-          </exclusion>
-          <exclusion>
             <groupId>org.checkerframework</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
             <artifactId>checker-qual</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
           </exclusion>

--- a/poms/bom/src/main/generated/flattened-reduced-pom.xml
+++ b/poms/bom/src/main/generated/flattened-reduced-pom.xml
@@ -2343,14 +2343,6 @@
             <artifactId>commons-logging</artifactId>
           </exclusion>
           <exclusion>
-            <groupId>javax.activation</groupId>
-            <artifactId>javax.activation-api</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-          </exclusion>
-          <exclusion>
             <groupId>org.checkerframework</groupId>
             <artifactId>checker-qual</artifactId>
           </exclusion>

--- a/poms/bom/src/main/generated/flattened-reduced-verbose-pom.xml
+++ b/poms/bom/src/main/generated/flattened-reduced-verbose-pom.xml
@@ -2343,14 +2343,6 @@
             <artifactId>commons-logging</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
           </exclusion>
           <exclusion>
-            <groupId>javax.activation</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-            <artifactId>javax.activation-api</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-          </exclusion>
-          <exclusion>
-            <groupId>javax.xml.bind</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-            <artifactId>jaxb-api</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-          </exclusion>
-          <exclusion>
             <groupId>org.checkerframework</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
             <artifactId>checker-qual</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
           </exclusion>


### PR DESCRIPTION
fixes #4527 

## Motivation

The version of Twilio used is not Jakarta-compatible so it needs to be upgraded.

## Modifications

* Remove all the Joda-related code as the new version doesn't use Joda time anymore
* Remove the exclusions no more needed 

## Result

The integration test properly passes with a version of Camel including the fix for  https://issues.apache.org/jira/browse/CAMEL-19029