### PR TITLE
Fix quarkus-maven-plugin groupId & version for gRPC itest module

### DIFF
--- a/integration-tests/grpc/pom.xml
+++ b/integration-tests/grpc/pom.xml
@@ -129,8 +129,9 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>io.quarkus</groupId>
+                <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
+                <version>${quarkus.platform.version}</version>
                 <extensions>true</extensions>
                 <executions>
                     <execution>


### PR DESCRIPTION
Make it consistent with how we do things elsewhere in the project (Avro, CXF, Protobuf etc).