### PR TITLE
Revert "Bump quarkiverse-tika.version from 2.0.2 to 2.0.3"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <quarkiverse-minio.version>3.3.1</quarkiverse-minio.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/minio/quarkus-minio-parent/ -->
         <quarkiverse-mybatis.version>2.2.0</quarkiverse-mybatis.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/mybatis/quarkus-mybatis-parent/ -->
         <quarkiverse-pooled-jms.version>2.2.0</quarkiverse-pooled-jms.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/messaginghub/quarkus-pooled-jms-parent/ -->
-        <quarkiverse-tika.version>2.0.3</quarkiverse-tika.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/tika/quarkus-tika-parent/ -->
+        <quarkiverse-tika.version>2.0.2</quarkiverse-tika.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/tika/quarkus-tika-parent/ -->
         <quarkus.version>3.5.1</quarkus.version><!-- https://repo1.maven.org/maven2/io/quarkus/quarkus-bom/ -->
         <quarkus-hazelcast-client.version>4.0.0</quarkus-hazelcast-client.version><!-- https://repo1.maven.org/maven2/com/hazelcast/quarkus-hazelcast-client-bom/ -->
         <quarkus-qpid-jms.version>2.4.0</quarkus-qpid-jms.version><!-- This should be in sync with quarkus-platform https://repo1.maven.org/maven2/org/amqphub/quarkus/quarkus-qpid-jms-bom/ -->

--- a/poms/bom/src/main/generated/flattened-full-pom.xml
+++ b/poms/bom/src/main/generated/flattened-full-pom.xml
@@ -6346,7 +6346,7 @@
       <dependency>
         <groupId>io.quarkiverse.tika</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>quarkus-tika</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <version>2.0.3</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+        <version>2.0.2</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
@@ -6357,7 +6357,7 @@
       <dependency>
         <groupId>io.quarkiverse.tika</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>quarkus-tika-deployment</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <version>2.0.3</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+        <version>2.0.2</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->

--- a/poms/bom/src/main/generated/flattened-reduced-pom.xml
+++ b/poms/bom/src/main/generated/flattened-reduced-pom.xml
@@ -6326,7 +6326,7 @@
       <dependency>
         <groupId>io.quarkiverse.tika</groupId>
         <artifactId>quarkus-tika</artifactId>
-        <version>2.0.3</version>
+        <version>2.0.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -6337,7 +6337,7 @@
       <dependency>
         <groupId>io.quarkiverse.tika</groupId>
         <artifactId>quarkus-tika-deployment</artifactId>
-        <version>2.0.3</version>
+        <version>2.0.2</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>

--- a/poms/bom/src/main/generated/flattened-reduced-verbose-pom.xml
+++ b/poms/bom/src/main/generated/flattened-reduced-verbose-pom.xml
@@ -6326,7 +6326,7 @@
       <dependency>
         <groupId>io.quarkiverse.tika</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>quarkus-tika</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <version>2.0.3</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+        <version>2.0.2</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
@@ -6337,7 +6337,7 @@
       <dependency>
         <groupId>io.quarkiverse.tika</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>quarkus-tika-deployment</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <version>2.0.3</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+        <version>2.0.2</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->


### PR DESCRIPTION
The upgrade to 2.0.3 causes a bunch of dependency convergence issues:

```
 Dependency convergence error for org.apache.poi:poi-ooxml:5.2.4 paths to dependency are:
+-org.apache.camel.quarkus:camel-quarkus-tika:3.6.0-SNAPSHOT
  +-io.quarkiverse.tika:quarkus-tika:2.0.3
    +-io.quarkiverse.poi:quarkus-poi:2.0.4
      +-org.apache.poi:poi-ooxml:5.2.4
and
+-org.apache.camel.quarkus:camel-quarkus-tika:3.6.0-SNAPSHOT
  +-io.quarkiverse.tika:quarkus-tika:2.0.3
    +-org.apache.tika:tika-parser-microsoft-module:2.9.1
      +-org.apache.poi:poi-ooxml:5.2.3

Warning:  
Dependency convergence error for org.apache.poi:poi:5.2.4 paths to dependency are:
+-org.apache.camel.quarkus:camel-quarkus-tika:3.6.0-SNAPSHOT
  +-io.quarkiverse.tika:quarkus-tika:2.0.3
    +-io.quarkiverse.poi:quarkus-poi:2.0.4
      +-org.apache.poi:poi:5.2.4
and
+-org.apache.camel.quarkus:camel-quarkus-tika:3.6.0-SNAPSHOT
  +-io.quarkiverse.tika:quarkus-tika:2.0.3
    +-io.quarkiverse.poi:quarkus-poi:2.0.4
      +-org.apache.poi:poi-ooxml:5.2.4
        +-org.apache.poi:poi:5.2.4
and
+-org.apache.camel.quarkus:camel-quarkus-tika:3.6.0-SNAPSHOT
  +-io.quarkiverse.tika:quarkus-tika:2.0.3
    +-io.quarkiverse.poi:quarkus-poi:2.0.4
      +-org.apache.poi:poi-scratchpad:5.2.4
        +-org.apache.poi:poi:5.2.4
and
+-org.apache.camel.quarkus:camel-quarkus-tika:3.6.0-SNAPSHOT
  +-io.quarkiverse.tika:quarkus-tika:2.0.3
    +-org.apache.tika:tika-parser-microsoft-module:2.9.1
      +-org.apache.poi:poi:5.2.3
and
+-org.apache.camel.quarkus:camel-quarkus-tika:3.6.0-SNAPSHOT
  +-io.quarkiverse.tika:quarkus-tika:2.0.3
    +-org.apache.tika:tika-parser-miscoffice-module:2.9.1
      +-org.apache.poi:poi:5.2.3

Warning:  
Dependency convergence error for org.apache.poi:poi-scratchpad:5.2.4 paths to dependency are:
+-org.apache.camel.quarkus:camel-quarkus-tika:3.6.0-SNAPSHOT
  +-io.quarkiverse.tika:quarkus-tika:2.0.3
    +-io.quarkiverse.poi:quarkus-poi:2.0.4
      +-org.apache.poi:poi-scratchpad:5.2.4
and
+-org.apache.camel.quarkus:camel-quarkus-tika:3.6.0-SNAPSHOT
  +-io.quarkiverse.tika:quarkus-tika:2.0.3
    +-org.apache.tika:tika-parser-microsoft-module:2.9.1
      +-org.apache.poi:poi-scratchpad:5.2.3
````