### PR TITLE
Remove reserve-network-port execution for integration tests

### DIFF
--- a/poms/build-parent-it/pom.xml
+++ b/poms/build-parent-it/pom.xml
@@ -84,16 +84,6 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
-                    <executions>
-                        <execution>
-                            <configuration>
-                                <systemProperties>
-                                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                                </systemProperties>
-                            </configuration>
-                        </execution>
-                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.camel.maven</groupId>
@@ -138,28 +128,6 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>build-helper-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>reserve-network-port</id>
-                                <goals>
-                                    <goal>reserve-network-port</goal>
-                                </goals>
-                                <phase>process-resources</phase>
-                                <configuration>
-                                    <portNames>
-                                        <portName>test.http.port.jvm</portName>
-                                        <portName>test.https.port.jvm</portName>
-                                        <portName>test.http.port.native</portName>
-                                        <portName>test.https.port.native</portName>
-                                    </portNames>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-
-                    <plugin>
                         <groupId>${quarkus.platform.group-id}</groupId>
                         <artifactId>quarkus-maven-plugin</artifactId>
                         <executions>
@@ -175,20 +143,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>default-test</id>
-                                <phase>test</phase>
-                                <configuration>
-                                    <systemProperties>
-                                        <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-                                        <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-                                    </systemProperties>
-                                </configuration>
-                            </execution>
-                        </executions>
                     </plugin>
-
                 </plugins>
             </build>
         </profile>


### PR DESCRIPTION
Motivation:

* AFAIK no other project in the Quarkus ecosystem does this
* Avoids having another mojo execution in the build and allocating 250+ ports
* It would probably fix #4988


Let's see how the CI build goes.