### PR TITLE
Remove redundant cxf.version property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,6 @@
         <commons-cli.version>1.4</commons-cli.version><!-- keep in sync with Quarkus, via quarkus-bootstrap-core -->
         <commons-exec.version>${commons-exec-version}</commons-exec.version>
         <commons-lang.version>2.6</commons-lang.version><!-- used by hbase, should be pretty stable as commons-lang is not developed actively anymore -->
-        <cxf.version>4.0.3</cxf.version><!-- @sync io.quarkiverse.cxf:quarkus-cxf-parent:${quarkiverse-cxf.version} prop:cxf.version -->
         <dropwizard-metrics.version>${metrics-version}</dropwizard-metrics.version>
         <eddsa.version>${eddsa-version}</eddsa.version>
         <eclipse-transformer.version>0.5.0</eclipse-transformer.version>


### PR DESCRIPTION
I believe this is a relic of when we used to have CXF maven plugins in our tests. But that's since been removed in favor of Quarkus codegen.