### PR TITLE
Ref #5056: Replace the deprecated RecorderContext#classProxy

### DIFF
--- a/extensions-support/language/runtime/src/main/java/org/apache/camel/quarkus/support/language/runtime/LanguageSupportRecorder.java
+++ b/extensions-support/language/runtime/src/main/java/org/apache/camel/quarkus/support/language/runtime/LanguageSupportRecorder.java
@@ -14,30 +14,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.quarkus.component.groovy.runtime;
+package org.apache.camel.quarkus.support.language.runtime;
 
-import groovy.lang.Script;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
-import org.apache.camel.language.groovy.GroovyLanguage;
 
 @Recorder
-public class GroovyExpressionRecorder {
+public class LanguageSupportRecorder {
 
-    public RuntimeValue<GroovyLanguage.Builder> languageBuilder() {
-        return new RuntimeValue<>(new GroovyLanguage.Builder());
-    }
-
-    @SuppressWarnings("unchecked")
-    public void addScript(RuntimeValue<GroovyLanguage.Builder> builder, String content, RuntimeValue<Class<?>> clazz) {
-        try {
-            builder.getValue().addScript(content, (Class<Script>) clazz.getValue());
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    public RuntimeValue<GroovyLanguage> languageNewInstance(RuntimeValue<GroovyLanguage.Builder> builder) {
-        return new RuntimeValue<>(builder.getValue().build());
+    public RuntimeValue<Class<?>> loadClass(String name) throws ClassNotFoundException {
+        return new RuntimeValue<>(Class.forName(name, true, Thread.currentThread().getContextClassLoader()));
     }
 }

--- a/extensions/joor/runtime/src/main/java/org/apache/camel/quarkus/component/joor/runtime/JoorExpressionRecorder.java
+++ b/extensions/joor/runtime/src/main/java/org/apache/camel/quarkus/component/joor/runtime/JoorExpressionRecorder.java
@@ -36,8 +36,8 @@ public class JoorExpressionRecorder {
         return language;
     }
 
-    public void setResultType(RuntimeValue<JoorLanguage> language, Class<?> resultType) {
-        language.getValue().setResultType(resultType);
+    public void setResultType(RuntimeValue<JoorLanguage> language, RuntimeValue<Class<?>> resultType) {
+        language.getValue().setResultType(resultType.getValue());
     }
 
     public RuntimeValue<JoorExpressionCompiler.Builder> expressionCompilerBuilder() {
@@ -49,21 +49,20 @@ public class JoorExpressionRecorder {
     }
 
     public void addExpression(RuntimeValue<JoorExpressionCompiler.Builder> builder, RuntimeValue<CamelContext> ctx, String id,
-            Class<?> clazz) {
+            RuntimeValue<Class<?>> clazz) {
         try {
             builder.getValue().addExpression(id,
-                    (JoorMethod) clazz.getConstructor(CamelContext.class).newInstance(ctx.getValue()));
+                    (JoorMethod) clazz.getValue().getConstructor(CamelContext.class).newInstance(ctx.getValue()));
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
 
     public void addScript(RuntimeValue<JoorExpressionScriptingCompiler.Builder> builder, RuntimeValue<CamelContext> ctx,
-            String id,
-            Class<?> clazz) {
+            String id, RuntimeValue<Class<?>> clazz) {
         try {
             builder.getValue().addScript(id,
-                    (JoorScriptingMethod) clazz.getConstructor(CamelContext.class).newInstance(ctx.getValue()));
+                    (JoorScriptingMethod) clazz.getValue().getConstructor(CamelContext.class).newInstance(ctx.getValue()));
         } catch (Exception e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
fixes #5056 

## Motivation

The method `RecorderContext#classProxy` is deprecated and could be removed in future versions of Quarkus so we should replace it to avoid problems.

## Modifications:

* Add a common recorder with a method allowing to delay the loading of the generated classes
* Replace calls to `RecorderContext#classProxy` with calls to `loadClass` of the common recorder 