### PR TITLE
Ref #4220: Upgrade to SRU2022-10.0.1

### DIFF
--- a/integration-tests/swift/pom.xml
+++ b/integration-tests/swift/pom.xml
@@ -63,17 +63,6 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <argLine>--add-opens java.base/java.time=ALL-UNNAMED
-                    </argLine>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
     <profiles>
         <profile>
             <id>native</id>


### PR DESCRIPTION
fixes #4220 (part 2)

## Motivation

After migrating to Upgrade to SRU2022-10.0.0, some tests failed due to [a reflection issue when serializing the MX messages in JSON ](https://github.com/prowide/prowide-iso20022/pull/83#issuecomment-1580150900).

## Modifications

* Removes the temporary workaround