### PR TITLE
Set the official snapshot repositories

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1220,7 +1220,7 @@
             <repositories>
                 <repository>
                     <id>oss-snapshots-repo</id>
-                    <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+                    <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
                     <releases>
                         <enabled>false</enabled>
                     </releases>
@@ -1232,7 +1232,7 @@
             <pluginRepositories>
                 <pluginRepository>
                     <id>oss-snapshots-repo</id>
-                    <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+                    <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
                     <releases>
                         <enabled>false</enabled>
                     </releases>


### PR DESCRIPTION
## Motivation

The old snapshot repositories don't work anymore, indeed it returns a 404 error code when trying to access any file which causes failures in the builds of the `quarkus-main` branch https://github.com/apache/camel-quarkus/actions/runs/5420932224/jobs/9965211122

## Modifications:

* Set the new official snapshot repositories that are specified in the contributing guide of Quarkus https://github.com/quarkusio/quarkus/blob/main/CONTRIBUTING.md?plain=1#L79