### PR TITLE
[IBM-MQ] Add tests for IBM MQ client

### DIFF
--- a/integration-tests/jms-artemis-client/src/test/java/org/apache/camel/quarkus/component/jms/artemis/it/JmsArtemisXATest.java
+++ b/integration-tests/jms-artemis-client/src/test/java/org/apache/camel/quarkus/component/jms/artemis/it/JmsArtemisXATest.java
@@ -19,6 +19,8 @@ package org.apache.camel.quarkus.component.jms.artemis.it;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import io.restassured.RestAssured;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.core.Is.is;
@@ -26,6 +28,14 @@ import static org.hamcrest.core.Is.is;
 @QuarkusTest
 @TestProfile(JmsArtemisXAEnabled.class)
 public class JmsArtemisXATest {
+    @BeforeAll
+    public static void startRoutes() {
+        RestAssured.given()
+                // see AbstractMessagingTest#beforeAll
+                .port(ConfigProvider.getConfig().getValue("quarkus.http.test-port", Integer.class))
+                .get("/messaging/jms/artemis/routes/start");
+    }
+
     @Test
     public void testJmsXACommit() {
         RestAssured.given()

--- a/integration-tests/jms-ibmmq-client/README.adoc
+++ b/integration-tests/jms-ibmmq-client/README.adoc
@@ -1,0 +1,7 @@
+== Running the tests
+
+To run the tests, you need to accept the license from the official docker image for IBM MQ.
+
+You can run `docker run -e LICENSE=view icr.io/ibm-messaging/mq:9.3.2.1-r1` to view the license.
+
+If you accept the license and want to run the tests, use `-Dibm.mq.container.license=accept` property.

--- a/integration-tests/jms-ibmmq-client/pom.xml
+++ b/integration-tests/jms-ibmmq-client/pom.xml
@@ -1,0 +1,168 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.camel.quarkus</groupId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
+        <version>3.0.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>camel-quarkus-integration-test-jms-ibmmq-client</artifactId>
+    <name>Camel Quarkus :: Integration Tests :: JMS IBM MQ Client</name>
+    <description>Integration tests for Camel Quarkus JMS extension with the IBM MQ Client</description>
+
+    <properties>
+    </properties>
+
+    <dependencies>
+        <!-- Messaging extension to test -->
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-jms</artifactId>
+        </dependency>
+
+        <!-- Inherit base messaging routes -->
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-integration-test-messaging-jms</artifactId>
+        </dependency>
+
+        <!-- The JMS client library to test with -->
+        <dependency>
+            <groupId>com.ibm.mq</groupId>
+            <artifactId>com.ibm.mq.jakarta.client</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- IBM MQ Test Resource -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit4-mock</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- Inherit base messaging tests -->
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-integration-test-messaging-common</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-integration-test-messaging-jms</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <profiles>
+        <!-- IBM MQ client does not work in native: https://github.com/apache/camel-quarkus/issues/4924
+        <profile>
+            <id>native</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <properties>
+                <quarkus.package.type>native</quarkus.package.type>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+            -->
+        <profile>
+            <id>virtualDependencies</id>
+            <activation>
+                <property>
+                    <name>!noVirtualDependencies</name>
+                </property>
+            </activation>
+            <dependencies>
+                <!-- The following dependencies guarantee that this module is built after them. You can update them by running `mvn process-resources -Pformat -N` from the source tree root directory -->
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-jms-deployment</artifactId>
+                    <version>${project.version}</version>
+                    <type>pom</type>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>skip-testcontainers-tests</id>
+            <activation>
+                <property>
+                    <name>skip-testcontainers-tests</name>
+                </property>
+            </activation>
+            <properties>
+                <skipTests>true</skipTests>
+            </properties>
+        </profile>
+    </profiles>
+</project>

--- a/integration-tests/jms-ibmmq-client/src/main/java/org/apache/camel/quarkus/component/jms/ibmmq/it/IBMMQProducers.java
+++ b/integration-tests/jms-ibmmq-client/src/main/java/org/apache/camel/quarkus/component/jms/ibmmq/it/IBMMQProducers.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.jms.ibmmq.it;
+
+import com.ibm.mq.jakarta.jms.MQConnectionFactory;
+import com.ibm.msg.client.jakarta.wmq.WMQConstants;
+import jakarta.enterprise.inject.Produces;
+import jakarta.jms.ConnectionFactory;
+import org.eclipse.microprofile.config.ConfigProvider;
+
+public class IBMMQProducers {
+    @Produces
+    ConnectionFactory createConnectionFactory() {
+        MQConnectionFactory connectionFactory = new MQConnectionFactory();
+        connectionFactory.setHostName(ConfigProvider.getConfig().getValue("ibm.mq.host", String.class));
+        try {
+            connectionFactory.setPort(ConfigProvider.getConfig().getValue("ibm.mq.port", Integer.class));
+            connectionFactory.setChannel(ConfigProvider.getConfig().getValue("ibm.mq.channel", String.class));
+            connectionFactory.setQueueManager(ConfigProvider.getConfig().getValue("ibm.mq.queueManagerName", String.class));
+            connectionFactory.setTransportType(WMQConstants.WMQ_CM_CLIENT);
+            connectionFactory.setStringProperty(WMQConstants.USERID,
+                    ConfigProvider.getConfig().getValue("ibm.mq.user", String.class));
+            connectionFactory.setStringProperty(WMQConstants.PASSWORD,
+                    ConfigProvider.getConfig().getValue("ibm.mq.password", String.class));
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to create new IBM MQ connection factory", e);
+        }
+        return connectionFactory;
+    }
+}

--- a/integration-tests/jms-ibmmq-client/src/main/java/org/apache/camel/quarkus/component/jms/ibmmq/it/IBMMQResource.java
+++ b/integration-tests/jms-ibmmq-client/src/main/java/org/apache/camel/quarkus/component/jms/ibmmq/it/IBMMQResource.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.quarkus.component.jms.artemis.it;
+package org.apache.camel.quarkus.component.jms.ibmmq.it;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -24,27 +24,17 @@ import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
-import org.apache.camel.CamelContext;
-import org.apache.camel.CamelExecutionException;
 import org.apache.camel.Produce;
 import org.apache.camel.ProducerTemplate;
-import org.apache.camel.component.mock.MockEndpoint;
 
 @ApplicationScoped
-@Path("/messaging/jms/artemis")
-public class JmsArtemisResource {
-
+@Path("/messaging/jms/ibmmq")
+public class IBMMQResource {
     @Inject
     ConnectionFactory connectionFactory;
 
-    @Produce("jms:queue:pojoProduce")
+    @Produce("jms:queue:testPojoProducer")
     ProducerTemplate pojoProducer;
-
-    @Inject
-    CamelContext context;
-
-    @Inject
-    ProducerTemplate producerTemplate;
 
     @GET
     @Path("/connection/factory")
@@ -57,45 +47,5 @@ public class JmsArtemisResource {
     @Path("/pojo/producer")
     public void pojoProducer(String message) {
         pojoProducer.sendBody(message);
-    }
-
-    @POST
-    @Path("/xa")
-    public String testXA(String message) throws Exception {
-        MockEndpoint mockEndpoint = context.getEndpoint("mock:xaResult", MockEndpoint.class);
-
-        mockEndpoint.reset();
-        if (isValid(message)) {
-            mockEndpoint.expectedMessageCount(1);
-        } else {
-            mockEndpoint.expectedMessageCount(0);
-        }
-
-        try {
-            producerTemplate.sendBody("direct:xa", message);
-        } catch (CamelExecutionException e) {
-            // ignore the exception and we will check the mock:xaResult
-        }
-        mockEndpoint.assertIsSatisfied(5000);
-
-        if (isValid(message)) {
-            return mockEndpoint.getExchanges().get(0).getIn().getBody(String.class);
-        } else {
-            return "rollback";
-        }
-    }
-
-    private boolean isValid(String message) {
-        return !message.startsWith("fail");
-    }
-
-    @Path("/routes/start")
-    @GET
-    public void startRoutes() {
-        try {
-            context.getRouteController().startAllRoutes();
-        } catch (Exception e) {
-            throw new RuntimeException("Unable to start camel routes", e);
-        }
     }
 }

--- a/integration-tests/jms-ibmmq-client/src/test/java/org/apache/camel/quarkus/component/jms/ibmmq/it/IBMMQTest.java
+++ b/integration-tests/jms-ibmmq-client/src/test/java/org/apache/camel/quarkus/component/jms/ibmmq/it/IBMMQTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.jms.ibmmq.it;
+
+import java.lang.reflect.Method;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import org.apache.camel.quarkus.component.jms.ibmmq.support.IBMMQDestinations;
+import org.apache.camel.quarkus.component.jms.ibmmq.support.IBMMQTestResource;
+import org.apache.camel.quarkus.messaging.jms.AbstractJmsMessagingTest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
+
+@QuarkusTest
+@QuarkusTestResource(IBMMQTestResource.class)
+@EnabledIfSystemProperty(named = "ibm.mq.container.license", matches = "accept")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class IBMMQTest extends AbstractJmsMessagingTest {
+    private IBMMQDestinations destinations;
+
+    /**
+     * IBM MQ needs to have the destinations created before you can use them.
+     * <p>
+     * This method is called after the routes start, so the routes will print a warning first that the destinations don't
+     * exist, only then they are
+     * created using this method
+     *
+     * @param test test
+     */
+    @BeforeAll
+    @Override
+    public void startRoutes(TestInfo test) {
+        for (Method method : test.getTestClass().get().getMethods()) {
+            destinations.createQueue(method.getName());
+            // Some tests use two queues
+            destinations.createQueue(method.getName() + "2");
+            destinations.createTopic(method.getName());
+        }
+
+        super.startRoutes(test);
+    }
+
+    @Test
+    public void connectionFactoryImplementation() {
+        RestAssured.get("/messaging/jms/ibmmq/connection/factory")
+                .then()
+                .statusCode(200)
+                .body(startsWith("com.ibm.mq"));
+    }
+
+    @Test
+    public void testPojoProducer() {
+        String message = "Camel Quarkus IBM MQ Pojo Producer";
+
+        RestAssured.given()
+                .body(message)
+                .post("/messaging/jms/ibmmq/pojo/producer")
+                .then()
+                .statusCode(204);
+
+        RestAssured.get("/messaging/{queueName}", queue)
+                .then()
+                .statusCode(200)
+                .body(is(message));
+    }
+}

--- a/integration-tests/jms-ibmmq-client/src/test/java/org/apache/camel/quarkus/component/jms/ibmmq/support/IBMMQDestinations.java
+++ b/integration-tests/jms-ibmmq-client/src/test/java/org/apache/camel/quarkus/component/jms/ibmmq/support/IBMMQDestinations.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.jms.ibmmq.support;
+
+import java.util.HashSet;
+import java.util.Hashtable;
+import java.util.Set;
+
+import com.ibm.mq.MQException;
+import com.ibm.mq.MQQueueManager;
+import com.ibm.mq.constants.MQConstants;
+import com.ibm.mq.headers.MQDataException;
+import com.ibm.mq.headers.pcf.PCFMessage;
+import com.ibm.mq.headers.pcf.PCFMessageAgent;
+
+/**
+ * Before using the destinations in IBM MQ, it is needed to create them.
+ */
+public class IBMMQDestinations {
+    private static final String ADMIN_USER = "admin";
+    private static final String ADMIN_PASSWORD = "passw0rd";
+    private static final String ADMIN_CHANNEL = "DEV.ADMIN.SVRCONN";
+
+    private final String host;
+    private final int port;
+    private final String queueManagerName;
+
+    private final PCFMessageAgent agent;
+    // The destination can be created only once, otherwise the request will fail
+    private final Set<String> createdQueues = new HashSet<>();
+    private final Set<String> createdTopics = new HashSet<>();
+
+    public IBMMQDestinations(String host, int port, String queueManagerName) {
+        this.host = host;
+        this.port = port;
+        this.queueManagerName = queueManagerName;
+
+        // Disable creating log files for client
+        System.setProperty("com.ibm.msg.client.commonservices.log.status", "OFF");
+
+        agent = createPCFAgent();
+    }
+
+    private MQQueueManager createQueueManager() {
+        Hashtable<String, Object> properties = new Hashtable<>();
+        properties.put(MQConstants.HOST_NAME_PROPERTY, host);
+        properties.put(MQConstants.PORT_PROPERTY, port);
+        properties.put(MQConstants.CHANNEL_PROPERTY, ADMIN_CHANNEL);
+        properties.put(MQConstants.USE_MQCSP_AUTHENTICATION_PROPERTY, true);
+        properties.put(MQConstants.USER_ID_PROPERTY, ADMIN_USER);
+        properties.put(MQConstants.PASSWORD_PROPERTY, ADMIN_PASSWORD);
+        try {
+            return new MQQueueManager(queueManagerName, properties);
+        } catch (MQException e) {
+            throw new RuntimeException("Unable to create MQQueueManager:", e);
+        }
+    }
+
+    private PCFMessageAgent createPCFAgent() {
+        try {
+            return new PCFMessageAgent(createQueueManager());
+        } catch (MQDataException e) {
+            throw new RuntimeException("Unable to create PCFMessageAgent:", e);
+        }
+    }
+
+    private void sendRequest(PCFMessage request) {
+        try {
+            agent.send(request);
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to send PCFMessage:", e);
+        }
+    }
+
+    public void createQueue(String queueName) {
+        if (!createdQueues.contains(queueName)) {
+            PCFMessage request = new PCFMessage(MQConstants.MQCMD_CREATE_Q);
+            request.addParameter(MQConstants.MQCA_Q_NAME, queueName);
+            request.addParameter(MQConstants.MQIA_Q_TYPE, MQConstants.MQQT_LOCAL);
+            sendRequest(request);
+            createdQueues.add(queueName);
+        }
+    }
+
+    public void createTopic(String topicName) {
+        if (!createdTopics.contains(topicName)) {
+            PCFMessage request = new PCFMessage(MQConstants.MQCMD_CREATE_TOPIC);
+            request.addParameter(MQConstants.MQCA_TOPIC_NAME, topicName);
+            request.addParameter(MQConstants.MQCA_TOPIC_STRING, topicName);
+            request.addParameter(MQConstants.MQIA_TOPIC_TYPE, MQConstants.MQTOPT_LOCAL);
+            sendRequest(request);
+            createdTopics.add(topicName);
+        }
+    }
+}

--- a/integration-tests/jms-ibmmq-client/src/test/java/org/apache/camel/quarkus/component/jms/ibmmq/support/IBMMQTestResource.java
+++ b/integration-tests/jms-ibmmq-client/src/test/java/org/apache/camel/quarkus/component/jms/ibmmq/support/IBMMQTestResource.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.jms.ibmmq.support;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.Map;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import org.apache.commons.io.FileUtils;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+public class IBMMQTestResource implements QuarkusTestResourceLifecycleManager {
+    private static final String IMAGE_NAME = System.getProperty("ibm.mq.container.image", "icr.io/ibm-messaging/mq:9.3.2.1-r1");
+    private static final int PORT = 1414;
+    private static final String QUEUE_MANAGER_NAME = "QM1";
+    private static final String USER = "app";
+    private static final String PASSWORD = "passw0rd";
+    private static final String MESSAGING_CHANNEL = "DEV.APP.SVRCONN";
+    private static final String MQSC_COMMAND_FILE_NAME = "99-auth.mqsc";
+    private static final String MQSC_FILE = "target/" + MQSC_COMMAND_FILE_NAME;
+    private static final String MQSC_FILE_CONTAINER_PATH = "/etc/mqm/" + MQSC_COMMAND_FILE_NAME;
+
+    private GenericContainer<?> container;
+    private IBMMQDestinations destinations;
+
+    @Override
+    public Map<String, String> start() {
+        container = new GenericContainer<>(DockerImageName.parse(IMAGE_NAME))
+                .withExposedPorts(PORT)
+                .withEnv(Map.of(
+                        "LICENSE", System.getProperty("ibm.mq.container.license"),
+                        "MQ_QMGR_NAME", QUEUE_MANAGER_NAME,
+                        "MQ_APP_PASSWORD", PASSWORD))
+                .withFileSystemBind(mqscConfig(), MQSC_FILE_CONTAINER_PATH)
+                // AMQ5806I is a message code for queue manager start
+                .waitingFor(Wait.forLogMessage(".*AMQ5806I.*", 1));
+        container.start();
+
+        destinations = new IBMMQDestinations(container.getHost(), container.getMappedPort(PORT), QUEUE_MANAGER_NAME);
+
+        return Map.of(
+                "ibm.mq.host", container.getHost(),
+                "ibm.mq.port", container.getMappedPort(PORT).toString(),
+                "ibm.mq.user", USER,
+                "ibm.mq.password", PASSWORD,
+                "ibm.mq.queueManagerName", QUEUE_MANAGER_NAME,
+                "ibm.mq.channel", MESSAGING_CHANNEL);
+    }
+
+    @Override
+    public void stop() {
+        if (container != null) {
+            container.stop();
+        }
+    }
+
+    @Override
+    public void inject(TestInjector testInjector) {
+        testInjector.injectIntoFields(destinations, new TestInjector.MatchesType(IBMMQDestinations.class));
+    }
+
+    /**
+     * By default the user does have access just to predefined queues, this will add permissions to access
+     * all standard queues + topics and a special system queue.
+     *
+     * @return mqsc config string
+     */
+    private String mqscConfig() {
+        final String content = "SET AUTHREC PROFILE('*') PRINCIPAL('" + USER + "') OBJTYPE(TOPIC) AUTHADD(ALL)\n"
+                + "SET AUTHREC PROFILE('*') PRINCIPAL('" + USER + "') OBJTYPE(QUEUE) AUTHADD(ALL)\n"
+                + "SET AUTHREC PROFILE('SYSTEM.DEFAULT.MODEL.QUEUE') OBJTYPE(QUEUE) PRINCIPAL('" + USER + "') AUTHADD(ALL)";
+        File targetFile = new File(MQSC_FILE);
+        try {
+            FileUtils.writeStringToFile(targetFile, content, Charset.defaultCharset());
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to write to file", e);
+        }
+        return targetFile.getAbsolutePath();
+    }
+}

--- a/integration-tests/messaging/common/src/main/java/org/apache/camel/quarkus/component/messaging/it/MessagingPojoConsumer.java
+++ b/integration-tests/messaging/common/src/main/java/org/apache/camel/quarkus/component/messaging/it/MessagingPojoConsumer.java
@@ -28,13 +28,13 @@ import org.apache.camel.quarkus.component.messaging.it.util.scheme.ComponentSche
 @Singleton
 public class MessagingPojoConsumer {
 
-    private static BlockingQueue<String> messages = new LinkedBlockingQueue<>();
+    private static final BlockingQueue<String> messages = new LinkedBlockingQueue<>();
 
     @Inject
     ComponentScheme scheme;
 
     public String getMessagingUri() {
-        return scheme + ":queue:pojoConsume";
+        return scheme + ":queue:testJmsPojoConsumer";
     }
 
     @Consume(property = "messagingUri")

--- a/integration-tests/messaging/jms/src/main/java/org/apache/camel/quarkus/messaging/jms/JmsProducers.java
+++ b/integration-tests/messaging/jms/src/main/java/org/apache/camel/quarkus/messaging/jms/JmsProducers.java
@@ -52,7 +52,7 @@ public class JmsProducers {
         return (session, destinationName, pubSubDomain) -> {
             if (destinationName.equals("ignored")) {
                 // Ignore and override the original queue name
-                return session.createQueue("destinationOverride");
+                return session.createQueue("testJmsDestinationResolver");
             }
 
             if (pubSubDomain) {

--- a/integration-tests/messaging/jms/src/main/java/org/apache/camel/quarkus/messaging/jms/JmsResource.java
+++ b/integration-tests/messaging/jms/src/main/java/org/apache/camel/quarkus/messaging/jms/JmsResource.java
@@ -55,16 +55,16 @@ public class JmsResource {
     @Inject
     ComponentScheme componentScheme;
 
-    @Path("/custom/message/listener/factory")
+    @Path("/{queueName}/custom/message/listener/factory")
     @POST
     @Consumes(MediaType.TEXT_PLAIN)
     @Produces(MediaType.TEXT_PLAIN)
-    public String customMessageListenerContainerFactory(String message) {
+    public String customMessageListenerContainerFactory(@PathParam("queueName") String queueName, String message) {
         producerTemplate.sendBody(
                 componentScheme
-                        + ":queue:listener?messageListenerContainerFactory=#customMessageListener",
+                        + ":queue:" + queueName + "?messageListenerContainerFactory=#customMessageListener",
                 message);
-        return consumerTemplate.receiveBody(componentScheme + ":queue:listener", 5000,
+        return consumerTemplate.receiveBody(componentScheme + ":queue:" + queueName, 5000,
                 String.class);
     }
 
@@ -78,37 +78,37 @@ public class JmsResource {
                         + ":queue:ignored?destinationResolver=#customDestinationResolver",
                 message);
 
-        // The custom DestinationResolver should have overridden the original queue name to 'destinationOverride'
-        return consumerTemplate.receiveBody(componentScheme + ":queue:destinationOverride",
+        // The custom DestinationResolver should have overridden the original queue name to 'testJmsDestinationResolver'
+        return consumerTemplate.receiveBody(componentScheme + ":queue:testJmsDestinationResolver",
                 5000, String.class);
     }
 
-    @Path("/custom/message/converter")
+    @Path("/{queueName}/custom/message/converter")
     @POST
     @Consumes(MediaType.TEXT_PLAIN)
     @Produces(MediaType.TEXT_PLAIN)
-    public String customMessageConverter(String message) {
+    public String customMessageConverter(@PathParam("queueName") String queueName, String message) {
         producerTemplate.sendBody(
                 componentScheme
-                        + ":queue:converter?messageConverter=#customMessageConverter",
+                        + ":queue:" + queueName + "?messageConverter=#customMessageConverter",
                 message);
         return consumerTemplate.receiveBody(
                 componentScheme
-                        + ":queue:converter?messageConverter=#customMessageConverter",
+                        + ":queue:" + queueName + "?messageConverter=#customMessageConverter",
                 5000,
                 String.class);
     }
 
-    @Path("/transfer/exchange")
+    @Path("/{queueName}/transfer/exchange")
     @Consumes(MediaType.TEXT_PLAIN)
     @Produces(MediaType.TEXT_PLAIN)
     @POST
-    public Response testTransferExchange(String message) throws InterruptedException {
+    public Response testTransferExchange(@PathParam("queueName") String queueName, String message) throws InterruptedException {
         MockEndpoint mockEndpoint = context.getEndpoint("mock:transferExchangeResult", MockEndpoint.class);
         mockEndpoint.expectedMessageCount(1);
 
         producerTemplate.sendBody(
-                componentScheme + ":queue:transferExchange?transferExchange=true", message);
+                componentScheme + ":queue:" + queueName + "?transferExchange=true", message);
 
         mockEndpoint.assertIsSatisfied();
 
@@ -119,13 +119,13 @@ public class JmsResource {
         return Response.ok().entity(result).build();
     }
 
-    @Path("/transfer/exception")
+    @Path("/{queueName}/transfer/exception")
     @Produces(MediaType.TEXT_PLAIN)
     @GET
-    public Response testTransferException() {
+    public Response testTransferException(@PathParam("queueName") String queueName) {
         try {
             producerTemplate.requestBody(
-                    componentScheme + ":queue:transferException?transferException=true",
+                    componentScheme + ":queue:" + queueName + "?transferException=true",
                     "bad payload");
         } catch (RuntimeCamelException e) {
             Class<? extends Throwable> exception = e.getCause().getClass();

--- a/integration-tests/messaging/jms/src/main/java/org/apache/camel/quarkus/messaging/jms/JmsRoutes.java
+++ b/integration-tests/messaging/jms/src/main/java/org/apache/camel/quarkus/messaging/jms/JmsRoutes.java
@@ -34,10 +34,10 @@ public class JmsRoutes extends RouteBuilder {
     @Override
     public void configure() throws Exception {
 
-        fromF("%s:queue:transferExchange?transferExchange=true", componentScheme)
+        fromF("%s:queue:testJmsTransferExchange?transferExchange=true", componentScheme)
                 .to("mock:transferExchangeResult");
 
-        fromF("%s:queue:transferException?transferException=true", componentScheme)
+        fromF("%s:queue:testJmsTransferException?transferException=true", componentScheme)
                 .throwException(new IllegalStateException("Forced exception"));
 
         from("direct:computedDestination")

--- a/integration-tests/messaging/jms/src/test/java/org/apache/camel/quarkus/messaging/jms/AbstractJmsMessagingTest.java
+++ b/integration-tests/messaging/jms/src/test/java/org/apache/camel/quarkus/messaging/jms/AbstractJmsMessagingTest.java
@@ -33,7 +33,7 @@ public class AbstractJmsMessagingTest extends AbstractMessagingTest {
         String message = "Test transfer message";
         RestAssured.given()
                 .body(message)
-                .post("/messaging/jms/transfer/exchange")
+                .post("/messaging/jms/{queueName}/transfer/exchange", queue)
                 .then()
                 .statusCode(200)
                 .body(is(message));
@@ -42,7 +42,7 @@ public class AbstractJmsMessagingTest extends AbstractMessagingTest {
     @Test
     public void testJmsTransferException() {
         RestAssured.given()
-                .get("/messaging/jms/transfer/exception")
+                .get("/messaging/jms/{queueName}/transfer/exception", queue)
                 .then()
                 .statusCode(200)
                 .body(is("java.lang.IllegalStateException"));
@@ -53,7 +53,7 @@ public class AbstractJmsMessagingTest extends AbstractMessagingTest {
         String message = "Camel JMS With Custom MessageListenerContainerFactory";
         RestAssured.given()
                 .body(message)
-                .post("/messaging/jms/custom/message/listener/factory")
+                .post("/messaging/jms/{queueName}/custom/message/listener/factory", queue)
                 .then()
                 .statusCode(200)
                 .body(is(message));
@@ -74,7 +74,7 @@ public class AbstractJmsMessagingTest extends AbstractMessagingTest {
     public void testJmsMessageConverter() {
         String result = RestAssured.given()
                 .body("a test message")
-                .post("/messaging/jms/custom/message/converter")
+                .post("/messaging/jms/{queueName}/custom/message/converter", queue)
                 .then()
                 .statusCode(200)
                 .extract()
@@ -90,34 +90,32 @@ public class AbstractJmsMessagingTest extends AbstractMessagingTest {
         String message = UUID.randomUUID().toString();
 
         // Send a message with java.lang.String destination header
-        String destinationA = "queue-" + UUID.randomUUID().toString().split("-")[0];
         RestAssured.given()
                 .queryParam("isStringDestination", "true")
                 .body(message)
-                .post("/messaging/jms/custom/destination/{destinationName}", destinationA)
+                .post("/messaging/jms/custom/destination/{destinationName}", queue)
                 .then()
                 .statusCode(201);
 
         // Send a message with jakarta.jms.Destination destination header
-        String destinationB = "queue-" + UUID.randomUUID().toString().split("-")[0];
         RestAssured.given()
                 .queryParam("isStringDestination", "false")
                 .body(message)
-                .post("/messaging/jms/custom/destination/{destinationName}", destinationB)
+                .post("/messaging/jms/custom/destination/{destinationName}", queue2)
                 .then()
                 .statusCode(201);
 
         // Verify messages sent to destinations
         RestAssured.given()
                 .contentType(ContentType.TEXT)
-                .get("/messaging/{destinationName}", destinationA)
+                .get("/messaging/{destinationName}", queue)
                 .then()
                 .statusCode(200)
                 .body(is(message));
 
         RestAssured.given()
                 .contentType(ContentType.TEXT)
-                .get("/messaging/{destinationName}", destinationB)
+                .get("/messaging/{destinationName}", queue2)
                 .then()
                 .statusCode(200)
                 .body(is(message));

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -17,7 +17,8 @@
     limitations under the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
     <parent>
@@ -121,6 +122,7 @@
         <module>jfr</module>
         <!--<module>jira</module> https://github.com/apache/camel-quarkus/issues/4524 -->
         <module>jms-artemis-client</module>
+        <module>jms-ibmmq-client</module>
         <module>jms-qpid-amqp-client</module>
         <module>jolt</module>
         <module>joor</module>

--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,7 @@
         <hapi-fhir.version>${hapi-fhir-version}</hapi-fhir.version>
         <hapi-fhir-core.version>5.6.971</hapi-fhir-core.version><!-- @sync ca.uhn.hapi.fhir:hapi-fhir:${hapi-fhir.version} prop:fhir_core_version -->
         <httpclient5.version>5.2.1</httpclient5.version><!-- Saxon and Wiremock -->
+        <ibm.mq.client.version>9.3.2.1</ibm.mq.client.version>
         <influxdb.version>${influx-java-driver-version}</influxdb.version>
         <io-netty-iouring.version>0.0.16.Final</io-netty-iouring.version><!-- @sync org.asynchttpclient:async-http-client-project:${ahc.version} prop:netty.iouring -->
         <jackson.version>2.15.0</jackson.version><!-- @sync io.quarkus:quarkus-bom:${quarkus.version} dep:com.fasterxml.jackson.core:jackson-core -->

--- a/poms/bom-test/pom.xml
+++ b/poms/bom-test/pom.xml
@@ -154,7 +154,6 @@
                 <artifactId>camel-quarkus-integration-tests-process-executor-support</artifactId>
                 <version>${camel-quarkus.version}</version>
             </dependency>
-
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
                 <artifactId>camel-quarkus-integration-tests-support-google</artifactId>

--- a/poms/bom/pom.xml
+++ b/poms/bom/pom.xml
@@ -6056,6 +6056,11 @@
                 </exclusions>
             </dependency>
             <dependency>
+                <groupId>com.ibm.mq</groupId>
+                <artifactId>com.ibm.mq.jakarta.client</artifactId>
+                <version>${ibm.mq.client.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>com.jayway.jsonpath</groupId>
                 <artifactId>json-path</artifactId>
                 <version>${json-path.version}</version>
@@ -6747,6 +6752,7 @@
                                 <resolutionEntryPointInclude>io.quarkiverse.messaginghub:*</resolutionEntryPointInclude>
                                 <resolutionEntryPointInclude>net.openhft:affinity</resolutionEntryPointInclude> <!-- https://github.com/apache/camel-quarkus/issues/3788 -->
                                 <resolutionEntryPointInclude>xerces:xercesImpl</resolutionEntryPointInclude>
+                                <resolutionEntryPointInclude>com.ibm.mq:com.ibm.mq.jakarta.client</resolutionEntryPointInclude>
                             </resolutionEntryPointIncludes>
                             <bannedDependencyResources>
                                 <bannedDependencyResource>

--- a/poms/bom/src/main/generated/flattened-full-pom.xml
+++ b/poms/bom/src/main/generated/flattened-full-pom.xml
@@ -5979,6 +5979,11 @@
         </exclusions>
       </dependency>
       <dependency>
+        <groupId>com.ibm.mq</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+        <artifactId>com.ibm.mq.jakarta.client</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+        <version>9.3.2.1</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+      </dependency>
+      <dependency>
         <groupId>com.jayway.jsonpath</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>json-path</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <version>2.8.0</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->

--- a/poms/bom/src/main/generated/flattened-reduced-pom.xml
+++ b/poms/bom/src/main/generated/flattened-reduced-pom.xml
@@ -5979,6 +5979,11 @@
         </exclusions>
       </dependency>
       <dependency>
+        <groupId>com.ibm.mq</groupId>
+        <artifactId>com.ibm.mq.jakarta.client</artifactId>
+        <version>9.3.2.1</version>
+      </dependency>
+      <dependency>
         <groupId>com.jayway.jsonpath</groupId>
         <artifactId>json-path</artifactId>
         <version>2.8.0</version>

--- a/poms/bom/src/main/generated/flattened-reduced-verbose-pom.xml
+++ b/poms/bom/src/main/generated/flattened-reduced-verbose-pom.xml
@@ -5979,6 +5979,11 @@
         </exclusions>
       </dependency>
       <dependency>
+        <groupId>com.ibm.mq</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+        <artifactId>com.ibm.mq.jakarta.client</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+        <version>9.3.2.1</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+      </dependency>
+      <dependency>
         <groupId>com.jayway.jsonpath</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>json-path</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <version>2.8.0</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->

--- a/tooling/scripts/test-categories.yaml
+++ b/tooling/scripts/test-categories.yaml
@@ -25,6 +25,7 @@ group-01:
   - infinispan-quarkus-client
   - jcache
   - jms-artemis-client
+  - jms-ibmmq-client
   - jsch
   - kafka
   - kafka-sasl


### PR DESCRIPTION
- add ibm mq test resource + tests with ibm mq client
- changed messaging tests to use "predictable" destination names (named after the test method), as IBM MQ requires destinations to exist before one can use them