### PR TITLE
Remove redundant quarkus-virtual-threads dependency from knative extension

### DIFF
--- a/extensions/knative/deployment/pom.xml
+++ b/extensions/knative/deployment/pom.xml
@@ -46,10 +46,6 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-vertx-http-deployment</artifactId>
         </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-virtual-threads-deployment</artifactId>
-        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/knative/runtime/pom.xml
+++ b/extensions/knative/runtime/pom.xml
@@ -56,10 +56,6 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-vertx-http</artifactId>
         </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-virtual-threads</artifactId>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
I forgot to do this in the Quarkus 3.4.0 upgrade after #5274 was merged.