### PR TITLE
Reinstate auto update of antora.yml camel-docs-version attribute

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -29,7 +29,7 @@ asciidoc:
 
     # Project versions
     camel-version: 4.0.0 # replace ${camel.version}
-    camel-docs-version: ""
+    camel-docs-version: 4.0.x # replace ${camel.docs.components.version}
     quarkus-version: 3.2.5.Final # replace ${quarkus.version}
     graalvm-version: 23.0.1 # replace ${graalvm.version}
     graalvm-docs-version: 22.3


### PR DESCRIPTION
We should backport this to the `3.2.x` branch.