### PR TITLE
[2.13.x] Be more precise about the WS standards coverage, add ,subs="attributes+" to code snippets on the CXF extension page

### DIFF
--- a/docs/modules/ROOT/pages/reference/extensions/cxf-soap.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/cxf-soap.adoc
@@ -272,7 +272,7 @@ NOTE: The support for `org.apache.cxf.ext.logging.LoggingFeature` is provided by
 
 The extent of supported WS specifications is given by the Quarkus CXF project.
 
-`camel-quarkus-cxf-soap` covers the following specifications via the `{link-quarkus-cxf-doc}/reference/extensions/quarkus-cxf.html[io.quarkiverse.cxf:quarkus-cxf]` extension:
+`camel-quarkus-cxf-soap` covers only the following specifications via the `{link-quarkus-cxf-doc}/reference/extensions/quarkus-cxf.html[io.quarkiverse.cxf:quarkus-cxf]` extension:
 
 * JAX-WS
 * JAXB
@@ -280,7 +280,7 @@ The extent of supported WS specifications is given by the Quarkus CXF project.
 * WS-Policy
 * MTOM
 
-If your application requires some other WS specification, you must add an additional Quarkus CXF dependency covering it.
+If your application requires some other WS specification, such as WS-Security or WS-Trust, you must add an additional Quarkus CXF dependency covering it.
 Refer to Quarkus CXF {link-quarkus-cxf-doc}/reference/index.html[Reference] page to see which WS specifications are covered by which Quarkus CXF extensions.
 
 TIP: Both {project-name} and Quarkus CXF contain a number of

--- a/docs/modules/ROOT/pages/reference/extensions/cxf-soap.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/cxf-soap.adoc
@@ -64,7 +64,7 @@ The CXF and `quarkus-cxf` versions are xref:user-guide/dependency-management.ado
 
 With `camel-quarkus-cxf-soap` (no additional dependencies required), you can use CXF clients as producers in Camel routes:
 
-[source,java]
+[source,java,subs="attributes+"]
 ----
 import org.apache.camel.builder.RouteBuilder;
 import {javaxOrJakartaPackagePrefix}.enterprise.context.ApplicationScoped;
@@ -103,7 +103,7 @@ public class CxfSoapClientRoutes extends RouteBuilder {
 
 The `CalculatorService` may look like the following:
 
-[source,java]
+[source,java,subs="attributes+"]
 ----
 import {javaxOrJakartaPackagePrefix}.jws.WebMethod;
 import {javaxOrJakartaPackagePrefix}.jws.WebService;
@@ -149,7 +149,7 @@ NOTE: `quarkus-cxf` supports {link-quarkus-cxf-doc}/user-guide/first-soap-client
 With `camel-quarkus-cxf-soap`, you can expose SOAP endpoints as consumers in Camel routes.
 No additional dependencies are required for this use case.
 
-[source,java]
+[source,java,subs="attributes+"]
 ----
 import org.apache.camel.builder.RouteBuilder;
 import {javaxOrJakartaPackagePrefix}.enterprise.context.ApplicationScoped;
@@ -214,7 +214,7 @@ NOTE: `quarkus-cxf` supports alternative ways of exposing SOAP endpoints.
 
 You can enable verbose logging of SOAP messages for both clients and servers with `org.apache.cxf.ext.logging.LoggingFeature`:
 
-[source,java]
+[source,java,subs="attributes+"]
 ----
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.cxf.ext.logging.LoggingFeature;

--- a/extensions/cxf-soap/runtime/src/main/doc/usage.adoc
+++ b/extensions/cxf-soap/runtime/src/main/doc/usage.adoc
@@ -218,7 +218,7 @@ NOTE: The support for `org.apache.cxf.ext.logging.LoggingFeature` is provided by
 
 The extent of supported WS specifications is given by the Quarkus CXF project.
 
-`camel-quarkus-cxf-soap` covers the following specifications via the `{link-quarkus-cxf-doc}/reference/extensions/quarkus-cxf.html[io.quarkiverse.cxf:quarkus-cxf]` extension:
+`camel-quarkus-cxf-soap` covers only the following specifications via the `{link-quarkus-cxf-doc}/reference/extensions/quarkus-cxf.html[io.quarkiverse.cxf:quarkus-cxf]` extension:
 
 * JAX-WS
 * JAXB
@@ -226,7 +226,7 @@ The extent of supported WS specifications is given by the Quarkus CXF project.
 * WS-Policy
 * MTOM
 
-If your application requires some other WS specification, you must add an additional Quarkus CXF dependency covering it.
+If your application requires some other WS specification, such as WS-Security or WS-Trust, you must add an additional Quarkus CXF dependency covering it.
 Refer to Quarkus CXF {link-quarkus-cxf-doc}/reference/index.html[Reference] page to see which WS specifications are covered by which Quarkus CXF extensions.
 
 TIP: Both {project-name} and Quarkus CXF contain a number of

--- a/extensions/cxf-soap/runtime/src/main/doc/usage.adoc
+++ b/extensions/cxf-soap/runtime/src/main/doc/usage.adoc
@@ -13,7 +13,7 @@ The CXF and `quarkus-cxf` versions are xref:user-guide/dependency-management.ado
 
 With `camel-quarkus-cxf-soap` (no additional dependencies required), you can use CXF clients as producers in Camel routes:
 
-[source,java]
+[source,java,subs="attributes+"]
 ----
 import org.apache.camel.builder.RouteBuilder;
 import {javaxOrJakartaPackagePrefix}.enterprise.context.ApplicationScoped;
@@ -52,7 +52,7 @@ public class CxfSoapClientRoutes extends RouteBuilder {
 
 The `CalculatorService` may look like the following:
 
-[source,java]
+[source,java,subs="attributes+"]
 ----
 import {javaxOrJakartaPackagePrefix}.jws.WebMethod;
 import {javaxOrJakartaPackagePrefix}.jws.WebService;
@@ -97,7 +97,7 @@ NOTE: `quarkus-cxf` supports {link-quarkus-cxf-doc}/user-guide/first-soap-client
 With `camel-quarkus-cxf-soap`, you can expose SOAP endpoints as consumers in Camel routes.
 No additional dependencies are required for this use case.
 
-[source,java]
+[source,java,subs="attributes+"]
 ----
 import org.apache.camel.builder.RouteBuilder;
 import {javaxOrJakartaPackagePrefix}.enterprise.context.ApplicationScoped;
@@ -161,7 +161,7 @@ NOTE: `quarkus-cxf` supports alternative ways of exposing SOAP endpoints.
 
 You can enable verbose logging of SOAP messages for both clients and servers with `org.apache.cxf.ext.logging.LoggingFeature`:
 
-[source,java]
+[source,java,subs="attributes+"]
 ----
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.cxf.ext.logging.LoggingFeature;


### PR DESCRIPTION
Backport of https://github.com/apache/camel-quarkus/pull/4969