### PR TITLE
Build Camel on the nightly build instead of relying on the SNAPSHOT repo

### DIFF
--- a/.github/workflows/camel-master-cron.yaml
+++ b/.github/workflows/camel-master-cron.yaml
@@ -26,7 +26,6 @@ env:
   LANG: en_US.UTF-8
   MAVEN_OPTS: -Xmx3000m
   CQ_MAVEN_ARGS: -V -ntp -e -Daether.connector.http.connectionMaxTtl=120
-  BRANCH_OPTIONS: -Papache-snapshots
   TESTCONTAINERS_RYUK_DISABLED: true
   ISSUE_ID: 2927
 
@@ -63,9 +62,16 @@ jobs:
           git fetch origin main
           git rebase origin/main
           git rev-parse origin/main > ~/build-data/main-sha.txt
+      - name: Build Camel
+        run: |
+          cd ../
+          git clone --depth 1 --branch main https://github.com/apache/camel.git \
+            && cd camel \
+            && echo "Current Camel commit:" $(git rev-parse HEAD) \
+            && ./mvnw ${CQ_MAVEN_ARGS} clean install -Dquickly
       - name: mvn clean install -DskipTests
         run: |
-          eval ./mvnw ${CQ_MAVEN_ARGS} ${BRANCH_OPTIONS} clean install -DskipTests -Dquarkus.build.skip
+          eval ./mvnw ${CQ_MAVEN_ARGS} clean install -DskipTests -Dquarkus.build.skip
       - name: Sync Maven properties
         run: |
           ./mvnw cq:sync-versions ${CQ_MAVEN_ARGS} -N
@@ -158,14 +164,14 @@ jobs:
 
           IFS=,
           if [[ ${JVM_MODULES[@]} ]]; then
-            eval ./mvnw ${CQ_MAVEN_ARGS} ${BRANCH_OPTIONS} clean test \
+            eval ./mvnw ${CQ_MAVEN_ARGS} clean test \
               -Dformatter.skip -Dimpsort.skip -Denforcer.skip \
               -Pdocker,ci \
               -pl "${JVM_MODULES[*]}"
           fi
 
           if [[ ${NATIVE_MODULES[@]} ]]; then
-            eval ./mvnw ${CQ_MAVEN_ARGS} ${BRANCH_OPTIONS} clean verify \
+            eval ./mvnw ${CQ_MAVEN_ARGS} clean verify \
               -Dformatter.skip -Dimpsort.skip -Denforcer.skip \
               -Pnative,docker,ci \
               --fail-at-end \
@@ -216,31 +222,31 @@ jobs:
       - name: cd extensions-core && mvn test
         run: |
           cd extensions-core
-          ../mvnw ${CQ_MAVEN_ARGS} ${BRANCH_OPTIONS} \
+          ../mvnw ${CQ_MAVEN_ARGS} \
             -Dformatter.skip -Dimpsort.skip -Denforcer.skip -Dcamel-quarkus.update-extension-doc-page.skip \
             test
       - name: cd extensions && mvn test
         run: |
           cd extensions
-          ../mvnw ${CQ_MAVEN_ARGS} ${BRANCH_OPTIONS} \
+          ../mvnw ${CQ_MAVEN_ARGS} \
             -Dformatter.skip -Dimpsort.skip -Denforcer.skip -Dcamel-quarkus.update-extension-doc-page.skip \
             test
       - name: cd test-framework && mvn test
         run: |
           cd test-framework
-          ../mvnw ${CQ_MAVEN_ARGS} ${BRANCH_OPTIONS} \
+          ../mvnw ${CQ_MAVEN_ARGS} \
             -Dformatter.skip -Dimpsort.skip -Denforcer.skip -Dcamel-quarkus.update-extension-doc-page.skip \
             test
       - name: cd tooling/perf-regression && mvn verify
         run: |
           cd tooling/perf-regression
-          ../../mvnw ${CQ_MAVEN_ARGS} ${BRANCH_OPTIONS} \
+          ../../mvnw ${CQ_MAVEN_ARGS} \
             -Dformatter.skip -Dimpsort.skip -Denforcer.skip \
             verify
       - name: cd catalog && mvn test
         run: |
           cd catalog
-          ../mvnw ${CQ_MAVEN_ARGS} ${BRANCH_OPTIONS} \
+          ../mvnw ${CQ_MAVEN_ARGS} \
             -Dformatter.skip -Dimpsort.skip -Denforcer.skip \
             test
       - name: Report Build Failure
@@ -295,7 +301,7 @@ jobs:
       - name: cd integration-tests-jvm && mvn clean test
         run: |
           cd integration-tests-jvm
-          ../mvnw ${CQ_MAVEN_ARGS} ${BRANCH_OPTIONS} \
+          ../mvnw ${CQ_MAVEN_ARGS} \
             -Dformatter.skip -Dimpsort.skip -Denforcer.skip \
             --fail-at-end \
             clean test
@@ -343,7 +349,7 @@ jobs:
         shell: bash
         run: |
           cd integration-tests
-          ../mvnw ${CQ_MAVEN_ARGS} ${BRANCH_OPTIONS} \
+          ../mvnw ${CQ_MAVEN_ARGS} \
             -Dskip-testcontainers-tests -Dformatter.skip -Dimpsort.skip -Denforcer.skip \
             --fail-at-end \
             clean verify
@@ -397,8 +403,8 @@ jobs:
           git clone --depth 1 --branch ${EXAMPLES_BRANCH} https://github.com/apache/camel-quarkus-examples.git \
             && cd camel-quarkus-examples \
             && echo "Current Examples commit:" $(git rev-parse HEAD) \
-            && ./mvnw ${CQ_MAVEN_ARGS} ${BRANCH_OPTIONS} org.l2x6.cq:cq-maven-plugin:2.10.0:examples-set-platform -Dcq.camel-quarkus.version=${CQ_VERSION} \
-            && ./mvnw-for-each.sh ${CQ_MAVEN_ARGS} ${BRANCH_OPTIONS} -Pnative,docker clean verify
+            && ./mvnw ${CQ_MAVEN_ARGS} org.l2x6.cq:cq-maven-plugin:2.10.0:examples-set-platform -Dcq.camel-quarkus.version=${CQ_VERSION} \
+            && ./mvnw-for-each.sh ${CQ_MAVEN_ARGS} -Pnative,docker clean verify
       - name: Report Build Failure
         if: failure() || cancelled()
         run: |


### PR DESCRIPTION
We can revert this if it takes too long or does not work out...