### PR TITLE
Add missing graal-sdk dependency declaration to extensions that use GraalVM APIs

### DIFF
--- a/extensions-core/xml-jaxb/runtime/pom.xml
+++ b/extensions-core/xml-jaxb/runtime/pom.xml
@@ -52,6 +52,11 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jaxb</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.graalvm.sdk</groupId>
+            <artifactId>graal-sdk</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions-support/swagger/runtime/pom.xml
+++ b/extensions-support/swagger/runtime/pom.xml
@@ -47,6 +47,11 @@
             <groupId>io.swagger.parser.v3</groupId>
             <artifactId>swagger-parser</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.graalvm.sdk</groupId>
+            <artifactId>graal-sdk</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/java-joor-dsl/runtime/pom.xml
+++ b/extensions/java-joor-dsl/runtime/pom.xml
@@ -44,6 +44,11 @@
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-java-joor-dsl</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.graalvm.sdk</groupId>
+            <artifactId>graal-sdk</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/jsh-dsl/runtime/pom.xml
+++ b/extensions/jsh-dsl/runtime/pom.xml
@@ -48,6 +48,11 @@
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-jsh-dsl</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.graalvm.sdk</groupId>
+            <artifactId>graal-sdk</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/json-validator/runtime/pom.xml
+++ b/extensions/json-validator/runtime/pom.xml
@@ -44,6 +44,11 @@
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-json-validator</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.graalvm.sdk</groupId>
+            <artifactId>graal-sdk</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/kotlin-dsl/runtime/pom.xml
+++ b/extensions/kotlin-dsl/runtime/pom.xml
@@ -52,6 +52,11 @@
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-kotlin-dsl</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.graalvm.sdk</groupId>
+            <artifactId>graal-sdk</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/nitrite/runtime/pom.xml
+++ b/extensions/nitrite/runtime/pom.xml
@@ -48,6 +48,11 @@
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-nitrite</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.graalvm.sdk</groupId>
+            <artifactId>graal-sdk</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Seems in Quarkus 3.2.x `graal-sdk` is a `compile` scope transitive of `quarkus-core`. From Quarkus 3.3.0, it becomes `provided` scope, thus there are multiple compilation failures.

I thought it'd be ok to deal with this change now on `main` instead of `quarkus-main`.