### PR TITLE
Restrict downloading of com.atlassian dependencies to packages.atlassian.com

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-Daether.remoteRepositoryFilter.groupId=true
+-Daether.remoteRepositoryFilter.groupId.basedir=${session.rootDirectory}/.mvn/rrf/

--- a/.mvn/rrf/groupId-atlassian.txt
+++ b/.mvn/rrf/groupId-atlassian.txt
@@ -1,0 +1,6 @@
+com.atlassian.event
+com.atlassian.httpclient
+com.atlassian.jira
+com.atlassian.platform
+com.atlassian.pom
+com.atlassian.sal


### PR DESCRIPTION
Test to see if we can avoid slurping down the entire internet from packages.atlassian.com.