### PR TITLE
Ref #2800: Remove the addition of affinity for mac os

### DIFF
--- a/integration-tests/hazelcast/pom.xml
+++ b/integration-tests/hazelcast/pom.xml
@@ -96,22 +96,6 @@
             </build>
         </profile>
         <profile>
-            <!--this profile should be removed once https://github.com/apache/camel-quarkus/issues/2800
-                or https://github.com/hazelcast/quarkus-hazelcast-client/issues/189 get resolved
-            -->
-            <id>hazelcast-mac</id>
-            <activation>
-                <os><family>mac</family></os>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>net.openhft</groupId>
-                    <artifactId>affinity</artifactId>
-                    <version>3.20.0</version>
-                </dependency>
-            </dependencies>
-        </profile>
-        <profile>
             <id>virtualDependencies</id>
             <activation>
                 <property>


### PR DESCRIPTION
related to #2800

## Motivation

Thx to https://github.com/hazelcast/quarkus-hazelcast-client/issues/189, affinity is already included so we need to remove the automatic addition of the library otherwise on MacOS we end up with a build error of type:
```
[WARN] 
Dependency convergence error for net.openhft:affinity:3.23.3 paths to dependency are:
+-org.apache.camel.quarkus:camel-quarkus-integration-test-hazelcast:3.0.0-SNAPSHOT
  +-org.apache.camel.quarkus:camel-quarkus-hazelcast:3.0.0-SNAPSHOT
    +-com.hazelcast:quarkus-hazelcast-client:4.0.0
      +-net.openhft:affinity:3.23.3
and
+-org.apache.camel.quarkus:camel-quarkus-integration-test-hazelcast:3.0.0-SNAPSHOT
  +-net.openhft:affinity:3.20.0
[WARN] Rule 1: org.apache.maven.plugins.enforcer.DependencyConvergence failed with message:
Failed while enforcing releasability. See above detailed error message.
```

## Modifications

* Remove the maven profile adding `affinity` for MacOS