### PR TITLE
Ref #4596: Create jdbc tests for generated keys and other headers

### DIFF
--- a/integration-tests/jdbc/pom.xml
+++ b/integration-tests/jdbc/pom.xml
@@ -17,7 +17,8 @@
     limitations under the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
@@ -46,6 +47,14 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jdbc-h2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-direct</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-jsonb</artifactId>
         </dependency>
 
         <!-- test dependencies -->

--- a/integration-tests/jdbc/src/main/java/org/apache/camel/quarkus/component/jdbc/CamelResource.java
+++ b/integration-tests/jdbc/src/main/java/org/apache/camel/quarkus/component/jdbc/CamelResource.java
@@ -19,6 +19,7 @@ package org.apache.camel.quarkus.component.jdbc;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 
@@ -53,9 +54,11 @@ public class CamelResource {
             try (Statement statement = con.createStatement()) {
                 try {
                     statement.execute("drop table camels");
+                    statement.execute("drop table camelsGenerated");
                 } catch (Exception ignored) {
                 }
                 statement.execute("create table camels (id int primary key, species varchar(255))");
+                statement.execute("create table camelsGenerated (id int primary key auto_increment, species varchar(255))");
                 statement.execute("insert into camels (id, species) values (1, 'Camelus dromedarius')");
                 statement.execute("insert into camels (id, species) values (2, 'Camelus bactrianus')");
                 statement.execute("insert into camels (id, species) values (3, 'Camelus ferus')");
@@ -108,5 +111,30 @@ public class CamelResource {
     @Produces(MediaType.TEXT_PLAIN)
     public String executeStatement(String statement) throws Exception {
         return template.requestBody("jdbc:camel-ds", statement, String.class);
+    }
+
+    @Path("/generated-keys/rows")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public List generatedKeysRows() throws Exception {
+        return template.requestBodyAndHeader("direct://get-generated-keys",
+                "insert into camelsGenerated (species) values ('Camelus testus'), ('Camelus legendarius')",
+                "CamelRetrieveGeneratedKeys", "true", ArrayList.class);
+    }
+
+    @Path("/headers/insert")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public String headersFromInsertOrUpdate() throws Exception {
+        return template.requestBodyAndHeader("direct://get-headers",
+                "insert into camelsGenerated (species) values ('Camelus status'), ('Camelus linus')",
+                "CamelRetrieveGeneratedKeys", "true", String.class);
+    }
+
+    @Path("/headers/select")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public String headersFromSelect() throws Exception {
+        return template.requestBody("direct://get-headers", "select * from camelsGenerated", String.class);
     }
 }

--- a/integration-tests/jdbc/src/main/java/org/apache/camel/quarkus/component/jdbc/JdbcRoutes.java
+++ b/integration-tests/jdbc/src/main/java/org/apache/camel/quarkus/component/jdbc/JdbcRoutes.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.jdbc;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+import org.apache.camel.builder.RouteBuilder;
+
+@ApplicationScoped
+public class JdbcRoutes extends RouteBuilder {
+    @Override
+    public void configure() {
+        from("direct://get-generated-keys")
+                .to("jdbc:camel-ds")
+                .process(new Processor() {
+                    @Override
+                    public void process(Exchange exchange) throws Exception {
+                        Object in = exchange.getIn().getHeader("CamelGeneratedKeysRows");
+                        exchange.getIn().setBody(in);
+                    }
+                });
+
+        from("direct://get-headers")
+                .to("jdbc:camel-ds")
+                .process(new Processor() {
+                    @Override
+                    public void process(Exchange exchange) throws Exception {
+                        Object in = exchange.getIn().getHeaders();
+                        exchange.getIn().setBody(in);
+                    }
+                });
+    }
+}


### PR DESCRIPTION
Partially fixes #4596:
1. Generated keys
2. Message headers ( except for CamelJdbcParameters header, which will be done in the next PR)