### PR TITLE
Micrometer: Message History factory and JMX MicrometerMessageHistory is not covered

### DIFF
--- a/docs/modules/ROOT/pages/reference/extensions/micrometer.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/micrometer.adoc
@@ -58,22 +58,29 @@ Your application should declare the following dependency or  one of the dependen
 </dependency>
 ----
 
-If no dependency is declared, the Micrometer extension creates a SimpleMeterRegistry instance, suitable mainly for testing.
+If no dependency is declared, the Micrometer extension creates a `SimpleMeterRegistry` instance, suitable mainly for testing.
 
 
 [id="extensions-micrometer-camel-quarkus-limitations"]
 == Camel Quarkus limitations
 
-[id="extensions-micrometer-limitations-exposing-micrometer-statisctics-in-jmx"]
-=== Exposing Micrometer statisctics in JMX
+[id="extensions-micrometer-limitations-exposing-micrometer-statistics-in-jmx"]
+=== Exposing Micrometer statistics in JMX
 
-The `Exposing Micrometer statisctics in JMX` action is not available in native mode as JMX is not supported on GraalVM.
+Exposing Micrometer statistics in JMX is not available in native mode as `quarkus-micrometer-registry-jmx` does not
+have native support at present.
 
 [id="extensions-micrometer-limitations-decrement-header-for-counter-is-ignored-by-prometheus"]
 === Decrement header for Counter is ignored by Prometheus
 
 Prometheus backend ignores negative values during increment of Counter metrics.
 
+[id="extensions-micrometer-limitations-exposing-statistics-in-jmx"]
+=== Exposing statistics in JMX ===
+
+In {project-name}, registering a `JmxMeterRegistry` is simplified. Add a dependency for
+`io.quarkiverse.micrometer.registry:quarkus-micrometer-registry-jmx` and a `JmxMeterRegistry` will automatically
+get created for you.
 
 
 [id="extensions-micrometer-additional-camel-quarkus-configuration"]

--- a/extensions/micrometer/runtime/src/main/doc/limitations.adoc
+++ b/extensions/micrometer/runtime/src/main/doc/limitations.adoc
@@ -1,8 +1,14 @@
-=== Exposing Micrometer statisctics in JMX
+=== Exposing Micrometer statistics in JMX
 
-The `Exposing Micrometer statisctics in JMX` action is not available in native mode as JMX is not supported on GraalVM.
+Exposing Micrometer statistics in JMX is not available in native mode as `quarkus-micrometer-registry-jmx` does not
+have native support at present.
 
 === Decrement header for Counter is ignored by Prometheus
 
 Prometheus backend ignores negative values during increment of Counter metrics.
 
+=== Exposing statistics in JMX ===
+
+In {project-name}, registering a `JmxMeterRegistry` is simplified. Add a dependency for
+`io.quarkiverse.micrometer.registry:quarkus-micrometer-registry-jmx` and a `JmxMeterRegistry` will automatically
+get created for you.

--- a/extensions/micrometer/runtime/src/main/doc/usage.adoc
+++ b/extensions/micrometer/runtime/src/main/doc/usage.adoc
@@ -10,4 +10,4 @@ Your application should declare the following dependency or  one of the dependen
 </dependency>
 ----
 
-If no dependency is declared, the Micrometer extension creates a SimpleMeterRegistry instance, suitable mainly for testing.
+If no dependency is declared, the Micrometer extension creates a `SimpleMeterRegistry` instance, suitable mainly for testing.

--- a/integration-tests/micrometer/pom.xml
+++ b/integration-tests/micrometer/pom.xml
@@ -48,6 +48,10 @@
             <artifactId>camel-quarkus-bean</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-management</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-prometheus</artifactId>
         </dependency>

--- a/integration-tests/micrometer/src/main/java/org/apache/camel/quarkus/component/micrometer/it/MicrometerProducers.java
+++ b/integration-tests/micrometer/src/main/java/org/apache/camel/quarkus/component/micrometer/it/MicrometerProducers.java
@@ -16,7 +16,7 @@
  */
 package org.apache.camel.quarkus.component.micrometer.it;
 
-import java.util.Arrays;
+import java.util.List;
 
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.Meter;
@@ -40,7 +40,7 @@ public class MicrometerProducers {
     @Produces
     @Singleton
     @IfBuildProfile("test")
-    public MeterRegistry registry(Clock clock) {
+    public MeterRegistry registry() {
         return new JmxMeterRegistry(CamelJmxConfig.DEFAULT, Clock.SYSTEM, HierarchicalNameMapper.DEFAULT);
     }
 
@@ -48,7 +48,7 @@ public class MicrometerProducers {
     @Singleton
     @MeterFilterConstraint(applyTo = PrometheusMeterRegistry.class)
     public MeterFilter configurePrometheusRegistries() {
-        return MeterFilter.commonTags(Arrays.asList(
+        return MeterFilter.commonTags(List.of(
                 Tag.of("customTag", "prometheus")));
     }
 

--- a/integration-tests/micrometer/src/main/java/org/apache/camel/quarkus/component/micrometer/it/MicrometerResource.java
+++ b/integration-tests/micrometer/src/main/java/org/apache/camel/quarkus/component/micrometer/it/MicrometerResource.java
@@ -21,7 +21,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
@@ -42,6 +41,7 @@ import org.apache.camel.ProducerTemplate;
 import org.apache.camel.component.micrometer.MicrometerComponent;
 import org.apache.camel.component.micrometer.MicrometerConstants;
 import org.apache.camel.component.micrometer.eventnotifier.MicrometerEventNotifierService;
+import org.apache.camel.component.micrometer.messagehistory.MicrometerMessageHistoryService;
 
 @Path("/micrometer")
 public class MicrometerResource {
@@ -139,10 +139,7 @@ public class MicrometerResource {
             producerTemplate.sendBodyAndHeader(path, null, MicrometerConstants.HEADER_COUNTER_INCREMENT, increment);
         } else if (increment < 0) {
             producerTemplate.sendBodyAndHeader(path, null, MicrometerConstants.HEADER_COUNTER_DECREMENT,
-                    0 - increment);
-            List l = meterRegistry.getMeters().stream().filter(m -> m.getId().getName().contains("executor"))
-                    .collect(Collectors.toList());//forEach(System.out::println);
-            System.out.println(l);
+                    -increment);
         } else {
             producerTemplate.sendBody(path, null);
         }
@@ -178,10 +175,34 @@ public class MicrometerResource {
         return Response.ok().entity(json).build();
     }
 
+    @Path("/history")
+    @GET
+    public Response history() {
+        MicrometerMessageHistoryService service = camelContext.hasService(MicrometerMessageHistoryService.class);
+        if (service == null) {
+            return Response.status(500).entity("History is null").build();
+        }
+        String json = service.dumpStatisticsAsJson();
+        return Response.ok().entity(json).build();
+    }
+
     @Path("/annotations/call/{number}")
     @GET
     public Response annotationsCall(@PathParam("number") int number) {
         producerTemplate.requestBodyAndHeader("direct:annotatedBean", (Object) null, "number", number);
+        return Response.ok().build();
+    }
+
+    @Path("/getContextManagementName")
+    @GET
+    public Response getContextManagemetName() throws Exception {
+        return Response.ok().entity(camelContext.getManagementName()).build();
+    }
+
+    @Path("/sendJmxHistory")
+    @GET
+    public Response annotationsCall() {
+        producerTemplate.sendBody("direct:jmxHistory", "hello");
         return Response.ok().build();
     }
 

--- a/integration-tests/micrometer/src/main/java/org/apache/camel/quarkus/component/micrometer/it/MicrometerRoutes.java
+++ b/integration-tests/micrometer/src/main/java/org/apache/camel/quarkus/component/micrometer/it/MicrometerRoutes.java
@@ -17,8 +17,7 @@
 package org.apache.camel.quarkus.component.micrometer.it;
 
 import org.apache.camel.builder.RouteBuilder;
-
-import static org.apache.camel.component.micrometer.MicrometerConstants.HEADER_HISTOGRAM_VALUE;
+import org.apache.camel.component.micrometer.MicrometerConstants;
 
 public class MicrometerRoutes extends RouteBuilder {
 
@@ -34,7 +33,7 @@ public class MicrometerRoutes extends RouteBuilder {
                 .to("micrometerCustom:counter:camel-quarkus-custom-counter");
 
         from("direct:summary")
-                .setHeader(HEADER_HISTOGRAM_VALUE, simple("${body}"))
+                .setHeader(MicrometerConstants.HEADER_HISTOGRAM_VALUE, simple("${body}"))
                 .to("micrometer:summary:camel-quarkus-summary");
 
         from("direct:timer")
@@ -51,6 +50,10 @@ public class MicrometerRoutes extends RouteBuilder {
                 .when(simple("${header.number} == 1")).bean("testMetric", "call1")
                 .otherwise().bean("testMetric", "call2")
                 .end();
+
+        from("direct:jmxHistory")
+                .id("jmxHistory")
+                .log("log: ${body}");
 
     }
 }

--- a/integration-tests/micrometer/src/test/java/org/apache/camel/quarkus/component/micrometer/it/NoMessageHistoryMicrometerTest.java
+++ b/integration-tests/micrometer/src/test/java/org/apache/camel/quarkus/component/micrometer/it/NoMessageHistoryMicrometerTest.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.micrometer.it;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.RestAssured;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@TestProfile(NoMessageHistoryProfile.class)
+class NoMessageHistoryMicrometerTest extends AbstractMicrometerTest {
+
+    @Test
+    public void testNoHistory() {
+        RestAssured.get("/micrometer/history")
+                .then()
+                .statusCode(500)
+                .body(Matchers.is("History is null"));
+    }
+}

--- a/integration-tests/micrometer/src/test/java/org/apache/camel/quarkus/component/micrometer/it/NoMessageHistoryProfile.java
+++ b/integration-tests/micrometer/src/test/java/org/apache/camel/quarkus/component/micrometer/it/NoMessageHistoryProfile.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.micrometer.it;
+
+import java.util.Map;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+public class NoMessageHistoryProfile implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        return Map.of("quarkus.camel.metrics.enable-message-history", "false");
+    }
+}


### PR DESCRIPTION
Clone of https://github.com/apache/camel-quarkus/pull/5051, rebased from latest `main` + some minor tweaks.