### PR TITLE
Fix grpc integration test, missing quarkus-maven-plugin version

### DIFF
--- a/integration-tests/grpc/pom.xml
+++ b/integration-tests/grpc/pom.xml
@@ -131,6 +131,7 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
+                <version>${quarkus.platform.version}</version>
                 <extensions>true</extensions>
                 <executions>
                     <execution>


### PR DESCRIPTION
It fails with
```
[WARNING] Some problems were encountered while building the effective model for org.apache.camel.quarkus:camel-quarkus-integration-test-grpc:jar:3.0.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for io.quarkus:quarkus-maven-plugin is missing. @ line 131, column 21


```