### PR TITLE
Ref #4731: java-joor-dsl - Add support of inner classes

### DIFF
--- a/extensions/java-joor-dsl/deployment/src/main/java/org/apache/camel/quarkus/dsl/java/joor/deployment/JavaJoorDslProcessor.java
+++ b/extensions/java-joor-dsl/deployment/src/main/java/org/apache/camel/quarkus/dsl/java/joor/deployment/JavaJoorDslProcessor.java
@@ -100,8 +100,15 @@ public class JavaJoorDslProcessor {
             generatedClass
                     .produce(new JavaJoorGeneratedClassBuildItem(className, nameToResource.get(className).getLocation(),
                             result.getByteCode(className)));
+            Class<?> aClass = result.getClass(className);
+            for (Class<?> clazz : aClass.getDeclaredClasses()) {
+                String name = clazz.getName();
+                generatedClass
+                        .produce(new JavaJoorGeneratedClassBuildItem(name, nameToResource.get(className).getLocation(),
+                                result.getByteCode(name)));
+            }
             registerForReflection(reflectiveClass, lambdaCapturingTypeProducer,
-                    result.getClass(className).getAnnotation(RegisterForReflection.class));
+                    aClass.getAnnotation(RegisterForReflection.class));
         }
     }
 

--- a/integration-tests/java-joor-dsl/src/main/java/org/apache/camel/quarkus/dsl/java/joor/JavaJoorDslResource.java
+++ b/integration-tests/java-joor-dsl/src/main/java/org/apache/camel/quarkus/dsl/java/joor/JavaJoorDslResource.java
@@ -87,4 +87,12 @@ public class JavaJoorDslResource {
         return producerTemplate.requestBody("direct:joorHi", name, String.class);
     }
 
+    @POST
+    @Path("/echo")
+    @Consumes(MediaType.TEXT_PLAIN)
+    @Produces(MediaType.TEXT_PLAIN)
+    public String echo(String msg) {
+        return producerTemplate.requestBody("direct:joorEcho", msg, String.class);
+    }
+
 }

--- a/integration-tests/java-joor-dsl/src/main/resources/routes/MyRoutes.java
+++ b/integration-tests/java-joor-dsl/src/main/resources/routes/MyRoutes.java
@@ -14,6 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import java.util.function.Function;
+
 import io.quarkus.runtime.annotations.RegisterForReflection;
 import org.apache.camel.builder.RouteBuilder;
 
@@ -32,5 +34,18 @@ public class MyRoutes extends RouteBuilder {
                 Class<?> c2 = Thread.currentThread().getContextClassLoader().loadClass("org.apache.camel.quarkus.dsl.java.joor.JavaJoorDslBean$Inner");
                 exchange.getMessage().setBody(c2.getMethod("addSource", String.class).invoke(null, hi));
             });
+        from("direct:joorEcho")
+                .id("inner-classes-route")
+                .process(exchange -> {
+                    exchange.getMessage().setBody(Inner.format((String) exchange.getMessage().getBody()));
+                });
+    }
+
+    public static class Inner {
+
+        public static String format(String result) {
+            Function<String, String> toUpperCase = String::toUpperCase;
+            return String.format("Msg: %s", toUpperCase.apply(result));
+        }
     }
 }

--- a/integration-tests/java-joor-dsl/src/test/java/org/apache/camel/quarkus/dsl/java/joor/JavaJoorDslTest.java
+++ b/integration-tests/java-joor-dsl/src/test/java/org/apache/camel/quarkus/dsl/java/joor/JavaJoorDslTest.java
@@ -46,6 +46,16 @@ class JavaJoorDslTest {
     }
 
     @Test
+    void joorEcho() {
+        RestAssured.given()
+                .body("Ping")
+                .post("/java-joor-dsl/echo")
+                .then()
+                .statusCode(200)
+                .body(CoreMatchers.is("Msg: PING"));
+    }
+
+    @Test
     void testMainInstanceWithJavaRoutes() {
         RestAssured.given()
                 .get("/java-joor-dsl/main/javaRoutesBuilderLoader")
@@ -63,6 +73,6 @@ class JavaJoorDslTest {
                 .get("/java-joor-dsl/main/routes")
                 .then()
                 .statusCode(200)
-                .body(CoreMatchers.is("my-java-route,reflection-route"));
+                .body(CoreMatchers.is("inner-classes-route,my-java-route,reflection-route"));
     }
 }


### PR DESCRIPTION
fixes #4731 

## Motivation

When a `RouteBuilder` class has an inner class, the inner class is unknown by Quarkus in native mode which causes a native compilation issue. The goal of this PR is to add the support of inner classes to prevent the native compilation issue.

## Modifications

* Produce `JavaJoorGeneratedClassBuildItem` for inner classes too
* Add a unit test to ensure that it works as expected
