### PR TITLE
Start JDBC polling after database initialization #4723

### DIFF
--- a/integration-tests/jdbc/src/main/java/org/apache/camel/quarkus/component/jdbc/CamelResource.java
+++ b/integration-tests/jdbc/src/main/java/org/apache/camel/quarkus/component/jdbc/CamelResource.java
@@ -17,7 +17,6 @@
 package org.apache.camel.quarkus.component.jdbc;
 
 import java.sql.Connection;
-import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -55,7 +54,7 @@ public class CamelResource {
     CamelContext context;
 
     @PostConstruct
-    void postConstruct() throws SQLException {
+    void postConstruct() throws Exception {
         try (Connection con = dataSource.getConnection()) {
             try (Statement statement = con.createStatement()) {
                 try {
@@ -70,6 +69,8 @@ public class CamelResource {
                 statement.execute("insert into camels (id, species) values (1, 'Camelus dromedarius')");
                 statement.execute("insert into camels (id, species) values (2, 'Camelus bactrianus')");
                 statement.execute("insert into camels (id, species) values (3, 'Camelus ferus')");
+
+                context.getRouteController().startRoute("jdbc-poll");
             }
         }
     }

--- a/integration-tests/jdbc/src/main/java/org/apache/camel/quarkus/component/jdbc/JdbcRoutes.java
+++ b/integration-tests/jdbc/src/main/java/org/apache/camel/quarkus/component/jdbc/JdbcRoutes.java
@@ -51,7 +51,7 @@ public class JdbcRoutes extends RouteBuilder {
         from("direct://headers-as-parameters")
                 .to("jdbc:camel-ds?useHeadersAsParameters=true");
 
-        from("timer://interval-polling?delay=2000&repeatCount=1")
+        from("timer://interval-polling?delay=2000&repeatCount=1").routeId("jdbc-poll").autoStartup(false)
                 .setBody(constant("select * from camelsGenerated order by id desc"))
                 .to("jdbc:camel-ds")
                 .to("mock:interval-polling");


### PR DESCRIPTION
Should fix intermittent JDBC test failures.

I can leave #4723 open. If we want to start testing with multiple JDBC providers, then it might be better to have flyway...