### PR TITLE
Test also GITHUB_BASE_REF to checkout the right examples branch

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -467,6 +467,8 @@ jobs:
 
           if [[ ${GITHUB_REF_NAME} =~ [0-9]+.[0-9]+.x ]]; then
               EXAMPLES_BRANCH=${GITHUB_REF_NAME}
+          elif [[ ${GITHUB_BASE_REF} =~ [0-9]+.[0-9]+.x ]]; then
+              EXAMPLES_BRANCH=${GITHUB_BASE_REF}
           fi
 
           git clone --depth 1 --branch ${EXAMPLES_BRANCH} https://github.com/apache/camel-quarkus-examples.git \


### PR DESCRIPTION
This should make the examples job checkout the appropriate examples branch when a PR is sent against a maintenance branch such as 2.13.x.