### PR TITLE
Upgrade to Quarkus Cassandra 1.2.0-alpha1

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,3 +1,3 @@
--Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+-Dmaven.wagon.httpconnectionManager.ttlSeconds=60
 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true
 -Dmaven.wagon.http.retryHandler.count=10

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -71,7 +71,7 @@
         <module>box</module>
         <module>braintree</module>
         <module>caffeine</module>
-        <!--<module>cassandraql</module> https://github.com/apache/camel-quarkus/issues/4488 -->
+        <module>cassandraql</module>
         <module>cbor</module>
         <module>compression-grouped</module>
         <module>consul</module>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <camel.docs.components.xref>${camel.docs.components.version}@components</camel.docs.components.xref><!-- the version in Camel's docs/components/antora.yml -->
         <camel.docs.branch>camel-${camel.major.minor}.x</camel.docs.branch><!-- The stable camel branch on which our Antora docs depends -->
         <camel.sb.docs.branch>camel-spring-boot-${camel.major.minor}.x</camel.sb.docs.branch><!-- The stable camel-spring-boot branch on which our Antora docs depends -->
-        <cassandra-quarkus.version>1.1.3</cassandra-quarkus.version><!-- https://repo1.maven.org/maven2/com/datastax/oss/quarkus/cassandra-quarkus-bom/ -->
+        <cassandra-quarkus.version>1.2.0-alpha1</cassandra-quarkus.version><!-- https://repo1.maven.org/maven2/com/datastax/oss/quarkus/cassandra-quarkus-bom/ -->
         <debezium.version>2.1.2.Final</debezium.version><!-- May go back to Camel's ${debezium-version} when they are in sync https://repo1.maven.org/maven2/io/debezium/debezium-bom/ -->
         <optaplanner.version>8.31.0.Final</optaplanner.version><!-- May go back to Camel's ${optaplanner-version} when they are in sync https://repo1.maven.org/maven2/org/optaplanner/optaplanner-quarkus/ -->
         <quarkiverse-amazonservices.version>2.0.0.Alpha1</quarkiverse-amazonservices.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/amazonservices/quarkus-amazon-services-parent/ -->

--- a/poms/bom/src/main/generated/flattened-full-pom.xml
+++ b/poms/bom/src/main/generated/flattened-full-pom.xml
@@ -20010,9 +20010,9 @@
         <version>12.15.2</version><!-- com.azure:azure-sdk-bom:1.2.9 -->
       </dependency>
       <dependency>
-        <groupId>com.datastax.oss</groupId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.1.3 -->
-        <artifactId>java-driver-core</artifactId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.1.3 -->
-        <version>4.15.0</version><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.1.3 -->
+        <groupId>com.datastax.oss</groupId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.2.0-alpha1 -->
+        <artifactId>java-driver-core</artifactId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.2.0-alpha1 -->
+        <version>4.15.0</version><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.2.0-alpha1 -->
         <exclusions>
           <exclusion>
             <groupId>com.github.stephenc.jcip</groupId>
@@ -20023,70 +20023,70 @@
             <artifactId>jsr305</artifactId>
           </exclusion>
           <exclusion>
-            <groupId>io.dropwizard.metrics</groupId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.1.3 -->
-            <artifactId>metrics-core</artifactId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.1.3 -->
+            <groupId>io.dropwizard.metrics</groupId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.2.0-alpha1 -->
+            <artifactId>metrics-core</artifactId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.2.0-alpha1 -->
           </exclusion>
           <exclusion>
-            <groupId>org.hdrhistogram</groupId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.1.3 -->
-            <artifactId>HdrHistogram</artifactId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.1.3 -->
+            <groupId>org.hdrhistogram</groupId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.2.0-alpha1 -->
+            <artifactId>HdrHistogram</artifactId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.2.0-alpha1 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.tinkerpop</groupId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.1.3 -->
-        <artifactId>gremlin-core</artifactId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.1.3 -->
-        <version>3.5.3</version><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.1.3 -->
+        <groupId>org.apache.tinkerpop</groupId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.2.0-alpha1 -->
+        <artifactId>gremlin-core</artifactId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.2.0-alpha1 -->
+        <version>3.5.3</version><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.2.0-alpha1 -->
         <exclusions>
           <exclusion>
-            <groupId>org.yaml</groupId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.1.3 -->
-            <artifactId>snakeyaml</artifactId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.1.3 -->
+            <groupId>org.yaml</groupId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.2.0-alpha1 -->
+            <artifactId>snakeyaml</artifactId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.2.0-alpha1 -->
           </exclusion>
           <exclusion>
-            <groupId>com.carrotsearch</groupId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.1.3 -->
-            <artifactId>hppc</artifactId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.1.3 -->
+            <groupId>com.carrotsearch</groupId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.2.0-alpha1 -->
+            <artifactId>hppc</artifactId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.2.0-alpha1 -->
           </exclusion>
           <exclusion>
-            <groupId>com.jcabi</groupId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.1.3 -->
-            <artifactId>*</artifactId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.1.3 -->
+            <groupId>com.jcabi</groupId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.2.0-alpha1 -->
+            <artifactId>*</artifactId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.2.0-alpha1 -->
           </exclusion>
           <exclusion>
-            <groupId>net.objecthunter</groupId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.1.3 -->
-            <artifactId>exp4j</artifactId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.1.3 -->
+            <groupId>net.objecthunter</groupId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.2.0-alpha1 -->
+            <artifactId>exp4j</artifactId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.2.0-alpha1 -->
           </exclusion>
         </exclusions>
-        <optional>true</optional><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.1.3 -->
+        <optional>true</optional><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.2.0-alpha1 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.tinkerpop</groupId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.1.3 -->
-        <artifactId>tinkergraph-gremlin</artifactId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.1.3 -->
-        <version>3.5.3</version><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.1.3 -->
-        <optional>true</optional><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.1.3 -->
+        <groupId>org.apache.tinkerpop</groupId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.2.0-alpha1 -->
+        <artifactId>tinkergraph-gremlin</artifactId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.2.0-alpha1 -->
+        <version>3.5.3</version><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.2.0-alpha1 -->
+        <optional>true</optional><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.2.0-alpha1 -->
       </dependency>
       <dependency>
-        <groupId>com.esri.geometry</groupId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.1.3 -->
-        <artifactId>esri-geometry-api</artifactId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.1.3 -->
-        <version>1.2.1</version><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.1.3 -->
-        <optional>true</optional><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.1.3 -->
+        <groupId>com.esri.geometry</groupId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.2.0-alpha1 -->
+        <artifactId>esri-geometry-api</artifactId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.2.0-alpha1 -->
+        <version>1.2.1</version><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.2.0-alpha1 -->
+        <optional>true</optional><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.2.0-alpha1 -->
       </dependency>
       <dependency>
-        <groupId>com.datastax.oss.quarkus</groupId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.1.3 -->
-        <artifactId>cassandra-quarkus-client</artifactId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.1.3 -->
-        <version>1.1.3</version><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.1.3 -->
+        <groupId>com.datastax.oss.quarkus</groupId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.2.0-alpha1 -->
+        <artifactId>cassandra-quarkus-client</artifactId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.2.0-alpha1 -->
+        <version>1.2.0-alpha1</version><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.2.0-alpha1 -->
       </dependency>
       <dependency>
-        <groupId>com.datastax.oss.quarkus</groupId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.1.3 -->
-        <artifactId>cassandra-quarkus-client-deployment</artifactId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.1.3 -->
-        <version>1.1.3</version><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.1.3 -->
+        <groupId>com.datastax.oss.quarkus</groupId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.2.0-alpha1 -->
+        <artifactId>cassandra-quarkus-client-deployment</artifactId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.2.0-alpha1 -->
+        <version>1.2.0-alpha1</version><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.2.0-alpha1 -->
       </dependency>
       <dependency>
-        <groupId>com.datastax.oss.quarkus</groupId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.1.3 -->
-        <artifactId>cassandra-quarkus-test-framework</artifactId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.1.3 -->
-        <version>1.1.3</version><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.1.3 -->
+        <groupId>com.datastax.oss.quarkus</groupId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.2.0-alpha1 -->
+        <artifactId>cassandra-quarkus-test-framework</artifactId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.2.0-alpha1 -->
+        <version>1.2.0-alpha1</version><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.2.0-alpha1 -->
       </dependency>
       <dependency>
-        <groupId>com.datastax.oss.quarkus</groupId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.1.3 -->
-        <artifactId>cassandra-quarkus-mapper-processor</artifactId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.1.3 -->
-        <version>1.1.3</version><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.1.3 -->
+        <groupId>com.datastax.oss.quarkus</groupId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.2.0-alpha1 -->
+        <artifactId>cassandra-quarkus-mapper-processor</artifactId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.2.0-alpha1 -->
+        <version>1.2.0-alpha1</version><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.2.0-alpha1 -->
       </dependency>
       <dependency>
         <groupId>com.datastax.oss</groupId><!-- com.datastax.oss:java-driver-bom:4.15.0 -->

--- a/poms/bom/src/main/generated/flattened-reduced-pom.xml
+++ b/poms/bom/src/main/generated/flattened-reduced-pom.xml
@@ -7313,12 +7313,12 @@
       <dependency>
         <groupId>com.datastax.oss.quarkus</groupId>
         <artifactId>cassandra-quarkus-client</artifactId>
-        <version>1.1.3</version>
+        <version>1.2.0-alpha1</version>
       </dependency>
       <dependency>
         <groupId>com.datastax.oss.quarkus</groupId>
         <artifactId>cassandra-quarkus-client-deployment</artifactId>
-        <version>1.1.3</version>
+        <version>1.2.0-alpha1</version>
       </dependency>
       <dependency>
         <groupId>com.datastax.oss</groupId>

--- a/poms/bom/src/main/generated/flattened-reduced-verbose-pom.xml
+++ b/poms/bom/src/main/generated/flattened-reduced-verbose-pom.xml
@@ -7288,9 +7288,9 @@
         <version>12.15.2</version><!-- com.azure:azure-sdk-bom:1.2.9 -->
       </dependency>
       <dependency>
-        <groupId>com.datastax.oss</groupId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.1.3 -->
-        <artifactId>java-driver-core</artifactId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.1.3 -->
-        <version>4.15.0</version><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.1.3 -->
+        <groupId>com.datastax.oss</groupId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.2.0-alpha1 -->
+        <artifactId>java-driver-core</artifactId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.2.0-alpha1 -->
+        <version>4.15.0</version><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.2.0-alpha1 -->
         <exclusions>
           <exclusion>
             <groupId>com.github.stephenc.jcip</groupId>
@@ -7301,24 +7301,24 @@
             <artifactId>jsr305</artifactId>
           </exclusion>
           <exclusion>
-            <groupId>io.dropwizard.metrics</groupId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.1.3 -->
-            <artifactId>metrics-core</artifactId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.1.3 -->
+            <groupId>io.dropwizard.metrics</groupId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.2.0-alpha1 -->
+            <artifactId>metrics-core</artifactId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.2.0-alpha1 -->
           </exclusion>
           <exclusion>
-            <groupId>org.hdrhistogram</groupId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.1.3 -->
-            <artifactId>HdrHistogram</artifactId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.1.3 -->
+            <groupId>org.hdrhistogram</groupId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.2.0-alpha1 -->
+            <artifactId>HdrHistogram</artifactId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.2.0-alpha1 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>com.datastax.oss.quarkus</groupId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.1.3 -->
-        <artifactId>cassandra-quarkus-client</artifactId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.1.3 -->
-        <version>1.1.3</version><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.1.3 -->
+        <groupId>com.datastax.oss.quarkus</groupId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.2.0-alpha1 -->
+        <artifactId>cassandra-quarkus-client</artifactId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.2.0-alpha1 -->
+        <version>1.2.0-alpha1</version><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.2.0-alpha1 -->
       </dependency>
       <dependency>
-        <groupId>com.datastax.oss.quarkus</groupId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.1.3 -->
-        <artifactId>cassandra-quarkus-client-deployment</artifactId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.1.3 -->
-        <version>1.1.3</version><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.1.3 -->
+        <groupId>com.datastax.oss.quarkus</groupId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.2.0-alpha1 -->
+        <artifactId>cassandra-quarkus-client-deployment</artifactId><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.2.0-alpha1 -->
+        <version>1.2.0-alpha1</version><!-- com.datastax.oss.quarkus:cassandra-quarkus-bom:1.2.0-alpha1 -->
       </dependency>
       <dependency>
         <groupId>com.datastax.oss</groupId><!-- com.datastax.oss:java-driver-bom:4.15.0 -->

--- a/tooling/scripts/test-categories.yaml
+++ b/tooling/scripts/test-categories.yaml
@@ -61,6 +61,7 @@ group-03:
 group-04:
   - arangodb
   - debezium
+  - cassandraql
   - couchdb
   - influxdb
   - jdbc


### PR DESCRIPTION
Fix #4488

A draft because it depends on Quarkus Cassandra 1.2.0-alpha1-SNAPSHOT as built from this PR: https://github.com/datastax/cassandra-quarkus/pull/222