### PR TITLE
Add codestart for camel-quarkus-kotlin

### DIFF
--- a/extensions/kotlin/deployment/pom.xml
+++ b/extensions/kotlin/deployment/pom.xml
@@ -41,6 +41,17 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-kotlin-deployment</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devtools-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/kotlin/deployment/src/test/kotlin/org/apache/camel/quarkus/kotlin/deployment/KotlinCodestartTest.kt
+++ b/extensions/kotlin/deployment/src/test/kotlin/org/apache/camel/quarkus/kotlin/deployment/KotlinCodestartTest.kt
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.kotlin.deployment
+
+import io.quarkus.devtools.codestarts.quarkus.QuarkusCodestartCatalog
+import io.quarkus.devtools.testing.codestarts.QuarkusCodestartTest
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+
+import org.junit.jupiter.api.extension.RegisterExtension
+
+class KotlinCodestartTest {
+
+    @Test
+    @Throws(Throwable::class)
+    fun testContent() {
+        Companion.codestartTest.checkGeneratedSource("org.acme.Routes")
+    }
+
+    @Disabled("https://github.com/quarkusio/quarkus/issues/34308")
+    @Test
+    @Throws(Throwable::class)
+    fun buildAllProjects() {
+        Companion.codestartTest.buildAllProjects()
+    }
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        var codestartTest = QuarkusCodestartTest.builder()
+            .languages(QuarkusCodestartCatalog.Language.KOTLIN)
+            .setupStandaloneExtensionTest("org.apache.camel.quarkus:camel-quarkus-kotlin")
+            .build()
+    }
+}

--- a/extensions/kotlin/deployment/src/test/resources/__snapshots__/KotlinCodestartTest/testContent/src_main_kotlin_ilove_quark_us_Routes.kt
+++ b/extensions/kotlin/deployment/src/test/resources/__snapshots__/KotlinCodestartTest/testContent/src_main_kotlin_ilove_quark_us_Routes.kt
@@ -1,0 +1,21 @@
+package ilove.quark.us
+
+import org.apache.camel.quarkus.kotlin.routes
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.inject.Produces
+
+@ApplicationScoped
+class Routes {
+    @Produces
+    fun timerToLogRoute() = routes {
+        from("timer:greet?period=5s")
+                .setBody().constant("Hello World!")
+                .log("\${body}")
+    }
+
+    @Produces
+    fun greetingRoute() = routes {
+        from("direct:greet")
+            .setBody().simple("Hello \${body}")
+    }
+}

--- a/extensions/kotlin/runtime/pom.xml
+++ b/extensions/kotlin/runtime/pom.xml
@@ -89,6 +89,26 @@
                     <jvmTarget>${maven.compiler.release}</jvmTarget>
                 </configuration>
             </plugin>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>generate-codestart-jar</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <classesDirectory>${project.basedir}/src/main</classesDirectory>
+                            <includes>
+                                <include>codestarts/**</include>
+                            </includes>
+                            <classifier>codestarts</classifier>
+                            <skipIfEmpty>true</skipIfEmpty>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/extensions/kotlin/runtime/src/main/codestarts/quarkus/camel-quarkus-kotlin-codestart/codestart.yml
+++ b/extensions/kotlin/runtime/src/main/codestarts/quarkus/camel-quarkus-kotlin-codestart/codestart.yml
@@ -15,23 +15,20 @@
 # limitations under the License.
 #
 
-# This is a generated file. Do not edit directly!
-# To re-generate, run the following command from the top level directory:
-#
-#   mvn -N cq:update-quarkus-metadata
-#
----
-name: "Camel Kotlin"
-description: "Write Camel integration routes in Kotlin"
-icon-url: "https://camel.apache.org/_/img/logo-d-f21b25ba38.svg"
+name: "camel-quarkus-kotlin"
+ref: "camel-quarkus-kotlin"
+type: "code"
+tags: "extension-codestart"
 metadata:
-  guide: "https://camel.apache.org/camel-quarkus/latest/reference/extensions/kotlin.html"
-  categories:
-  - "integration"
-  status:
-  - "stable"
-  codestart:
-    name: "camel-quarkus-kotlin"
-    languages:
-    - "kotlin"
-    artifact: "org.apache.camel.quarkus:camel-quarkus-kotlin:codestarts:jar:${project.version}"
+  title: "Camel Quarkus Kotlin"
+  description: "Start to code with the Camel Quarkus Kotlin extension."
+  related-guide-section: "https://camel.apache.org/camel-quarkus/latest/reference/extensions/kotlin.html"
+language:
+  base:
+    dependencies:
+      - "org.apache.camel.quarkus:camel-quarkus-direct"
+      - "org.apache.camel.quarkus:camel-quarkus-log"
+      - "org.apache.camel.quarkus:camel-quarkus-timer"
+    test-dependencies:
+      - "org.apache.camel.quarkus:camel-quarkus-junit5"
+      - "org.jetbrains.kotlin:kotlin-test-junit5"

--- a/extensions/kotlin/runtime/src/main/codestarts/quarkus/camel-quarkus-kotlin-codestart/kotlin/README.tpl.qute.md
+++ b/extensions/kotlin/runtime/src/main/codestarts/quarkus/camel-quarkus-kotlin-codestart/kotlin/README.tpl.qute.md
@@ -1,0 +1,3 @@
+{#include readme-header /}
+
+Example Camel Kotlin routes are located at `src/main/kotlin/org/acme/Routes.kt`. There is also an example test case at `src/main/kotlin/org/acme/RoutesTest.kt`.

--- a/extensions/kotlin/runtime/src/main/codestarts/quarkus/camel-quarkus-kotlin-codestart/kotlin/src/main/kotlin/org/acme/Routes.kt
+++ b/extensions/kotlin/runtime/src/main/codestarts/quarkus/camel-quarkus-kotlin-codestart/kotlin/src/main/kotlin/org/acme/Routes.kt
@@ -1,0 +1,21 @@
+package org.acme
+
+import org.apache.camel.quarkus.kotlin.routes
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.inject.Produces
+
+@ApplicationScoped
+class Routes {
+    @Produces
+    fun timerToLogRoute() = routes {
+        from("timer:greet?period=5s")
+                .setBody().constant("Hello World!")
+                .log("\${body}")
+    }
+
+    @Produces
+    fun greetingRoute() = routes {
+        from("direct:greet")
+            .setBody().simple("Hello \${body}")
+    }
+}

--- a/extensions/kotlin/runtime/src/main/codestarts/quarkus/camel-quarkus-kotlin-codestart/kotlin/src/test/kotlin/org/acme/RoutesTest.kt
+++ b/extensions/kotlin/runtime/src/main/codestarts/quarkus/camel-quarkus-kotlin-codestart/kotlin/src/test/kotlin/org/acme/RoutesTest.kt
@@ -1,0 +1,15 @@
+package org.acme
+
+import io.quarkus.test.junit.QuarkusTest
+import kotlin.test.assertEquals
+import org.apache.camel.quarkus.test.CamelQuarkusTestSupport
+import org.junit.jupiter.api.Test
+
+@QuarkusTest
+class RoutesTest : CamelQuarkusTestSupport() {
+    @Test
+    fun `Exchange body is prefixed with a greeting`() {
+        val greeting = template.requestBody("direct:greet", "Camel Quarkus Kotlin", String::class.java)
+        assertEquals("Hello Camel Quarkus Kotlin", greeting)
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -537,6 +537,8 @@
                             <exclude>.gitattributes</exclude>
                             <exclude>**/src/test/resources/__files/*.xml</exclude>
                             <exclude>.github/actions/**</exclude>
+                            <exclude>src/main/codestarts/quarkus/**/*</exclude>
+                            <exclude>src/test/resources/__snapshots__/**</exclude>
                         </excludes>
                         <mapping>
                             <cli>CAMEL_PROPERTIES_STYLE</cli>

--- a/tooling/create-extension-templates/quarkus-extension.yaml
+++ b/tooling/create-extension-templates/quarkus-extension.yaml
@@ -40,4 +40,12 @@ metadata:
 [/#if]
   status:
   - "[=status]"
-[#if deprecated ]  - "deprecated"[/#if]
+[#if deprecated ]  - "deprecated"
+[/#if]
+[#if codeStartLanguages?size > 0]  codestart:
+    name: "camel-quarkus-[=artifactIdBase]"
+    languages:
+[#list codeStartLanguages as language]
+    - "[=language]"
+[/#list]
+    artifact: "org.apache.camel.quarkus:camel-quarkus-[=artifactIdBase]:codestarts:jar:${project.version}"[/#if]


### PR DESCRIPTION
POC of a basic Camel Quarkus codestart. I thought we could try it on a 'low traffic' extension initially and then evaluate expanding it to other extensions.

The codestart will bootstrap a project with some basic routes and a JVM mode test that leverages `CamelQuarkusTestSupport`.

Feedback is welcome. If we think this is worthwhile, I would need to make some tweaks to the `cq-maven-plugin` before this PR is merged, so that the codestart config is preserved in the extension metadata.

