### PR TITLE
Upgrade to Quarkus CXF 2.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <optaplanner.version>9.37.0.Final</optaplanner.version><!-- May go back to Camel's ${optaplanner-version} when they are in sync https://repo1.maven.org/maven2/org/optaplanner/optaplanner-quarkus/ -->
         <quarkiverse-amazonservices.version>2.4.4</quarkiverse-amazonservices.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/amazonservices/quarkus-amazon-services-parent/ -->
         <quarkiverse-artemis.version>3.0.1</quarkiverse-artemis.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/artemis/quarkus-artemis-parent/ -->
-        <quarkiverse-cxf.version>2.2.1</quarkiverse-cxf.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/cxf/quarkus-cxf-parent/ -->
+        <quarkiverse-cxf.version>2.2.2</quarkiverse-cxf.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/cxf/quarkus-cxf-parent/ -->
         <quarkiverse-freemarker.version>1.0.0</quarkiverse-freemarker.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/freemarker/quarkus-freemarker-parent/ -->
         <quarkiverse-groovy.version>3.2.2</quarkiverse-groovy.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/groovy/quarkus-groovy-parent/ -->
         <quarkiverse-jackson-jq.version>2.0.1</quarkiverse-jackson-jq.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/jackson-jq/quarkus-jackson-jq-parent/ -->

--- a/poms/bom/src/main/generated/flattened-full-pom.xml
+++ b/poms/bom/src/main/generated/flattened-full-pom.xml
@@ -6731,436 +6731,436 @@
         <version>3.6.4</version><!-- org.apache:apache:25 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-rt-features-logging</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-rt-features-logging</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-rt-features-metrics</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-rt-features-metrics</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-rt-frontend-jaxws</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-rt-frontend-jaxws</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
         <exclusions>
           <exclusion>
-            <groupId>org.ow2.asm</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-            <artifactId>asm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+            <groupId>org.ow2.asm</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+            <artifactId>asm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-rt-transports-http</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-rt-transports-http</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-rt-transports-http-hc5</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-rt-transports-http-hc5</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
         <exclusions>
           <exclusion>
-            <groupId>org.slf4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-            <artifactId>jcl-over-slf4j</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+            <groupId>org.slf4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+            <artifactId>jcl-over-slf4j</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-rt-ws-mex</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-rt-ws-mex</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-rt-ws-security</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-rt-ws-security</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-rt-ws-rm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-rt-ws-rm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-rt-wsdl</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-rt-wsdl</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
         <exclusions>
           <exclusion>
-            <groupId>org.ow2.asm</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-            <artifactId>asm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+            <groupId>org.ow2.asm</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+            <artifactId>asm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.services.sts</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-services-sts-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf.services.sts</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-services-sts-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-xjc-boolean</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-xjc-boolean</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-xjc-dv</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-xjc-dv</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-xjc-javadoc</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-xjc-javadoc</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-xjc-pl</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-xjc-pl</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-xjc-ts</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-xjc-ts</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-xjc-wsdlextension</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-xjc-wsdlextension</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.xjc-utils</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-xjc-runtime</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf.xjc-utils</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-xjc-runtime</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>quarkus-cxf</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>2.2.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>quarkus-cxf</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>2.2.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>quarkus-cxf-axiom-api-stub</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>2.2.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>quarkus-cxf-axiom-api-stub</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>2.2.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>quarkus-cxf-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>2.2.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>quarkus-cxf-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>2.2.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>quarkus-cxf-rt-features-logging</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>2.2.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>quarkus-cxf-rt-features-logging</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>2.2.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>quarkus-cxf-rt-features-logging-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>2.2.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>quarkus-cxf-rt-features-logging-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>2.2.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>quarkus-cxf-rt-features-metrics</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>2.2.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>quarkus-cxf-rt-features-metrics</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>2.2.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>quarkus-cxf-rt-features-metrics-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>2.2.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>quarkus-cxf-rt-features-metrics-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>2.2.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>quarkus-cxf-rt-transports-http-hc5</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>2.2.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>quarkus-cxf-rt-transports-http-hc5</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>2.2.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>quarkus-cxf-rt-transports-http-hc5-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>2.2.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>quarkus-cxf-rt-transports-http-hc5-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>2.2.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>quarkus-cxf-rt-ws-security</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>2.2.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>quarkus-cxf-rt-ws-security</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>2.2.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>quarkus-cxf-rt-ws-security-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>2.2.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>quarkus-cxf-rt-ws-security-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>2.2.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>quarkus-cxf-rt-ws-rm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>2.2.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>quarkus-cxf-rt-ws-rm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>2.2.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>quarkus-cxf-rt-ws-rm-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>2.2.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>quarkus-cxf-rt-ws-rm-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>2.2.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>quarkus-cxf-saaj</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>2.2.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>quarkus-cxf-saaj</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>2.2.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>quarkus-cxf-saaj-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>2.2.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>quarkus-cxf-saaj-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>2.2.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>quarkus-cxf-services-sts</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>2.2.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>quarkus-cxf-services-sts</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>2.2.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>quarkus-cxf-services-sts-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>2.2.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>quarkus-cxf-services-sts-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>2.2.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>quarkus-cxf-woodstox</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>2.2.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>quarkus-cxf-woodstox</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>2.2.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>quarkus-cxf-woodstox-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>2.2.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>quarkus-cxf-woodstox-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>2.2.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>quarkus-cxf-xjc-plugins</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>2.2.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>quarkus-cxf-xjc-plugins</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>2.2.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>quarkus-cxf-xjc-plugins-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>2.2.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>quarkus-cxf-xjc-plugins-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>2.2.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>com.fasterxml.woodstox</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>woodstox-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>6.5.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>com.fasterxml.woodstox</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>woodstox-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>6.5.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>com.sun.xml.messaging.saaj</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>saaj-impl</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>2.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>com.sun.xml.messaging.saaj</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>saaj-impl</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>2.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
         <exclusions>
           <exclusion>
-            <groupId>com.sun.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-            <artifactId>jakarta.activation</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+            <groupId>com.sun.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+            <artifactId>jakarta.activation</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>wss4j-bindings</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>3.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>wss4j-bindings</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>3.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>wss4j-policy</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>3.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>wss4j-policy</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>3.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>wss4j-ws-security-common</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>3.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>wss4j-ws-security-common</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>3.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>wss4j-ws-security-dom</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>3.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>wss4j-ws-security-dom</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>3.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>wss4j-ws-security-policy-stax</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>3.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>wss4j-ws-security-policy-stax</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>3.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>wss4j-ws-security-stax</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>3.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>wss4j-ws-security-stax</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>3.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.neethi</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>neethi</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>3.2.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.neethi</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>neethi</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>3.2.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.codehaus.woodstox</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>stax2-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.2.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.codehaus.woodstox</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>stax2-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.2.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.ehcache</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>ehcache</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>3.10.8</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <classifier>jakarta</classifier><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.ehcache</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>ehcache</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>3.10.8</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <classifier>jakarta</classifier><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.glassfish.jaxb</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>jaxb-runtime</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.glassfish.jaxb</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>jaxb-runtime</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.glassfish.jaxb</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>jaxb-xjc</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.glassfish.jaxb</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>jaxb-xjc</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.jvnet.mimepull</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>mimepull</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>1.10.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.jvnet.mimepull</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>mimepull</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>1.10.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>jakarta.jws</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>jakarta.jws-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>3.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>jakarta.jws</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>jakarta.jws-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>3.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>jakarta.mail</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>jakarta.mail-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>2.1.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>jakarta.mail</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>jakarta.mail-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>2.1.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>jakarta.xml.soap</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>jakarta.xml.soap-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>2.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>jakarta.xml.soap</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>jakarta.xml.soap-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>2.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
         <exclusions>
           <exclusion>
-            <groupId>com.sun.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-            <artifactId>jakarta.activation</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+            <groupId>com.sun.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+            <artifactId>jakarta.activation</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>jakarta.xml.ws</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>jakarta.xml.ws-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>3.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>jakarta.xml.ws</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>jakarta.xml.ws-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>3.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.santuario</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>xmlsec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>3.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.santuario</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>xmlsec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>3.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.xmlsec</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>quarkus-xmlsec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>2.1.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>io.quarkiverse.xmlsec</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>quarkus-xmlsec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>2.1.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.xmlsec</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>quarkus-xmlsec-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>2.1.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>io.quarkiverse.xmlsec</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>quarkus-xmlsec-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>2.1.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
         <exclusions>
           <exclusion>
-            <groupId>org.ow2.asm</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-            <artifactId>asm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+            <groupId>org.ow2.asm</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+            <artifactId>asm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-rt-bindings-soap</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-rt-bindings-soap</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-rt-bindings-xml</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-rt-bindings-xml</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-rt-databinding-aegis</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-rt-databinding-aegis</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-rt-databinding-jaxb</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-rt-databinding-jaxb</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-rt-frontend-simple</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-rt-frontend-simple</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-rt-javascript</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-rt-javascript</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-rt-management</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-rt-management</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-rt-rs-json-basic</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-rt-rs-json-basic</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-rt-rs-security-jose</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-rt-rs-security-jose</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-rt-security-saml</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-rt-security-saml</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-rt-ws-addr</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-rt-ws-addr</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-rt-ws-policy</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-rt-ws-policy</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-rt-security</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-rt-security</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-tools-common</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-tools-common</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-tools-java2ws</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-tools-java2ws</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-tools-validator</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-tools-validator</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-tools-wsdlto-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-tools-wsdlto-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-tools-wsdlto-databinding-jaxb</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-tools-wsdlto-databinding-jaxb</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-tools-wsdlto-frontend-jaxws</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-tools-wsdlto-frontend-jaxws</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
         <groupId>org.apache.groovy</groupId><!-- org.apache.groovy:groovy-bom:4.0.13 -->

--- a/poms/bom/src/main/generated/flattened-reduced-pom.xml
+++ b/poms/bom/src/main/generated/flattened-reduced-pom.xml
@@ -6786,107 +6786,107 @@
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf</artifactId>
-        <version>2.2.1</version>
+        <version>2.2.2</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-axiom-api-stub</artifactId>
-        <version>2.2.1</version>
+        <version>2.2.2</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-deployment</artifactId>
-        <version>2.2.1</version>
+        <version>2.2.2</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-features-logging</artifactId>
-        <version>2.2.1</version>
+        <version>2.2.2</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-features-logging-deployment</artifactId>
-        <version>2.2.1</version>
+        <version>2.2.2</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-features-metrics</artifactId>
-        <version>2.2.1</version>
+        <version>2.2.2</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-features-metrics-deployment</artifactId>
-        <version>2.2.1</version>
+        <version>2.2.2</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-transports-http-hc5</artifactId>
-        <version>2.2.1</version>
+        <version>2.2.2</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-transports-http-hc5-deployment</artifactId>
-        <version>2.2.1</version>
+        <version>2.2.2</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-ws-security</artifactId>
-        <version>2.2.1</version>
+        <version>2.2.2</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-ws-security-deployment</artifactId>
-        <version>2.2.1</version>
+        <version>2.2.2</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-ws-rm</artifactId>
-        <version>2.2.1</version>
+        <version>2.2.2</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-ws-rm-deployment</artifactId>
-        <version>2.2.1</version>
+        <version>2.2.2</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-saaj</artifactId>
-        <version>2.2.1</version>
+        <version>2.2.2</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-saaj-deployment</artifactId>
-        <version>2.2.1</version>
+        <version>2.2.2</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-services-sts</artifactId>
-        <version>2.2.1</version>
+        <version>2.2.2</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-services-sts-deployment</artifactId>
-        <version>2.2.1</version>
+        <version>2.2.2</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-woodstox</artifactId>
-        <version>2.2.1</version>
+        <version>2.2.2</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-woodstox-deployment</artifactId>
-        <version>2.2.1</version>
+        <version>2.2.2</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-xjc-plugins</artifactId>
-        <version>2.2.1</version>
+        <version>2.2.2</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-xjc-plugins-deployment</artifactId>
-        <version>2.2.1</version>
+        <version>2.2.2</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.woodstox</groupId>

--- a/poms/bom/src/main/generated/flattened-reduced-verbose-pom.xml
+++ b/poms/bom/src/main/generated/flattened-reduced-verbose-pom.xml
@@ -6676,436 +6676,436 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-rt-features-logging</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-rt-features-logging</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-rt-features-metrics</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-rt-features-metrics</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-rt-frontend-jaxws</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-rt-frontend-jaxws</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
         <exclusions>
           <exclusion>
-            <groupId>org.ow2.asm</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-            <artifactId>asm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+            <groupId>org.ow2.asm</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+            <artifactId>asm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-rt-transports-http</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-rt-transports-http</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-rt-transports-http-hc5</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-rt-transports-http-hc5</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
         <exclusions>
           <exclusion>
-            <groupId>org.slf4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-            <artifactId>jcl-over-slf4j</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+            <groupId>org.slf4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+            <artifactId>jcl-over-slf4j</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-rt-ws-mex</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-rt-ws-mex</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-rt-ws-security</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-rt-ws-security</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-rt-ws-rm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-rt-ws-rm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-rt-wsdl</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-rt-wsdl</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
         <exclusions>
           <exclusion>
-            <groupId>org.ow2.asm</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-            <artifactId>asm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+            <groupId>org.ow2.asm</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+            <artifactId>asm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.services.sts</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-services-sts-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf.services.sts</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-services-sts-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-xjc-boolean</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-xjc-boolean</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-xjc-dv</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-xjc-dv</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-xjc-javadoc</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-xjc-javadoc</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-xjc-pl</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-xjc-pl</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-xjc-ts</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-xjc-ts</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-xjc-wsdlextension</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-xjc-wsdlextension</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.xjc-utils</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-xjc-runtime</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf.xjc-utils</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-xjc-runtime</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>quarkus-cxf</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>2.2.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>quarkus-cxf</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>2.2.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>quarkus-cxf-axiom-api-stub</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>2.2.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>quarkus-cxf-axiom-api-stub</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>2.2.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>quarkus-cxf-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>2.2.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>quarkus-cxf-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>2.2.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>quarkus-cxf-rt-features-logging</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>2.2.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>quarkus-cxf-rt-features-logging</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>2.2.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>quarkus-cxf-rt-features-logging-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>2.2.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>quarkus-cxf-rt-features-logging-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>2.2.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>quarkus-cxf-rt-features-metrics</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>2.2.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>quarkus-cxf-rt-features-metrics</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>2.2.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>quarkus-cxf-rt-features-metrics-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>2.2.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>quarkus-cxf-rt-features-metrics-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>2.2.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>quarkus-cxf-rt-transports-http-hc5</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>2.2.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>quarkus-cxf-rt-transports-http-hc5</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>2.2.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>quarkus-cxf-rt-transports-http-hc5-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>2.2.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>quarkus-cxf-rt-transports-http-hc5-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>2.2.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>quarkus-cxf-rt-ws-security</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>2.2.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>quarkus-cxf-rt-ws-security</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>2.2.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>quarkus-cxf-rt-ws-security-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>2.2.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>quarkus-cxf-rt-ws-security-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>2.2.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>quarkus-cxf-rt-ws-rm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>2.2.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>quarkus-cxf-rt-ws-rm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>2.2.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>quarkus-cxf-rt-ws-rm-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>2.2.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>quarkus-cxf-rt-ws-rm-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>2.2.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>quarkus-cxf-saaj</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>2.2.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>quarkus-cxf-saaj</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>2.2.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>quarkus-cxf-saaj-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>2.2.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>quarkus-cxf-saaj-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>2.2.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>quarkus-cxf-services-sts</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>2.2.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>quarkus-cxf-services-sts</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>2.2.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>quarkus-cxf-services-sts-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>2.2.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>quarkus-cxf-services-sts-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>2.2.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>quarkus-cxf-woodstox</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>2.2.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>quarkus-cxf-woodstox</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>2.2.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>quarkus-cxf-woodstox-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>2.2.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>quarkus-cxf-woodstox-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>2.2.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>quarkus-cxf-xjc-plugins</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>2.2.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>quarkus-cxf-xjc-plugins</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>2.2.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>quarkus-cxf-xjc-plugins-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>2.2.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>quarkus-cxf-xjc-plugins-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>2.2.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>com.fasterxml.woodstox</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>woodstox-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>6.5.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>com.fasterxml.woodstox</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>woodstox-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>6.5.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>com.sun.xml.messaging.saaj</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>saaj-impl</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>2.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>com.sun.xml.messaging.saaj</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>saaj-impl</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>2.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
         <exclusions>
           <exclusion>
-            <groupId>com.sun.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-            <artifactId>jakarta.activation</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+            <groupId>com.sun.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+            <artifactId>jakarta.activation</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>wss4j-bindings</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>3.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>wss4j-bindings</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>3.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>wss4j-policy</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>3.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>wss4j-policy</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>3.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>wss4j-ws-security-common</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>3.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>wss4j-ws-security-common</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>3.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>wss4j-ws-security-dom</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>3.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>wss4j-ws-security-dom</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>3.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>wss4j-ws-security-policy-stax</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>3.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>wss4j-ws-security-policy-stax</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>3.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>wss4j-ws-security-stax</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>3.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>wss4j-ws-security-stax</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>3.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.neethi</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>neethi</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>3.2.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.neethi</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>neethi</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>3.2.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.codehaus.woodstox</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>stax2-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.2.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.codehaus.woodstox</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>stax2-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.2.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.ehcache</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>ehcache</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>3.10.8</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <classifier>jakarta</classifier><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.ehcache</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>ehcache</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>3.10.8</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <classifier>jakarta</classifier><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.glassfish.jaxb</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>jaxb-runtime</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.glassfish.jaxb</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>jaxb-runtime</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.glassfish.jaxb</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>jaxb-xjc</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.glassfish.jaxb</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>jaxb-xjc</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.jvnet.mimepull</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>mimepull</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>1.10.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.jvnet.mimepull</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>mimepull</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>1.10.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>jakarta.jws</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>jakarta.jws-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>3.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>jakarta.jws</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>jakarta.jws-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>3.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>jakarta.mail</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>jakarta.mail-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>2.1.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>jakarta.mail</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>jakarta.mail-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>2.1.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>jakarta.xml.soap</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>jakarta.xml.soap-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>2.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>jakarta.xml.soap</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>jakarta.xml.soap-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>2.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
         <exclusions>
           <exclusion>
-            <groupId>com.sun.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-            <artifactId>jakarta.activation</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+            <groupId>com.sun.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+            <artifactId>jakarta.activation</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>jakarta.xml.ws</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>jakarta.xml.ws-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>3.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>jakarta.xml.ws</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>jakarta.xml.ws-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>3.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.santuario</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>xmlsec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>3.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.santuario</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>xmlsec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>3.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.xmlsec</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>quarkus-xmlsec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>2.1.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>io.quarkiverse.xmlsec</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>quarkus-xmlsec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>2.1.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.xmlsec</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>quarkus-xmlsec-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>2.1.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>io.quarkiverse.xmlsec</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>quarkus-xmlsec-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>2.1.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
         <exclusions>
           <exclusion>
-            <groupId>org.ow2.asm</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-            <artifactId>asm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+            <groupId>org.ow2.asm</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+            <artifactId>asm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-rt-bindings-soap</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-rt-bindings-soap</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-rt-bindings-xml</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-rt-bindings-xml</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-rt-databinding-aegis</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-rt-databinding-aegis</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-rt-databinding-jaxb</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-rt-databinding-jaxb</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-rt-frontend-simple</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-rt-frontend-simple</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-rt-javascript</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-rt-javascript</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-rt-management</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-rt-management</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-rt-rs-json-basic</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-rt-rs-json-basic</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-rt-rs-security-jose</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-rt-rs-security-jose</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-rt-security-saml</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-rt-security-saml</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-rt-ws-addr</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-rt-ws-addr</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-rt-ws-policy</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-rt-ws-policy</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-rt-security</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-rt-security</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-tools-common</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-tools-common</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-tools-java2ws</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-tools-java2ws</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-tools-validator</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-tools-validator</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-tools-wsdlto-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-tools-wsdlto-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-tools-wsdlto-databinding-jaxb</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-tools-wsdlto-databinding-jaxb</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <artifactId>cxf-tools-wsdlto-frontend-jaxws</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.1 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <artifactId>cxf-tools-wsdlto-frontend-jaxws</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:2.2.2 -->
       </dependency>
       <dependency>
         <groupId>org.apache.groovy</groupId><!-- org.apache.groovy:groovy-bom:4.0.13 -->


### PR DESCRIPTION
Quarkus CXF 2.2 line is compatible with Quarkus 3.2 so this should be merged before we release CQ 3.2.0.

cc @zhfeng 