### PR TITLE
Ref #5026: Delay the init of ICMPHelper on non Linux OS

### DIFF
--- a/extensions/hazelcast/deployment/src/main/java/org/apache/camel/quarkus/component/hazelcast/deployment/HazelcastProcessor.java
+++ b/extensions/hazelcast/deployment/src/main/java/org/apache/camel/quarkus/component/hazelcast/deployment/HazelcastProcessor.java
@@ -33,6 +33,7 @@ import com.hazelcast.collection.ISet;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.cp.IAtomicLong;
+import com.hazelcast.internal.util.ICMPHelper;
 import com.hazelcast.map.IMap;
 import com.hazelcast.multimap.MultiMap;
 import com.hazelcast.replicatedmap.ReplicatedMap;
@@ -45,6 +46,8 @@ import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveHierarchyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveHierarchyIgnoreWarningBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
+import io.quarkus.utilities.OS;
 import org.apache.camel.tooling.model.MainModel;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.Type;
@@ -94,6 +97,13 @@ class HazelcastProcessor {
                 TrustManager.class,
                 XPathFactory.class,
                 MainModel.class);
+    }
+
+    @BuildStep
+    void registerICMPHelper(BuildProducer<RuntimeInitializedClassBuildItem> initializedClasses) {
+        if (OS.determineOS() != OS.LINUX) {
+            initializedClasses.produce(new RuntimeInitializedClassBuildItem(ICMPHelper.class.getName()));
+        }
     }
 
     private static void registerTypeHierarchy(


### PR DESCRIPTION
fixes #5026 

## Motivation

The naitve compilation fails on Mac OS due to the initialization of the class `ICMPHelper`.

## Modifications:

* Delays the initialization of `ICMPHelper` on non-Linux OS

## Result

The native image can be built on MacOS and the hazelcast client can be used properly as long as the ICM is not needed like in JVM mode

Please note that there is still the next stack trace during the native compilation to ignore: 
```
om.oracle.svm.core.util.UserError$UserException: Incompatible change of initialization policy for com.hazelcast.internal.util.ICMPHelper: trying to change RUN_TIME from feature io.quarkus.runner.Feature.beforeAnalysis with 'ICMPHelper.class' to RERUN Quarkus
	at org.graalvm.nativeimage.builder/com.oracle.svm.core.util.UserError.abort(UserError.java:73)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.classinitialization.ClassInitializationConfiguration.insertRec(ClassInitializationConfiguration.java:103)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.classinitialization.ClassInitializationConfiguration.insertRec(ClassInitializationConfiguration.java:117)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.classinitialization.ClassInitializationConfiguration.insertRec(ClassInitializationConfiguration.java:117)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.classinitialization.ClassInitializationConfiguration.insertRec(ClassInitializationConfiguration.java:117)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.classinitialization.ClassInitializationConfiguration.insertRec(ClassInitializationConfiguration.java:117)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.classinitialization.ClassInitializationConfiguration.insertRec(ClassInitializationConfiguration.java:117)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.classinitialization.ClassInitializationConfiguration.insert(ClassInitializationConfiguration.java:64)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.classinitialization.ProvenSafeClassInitializationSupport.rerunInitialization(ProvenSafeClassInitializationSupport.java:158)
	at io.quarkus.runner.Feature.runtimeReinitializedClasses(Unknown Source)
	at io.quarkus.runner.Feature.beforeAnalysis(Unknown Source)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGenerator.lambda$runPointsToAnalysis$9(NativeImageGenerator.java:736)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.FeatureHandler.forEachFeature(FeatureHandler.java:85)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGenerator.runPointsToAnalysis(NativeImageGenerator.java:736)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGenerator.doRun(NativeImageGenerator.java:578)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGenerator.run(NativeImageGenerator.java:535)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGeneratorRunner.buildImage(NativeImageGeneratorRunner.java:403)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGeneratorRunner.build(NativeImageGeneratorRunner.java:580)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGeneratorRunner.main(NativeImageGeneratorRunner.java:128)
```

cc @jamesnetherton 