### PR TITLE
Temporarily disable auto milestone on PR merge due to permission issues

### DIFF
--- a/.github/workflows/assign-issue-milestone.yaml
+++ b/.github/workflows/assign-issue-milestone.yaml
@@ -16,11 +16,11 @@
 #
 
 on:
-  pull_request:
-    branches:
-      - main
-    types:
-      - closed
+  # pull_request:
+  #   branches:
+  #     - main
+  #   types:
+  #     - closed
 
   issues:
     types:


### PR DESCRIPTION
I need to rethink this as the workflow wont run without manual approval. Thus disabling it for now.