### PR TITLE
Ref #4960: Upgrade Groovy to 4.0.12

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -33,8 +33,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.codehaus.gmaven</groupId>
-                <artifactId>groovy-maven-plugin</artifactId>
+                <groupId>org.codehaus.gmavenplus</groupId>
+                <artifactId>gmavenplus-plugin</artifactId>
                 <executions>
                     <execution>
                         <id>update-antora-config</id>
@@ -43,10 +43,9 @@
                         </goals>
                         <phase>validate</phase>
                         <configuration>
-                            <source>file:${maven.multiModuleProjectDirectory}/tooling/scripts/update-antora-config.groovy</source>
-                            <properties>
-                                <maven.multiModuleProjectDirectory>${maven.multiModuleProjectDirectory}</maven.multiModuleProjectDirectory>
-                            </properties>
+                            <scripts>
+                                <script>file:${maven.multiModuleProjectDirectory}/tooling/scripts/update-antora-config.groovy</script>
+                            </scripts>
                         </configuration>
                     </execution>
                     <execution>
@@ -56,10 +55,9 @@
                         </goals>
                         <phase>validate</phase>
                         <configuration>
-                            <source>file:${maven.multiModuleProjectDirectory}/tooling/scripts/update-antora-yaml.groovy</source>
-                            <properties>
-                                <maven.multiModuleProjectDirectory>${maven.multiModuleProjectDirectory}</maven.multiModuleProjectDirectory>
-                            </properties>
+                            <scripts>
+                                <script>file:${maven.multiModuleProjectDirectory}/tooling/scripts/update-antora-yaml.groovy</script>
+                            </scripts>
                         </configuration>
                     </execution>
                 </executions>

--- a/integration-test-groups/aws2-quarkus-client/aws2-ddb/pom.xml
+++ b/integration-test-groups/aws2-quarkus-client/aws2-ddb/pom.xml
@@ -113,8 +113,8 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.gmaven</groupId>
-                <artifactId>groovy-maven-plugin</artifactId>
+                <groupId>org.codehaus.gmavenplus</groupId>
+                <artifactId>gmavenplus-plugin</artifactId>
                 <executions>
                     <execution>
                         <id>group-sources</id>
@@ -123,7 +123,9 @@
                         </goals>
                         <phase>generate-sources</phase>
                         <configuration>
-                            <source>file:${maven.multiModuleProjectDirectory}/tooling/scripts/copy-tests.groovy</source>
+                            <scripts>
+                                <script>file:${maven.multiModuleProjectDirectory}/tooling/scripts/copy-tests.groovy</script>
+                            </scripts>
                             <properties>
                                 <copy-tests.source.dir>${maven.multiModuleProjectDirectory}/integration-test-groups/aws2/aws2-ddb</copy-tests.source.dir>
                                 <copy-tests.dest.module.dir>${project.basedir}</copy-tests.dest.module.dir>

--- a/integration-test-groups/aws2-quarkus-client/aws2-s3/pom.xml
+++ b/integration-test-groups/aws2-quarkus-client/aws2-s3/pom.xml
@@ -117,8 +117,8 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.gmaven</groupId>
-                <artifactId>groovy-maven-plugin</artifactId>
+                <groupId>org.codehaus.gmavenplus</groupId>
+                <artifactId>gmavenplus-plugin</artifactId>
                 <executions>
                     <execution>
                         <id>group-sources</id>
@@ -127,7 +127,9 @@
                         </goals>
                         <phase>generate-sources</phase>
                         <configuration>
-                            <source>file:${maven.multiModuleProjectDirectory}/tooling/scripts/copy-tests.groovy</source>
+                            <scripts>
+                                <script>file:${maven.multiModuleProjectDirectory}/tooling/scripts/copy-tests.groovy</script>
+                            </scripts>
                             <properties>
                                 <copy-tests.source.dir>${maven.multiModuleProjectDirectory}/integration-test-groups/aws2/aws2-s3</copy-tests.source.dir>
                                 <copy-tests.dest.module.dir>${project.basedir}</copy-tests.dest.module.dir>

--- a/integration-test-groups/aws2-quarkus-client/aws2-ses/pom.xml
+++ b/integration-test-groups/aws2-quarkus-client/aws2-ses/pom.xml
@@ -118,8 +118,8 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.gmaven</groupId>
-                <artifactId>groovy-maven-plugin</artifactId>
+                <groupId>org.codehaus.gmavenplus</groupId>
+                <artifactId>gmavenplus-plugin</artifactId>
                 <executions>
                     <execution>
                         <id>group-sources</id>
@@ -128,7 +128,9 @@
                         </goals>
                         <phase>generate-sources</phase>
                         <configuration>
-                            <source>file:${maven.multiModuleProjectDirectory}/tooling/scripts/copy-tests.groovy</source>
+                            <scripts>
+                                <script>file:${maven.multiModuleProjectDirectory}/tooling/scripts/copy-tests.groovy</script>
+                            </scripts>
                             <properties>
                                 <copy-tests.source.dir>${maven.multiModuleProjectDirectory}/integration-test-groups/aws2/aws2-ses</copy-tests.source.dir>
                                 <copy-tests.dest.module.dir>${project.basedir}</copy-tests.dest.module.dir>

--- a/integration-test-groups/aws2-quarkus-client/aws2-sqs-sns/pom.xml
+++ b/integration-test-groups/aws2-quarkus-client/aws2-sqs-sns/pom.xml
@@ -121,8 +121,8 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.gmaven</groupId>
-                <artifactId>groovy-maven-plugin</artifactId>
+                <groupId>org.codehaus.gmavenplus</groupId>
+                <artifactId>gmavenplus-plugin</artifactId>
                 <executions>
                     <execution>
                         <id>group-sources</id>
@@ -131,7 +131,9 @@
                         </goals>
                         <phase>generate-sources</phase>
                         <configuration>
-                            <source>file:${maven.multiModuleProjectDirectory}/tooling/scripts/copy-tests.groovy</source>
+                            <scripts>
+                                <script>file:${maven.multiModuleProjectDirectory}/tooling/scripts/copy-tests.groovy</script>
+                            </scripts>
                             <properties>
                                 <copy-tests.source.dir>${maven.multiModuleProjectDirectory}/integration-test-groups/aws2/aws2-sqs-sns</copy-tests.source.dir>
                                 <copy-tests.dest.module.dir>${project.basedir}</copy-tests.dest.module.dir>

--- a/integration-test-groups/aws2-quarkus-client/aws2-sqs/pom.xml
+++ b/integration-test-groups/aws2-quarkus-client/aws2-sqs/pom.xml
@@ -118,8 +118,8 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.gmaven</groupId>
-                <artifactId>groovy-maven-plugin</artifactId>
+                <groupId>org.codehaus.gmavenplus</groupId>
+                <artifactId>gmavenplus-plugin</artifactId>
                 <executions>
                     <execution>
                         <id>group-sources</id>
@@ -128,7 +128,9 @@
                         </goals>
                         <phase>generate-sources</phase>
                         <configuration>
-                            <source>file:${maven.multiModuleProjectDirectory}/tooling/scripts/copy-tests.groovy</source>
+                            <scripts>
+                                <script>file:${maven.multiModuleProjectDirectory}/tooling/scripts/copy-tests.groovy</script>
+                            </scripts>
                             <properties>
                                 <copy-tests.source.dir>${maven.multiModuleProjectDirectory}/integration-test-groups/aws2/aws2-sqs</copy-tests.source.dir>
                                 <copy-tests.dest.module.dir>${project.basedir}</copy-tests.dest.module.dir>

--- a/integration-test-groups/aws2/aws2-s3/pom.xml
+++ b/integration-test-groups/aws2/aws2-s3/pom.xml
@@ -108,8 +108,8 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.gmaven</groupId>
-                <artifactId>groovy-maven-plugin</artifactId>
+                <groupId>org.codehaus.gmavenplus</groupId>
+                <artifactId>gmavenplus-plugin</artifactId>
                 <executions>
                     <execution>
                         <id>group-sources</id>
@@ -118,7 +118,9 @@
                         </goals>
                         <phase>generate-sources</phase>
                         <configuration>
-                            <source>file:${maven.multiModuleProjectDirectory}/tooling/scripts/copy-tests.groovy</source>
+                            <scripts>
+                                <script>file:${maven.multiModuleProjectDirectory}/tooling/scripts/copy-tests.groovy</script>
+                            </scripts>
                             <properties>
                                 <copy-tests.source.dir>${maven.multiModuleProjectDirectory}/integration-test-groups/aws2/aws2-s</copy-tests.source.dir>
                                 <copy-tests.dest.module.dir>${project.basedir}</copy-tests.dest.module.dir>

--- a/integration-tests-jvm/xml-grouped/pom.xml
+++ b/integration-tests-jvm/xml-grouped/pom.xml
@@ -100,8 +100,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.codehaus.gmaven</groupId>
-                <artifactId>groovy-maven-plugin</artifactId>
+                <groupId>org.codehaus.gmavenplus</groupId>
+                <artifactId>gmavenplus-plugin</artifactId>
                 <executions>
                     <execution>
                         <id>group-sources</id>
@@ -110,7 +110,9 @@
                         </goals>
                         <phase>generate-sources</phase>
                         <configuration>
-                            <source>file:${maven.multiModuleProjectDirectory}/tooling/scripts/group-tests.groovy</source>
+                            <scripts>
+                                <script>file:${maven.multiModuleProjectDirectory}/tooling/scripts/group-tests.groovy</script>
+                            </scripts>
                             <properties>
                                 <group-tests.source.dir>${maven.multiModuleProjectDirectory}/integration-test-groups/xml/jvm</group-tests.source.dir>
                                 <group-tests.dest.module.dir>${project.basedir}</group-tests.dest.module.dir>

--- a/integration-tests/aws2-grouped/pom.xml
+++ b/integration-tests/aws2-grouped/pom.xml
@@ -134,8 +134,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.codehaus.gmaven</groupId>
-                <artifactId>groovy-maven-plugin</artifactId>
+                <groupId>org.codehaus.gmavenplus</groupId>
+                <artifactId>gmavenplus-plugin</artifactId>
                 <executions>
                     <execution>
                         <id>group-sources</id>
@@ -144,7 +144,9 @@
                         </goals>
                         <phase>generate-sources</phase>
                         <configuration>
-                            <source>file:${maven.multiModuleProjectDirectory}/tooling/scripts/group-tests.groovy</source>
+                            <scripts>
+                                <script>file:${maven.multiModuleProjectDirectory}/tooling/scripts/group-tests.groovy</script>
+                            </scripts>
                             <properties>
                                 <group-tests.source.dir>${maven.multiModuleProjectDirectory}/integration-test-groups/aws2</group-tests.source.dir>
                                 <group-tests.dest.module.dir>${project.basedir}</group-tests.dest.module.dir>

--- a/integration-tests/aws2-quarkus-client-grouped/pom.xml
+++ b/integration-tests/aws2-quarkus-client-grouped/pom.xml
@@ -153,8 +153,8 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.gmaven</groupId>
-                <artifactId>groovy-maven-plugin</artifactId>
+                <groupId>org.codehaus.gmavenplus</groupId>
+                <artifactId>gmavenplus-plugin</artifactId>
                 <executions>
                     <execution>
                         <id>group-sources</id>
@@ -163,7 +163,9 @@
                         </goals>
                         <phase>generate-sources</phase>
                         <configuration>
-                            <source>file:${maven.multiModuleProjectDirectory}/tooling/scripts/group-tests.groovy</source>
+                            <scripts>
+                                <script>file:${maven.multiModuleProjectDirectory}/tooling/scripts/group-tests.groovy</script>
+                            </scripts>
                             <properties>
                                 <group-tests.source.dir>${maven.multiModuleProjectDirectory}/integration-test-groups/aws2-quarkus-client</group-tests.source.dir>
                                 <group-tests.dest.module.dir>${project.basedir}</group-tests.dest.module.dir>
@@ -179,7 +181,9 @@
                         </goals>
                         <phase>generate-sources</phase>
                         <configuration>
-                            <source>file:${maven.multiModuleProjectDirectory}/tooling/scripts/copy-tests.groovy</source>
+                            <scripts>
+                                <script>file:${maven.multiModuleProjectDirectory}/tooling/scripts/copy-tests.groovy</script>
+                            </scripts>
                             <properties>
                                 <copy-tests.source.dir>${maven.multiModuleProjectDirectory}/integration-test-groups/aws2/aws2-ses</copy-tests.source.dir>
                                 <copy-tests.dest.module.dir>${project.basedir}</copy-tests.dest.module.dir>
@@ -195,7 +199,9 @@
                         </goals>
                         <phase>generate-sources</phase>
                         <configuration>
-                            <source>file:${maven.multiModuleProjectDirectory}/tooling/scripts/copy-tests.groovy</source>
+                            <scripts>
+                                <script>file:${maven.multiModuleProjectDirectory}/tooling/scripts/copy-tests.groovy</script>
+                            </scripts>
                             <properties>
                                 <copy-tests.source.dir>${maven.multiModuleProjectDirectory}/integration-test-groups/aws2/aws2-ddb</copy-tests.source.dir>
                                 <copy-tests.dest.module.dir>${project.basedir}</copy-tests.dest.module.dir>
@@ -211,7 +217,9 @@
                         </goals>
                         <phase>generate-sources</phase>
                         <configuration>
-                            <source>file:${maven.multiModuleProjectDirectory}/tooling/scripts/copy-tests.groovy</source>
+                            <scripts>
+                                <script>file:${maven.multiModuleProjectDirectory}/tooling/scripts/copy-tests.groovy</script>
+                            </scripts>
                             <properties>
                                 <copy-tests.source.dir>${maven.multiModuleProjectDirectory}/integration-test-groups/aws2/aws2-s3</copy-tests.source.dir>
                                 <copy-tests.dest.module.dir>${project.basedir}</copy-tests.dest.module.dir>
@@ -227,7 +235,9 @@
                         </goals>
                         <phase>generate-sources</phase>
                         <configuration>
-                            <source>file:${maven.multiModuleProjectDirectory}/tooling/scripts/copy-tests.groovy</source>
+                            <scripts>
+                                <script>file:${maven.multiModuleProjectDirectory}/tooling/scripts/copy-tests.groovy</script>
+                            </scripts>
                             <properties>
                                 <copy-tests.source.dir>${maven.multiModuleProjectDirectory}/integration-test-groups/aws2/aws2-sqs</copy-tests.source.dir>
                                 <copy-tests.dest.module.dir>${project.basedir}</copy-tests.dest.module.dir>
@@ -243,7 +253,9 @@
                         </goals>
                         <phase>generate-sources</phase>
                         <configuration>
-                            <source>file:${maven.multiModuleProjectDirectory}/tooling/scripts/copy-tests.groovy</source>
+                            <scripts>
+                                <script>file:${maven.multiModuleProjectDirectory}/tooling/scripts/copy-tests.groovy</script>
+                            </scripts>
                             <properties>
                                 <copy-tests.source.dir>${maven.multiModuleProjectDirectory}/integration-test-groups/aws2/aws2-sqs-sns</copy-tests.source.dir>
                                 <copy-tests.dest.module.dir>${project.basedir}</copy-tests.dest.module.dir>

--- a/integration-tests/azure-grouped/pom.xml
+++ b/integration-tests/azure-grouped/pom.xml
@@ -106,8 +106,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.codehaus.gmaven</groupId>
-                <artifactId>groovy-maven-plugin</artifactId>
+                <groupId>org.codehaus.gmavenplus</groupId>
+                <artifactId>gmavenplus-plugin</artifactId>
                 <executions>
                     <execution>
                         <id>group-sources</id>
@@ -116,7 +116,9 @@
                         </goals>
                         <phase>generate-sources</phase>
                         <configuration>
-                            <source>file:${maven.multiModuleProjectDirectory}/tooling/scripts/group-tests.groovy</source>
+                            <scripts>
+                                <script>file:${maven.multiModuleProjectDirectory}/tooling/scripts/group-tests.groovy</script>
+                            </scripts>
                             <properties>
                                 <group-tests.source.dir>${maven.multiModuleProjectDirectory}/integration-test-groups/azure</group-tests.source.dir>
                                 <group-tests.dest.module.dir>${project.basedir}</group-tests.dest.module.dir>

--- a/integration-tests/compression-grouped/pom.xml
+++ b/integration-tests/compression-grouped/pom.xml
@@ -84,8 +84,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.codehaus.gmaven</groupId>
-                <artifactId>groovy-maven-plugin</artifactId>
+                <groupId>org.codehaus.gmavenplus</groupId>
+                <artifactId>gmavenplus-plugin</artifactId>
                 <executions>
                     <execution>
                         <id>group-sources</id>
@@ -94,7 +94,9 @@
                         </goals>
                         <phase>generate-sources</phase>
                         <configuration>
-                            <source>file:${maven.multiModuleProjectDirectory}/tooling/scripts/group-tests.groovy</source>
+                            <scripts>
+                                <script>file:${maven.multiModuleProjectDirectory}/tooling/scripts/group-tests.groovy</script>
+                            </scripts>
                             <properties>
                                 <group-tests.source.dir>${maven.multiModuleProjectDirectory}/integration-test-groups/compression</group-tests.source.dir>
                                 <group-tests.dest.module.dir>${project.basedir}</group-tests.dest.module.dir>

--- a/integration-tests/cxf-soap-grouped/pom.xml
+++ b/integration-tests/cxf-soap-grouped/pom.xml
@@ -119,8 +119,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.codehaus.gmaven</groupId>
-                <artifactId>groovy-maven-plugin</artifactId>
+                <groupId>org.codehaus.gmavenplus</groupId>
+                <artifactId>gmavenplus-plugin</artifactId>
                 <executions>
                     <execution>
                         <id>group-sources</id>
@@ -129,7 +129,9 @@
                         </goals>
                         <phase>generate-sources</phase>
                         <configuration>
-                            <source>file:${maven.multiModuleProjectDirectory}/tooling/scripts/group-tests.groovy</source>
+                            <scripts>
+                                <script>file:${maven.multiModuleProjectDirectory}/tooling/scripts/group-tests.groovy</script>
+                            </scripts>
                             <properties>
                                 <group-tests.source.dir>${maven.multiModuleProjectDirectory}/integration-test-groups/cxf-soap</group-tests.source.dir>
                                 <group-tests.dest.module.dir>${project.basedir}</group-tests.dest.module.dir>

--- a/integration-tests/dataformats-json-grouped/pom.xml
+++ b/integration-tests/dataformats-json-grouped/pom.xml
@@ -121,8 +121,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.codehaus.gmaven</groupId>
-                <artifactId>groovy-maven-plugin</artifactId>
+                <groupId>org.codehaus.gmavenplus</groupId>
+                <artifactId>gmavenplus-plugin</artifactId>
                 <executions>
                     <execution>
                         <id>group-sources</id>
@@ -131,7 +131,9 @@
                         </goals>
                         <phase>generate-sources</phase>
                         <configuration>
-                            <source>file:${maven.multiModuleProjectDirectory}/tooling/scripts/group-tests.groovy</source>
+                            <scripts>
+                                <script>file:${maven.multiModuleProjectDirectory}/tooling/scripts/group-tests.groovy</script>
+                            </scripts>
                             <properties>
                                 <group-tests.source.dir>${maven.multiModuleProjectDirectory}/integration-test-groups/dataformats-json</group-tests.source.dir>
                                 <group-tests.dest.module.dir>${project.basedir}</group-tests.dest.module.dir>

--- a/integration-tests/foundation-grouped/pom.xml
+++ b/integration-tests/foundation-grouped/pom.xml
@@ -191,8 +191,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.codehaus.gmaven</groupId>
-                <artifactId>groovy-maven-plugin</artifactId>
+                <groupId>org.codehaus.gmavenplus</groupId>
+                <artifactId>gmavenplus-plugin</artifactId>
                 <executions>
                     <execution>
                         <id>group-sources</id>
@@ -201,7 +201,9 @@
                         </goals>
                         <phase>generate-sources</phase>
                         <configuration>
-                            <source>file:${maven.multiModuleProjectDirectory}/tooling/scripts/group-tests.groovy</source>
+                            <scripts>
+                                <script>file:${maven.multiModuleProjectDirectory}/tooling/scripts/group-tests.groovy</script>
+                            </scripts>
                             <properties>
                                 <group-tests.source.dir>${maven.multiModuleProjectDirectory}/integration-test-groups/foundation</group-tests.source.dir>
                                 <group-tests.dest.module.dir>${project.basedir}</group-tests.dest.module.dir>

--- a/integration-tests/grpc/pom.xml
+++ b/integration-tests/grpc/pom.xml
@@ -98,8 +98,8 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.gmaven</groupId>
-                <artifactId>groovy-maven-plugin</artifactId>
+                <groupId>org.codehaus.gmavenplus</groupId>
+                <artifactId>gmavenplus-plugin</artifactId>
                 <executions>
                     <execution>
                         <!-- Skip code generation & tests on unsupported platforms -->
@@ -109,11 +109,13 @@
                             <goal>execute</goal>
                         </goals>
                         <configuration>
-                            <source>
-                                String platformUnsupported = project.properties['os.detected.classifier'].matches('^.*?(linux|windows|osx)-x86.*$') ? 'false' : 'true'
-                                project.properties['skipTests'] = platformUnsupported
-                                project.properties['cq.skip.protobuf'] = platformUnsupported || project.properties.containsKey('quickly')
-                            </source>
+                            <scripts>
+                                <script>
+                                    String platformUnsupported = project.properties['os.detected.classifier'].matches('^.*?(linux|windows|osx)-x86.*$') ? 'false' : 'true'
+                                    project.properties['skipTests'] = platformUnsupported
+                                    project.properties['cq.skip.protobuf'] = platformUnsupported || project.properties.containsKey('quickly')
+                                </script>
+                            </scripts>
                         </configuration>
                     </execution>
                     <execution>
@@ -134,15 +136,17 @@
                             <goal>execute</goal>
                         </goals>
                         <configuration>
-                            <source>
-                            def buildDir = project.build.directory
-                            new File("${buildDir}/generated-sources").eachFileRecurse { file -&gt;
-                                if (file.name.endsWith(".java") &amp;&amp; file.text.contains("javax.annotation.Generated")) {
-                                    def modifiedContent = file.text.replace("javax", "jakarta")
-                                    file.write(modifiedContent)
-                                }
-                            }
-                            </source>
+                            <scripts>
+                                <script><![CDATA[
+                                    def buildDir = project.build.directory
+                                    new File("${buildDir}/generated-sources").eachFileRecurse { file ->
+                                        if (file.name.endsWith('.java') && file.text.contains('javax.annotation.Generated')) {
+                                            def modifiedContent = file.text.replace('javax', 'jakarta')
+                                            file.write(modifiedContent)
+                                        }
+                                    }
+                                ]]></script>
+                            </scripts>
                         </configuration>
                     </execution>
                 </executions>

--- a/integration-tests/mongodb-grouped/pom.xml
+++ b/integration-tests/mongodb-grouped/pom.xml
@@ -77,8 +77,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.codehaus.gmaven</groupId>
-                <artifactId>groovy-maven-plugin</artifactId>
+                <groupId>org.codehaus.gmavenplus</groupId>
+                <artifactId>gmavenplus-plugin</artifactId>
                 <executions>
                     <execution>
                         <id>group-sources</id>
@@ -87,7 +87,9 @@
                         </goals>
                         <phase>generate-sources</phase>
                         <configuration>
-                            <source>file:${maven.multiModuleProjectDirectory}/tooling/scripts/group-tests.groovy</source>
+                            <scripts>
+                                <script>file:${maven.multiModuleProjectDirectory}/tooling/scripts/group-tests.groovy</script>
+                            </scripts>
                             <properties>
                                 <group-tests.source.dir>${maven.multiModuleProjectDirectory}/integration-test-groups/mongodb</group-tests.source.dir>
                                 <group-tests.dest.module.dir>${project.basedir}</group-tests.dest.module.dir>

--- a/integration-tests/xml-grouped/pom.xml
+++ b/integration-tests/xml-grouped/pom.xml
@@ -87,8 +87,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.codehaus.gmaven</groupId>
-                <artifactId>groovy-maven-plugin</artifactId>
+                <groupId>org.codehaus.gmavenplus</groupId>
+                <artifactId>gmavenplus-plugin</artifactId>
                 <executions>
                     <execution>
                         <id>group-sources</id>
@@ -97,7 +97,9 @@
                         </goals>
                         <phase>generate-sources</phase>
                         <configuration>
-                            <source>file:${maven.multiModuleProjectDirectory}/tooling/scripts/group-tests.groovy</source>
+                            <scripts>
+                                <script>file:${maven.multiModuleProjectDirectory}/tooling/scripts/group-tests.groovy</script>
+                            </scripts>
                             <properties>
                                 <group-tests.source.dir>${maven.multiModuleProjectDirectory}/integration-test-groups/xml/native</group-tests.source.dir>
                                 <group-tests.dest.module.dir>${project.basedir}</group-tests.dest.module.dir>

--- a/pom.xml
+++ b/pom.xml
@@ -169,8 +169,8 @@
         <build-helper-maven-plugin.version>3.4.0</build-helper-maven-plugin.version>
         <exec-maven-plugin.version>3.1.0</exec-maven-plugin.version>
         <formatter-maven-plugin.version>2.23.0</formatter-maven-plugin.version>
-        <groovy-maven-plugin.version>2.1.1</groovy-maven-plugin.version>
-        <groovy.version>3.0.14</groovy.version>
+        <gmavenplus-maven-plugin.version>3.0.0</gmavenplus-maven-plugin.version>
+        <groovy.version>4.0.12</groovy.version>
         <impsort-maven-plugin.version>1.9.0</impsort-maven-plugin.version>
         <jandex-maven-plugin.version>1.2.3</jandex-maven-plugin.version>
         <keytool-maven-plugin.version>1.7</keytool-maven-plugin.version>
@@ -436,22 +436,15 @@
                 </plugin>
 
                 <plugin>
-                    <groupId>org.codehaus.gmaven</groupId>
-                    <artifactId>groovy-maven-plugin</artifactId>
-                    <version>${groovy-maven-plugin.version}</version>
+                    <groupId>org.codehaus.gmavenplus</groupId>
+                    <artifactId>gmavenplus-plugin</artifactId>
+                    <version>${gmavenplus-maven-plugin.version}</version>
                     <dependencies>
                         <dependency>
-                            <groupId>org.codehaus.groovy</groupId>
+                            <groupId>org.apache.groovy</groupId>
                             <artifactId>groovy-all</artifactId>
                             <version>${groovy.version}</version>
                             <type>pom</type>
-                            <exclusions>
-                                <exclusion>
-                                    <!-- groovy-testng depends on testng 7.2.0 which is not on maven central -->
-                                    <groupId>org.codehaus.groovy</groupId>
-                                    <artifactId>groovy-testng</artifactId>
-                                </exclusion>
-                            </exclusions>
                         </dependency>
                     </dependencies>
                 </plugin>
@@ -715,8 +708,8 @@
                         </executions>
                     </plugin>
                     <plugin>
-                        <groupId>org.codehaus.gmaven</groupId>
-                        <artifactId>groovy-maven-plugin</artifactId>
+                        <groupId>org.codehaus.gmavenplus</groupId>
+                        <artifactId>gmavenplus-plugin</artifactId>
                         <executions>
                             <execution>
                                 <id>validate-github-workflows</id>
@@ -726,7 +719,9 @@
                                 </goals>
                                 <phase>process-resources</phase>
                                 <configuration>
-                                    <source>file:${project.basedir}/tooling/scripts/validate-github-workflows.groovy</source>
+                                    <scripts>
+                                        <script>file:${project.basedir}/tooling/scripts/validate-github-workflows.groovy</script>
+                                    </scripts>
                                 </configuration>
                             </execution>
                             <execution>
@@ -737,7 +732,9 @@
                                 </goals>
                                 <phase>verify</phase>
                                 <configuration>
-                                    <source>file:${project.basedir}/tooling/scripts/validate-extension-metadata.groovy</source>
+                                    <scripts>
+                                        <script>file:${project.basedir}/tooling/scripts/validate-extension-metadata.groovy</script>
+                                    </scripts>
                                     <properties>
                                         <extensionDirs>extensions-core,extensions-support,extensions</extensionDirs>
                                     </properties>
@@ -1064,8 +1061,8 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.codehaus.gmaven</groupId>
-                        <artifactId>groovy-maven-plugin</artifactId>
+                        <groupId>org.codehaus.gmavenplus</groupId>
+                        <artifactId>gmavenplus-plugin</artifactId>
                         <executions>
                             <execution>
                                 <id>update-antora-yaml</id>
@@ -1075,10 +1072,9 @@
                                 </goals>
                                 <phase>validate</phase>
                                 <configuration>
-                                    <source>file:${maven.multiModuleProjectDirectory}/tooling/scripts/update-antora-yaml.groovy</source>
-                                    <properties>
-                                        <maven.multiModuleProjectDirectory>${maven.multiModuleProjectDirectory}</maven.multiModuleProjectDirectory>
-                                    </properties>
+                                    <scripts>
+                                        <script>file:${maven.multiModuleProjectDirectory}/tooling/scripts/update-antora-yaml.groovy</script>
+                                    </scripts>
                                 </configuration>
                             </execution>
                         </executions>
@@ -1247,8 +1243,8 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.codehaus.gmaven</groupId>
-                        <artifactId>groovy-maven-plugin</artifactId>
+                        <groupId>org.codehaus.gmavenplus</groupId>
+                        <artifactId>gmavenplus-plugin</artifactId>
                         <executions>
                             <execution>
                                 <id>build-notify</id>
@@ -1258,7 +1254,9 @@
                                 </goals>
                                 <phase>verify</phase>
                                 <configuration>
-                                    <source>file:${project.basedir}/tooling/scripts/report-build-status.groovy</source>
+                                    <scripts>
+                                        <script>file:${project.basedir}/tooling/scripts/report-build-status.groovy</script>
+                                    </scripts>
                                 </configuration>
                             </execution>
                         </executions>

--- a/poms/bom/pom.xml
+++ b/poms/bom/pom.xml
@@ -44,7 +44,7 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
-                <groupId>org.codehaus.groovy</groupId>
+                <groupId>org.apache.groovy</groupId>
                 <artifactId>groovy-bom</artifactId>
                 <version>${groovy.version}</version>
                 <type>pom</type>

--- a/poms/bom/src/main/generated/flattened-full-pom.xml
+++ b/poms/bom/src/main/generated/flattened-full-pom.xml
@@ -7014,139 +7014,154 @@
         <version>4.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.1.0 -->
       </dependency>
       <dependency>
-        <groupId>org.codehaus.groovy</groupId><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
-        <artifactId>groovy</artifactId><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
-        <version>3.0.14</version><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
+        <groupId>org.apache.groovy</groupId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <artifactId>groovy</artifactId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <version>4.0.12</version><!-- org.apache.groovy:groovy-bom:4.0.12 -->
       </dependency>
       <dependency>
-        <groupId>org.codehaus.groovy</groupId><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
-        <artifactId>groovy-ant</artifactId><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
-        <version>3.0.14</version><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
+        <groupId>org.apache.groovy</groupId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <artifactId>groovy-ant</artifactId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <version>4.0.12</version><!-- org.apache.groovy:groovy-bom:4.0.12 -->
       </dependency>
       <dependency>
-        <groupId>org.codehaus.groovy</groupId><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
-        <artifactId>groovy-astbuilder</artifactId><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
-        <version>3.0.14</version><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
+        <groupId>org.apache.groovy</groupId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <artifactId>groovy-astbuilder</artifactId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <version>4.0.12</version><!-- org.apache.groovy:groovy-bom:4.0.12 -->
       </dependency>
       <dependency>
-        <groupId>org.codehaus.groovy</groupId><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
-        <artifactId>groovy-bsf</artifactId><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
-        <version>3.0.14</version><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
+        <groupId>org.apache.groovy</groupId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <artifactId>groovy-cli-commons</artifactId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <version>4.0.12</version><!-- org.apache.groovy:groovy-bom:4.0.12 -->
       </dependency>
       <dependency>
-        <groupId>org.codehaus.groovy</groupId><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
-        <artifactId>groovy-cli-commons</artifactId><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
-        <version>3.0.14</version><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
+        <groupId>org.apache.groovy</groupId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <artifactId>groovy-cli-picocli</artifactId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <version>4.0.12</version><!-- org.apache.groovy:groovy-bom:4.0.12 -->
       </dependency>
       <dependency>
-        <groupId>org.codehaus.groovy</groupId><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
-        <artifactId>groovy-cli-picocli</artifactId><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
-        <version>3.0.14</version><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
+        <groupId>org.apache.groovy</groupId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <artifactId>groovy-console</artifactId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <version>4.0.12</version><!-- org.apache.groovy:groovy-bom:4.0.12 -->
       </dependency>
       <dependency>
-        <groupId>org.codehaus.groovy</groupId><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
-        <artifactId>groovy-console</artifactId><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
-        <version>3.0.14</version><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
+        <groupId>org.apache.groovy</groupId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <artifactId>groovy-contracts</artifactId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <version>4.0.12</version><!-- org.apache.groovy:groovy-bom:4.0.12 -->
       </dependency>
       <dependency>
-        <groupId>org.codehaus.groovy</groupId><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
-        <artifactId>groovy-datetime</artifactId><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
-        <version>3.0.14</version><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
+        <groupId>org.apache.groovy</groupId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <artifactId>groovy-datetime</artifactId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <version>4.0.12</version><!-- org.apache.groovy:groovy-bom:4.0.12 -->
       </dependency>
       <dependency>
-        <groupId>org.codehaus.groovy</groupId><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
-        <artifactId>groovy-dateutil</artifactId><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
-        <version>3.0.14</version><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
+        <groupId>org.apache.groovy</groupId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <artifactId>groovy-dateutil</artifactId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <version>4.0.12</version><!-- org.apache.groovy:groovy-bom:4.0.12 -->
       </dependency>
       <dependency>
-        <groupId>org.codehaus.groovy</groupId><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
-        <artifactId>groovy-docgenerator</artifactId><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
-        <version>3.0.14</version><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
+        <groupId>org.apache.groovy</groupId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <artifactId>groovy-docgenerator</artifactId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <version>4.0.12</version><!-- org.apache.groovy:groovy-bom:4.0.12 -->
       </dependency>
       <dependency>
-        <groupId>org.codehaus.groovy</groupId><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
-        <artifactId>groovy-groovydoc</artifactId><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
-        <version>3.0.14</version><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
+        <groupId>org.apache.groovy</groupId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <artifactId>groovy-ginq</artifactId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <version>4.0.12</version><!-- org.apache.groovy:groovy-bom:4.0.12 -->
       </dependency>
       <dependency>
-        <groupId>org.codehaus.groovy</groupId><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
-        <artifactId>groovy-groovysh</artifactId><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
-        <version>3.0.14</version><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
+        <groupId>org.apache.groovy</groupId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <artifactId>groovy-groovydoc</artifactId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <version>4.0.12</version><!-- org.apache.groovy:groovy-bom:4.0.12 -->
       </dependency>
       <dependency>
-        <groupId>org.codehaus.groovy</groupId><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
-        <artifactId>groovy-jaxb</artifactId><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
-        <version>3.0.14</version><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
+        <groupId>org.apache.groovy</groupId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <artifactId>groovy-groovysh</artifactId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <version>4.0.12</version><!-- org.apache.groovy:groovy-bom:4.0.12 -->
       </dependency>
       <dependency>
-        <groupId>org.codehaus.groovy</groupId><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
-        <artifactId>groovy-jmx</artifactId><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
-        <version>3.0.14</version><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
+        <groupId>org.apache.groovy</groupId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <artifactId>groovy-jmx</artifactId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <version>4.0.12</version><!-- org.apache.groovy:groovy-bom:4.0.12 -->
       </dependency>
       <dependency>
-        <groupId>org.codehaus.groovy</groupId><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
-        <artifactId>groovy-json</artifactId><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
-        <version>3.0.14</version><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
+        <groupId>org.apache.groovy</groupId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <artifactId>groovy-json</artifactId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <version>4.0.12</version><!-- org.apache.groovy:groovy-bom:4.0.12 -->
       </dependency>
       <dependency>
-        <groupId>org.codehaus.groovy</groupId><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
-        <artifactId>groovy-jsr223</artifactId><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
-        <version>3.0.14</version><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
+        <groupId>org.apache.groovy</groupId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <artifactId>groovy-jsr223</artifactId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <version>4.0.12</version><!-- org.apache.groovy:groovy-bom:4.0.12 -->
       </dependency>
       <dependency>
-        <groupId>org.codehaus.groovy</groupId><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
-        <artifactId>groovy-macro</artifactId><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
-        <version>3.0.14</version><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
+        <groupId>org.apache.groovy</groupId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <artifactId>groovy-macro</artifactId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <version>4.0.12</version><!-- org.apache.groovy:groovy-bom:4.0.12 -->
       </dependency>
       <dependency>
-        <groupId>org.codehaus.groovy</groupId><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
-        <artifactId>groovy-nio</artifactId><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
-        <version>3.0.14</version><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
+        <groupId>org.apache.groovy</groupId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <artifactId>groovy-macro-library</artifactId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <version>4.0.12</version><!-- org.apache.groovy:groovy-bom:4.0.12 -->
       </dependency>
       <dependency>
-        <groupId>org.codehaus.groovy</groupId><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
-        <artifactId>groovy-servlet</artifactId><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
-        <version>3.0.14</version><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
+        <groupId>org.apache.groovy</groupId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <artifactId>groovy-nio</artifactId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <version>4.0.12</version><!-- org.apache.groovy:groovy-bom:4.0.12 -->
       </dependency>
       <dependency>
-        <groupId>org.codehaus.groovy</groupId><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
-        <artifactId>groovy-sql</artifactId><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
-        <version>3.0.14</version><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
+        <groupId>org.apache.groovy</groupId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <artifactId>groovy-servlet</artifactId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <version>4.0.12</version><!-- org.apache.groovy:groovy-bom:4.0.12 -->
       </dependency>
       <dependency>
-        <groupId>org.codehaus.groovy</groupId><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
-        <artifactId>groovy-swing</artifactId><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
-        <version>3.0.14</version><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
+        <groupId>org.apache.groovy</groupId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <artifactId>groovy-sql</artifactId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <version>4.0.12</version><!-- org.apache.groovy:groovy-bom:4.0.12 -->
       </dependency>
       <dependency>
-        <groupId>org.codehaus.groovy</groupId><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
-        <artifactId>groovy-templates</artifactId><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
-        <version>3.0.14</version><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
+        <groupId>org.apache.groovy</groupId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <artifactId>groovy-swing</artifactId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <version>4.0.12</version><!-- org.apache.groovy:groovy-bom:4.0.12 -->
       </dependency>
       <dependency>
-        <groupId>org.codehaus.groovy</groupId><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
-        <artifactId>groovy-test</artifactId><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
-        <version>3.0.14</version><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
+        <groupId>org.apache.groovy</groupId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <artifactId>groovy-templates</artifactId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <version>4.0.12</version><!-- org.apache.groovy:groovy-bom:4.0.12 -->
       </dependency>
       <dependency>
-        <groupId>org.codehaus.groovy</groupId><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
-        <artifactId>groovy-test-junit5</artifactId><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
-        <version>3.0.14</version><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
+        <groupId>org.apache.groovy</groupId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <artifactId>groovy-test</artifactId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <version>4.0.12</version><!-- org.apache.groovy:groovy-bom:4.0.12 -->
       </dependency>
       <dependency>
-        <groupId>org.codehaus.groovy</groupId><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
-        <artifactId>groovy-testng</artifactId><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
-        <version>3.0.14</version><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
+        <groupId>org.apache.groovy</groupId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <artifactId>groovy-test-junit5</artifactId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <version>4.0.12</version><!-- org.apache.groovy:groovy-bom:4.0.12 -->
       </dependency>
       <dependency>
-        <groupId>org.codehaus.groovy</groupId><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
-        <artifactId>groovy-xml</artifactId><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
-        <version>3.0.14</version><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
+        <groupId>org.apache.groovy</groupId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <artifactId>groovy-testng</artifactId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <version>4.0.12</version><!-- org.apache.groovy:groovy-bom:4.0.12 -->
       </dependency>
       <dependency>
-        <groupId>org.codehaus.groovy</groupId><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
-        <artifactId>groovy-yaml</artifactId><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
-        <version>3.0.14</version><!-- org.codehaus.groovy:groovy-bom:3.0.14 -->
+        <groupId>org.apache.groovy</groupId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <artifactId>groovy-toml</artifactId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <version>4.0.12</version><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+      </dependency>
+      <dependency>
+        <groupId>org.apache.groovy</groupId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <artifactId>groovy-typecheckers</artifactId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <version>4.0.12</version><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+      </dependency>
+      <dependency>
+        <groupId>org.apache.groovy</groupId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <artifactId>groovy-xml</artifactId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <version>4.0.12</version><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+      </dependency>
+      <dependency>
+        <groupId>org.apache.groovy</groupId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <artifactId>groovy-yaml</artifactId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <version>4.0.12</version><!-- org.apache.groovy:groovy-bom:4.0.12 -->
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.20.72 -->
@@ -20738,6 +20753,21 @@
         <groupId>ch.qos.logback</groupId><!-- io.debezium:debezium-bom:2.2.0.Final -->
         <artifactId>logback-classic</artifactId><!-- io.debezium:debezium-bom:2.2.0.Final -->
         <version>1.2.10</version><!-- io.debezium:debezium-bom:2.2.0.Final -->
+      </dependency>
+      <dependency>
+        <groupId>org.codehaus.groovy</groupId><!-- io.debezium:debezium-bom:2.2.0.Final -->
+        <artifactId>groovy</artifactId><!-- io.debezium:debezium-bom:2.2.0.Final -->
+        <version>3.0.7</version><!-- io.debezium:debezium-bom:2.2.0.Final -->
+      </dependency>
+      <dependency>
+        <groupId>org.codehaus.groovy</groupId><!-- io.debezium:debezium-bom:2.2.0.Final -->
+        <artifactId>groovy-json</artifactId><!-- io.debezium:debezium-bom:2.2.0.Final -->
+        <version>3.0.7</version><!-- io.debezium:debezium-bom:2.2.0.Final -->
+      </dependency>
+      <dependency>
+        <groupId>org.codehaus.groovy</groupId><!-- io.debezium:debezium-bom:2.2.0.Final -->
+        <artifactId>groovy-jsr223</artifactId><!-- io.debezium:debezium-bom:2.2.0.Final -->
+        <version>3.0.7</version><!-- io.debezium:debezium-bom:2.2.0.Final -->
       </dependency>
       <dependency>
         <groupId>io.vitess</groupId><!-- io.debezium:debezium-bom:2.2.0.Final -->

--- a/poms/bom/src/main/generated/flattened-reduced-pom.xml
+++ b/poms/bom/src/main/generated/flattened-reduced-pom.xml
@@ -6994,6 +6994,11 @@
         <version>4.0.1</version>
       </dependency>
       <dependency>
+        <groupId>org.apache.groovy</groupId>
+        <artifactId>groovy</artifactId>
+        <version>4.0.12</version>
+      </dependency>
+      <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>annotations</artifactId>
         <version>2.20.72</version>

--- a/poms/bom/src/main/generated/flattened-reduced-verbose-pom.xml
+++ b/poms/bom/src/main/generated/flattened-reduced-verbose-pom.xml
@@ -6994,6 +6994,11 @@
         <version>4.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.1.0 -->
       </dependency>
       <dependency>
+        <groupId>org.apache.groovy</groupId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <artifactId>groovy</artifactId><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+        <version>4.0.12</version><!-- org.apache.groovy:groovy-bom:4.0.12 -->
+      </dependency>
+      <dependency>
         <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.20.72 -->
         <artifactId>annotations</artifactId><!-- software.amazon.awssdk:bom:2.20.72 -->
         <version>2.20.72</version><!-- software.amazon.awssdk:bom:2.20.72 -->

--- a/poms/build-parent/pom.xml
+++ b/poms/build-parent/pom.xml
@@ -193,8 +193,8 @@
                         </executions>
                     </plugin>
                     <plugin>
-                        <groupId>org.codehaus.gmaven</groupId>
-                        <artifactId>groovy-maven-plugin</artifactId>
+                        <groupId>org.codehaus.gmavenplus</groupId>
+                        <artifactId>gmavenplus-plugin</artifactId>
                         <executions>
                             <execution>
                                 <id>sanity-checks</id>
@@ -203,10 +203,9 @@
                                 </goals>
                                 <phase>validate</phase>
                                 <configuration>
-                                    <source>file:${maven.multiModuleProjectDirectory}/tooling/scripts/sanity-checks.groovy</source>
-                                    <properties>
-                                        <maven.multiModuleProjectDirectory>${maven.multiModuleProjectDirectory}</maven.multiModuleProjectDirectory>
-                                    </properties>
+                                    <scripts>
+                                        <script>file:${maven.multiModuleProjectDirectory}/tooling/scripts/sanity-checks.groovy</script>
+                                    </scripts>
                                 </configuration>
                             </execution>
                         </executions>
@@ -266,8 +265,8 @@
                         </executions>
                     </plugin>
                     <plugin>
-                        <groupId>org.codehaus.gmaven</groupId>
-                        <artifactId>groovy-maven-plugin</artifactId>
+                        <groupId>org.codehaus.gmavenplus</groupId>
+                        <artifactId>gmavenplus-plugin</artifactId>
                         <executions>
                             <execution>
                                 <id>sanity-checks</id>
@@ -288,8 +287,8 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.codehaus.gmaven</groupId>
-                        <artifactId>groovy-maven-plugin</artifactId>
+                        <groupId>org.codehaus.gmavenplus</groupId>
+                        <artifactId>gmavenplus-plugin</artifactId>
                         <executions>
                             <execution>
                                 <id>sanity-checks</id>

--- a/tooling/scripts/copy-tests.groovy
+++ b/tooling/scripts/copy-tests.groovy
@@ -31,17 +31,17 @@ import groovy.ant.AntBuilder
  * so that the tests can be executed. Use of ('copy-tests.exclude') allows to exclude files.
  */
 
-final Path sourceDir = Paths.get(properties['copy-tests.source.dir'])
-final Path destinationModuleDir = Paths.get(properties['copy-tests.dest.module.dir'])
-final String excl = properties['copy-tests.excludes']
-final String classNamePrefix = properties['group-tests.class.name.prefix'] ?: ""
+final Path sourceDir = Paths.get(binding.properties.variables.'copy-tests.source.dir')
+final Path destinationModuleDir = Paths.get(binding.properties.variables.'copy-tests.dest.module.dir')
+final String excl = binding.properties.variables.'copy-tests.excludes'
+final String classNamePrefix = binding.properties.variables.'group-tests.class.name.prefix' ?: ""
 
 copyResources(sourceDir.resolve('src/main/resources'), destinationModuleDir.resolve('target/classes'), excl)
 copyResources(sourceDir.resolve('src/main/java'), destinationModuleDir.resolve('target/src/main/java'), excl)
 copyResources(sourceDir.resolve('src/test/java'), destinationModuleDir.resolve('target/src/test/java'), excl)
 copyResources(sourceDir.resolve('src/test/resources'), destinationModuleDir.resolve('target/test-classes'), excl)
 
-String scriptDir = new File(getClass().protectionDomain.codeSource.location.path).parent
+String scriptDir = new File(System.getProperty('maven.multiModuleProjectDirectory') + '/tooling/scripts')
 File sourceFile = new File("${scriptDir}/group-test-utils.groovy")
 Class groovyClass = new GroovyClassLoader(getClass().getClassLoader()).parseClass(sourceFile);
 GroovyObject utils = (GroovyObject) groovyClass.getDeclaredConstructor().newInstance();

--- a/tooling/scripts/report-build-status.groovy
+++ b/tooling/scripts/report-build-status.groovy
@@ -20,7 +20,7 @@ import org.kohsuke.github.*
 /**
  * A script to report on the build status of synchronization for branches camel-main and quarkus-main.
  *
- * A GitHub issue ID is passed to this script from the GitHub workflow. The issue is inteded to be repeatedly closed / reopened
+ * A GitHub issue ID is passed to this script from the GitHub workflow. The issue is intended to be repeatedly closed / reopened
  * whenever a build workflow run is successful / unsuccessful.
  *
  * If failures were encountered in the build, a comment is appended to a specified GitHub issue, with the body containing
@@ -32,17 +32,17 @@ import org.kohsuke.github.*
  * should automatically merge the latest changes from the main branch, to the target branch.
  */
 
-final String TOKEN = properties['token']
-final String STATUS = properties['status'].toLowerCase(Locale.US)
-final String BUILD_ID = properties['buildId']
-final String REPO = properties['repo']
-final String BRANCH = properties['branch']
+final String TOKEN = System.getProperty('token')
+final String STATUS = System.getProperty('status').toLowerCase(Locale.US)
+final String BUILD_ID = System.getProperty('buildId')
+final String REPO = System.getProperty('repo')
+final String BRANCH = System.getProperty('branch')
 final String BRANCH_NAME = "${BRANCH.split('-')[0].capitalize()} ${BRANCH.split('-')[1].capitalize()}"
-final String BRANCH_COMMIT = properties['branch-commit'] ?: 'Unknown'
+final String BRANCH_COMMIT = System.getProperty('branch-commit') ?: 'Unknown'
 final String ACTIONS_URL = "https://github.com/${REPO}/actions/runs/${BUILD_ID.split("-")[0]}"
 final String BRANCH_URL = "https://github.com/${REPO}/tree/${BRANCH}"
 final String ISSUE_LABEL = "build/${BRANCH}"
-final Integer ISSUE_ID = properties['issueId'] as Integer
+final Integer ISSUE_ID = System.getProperty('issueId') as Integer
 
 class Utils {
     static boolean workflowHasPreviousFailures(GHIssue issue, String buildId) {

--- a/tooling/scripts/sanity-checks.groovy
+++ b/tooling/scripts/sanity-checks.groovy
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import groovy.xml.XmlParser
 import java.nio.file.Path
 import java.nio.file.Paths
 
@@ -22,7 +23,7 @@ import java.nio.file.Paths
 final List<String> badDeps = []
 final File pomXml = new File(project.basedir, "pom.xml")
 
-final Path treeRootDir = Paths.get(properties['maven.multiModuleProjectDirectory'])
+final Path treeRootDir = Paths.get(System.getProperty('maven.multiModuleProjectDirectory'))
 final Path relativePomPath = treeRootDir.relativize(pomXml.toPath().normalize())
 
 if (pomXml.exists()) {

--- a/tooling/scripts/update-antora-config.groovy
+++ b/tooling/scripts/update-antora-config.groovy
@@ -27,7 +27,7 @@ import java.util.regex.Pattern
 import java.util.regex.Matcher
 
 
-final Path treeRootDir = Paths.get(properties['maven.multiModuleProjectDirectory'])
+final Path treeRootDir = Paths.get(System.getProperty('maven.multiModuleProjectDirectory'))
 
 final List<Path> replaceInFiles = [
     treeRootDir.resolve('docs/antora.yml')

--- a/tooling/scripts/update-antora-yaml.groovy
+++ b/tooling/scripts/update-antora-yaml.groovy
@@ -26,7 +26,7 @@ import java.util.regex.Matcher
 
 final String PROJECT_BRANCH_ROOT = ''
 
-final Path treeRootDir = Paths.get(properties['maven.multiModuleProjectDirectory'])
+final Path treeRootDir = Paths.get(System.getProperty('maven.multiModuleProjectDirectory'))
 
 final Path antoraYmlPath = treeRootDir.resolve('docs/antora.yml')
 final Path sourceMapPath = treeRootDir.resolve('docs/source-map.yml')

--- a/tooling/scripts/validate-extension-metadata.groovy
+++ b/tooling/scripts/validate-extension-metadata.groovy
@@ -15,11 +15,10 @@
  * limitations under the License.
  */
 
-import groovy.io.FileType
 import java.nio.file.Files
 import java.nio.file.Path
 
-final String[] extensionDirs = properties['extensionDirs'].split(',')
+final String[] extensionDirs = extensionDirs.split(',')
 
 final String quarkusExtensionRelPath = 'runtime/src/main/resources/META-INF/quarkus-extension.yaml'
 final List<String> messages = []


### PR DESCRIPTION
fixes #4960 

## Motivation

The project still depends on Groovy 3 while Camel has already been upgraded to Groovy 4 so it needs to be upgraded too.

## Modifications:

* Upgrades Groovy to 4.0.12
* Replaces the plugin `groovy-maven-plugin` with `gmavenplus-plugin` as it doesn't evolve anymore
* Adapts the Groovy scripts to the `gmavenplus-plugin`