### PR TITLE
Add GitHub Actions workflows to label issues and assign a milestone

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,30 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: "🐞 Bug Report"
+description: Report a bug in Camel Quarkus
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    validations:
+      required: true
+    attributes:
+      label: Bug description
+      description: >-
+        A clear and concise description of the bug with any steps to reproduce it
+

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,25 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+blank_issues_enabled: true
+contact_links:
+  - name: 💬 Apache Camel Zulip chat
+    url: https://camel.zulipchat.com/
+    about: Live chat for the Apache Camel project
+  - name: ✉️ Apache Camel mailing list
+    url: https://camel.apache.org/community/mailing-list/
+    about: Post a question on the Apache Camel User mailing list

--- a/.github/ISSUE_TEMPLATE/enhancement_request.yaml
+++ b/.github/ISSUE_TEMPLATE/enhancement_request.yaml
@@ -1,0 +1,27 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: "🚀 Feature Request / Enhancement"
+description: Request or propose a new feature or enhancement
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the feature here
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/task_housekeeping.yaml
+++ b/.github/ISSUE_TEMPLATE/task_housekeeping.yaml
@@ -1,0 +1,29 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: "🧹 Task / Housekeeping"
+description: A generalized task or cleanup not associated with a bug report or enhancement
+labels: ["area/housekeeping", "housekeeping"]
+body:
+  - type: textarea
+    id: description
+    validations:
+      required: true
+    attributes:
+      label: Description
+      description: >-
+        Describe the task here

--- a/.github/auto-label-configuration.yaml
+++ b/.github/auto-label-configuration.yaml
@@ -1,0 +1,121 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# Configuration to determine how issues are automatically labelled.
+#
+# A summary of the configuration keys is as follows:
+#
+#    id: A unique identifier for the label configuration element
+#    regex: The JavaScript regular expression that will apply the specified labels if the issue title or body content matches.
+#    labels: Array of labels to apply to the issue if the regex matches
+#    matchOn: Supported values are:
+#     title: The regex will attempt to match on the issue title
+#     body: The regex will attempt to match on the issue body
+#     titleBody: The regex will attempt to match on the issue title & body
+#
+# Matching only on the issue title may produce more reliable results in some cases. E.g to avoid prematurely matching common phrases in the issue body.
+# For example, strings like 'GitHub' or 'HTTP' would result in the issue being labelled with 'area/github' & 'area/http' as extensions exist with those names.
+#
+# However, some phrases are sufficiently unique to be matched on both the issue title and body.
+# For example, 'Quarkus Platform', 'GraalVM' etc.
+#
+# NOTE: The configuration to label match individual extensions is defined within the label-issue.yaml workflow script, as they get built dynamically.
+#
+# If you want to test changes to the configuration, there is a basic harness:
+#
+# https://github.com/jamesnetherton/cq-github-workflow-tests
+#
+#
+
+---
+config:
+  auto-label:
+  - id: area-build
+    regex: "(^\\[CI\\]|github action(s)?)"
+    labels: ["area/build", "build"]
+    matchOn: "title"
+
+  - id: area-core
+    regex: "\\bcamel-quarkus-(core|main)\\b|\\bcamel quarkus (core|main)\\b|\\b(?<!\\[)camel-main(?!\\])\\b|\\bcamel main(?!\\sbranch)\\b"
+    labels: ["area/core"]
+    matchOn: "titleBody"
+
+  - id: area-documentation
+    regex: "\\b(doc(s|umentation)?|guide(s)?)\\b"
+    labels: ["area/documentation", "documentation"]
+    matchOn: "title"
+
+  - id: area-examples
+    regex: "\\bexample(s)?\\b"
+    labels: ["area/examples", "example"]
+    matchOn: "title"
+
+  - id: area-housekeeping
+    regex: "\\b(ban(ned)?|remove)\\b"
+    labels: ["area/housekeeping", "housekeeping"]
+    matchOn: "title"
+
+  - id: area-jakarta-migration
+    regex: "\\bjakarta(ee)?\\b"
+    labels: ["area/jakarta", "jakarta"]
+    matchOn: "title"
+
+  - id: area-native
+    regex: "\\b(native|graal(vm)?|mandrel)\\b"
+    labels: ["area/native", "native"]
+    matchOn: "titleBody"
+
+  - id: area-openshift
+    regex: "\\bopenshift\\b"
+    labels: ["area/openshift"]
+    matchOn: "title"
+
+  - id: area-quarkus-platform
+    regex: "\\b(quarkus-platform|quarkus platform)\\b"
+    labels: ["area/quarkus-platform"]
+    matchOn: "titleBody"
+
+  - id: area-testing
+    regex: "\\bintegration test(s|ing)?\\b|\\bitest(s)?\\b|\\btest(s|ing)?\\b|\\bcoverage\\b|\\bjunit\\b|testsupport"
+    labels: ["area/testing", "test"]
+    matchOn: "title"
+
+  - id: platform-arm
+    regex: "\\b(arm([0-9]{2})?|aarch([0-9]{2})?)\\b"
+    labels: ["platform/arm"]
+    matchOn: "title"
+
+  - id: platform-mac
+    regex: "\\b(mac(os)?|os( )?x)\\b"
+    labels: ["platform/mac"]
+    matchOn: "title"
+
+  - id: platform-windows
+    regex: "windows"
+    labels: ["platform/windows"]
+    matchOn: "title"
+
+  - id: release-camel-main-next
+    regex: "^\\[camel-main\\]"
+    labels: ["release/camel-next"]
+    matchOn: "title"
+
+  - id: release-quarkus-main-next
+    regex: "^\\[quarkus-main\\]"
+    labels: ["release/quarkus-next"]
+    matchOn: "title"

--- a/.github/workflows/assign-issue-milestone.yaml
+++ b/.github/workflows/assign-issue-milestone.yaml
@@ -1,0 +1,143 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
+
+  issues:
+    types:
+      - closed
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  assign-issue-milestone:
+    if: github.repository == 'apache/camel-quarkus' &&
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.merged
+    runs-on: ubuntu-latest
+    concurrency:
+      group: assign-issue-milestone-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    steps:
+      - name: Assign Closed Issues To Latest Milestone
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const issueNumberFromCommitCommentRegex = new RegExp(`.*(?:fix(?:e[sd])?|(?:(?:resolve|close)[sd]?)):?\\s(?:https?:\\/\\/github\\.com\\/${context.repo.owner}\\/${context.repo.repo}\\/issues\\/|#)(\\d+)`, 'igm');
+            const prNumber = context.payload.number;
+            const prIssueReferencesQuery = `{
+              repository(owner: "${context.repo.owner}", name: "${context.repo.repo}") {
+                pullRequest(number: ${prNumber}) {
+                  commits(last: 50) {
+                    nodes {
+                      commit {
+                        message
+                      }
+                    }
+                  }
+                  closingIssuesReferences(last: 50) {
+                    nodes {
+                      number
+                    }
+                  }
+                }
+              }
+            }`;
+
+            const issueNumbers = new Set();
+
+            prIssueReferences = await github.graphql(prIssueReferencesQuery);
+            if (prIssueReferences) {
+              // Parse issue number references from commit comments
+              if (prIssueReferences.repository.pullRequest.commits) {
+                prIssueReferences.repository.pullRequest.commits.nodes.forEach(node => {
+                  for (const match of node.commit.message.matchAll(issueNumberFromCommitCommentRegex)) {
+                    let issueNumber = parseInt(match[1]);
+                    if (!isNaN(issueNumber)) {
+                      issueNumbers.add(issueNumber);
+                    }
+                  }
+                });
+              }
+
+              // Get any issue references GitHub associated with the PR
+              if (prIssueReferences.repository.pullRequest.closingIssuesReferences) {
+                prIssueReferences.repository.pullRequest.closingIssuesReferences.nodes.forEach(node => {
+                  if (node.number) {
+                    issueNumbers.add(node.number);
+                  }
+                });
+              }
+            }
+
+            // No issues associated with the merged PR so we can exit
+            if (issueNumbers.size === 0) {
+              return;
+            }
+
+            // Get open milestones
+            milestoneResults = await github.rest.issues.listMilestones({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sort: "title",
+              direction: "desc",
+            });
+
+            // Assign the latest milestone to issues associated with the merged PR
+            if (milestoneResults && milestoneResults.data.length > 0) {
+              const milestones = milestoneResults.data.filter(data => data.title.match("^[0-9].[0-9].[0-9].*"));
+              if (milestones && milestones.length > 0) {
+                const latestMilestone = milestones[0].number;
+                issueNumbers.forEach(issueNumber => {
+                  github.rest.issues.update({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issueNumber,
+                    milestone: latestMilestone,
+                  });
+                });
+              }
+            }
+
+  assign-wont-fix-issue-milestone:
+    if: github.repository == 'apache/camel-quarkus' &&
+        github.event_name == 'issues' &&
+        github.event.issue.milestone.number != 4 && (contains(github.event.issue.labels.*.name, 'wontfix') || github.event.issue.state_reason == 'not_planned')
+    runs-on: ubuntu-latest
+    concurrency:
+      group: assign-wont-fix-issue-milestone-${{ github.event.issue.number }}
+      cancel-in-progress: true
+    steps:
+      - name: Assign Closed Issue To Wont Fix Milestone
+        uses: actions/github-script@v6
+        with:
+          script: |
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              // https://github.com/apache/camel-quarkus/milestone/4
+              milestone: 4,
+            });

--- a/.github/workflows/label-issue.yaml
+++ b/.github/workflows/label-issue.yaml
@@ -1,0 +1,183 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Label Issue
+
+on:
+  issues:
+    types:
+      - opened
+      - reopened
+      - edited
+
+concurrency:
+  group: label-issue-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  label-issue:
+    if: "github.repository == 'apache/camel-quarkus' &&
+         !contains(github.event.issue.labels.*.name, 'autolabel/ignore') &&
+         !contains(github.event.issue.labels.*.name, 'build/camel-main') &&
+         !contains(github.event.issue.labels.*.name, 'build/quarkus-main')"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+        with:
+          ref: main
+      - name: Install js-yaml package
+        run: |
+          npm install js-yaml
+      - name: Label Issue
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const fs = require('fs');
+            const yaml = require('js-yaml');
+
+            const issue = context.payload.issue;
+            const labels = new Set();
+
+            // Some common words to not directly match against
+            const commonWords = ['github', 'http'];
+
+            // Read the auto labelling configuration
+            const config = yaml.load(fs.readFileSync(`./.github/auto-label-configuration.yaml`), 'utf8');
+
+            // Lazy way of getting the names of extensions without having to search the Camel catalog etc
+            const files = fs.readdirSync(`./docs/modules/ROOT/pages/reference/extensions/`);
+            files.forEach(file => {
+              if (!file.includes("core")) {
+                let extension = file.replace(".adoc", "");
+
+                // Build up regexes for each extension
+                let regex = `\\b(?:(?:camel-)(?:quarkus-)?${extension}(?!-))\\b|\\s${extension}\\sextension`
+                if (!commonWords.includes(extension)) {
+                  regex += `|\\s${extension}\\s|^${extension}(?::)?\\s|\\s${extension}$`;
+                }
+
+                config['config']['auto-label'].push({
+                  "regex": regex,
+                  "labels": ["area/" + extension],
+                  "matchOn": "title",
+                });
+              }
+            });
+
+            // Sanitize the issue title and body
+            let sanitizedTitle = null;
+            if (issue.title) {
+              sanitizedTitle = issue.title.toLowerCase();
+            }
+
+            let sanitizedBody = null;
+            if (issue.body) {
+              // Markdown code blocks are removed, as they can provide false positives for label matching
+              sanitizedBody = issue.body.toLowerCase().replace(/`{1,3}[\s\S]*?`{1,3}/g, '');
+            }
+
+            // Determine which labels should be applied to the issue
+            config['config']['auto-label'].forEach(labelCandidate => {
+              // Check issue title content matching configured expressions
+              if (sanitizedTitle && (labelCandidate.matchOn === "title" || labelCandidate.matchOn === "titleBody")) {
+                if (sanitizedTitle.match(new RegExp(labelCandidate.regex, 'gi'))) {
+                  labelCandidate.labels.forEach(label => labels.add(label));
+                }
+              }
+
+              // Check issue body content matching configured expressions
+              if (sanitizedBody && (labelCandidate.matchOn === "body" || labelCandidate.matchOn === "titleBody")) {
+                if (sanitizedBody.match(new RegExp(labelCandidate.regex, 'gi'))) {
+                  labelCandidate.labels.forEach(label => labels.add(label));
+                }
+              }
+            });
+
+            // Filter potentially stale existing issue labels and keep any custom user added ones
+            const prefixes = new Set();
+            config['config']['auto-label']
+              .flatMap(labelConfig => labelConfig.labels)
+              .map(label => label.split('/')[0])
+              .forEach(prefix => prefixes.add(prefix));
+
+            const prefixRegex = Array.from(prefixes).join('|');
+            issue.labels
+              .filter(label => label.name.match("^(?!" + prefixRegex + ").*"))
+              .map(label => label.name)
+              .forEach(label => labels.add(label));
+
+            // If we are not going to be adding any new labels then just exit the script
+            if (labels.size === issue.labels.length) {
+              const diffLabels = issue.labels.filter(label => !labels.has(label.name));
+              if (diffLabels.length === 0) {
+                return;
+              }
+            }
+
+            // Check to see if labels already exist, and if not, create them so we can set the color
+            const labelQuery = `{
+              repository(owner: "${context.repo.owner}", name: "${context.repo.repo}") {
+                labels(first: 50, query: "name: ${Array.from(labels).join(' ')}") {
+                  nodes {
+                    name
+                  }
+                }
+              }
+            }`;
+
+            labelQueryResults = await github.graphql(labelQuery);
+
+            if (labelQueryResults && labelQueryResults.repository.labels) {
+              const existingLabels = labelQueryResults.repository.labels.nodes.map(node => node.name);
+
+              for (let label of labels) {
+                if (!existingLabels.includes(label)) {
+                  labelColor = 'ededed';
+                  if (label.startsWith("area/")) {
+                    labelColor = '283482';
+                  }
+
+                  if (label.startsWith("platform/")) {
+                    labelColor = '7baaa4';
+                  }
+
+                  if (label.startsWith("release/")) {
+                    labelColor = '947593'
+                  }
+
+                  await github.rest.issues.createLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    name: label,
+                    color: labelColor,
+                  });
+                }
+              };
+            }
+
+            // Update issue labels
+            await github.rest.issues.setLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              labels: Array.from(labels)
+            });


### PR DESCRIPTION
Summary of the changes I'm proposing to make:

1. Add issue templates:

* Categorize issues into feature requests, bugs, housekeeping tasks etc
* Provide some useful links to chat & the mailing list

[Example of how it looks](https://github.com/apache/camel-quarkus/assets/4721408/fb8ac313-deea-4c72-8c54-b17c53c53a60).

2. Some new GitHub workflows:

* Automatically label and categorize issues based on the issue title and body content
* Automatically assign 'completed' closed issues to the latest milestone
* Automatically assign 'not planned' or 'wontfix' labelled closed issues to the 'wont fix' milestone

The label configuration is described in `.github/auto-label-configuration.yaml`.

Some screenshots of it in action:

* [Auto labeling](https://github.com/apache/camel-quarkus/assets/4721408/34686e34-11e7-4198-b40d-0fa1134b9d62)
* [Auto assign closed issue to the latest milestone](https://github.com/apache/camel-quarkus/assets/4721408/a6f5e01b-0a10-4876-b2f8-6485067eee49)
* [Auto assign not planned closed issues to wontfix milestone](https://github.com/apache/camel-quarkus/assets/4721408/e227619a-60cb-4d13-bd31-00e8f77577c3)

I see the benefits as cutting down on manual work at release time, being able to track issues better and maybe end up with a chance to generate better changelog / release notes.

WDYT?
