### PR TITLE
Remove redundant camel-quarkus-bom import in knative runtime module

### DIFF
--- a/extensions/knative/runtime/pom.xml
+++ b/extensions/knative/runtime/pom.xml
@@ -35,18 +35,6 @@
         <camel.quarkus.nativeSince>2.14.0</camel.quarkus.nativeSince>
     </properties>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom</artifactId>
-                <version>${project.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>


### PR DESCRIPTION
Relates to https://github.com/apache/camel-quarkus/pull/5270#issuecomment-1708594332.