### PR TITLE
Improve native support of camel-quarkus-debug

### DIFF
--- a/docs/modules/ROOT/pages/reference/extensions/debug.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/debug.adoc
@@ -82,6 +82,12 @@ quarkus.camel.debug.enabled=true
 
 | `boolean`
 | `false`
+
+|icon:lock[title=Fixed at build time] [[quarkus.camel.debug.suspend]]`link:#quarkus.camel.debug.suspend[quarkus.camel.debug.suspend]`
+
+
+| `boolean`
+| `false`
 |===
 
 [.configuration-legend]

--- a/extensions-core/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/CamelSerializationProcessor.java
+++ b/extensions-core/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/CamelSerializationProcessor.java
@@ -21,7 +21,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 
 import io.quarkus.deployment.annotations.BuildProducer;
@@ -59,6 +61,8 @@ public class CamelSerializationProcessor {
             StackTraceElement[].class.getName(),
             String.class.getName(),
             Throwable.class.getName(),
+            HashSet.class.getName(),
+            LinkedHashSet.class.getName(),
 
             // Camel classes
             CamelExecutionException.class.getName(),

--- a/extensions/debug/deployment/src/main/java/org/apache/camel/quarkus/component/debug/deployment/DebugProcessor.java
+++ b/extensions/debug/deployment/src/main/java/org/apache/camel/quarkus/component/debug/deployment/DebugProcessor.java
@@ -18,10 +18,14 @@ package org.apache.camel.quarkus.component.debug.deployment;
 
 import java.util.function.BooleanSupplier;
 
+import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.AllowJNDIBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.SystemPropertyBuildItem;
 import io.quarkus.runtime.LaunchMode;
+import org.apache.camel.api.management.JmxSystemPropertyKeys;
+import org.apache.camel.impl.debugger.BacklogDebugger;
 import org.apache.camel.quarkus.component.debug.DebugConfig;
 import org.apache.camel.quarkus.core.deployment.spi.CamelServiceDestination;
 import org.apache.camel.quarkus.core.deployment.spi.CamelServicePatternBuildItem;
@@ -46,6 +50,13 @@ class DebugProcessor {
         // core defines an include path filter for META-INF/services/org/apache/camel/*
         return new CamelServicePatternBuildItem(CamelServiceDestination.DISCOVERY, false,
                 "META-INF/services/org/apache/camel/debugger-factory");
+    }
+
+    @BuildStep(onlyIf = DebugEnabled.class)
+    void configureSystemProperties(BuildProducer<SystemPropertyBuildItem> producer, DebugConfig config) {
+        producer.produce(
+                new SystemPropertyBuildItem(BacklogDebugger.SUSPEND_MODE_SYSTEM_PROP_NAME, Boolean.toString(config.suspend)));
+        producer.produce(new SystemPropertyBuildItem(JmxSystemPropertyKeys.DISABLED, "false"));
     }
 
     static class DebugEnabled implements BooleanSupplier {

--- a/integration-tests/debug/pom.xml
+++ b/integration-tests/debug/pom.xml
@@ -36,6 +36,10 @@
             <artifactId>camel-quarkus-debug</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-direct</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy</artifactId>
         </dependency>
@@ -66,6 +70,19 @@
                 <dependency>
                     <groupId>org.apache.camel.quarkus</groupId>
                     <artifactId>camel-quarkus-debug-deployment</artifactId>
+                    <version>${project.version}</version>
+                    <type>pom</type>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-direct-deployment</artifactId>
                     <version>${project.version}</version>
                     <type>pom</type>
                     <scope>test</scope>

--- a/integration-tests/debug/src/main/java/org/apache/camel/quarkus/component/debug/it/DebugRoutes.java
+++ b/integration-tests/debug/src/main/java/org/apache/camel/quarkus/component/debug/it/DebugRoutes.java
@@ -14,21 +14,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.quarkus.component.debug;
+package org.apache.camel.quarkus.component.debug.it;
 
-import io.quarkus.runtime.annotations.ConfigPhase;
-import io.quarkus.runtime.annotations.ConfigRoot;
+import org.apache.camel.builder.RouteBuilder;
 
-@ConfigRoot(name = "camel.debug", phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
-public class DebugConfig {
-    /**
-     * Set whether to enable Camel debugging support.
-     */
-    public boolean enabled;
+public class DebugRoutes extends RouteBuilder {
 
-    /**
-     * Indicates whether the <i>suspend mode</i> is enabled or not. If {@code true} the message processing is
-     * immediately suspended until the method {@code attach()} is called.
-     */
-    public boolean suspend;
+    @Override
+    public void configure() {
+        getContext().setUseBreadcrumb(false);
+        getContext().setDebugging(true);
+        getContext().setMessageHistory(true);
+        from("direct:start")
+                .log("Processing");
+    }
 }

--- a/integration-tests/debug/src/test/java/org/apache/camel/quarkus/component/debug/it/DebugTest.java
+++ b/integration-tests/debug/src/test/java/org/apache/camel/quarkus/component/debug/it/DebugTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.quarkus.component.debug.it;
 import java.util.Iterator;
 import java.util.Set;
 
+import javax.management.JMX;
 import javax.management.MBeanServerConnection;
 import javax.management.ObjectInstance;
 import javax.management.ObjectName;
@@ -29,6 +30,7 @@ import javax.management.remote.JMXServiceURL;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import org.apache.camel.ServiceStatus;
+import org.apache.camel.api.management.mbean.ManagedBacklogDebuggerMBean;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.camel.component.debug.JmxConnectorService.DEFAULT_HOST;
@@ -73,6 +75,35 @@ public class DebugTest {
                 assertEquals(ServiceStatus.Started, ServiceStatus.valueOf(status));
             } else {
                 fail("Expected to find 1 CamelContext MBean");
+            }
+        }
+    }
+
+    @Test
+    void accessToBacklogDebugger() throws Exception {
+        String url = String.format("service:jmx:rmi:///jndi/rmi://%s:%d%s", DEFAULT_HOST, DEFAULT_REGISTRY_PORT,
+                DEFAULT_SERVICE_URL_PATH);
+        JMXServiceURL jmxUrl = new JMXServiceURL(url);
+
+        try (JMXConnector connector = JMXConnectorFactory.connect(jmxUrl)) {
+            MBeanServerConnection mbeanServer = connector.getMBeanServerConnection();
+
+            ObjectName objectName = new ObjectName("org.apache.camel:context=*,type=tracer,name=BacklogDebugger");
+            Set<ObjectName> names = mbeanServer.queryNames(objectName, null);
+            assertNotNull(names);
+
+            Iterator<ObjectName> iteratorNames = names.iterator();
+            if (iteratorNames.hasNext()) {
+                ObjectName debuggerMBeanObjectName = iteratorNames.next();
+                assertNotNull(debuggerMBeanObjectName);
+                ManagedBacklogDebuggerMBean backlogDebugger = JMX.newMBeanProxy(mbeanServer, debuggerMBeanObjectName,
+                        ManagedBacklogDebuggerMBean.class);
+                Set<String> breakpoints = backlogDebugger.breakpoints();
+                assertNotNull(breakpoints);
+                Set<String> suspendedBreakpointNodeIds = backlogDebugger.suspendedBreakpointNodeIds();
+                assertNotNull(suspendedBreakpointNodeIds);
+            } else {
+                fail("Expected to find 1 BacklogDebugger");
             }
         }
     }


### PR DESCRIPTION
fixes #5059
fixes #5058

## Motivation

Some small issues prevent the remote debugging of a Camel application in native mode.

## Modifications:

* Adds support of the suspend mode
* Fixes serialization issue when retrieving the breakpoints and suspended node ids

## Result

It is now possible to remote debug a Camel application in native mode.