### PR TITLE
Ref #4716: java-joor-dsl - Add RegisterForReflection support

### DIFF
--- a/docs/modules/ROOT/pages/reference/extensions/java-joor-dsl.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/java-joor-dsl.adoc
@@ -43,3 +43,11 @@ Or add the coordinates to your existing project:
 ifeval::[{doc-show-user-guide-link} == true]
 Check the xref:user-guide/index.adoc[User guide] for more information about writing Camel Quarkus applications.
 endif::[]
+
+[id="extensions-java-joor-dsl-camel-quarkus-limitations"]
+== Camel Quarkus limitations
+
+The annotations added to the classes to be compiled by the component are ignored by Quarkus. The only annotation that is
+partially supported by the extension is the annotation `RegisterForReflection` to ease the configuration of the reflection
+for the native mode however please note that the element `registerFullHierarchy` is not supported.
+

--- a/extensions/java-joor-dsl/runtime/src/main/doc/limitations.adoc
+++ b/extensions/java-joor-dsl/runtime/src/main/doc/limitations.adoc
@@ -1,0 +1,3 @@
+The annotations added to the classes to be compiled by the component are ignored by Quarkus. The only annotation that is
+partially supported by the extension is the annotation `RegisterForReflection` to ease the configuration of the reflection
+for the native mode however please note that the element `registerFullHierarchy` is not supported.

--- a/integration-tests/java-joor-dsl/src/main/java/org/apache/camel/quarkus/dsl/java/joor/JavaJoorDslBean.java
+++ b/integration-tests/java-joor-dsl/src/main/java/org/apache/camel/quarkus/dsl/java/joor/JavaJoorDslBean.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.dsl.java.joor;
+
+public class JavaJoorDslBean {
+
+    public static String hi(String name) {
+        return String.format("Hi %s", name);
+    }
+
+    public static class Inner {
+        public static String addSource(String value) {
+            return String.format("%s from jOOR!", value);
+        }
+    }
+}

--- a/integration-tests/java-joor-dsl/src/main/java/org/apache/camel/quarkus/dsl/java/joor/JavaJoorDslResource.java
+++ b/integration-tests/java-joor-dsl/src/main/java/org/apache/camel/quarkus/dsl/java/joor/JavaJoorDslResource.java
@@ -75,8 +75,16 @@ public class JavaJoorDslResource {
     @Path("/hello")
     @Consumes(MediaType.TEXT_PLAIN)
     @Produces(MediaType.TEXT_PLAIN)
-    public String hello(String message) throws Exception {
+    public String hello(String message) {
         return producerTemplate.requestBody("direct:joorHello", message, String.class);
+    }
+
+    @POST
+    @Path("/hi")
+    @Consumes(MediaType.TEXT_PLAIN)
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hi(String name) {
+        return producerTemplate.requestBody("direct:joorHi", name, String.class);
     }
 
 }

--- a/integration-tests/java-joor-dsl/src/test/java/org/apache/camel/quarkus/dsl/java/joor/JavaJoorDslTest.java
+++ b/integration-tests/java-joor-dsl/src/test/java/org/apache/camel/quarkus/dsl/java/joor/JavaJoorDslTest.java
@@ -36,6 +36,16 @@ class JavaJoorDslTest {
     }
 
     @Test
+    void joorHi() {
+        RestAssured.given()
+                .body("Will Smith")
+                .post("/java-joor-dsl/hi")
+                .then()
+                .statusCode(200)
+                .body(CoreMatchers.is("Hi Will Smith from jOOR!"));
+    }
+
+    @Test
     void testMainInstanceWithJavaRoutes() {
         RestAssured.given()
                 .get("/java-joor-dsl/main/javaRoutesBuilderLoader")
@@ -53,6 +63,6 @@ class JavaJoorDslTest {
                 .get("/java-joor-dsl/main/routes")
                 .then()
                 .statusCode(200)
-                .body(CoreMatchers.is("my-java-route"));
+                .body(CoreMatchers.is("my-java-route,reflection-route"));
     }
 }


### PR DESCRIPTION
fixes #4716 

## Motivation

All the annotations added to a class managed by the extension `java-joor-dsl` are not considered by Quarkus since it is not part of the Jandex index. 

This change aims to support the annotation `RegisterForReflection` to easily configure the reflection in Camel-K.

## Modifications:

* Produce the corresponding `ReflectiveClassBuildItem` and  `LambdaCapturingTypeBuildItem` if a `RouteBuilder` is annotated with `RegisterForReflection`.
* Add some doc to explain the limitations
* Add a unit test to ensure that it works as expected