### PR TITLE
Set native-image-xmx for camel-k-runtime integration tests for GitHub CI

### DIFF
--- a/integration-tests/camel-k-runtime/pom.xml
+++ b/integration-tests/camel-k-runtime/pom.xml
@@ -116,6 +116,12 @@
 
     <profiles>
         <profile>
+            <id>ci</id>
+            <properties>
+                <quarkus.native.native-image-xmx>5g</quarkus.native.native-image-xmx>
+            </properties>
+        </profile>
+        <profile>
             <id>native</id>
             <activation>
                 <property>


### PR DESCRIPTION
Should hopefully fix some build flakiness.