### PR TITLE
Prevent user added issue labels from being incorrectly removed

### DIFF
--- a/.github/workflows/label-issue.yaml
+++ b/.github/workflows/label-issue.yaml
@@ -116,6 +116,7 @@ jobs:
             const prefixes = new Set();
             config['config']['auto-label']
               .flatMap(labelConfig => labelConfig.labels)
+              .filter(label => label.includes('/'))
               .map(label => label.split('/')[0])
               .forEach(prefix => prefixes.add(prefix));
 


### PR DESCRIPTION
I need to find a better way for the workflow to deal with stale labels. This at least prevents them from being incorrectly removed (hopefully).