### PR TITLE
Update checkout action configuration to pick up dependabot branch changes

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -55,6 +55,7 @@ env:
   MAVEN_OPTS: -Xmx3000m
   CQ_MAVEN_ARGS: -V -ntp -Dhttp.keepAlive=false -e
   TESTCONTAINERS_RYUK_DISABLED: true
+  CHECKOUT_REF: ${{ github.event_name == 'pull_request' && github.actor == 'dependabot[bot]' && github.head_ref || '' }}
 
 jobs:
   pre-build-checks:
@@ -82,7 +83,7 @@ jobs:
         uses: actions/checkout@v2
         if: steps.init.outputs.run-checks == 'true'
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ env.CHECKOUT_REF }}
           fetch-depth: 0
       - name: Pre build checks
         id: pre-build-checks
@@ -147,6 +148,9 @@ jobs:
             && ./mvnw ${CQ_MAVEN_ARGS} clean install -Dquickly
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          ref: ${{ env.CHECKOUT_REF }}
+          fetch-depth: 0
       - name: mvn clean install -DskipTests
         run: |
           eval ./mvnw ${CQ_MAVEN_ARGS} ${BRANCH_OPTIONS} clean install -DskipTests -Dquarkus.build.skip
@@ -194,6 +198,9 @@ jobs:
           echo "BRANCH_OPTIONS=-Poss-snapshots -Dquarkus.version=999-SNAPSHOT" >> $GITHUB_ENV
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          ref: ${{ env.CHECKOUT_REF }}
+          fetch-depth: 0
       - name: Set up JDK 17
         uses: actions/setup-java@v2
         with:
@@ -266,7 +273,11 @@ jobs:
         if: github.ref == 'refs/heads/quarkus-main' || github.base_ref == 'quarkus-main'
         run: |
           echo "BRANCH_OPTIONS=-Poss-snapshots -Dquarkus.version=999-SNAPSHOT" >> $GITHUB_ENV
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ env.CHECKOUT_REF }}
+          fetch-depth: 0
       - name: Set up JDK 17
         uses: actions/setup-java@v2
         with:
@@ -332,7 +343,11 @@ jobs:
         if: github.ref == 'refs/heads/quarkus-main' || github.base_ref == 'quarkus-main'
         run: |
           echo "BRANCH_OPTIONS=-Poss-snapshots -Dquarkus.version=999-SNAPSHOT" >> $GITHUB_ENV
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ env.CHECKOUT_REF }}
+          fetch-depth: 0
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v2
         with:
@@ -385,7 +400,11 @@ jobs:
         if: github.ref == 'refs/heads/quarkus-main' || github.base_ref == 'quarkus-main'
         run: |
           echo "BRANCH_OPTIONS=-Poss-snapshots -Dquarkus.version=999-SNAPSHOT" >> $GITHUB_ENV
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ env.CHECKOUT_REF }}
+          fetch-depth: 0
       - name: Set up JDK 17
         uses: actions/setup-java@v2
         with:

--- a/.github/workflows/synchronize-dependabot-branch.yaml
+++ b/.github/workflows/synchronize-dependabot-branch.yaml
@@ -88,12 +88,11 @@ jobs:
 
           CHANGES_PATH=/home/runner/work/dependabot-pr/changes.patch
           if [[ -f "${CHANGES_PATH}" ]]; then
-            COMMIT_MESSAGE=$(git log -1 --pretty=%B)
+            COMMIT_MESSAGE="Auto generated changes for dependabot commit $(git log -1 --pretty=%H)"
 
-            git reset --soft HEAD~1
             git apply ${CHANGES_PATH}
             git commit -am"${COMMIT_MESSAGE}"
-            git push --force-with-lease origin ${BRANCH_REF}
+            git push origin ${BRANCH_REF}
 
             echo "updated=true" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
Should hopefully fix the issue encountered in #4674.

Also I changed things slightly to push a new commit to the dependabot branch instead of recreating the original commit and force pushing. This way it'll stop dependabot overwriting the generated changes from auto rebases.