### PR TITLE
Upgrade Debezium to 2.3.3.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <camel.docs.branch>camel-${camel.major.minor}.x</camel.docs.branch><!-- The stable camel branch on which our Antora docs depends -->
         <camel.sb.docs.branch>camel-spring-boot-${camel.major.minor}.x</camel.sb.docs.branch><!-- The stable camel-spring-boot branch on which our Antora docs depends -->
         <cassandra-quarkus.version>1.2.0</cassandra-quarkus.version><!-- This should be in sync with quarkus-platform https://repo1.maven.org/maven2/com/datastax/oss/quarkus/cassandra-quarkus-bom/ -->
-        <debezium.version>2.3.0.Final</debezium.version> <!-- This should be in sync with quarkus-platform https://github.com/quarkusio/quarkus-platform-->
+        <debezium.version>2.3.3.Final</debezium.version> <!-- This should be in sync with quarkus-platform https://github.com/quarkusio/quarkus-platform-->
         <optaplanner.version>9.37.0.Final</optaplanner.version><!-- This should be in sync with quarkus-platform https://repo1.maven.org/maven2/org/optaplanner/optaplanner-quarkus/ -->
         <quarkiverse-amazonservices.version>2.5.0</quarkiverse-amazonservices.version><!-- This should be in sync with quarkus-platform https://repo1.maven.org/maven2/io/quarkiverse/amazonservices/quarkus-amazon-services-parent/ -->
         <quarkiverse-artemis.version>3.1.2</quarkiverse-artemis.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/artemis/quarkus-artemis-parent/ -->

--- a/poms/bom/src/main/generated/flattened-full-pom.xml
+++ b/poms/bom/src/main/generated/flattened-full-pom.xml
@@ -21100,9 +21100,9 @@
         <version>25.1-jre-graal-sub-1</version><!-- com.datastax.oss:java-driver-bom:4.15.0 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.kafka</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>connect-api</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>3.4.0</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>org.apache.kafka</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>connect-api</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>3.4.0</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
         <exclusions>
           <exclusion>
             <groupId>javax.ws.rs</groupId>
@@ -21111,337 +21111,337 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.kafka</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>connect-json</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>3.4.0</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>org.apache.kafka</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>connect-json</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>3.4.0</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>org.apache.kafka</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>connect-file</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>3.4.0</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>org.apache.kafka</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>connect-file</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>3.4.0</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>org.apache.kafka</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>connect-transforms</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>3.4.0</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>org.apache.kafka</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>connect-transforms</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>3.4.0</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>org.apache.kafka</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>kafka_2.13</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>3.4.0</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <classifier>test</classifier><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>org.apache.kafka</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>kafka_2.13</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>3.4.0</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <classifier>test</classifier><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>io.confluent</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>kafka-connect-avro-converter</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>7.0.1</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>io.confluent</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>kafka-connect-avro-converter</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>7.0.1</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>io.confluent</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>kafka-connect-protobuf-converter</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>7.0.1</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>io.confluent</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>kafka-connect-protobuf-converter</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>7.0.1</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>io.apicurio</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>apicurio-registry-utils-converter</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>2.4.1.Final</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>io.apicurio</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>apicurio-registry-utils-converter</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>2.4.1.Final</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>com.mysql</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>mysql-connector-j</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>8.0.33</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>com.mysql</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>mysql-connector-j</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>8.0.33</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>com.zendesk</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>mysql-binlog-connector-java</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>0.27.2</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>com.zendesk</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>mysql-binlog-connector-java</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>0.27.2</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>mil.nga</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>wkb</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>1.0.2</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>mil.nga</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>wkb</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>1.0.2</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>com.oracle.instantclient</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>xstreams</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>21.6.0.0</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>com.oracle.instantclient</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>xstreams</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>21.6.0.0</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>ch.qos.logback</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>logback-classic</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>1.2.10</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>ch.qos.logback</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>logback-classic</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>1.2.10</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>org.codehaus.groovy</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>groovy</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>3.0.7</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>org.codehaus.groovy</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>groovy</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>3.0.7</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>org.codehaus.groovy</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>groovy-json</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>3.0.7</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>org.codehaus.groovy</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>groovy-json</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>3.0.7</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>org.codehaus.groovy</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>groovy-jsr223</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>3.0.7</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>org.codehaus.groovy</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>groovy-jsr223</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>3.0.7</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>io.vitess</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>vitess-grpc-client</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>12.0.0</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>io.vitess</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>vitess-grpc-client</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>12.0.0</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cassandra</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>cassandra-all</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>3.11.12</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>org.apache.cassandra</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>cassandra-all</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>3.11.12</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>com.datastax.cassandra</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>cassandra-driver-core</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>4.14.0</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>com.datastax.cassandra</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>cassandra-driver-core</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>4.14.0</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>io.dropwizard.metrics</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>metrics-core</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>4.0.1</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>io.dropwizard.metrics</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>metrics-core</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>4.0.1</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>io.dropwizard.metrics</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>metrics-healthchecks</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>4.0.1</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>io.dropwizard.metrics</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>metrics-healthchecks</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>4.0.1</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>io.dropwizard.metrics</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>metrics-servlets</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>4.0.1</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>io.dropwizard.metrics</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>metrics-servlets</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>4.0.1</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>javax.xml.bind</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>jaxb-api</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>2.3.1</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>javax.xml.bind</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>jaxb-api</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>2.3.1</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>org.infinispan</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>infinispan-core-jakarta</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>14.0.11.Final</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>org.infinispan</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>infinispan-core-jakarta</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>14.0.11.Final</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>org.apache.rocketmq</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>rocketmq-client</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>4.9.4</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>org.apache.rocketmq</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>rocketmq-client</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>4.9.4</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>org.apache.rocketmq</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>rocketmq-tools</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>4.9.4</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>org.apache.rocketmq</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>rocketmq-tools</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>4.9.4</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>junit</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>junit</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>4.13.1</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>junit</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>junit</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>4.13.1</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>org.easytesting</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>fest-assert</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>1.4</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>org.easytesting</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>fest-assert</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>1.4</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>org.assertj</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>assertj-core</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>3.11.1</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <scope>test</scope><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>org.assertj</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>assertj-core</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>3.11.1</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <scope>test</scope><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>org.openjdk.jmh</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>jmh-core</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>1.21</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>org.openjdk.jmh</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>jmh-core</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>1.21</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>org.openjdk.jmh</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>jmh-generator-annprocess</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>1.21</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>org.openjdk.jmh</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>jmh-generator-annprocess</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>1.21</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>org.skyscreamer</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>jsonassert</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>1.5.0</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <scope>test</scope><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>org.skyscreamer</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>jsonassert</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>1.5.0</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <scope>test</scope><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>org.reflections</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>reflections</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>0.9.12</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>org.reflections</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>reflections</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>0.9.12</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>org.cassandraunit</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>cassandra-unit</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>3.5.0.1</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <scope>test</scope><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>org.cassandraunit</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>cassandra-unit</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>3.5.0.1</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <scope>test</scope><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>debezium-api</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>2.3.0.Final</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>debezium-api</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>2.3.3.Final</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>debezium-core</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>2.3.0.Final</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>debezium-core</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>2.3.3.Final</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>debezium-storage-jdbc</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>2.3.0.Final</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>debezium-storage-jdbc</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>2.3.3.Final</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>debezium-storage-kafka</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>2.3.0.Final</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>debezium-storage-kafka</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>2.3.3.Final</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>debezium-storage-azure-blob</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>2.3.0.Final</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>debezium-storage-azure-blob</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>2.3.3.Final</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>debezium-storage-s3</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>2.3.0.Final</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>debezium-storage-s3</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>2.3.3.Final</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>debezium-storage-file</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>2.3.0.Final</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>debezium-storage-file</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>2.3.3.Final</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>debezium-storage-redis</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>2.3.0.Final</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>debezium-storage-redis</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>2.3.3.Final</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>debezium-storage-tests</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>2.3.0.Final</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>debezium-storage-tests</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>2.3.3.Final</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>debezium-scripting</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>2.3.0.Final</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>debezium-scripting</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>2.3.3.Final</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>debezium-scripting-languages</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>2.3.0.Final</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <type>pom</type><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>debezium-scripting-languages</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>2.3.3.Final</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <type>pom</type><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>debezium-embedded</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>2.3.0.Final</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>debezium-embedded</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>2.3.3.Final</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>debezium-connector-jdbc</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>2.3.0.Final</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>debezium-connector-jdbc</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>2.3.3.Final</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>debezium-connector-postgres</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>2.3.0.Final</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>debezium-connector-postgres</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>2.3.3.Final</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>debezium-connector-postgres-test</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>2.3.0.Final</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>debezium-connector-postgres-test</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>2.3.3.Final</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>debezium-connector-mysql</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>2.3.0.Final</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>debezium-connector-mysql</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>2.3.3.Final</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>debezium-ddl-parser</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>2.3.0.Final</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>debezium-ddl-parser</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>2.3.3.Final</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>debezium-connector-mongodb</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>2.3.0.Final</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>debezium-connector-mongodb</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>2.3.3.Final</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>debezium-connector-sqlserver</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>2.3.0.Final</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>debezium-connector-sqlserver</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>2.3.3.Final</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>debezium-connector-oracle</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>2.3.0.Final</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>debezium-connector-oracle</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>2.3.3.Final</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>debezium-connector-db2</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>2.3.0.Final</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>debezium-connector-db2</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>2.3.3.Final</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>debezium-connector-spanner</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>2.3.0.Final</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>debezium-connector-spanner</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>2.3.3.Final</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>debezium-connector-vitess</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>2.3.0.Final</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>debezium-connector-vitess</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>2.3.3.Final</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>debezium-connector-cassandra-3</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>2.3.0.Final</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>debezium-connector-cassandra-3</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>2.3.3.Final</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>debezium-connector-cassandra-4</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>2.3.0.Final</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>debezium-connector-cassandra-4</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>2.3.3.Final</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>debezium-testing-testcontainers</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>2.3.0.Final</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>debezium-testing-testcontainers</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>2.3.3.Final</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>debezium-schema-generator</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>2.3.0.Final</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>debezium-schema-generator</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>2.3.3.Final</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>debezium-quarkus-outbox</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>2.3.0.Final</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>debezium-quarkus-outbox</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>2.3.3.Final</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>debezium-quarkus-outbox-deployment</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>2.3.0.Final</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>debezium-quarkus-outbox-deployment</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>2.3.3.Final</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>debezium-core</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>2.3.0.Final</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <type>test-jar</type><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>debezium-core</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>2.3.3.Final</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <type>test-jar</type><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>debezium-embedded</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>2.3.0.Final</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <type>test-jar</type><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>debezium-embedded</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>2.3.3.Final</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <type>test-jar</type><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>debezium-connector-mysql</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>2.3.0.Final</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <type>test-jar</type><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>debezium-connector-mysql</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>2.3.3.Final</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <type>test-jar</type><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
         <groupId>com.hazelcast</groupId><!-- com.hazelcast:quarkus-hazelcast-client-bom:4.0.0 -->

--- a/poms/bom/src/main/generated/flattened-reduced-pom.xml
+++ b/poms/bom/src/main/generated/flattened-reduced-pom.xml
@@ -7680,69 +7680,69 @@
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-api</artifactId>
-        <version>2.3.0.Final</version>
+        <version>2.3.3.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-core</artifactId>
-        <version>2.3.0.Final</version>
+        <version>2.3.3.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-storage-kafka</artifactId>
-        <version>2.3.0.Final</version>
+        <version>2.3.3.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-storage-file</artifactId>
-        <version>2.3.0.Final</version>
+        <version>2.3.3.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-embedded</artifactId>
-        <version>2.3.0.Final</version>
+        <version>2.3.3.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-connector-postgres</artifactId>
-        <version>2.3.0.Final</version>
+        <version>2.3.3.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-connector-mysql</artifactId>
-        <version>2.3.0.Final</version>
+        <version>2.3.3.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-ddl-parser</artifactId>
-        <version>2.3.0.Final</version>
+        <version>2.3.3.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-connector-mongodb</artifactId>
-        <version>2.3.0.Final</version>
+        <version>2.3.3.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-connector-sqlserver</artifactId>
-        <version>2.3.0.Final</version>
+        <version>2.3.3.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-core</artifactId>
-        <version>2.3.0.Final</version>
+        <version>2.3.3.Final</version>
         <type>test-jar</type>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-embedded</artifactId>
-        <version>2.3.0.Final</version>
+        <version>2.3.3.Final</version>
         <type>test-jar</type>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-connector-mysql</artifactId>
-        <version>2.3.0.Final</version>
+        <version>2.3.3.Final</version>
         <type>test-jar</type>
       </dependency>
       <dependency>

--- a/poms/bom/src/main/generated/flattened-reduced-verbose-pom.xml
+++ b/poms/bom/src/main/generated/flattened-reduced-verbose-pom.xml
@@ -7632,9 +7632,9 @@
         <version>25.1-jre-graal-sub-1</version><!-- com.datastax.oss:java-driver-bom:4.15.0 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.kafka</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>connect-api</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>3.4.0</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>org.apache.kafka</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>connect-api</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>3.4.0</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
         <exclusions>
           <exclusion>
             <groupId>javax.ws.rs</groupId>
@@ -7643,107 +7643,107 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.kafka</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>connect-json</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>3.4.0</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>org.apache.kafka</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>connect-json</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>3.4.0</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>org.apache.kafka</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>connect-file</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>3.4.0</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>org.apache.kafka</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>connect-file</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>3.4.0</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>org.apache.kafka</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>connect-transforms</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>3.4.0</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>org.apache.kafka</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>connect-transforms</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>3.4.0</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>com.mysql</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>mysql-connector-j</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>8.0.33</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>com.mysql</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>mysql-connector-j</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>8.0.33</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>com.zendesk</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>mysql-binlog-connector-java</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>0.27.2</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>com.zendesk</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>mysql-binlog-connector-java</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>0.27.2</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>io.dropwizard.metrics</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>metrics-core</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>4.0.1</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>io.dropwizard.metrics</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>metrics-core</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>4.0.1</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>org.reflections</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>reflections</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>0.9.12</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>org.reflections</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>reflections</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>0.9.12</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>debezium-api</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>2.3.0.Final</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>debezium-api</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>2.3.3.Final</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>debezium-core</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>2.3.0.Final</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>debezium-core</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>2.3.3.Final</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>debezium-storage-kafka</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>2.3.0.Final</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>debezium-storage-kafka</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>2.3.3.Final</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>debezium-storage-file</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>2.3.0.Final</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>debezium-storage-file</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>2.3.3.Final</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>debezium-embedded</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>2.3.0.Final</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>debezium-embedded</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>2.3.3.Final</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>debezium-connector-postgres</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>2.3.0.Final</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>debezium-connector-postgres</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>2.3.3.Final</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>debezium-connector-mysql</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>2.3.0.Final</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>debezium-connector-mysql</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>2.3.3.Final</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>debezium-ddl-parser</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>2.3.0.Final</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>debezium-ddl-parser</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>2.3.3.Final</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>debezium-connector-mongodb</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>2.3.0.Final</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>debezium-connector-mongodb</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>2.3.3.Final</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>debezium-connector-sqlserver</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>2.3.0.Final</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>debezium-connector-sqlserver</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>2.3.3.Final</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>debezium-core</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>2.3.0.Final</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <type>test-jar</type><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>debezium-core</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>2.3.3.Final</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <type>test-jar</type><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>debezium-embedded</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>2.3.0.Final</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <type>test-jar</type><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>debezium-embedded</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>2.3.3.Final</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <type>test-jar</type><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
-        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <artifactId>debezium-connector-mysql</artifactId><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <version>2.3.0.Final</version><!-- io.debezium:debezium-bom:2.3.0.Final -->
-        <type>test-jar</type><!-- io.debezium:debezium-bom:2.3.0.Final -->
+        <groupId>io.debezium</groupId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <artifactId>debezium-connector-mysql</artifactId><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <version>2.3.3.Final</version><!-- io.debezium:debezium-bom:2.3.3.Final -->
+        <type>test-jar</type><!-- io.debezium:debezium-bom:2.3.3.Final -->
       </dependency>
       <dependency>
         <groupId>com.hazelcast</groupId><!-- com.hazelcast:quarkus-hazelcast-client-bom:4.0.0 -->


### PR DESCRIPTION
Debezium has been pretty broken since CQ 3.x. This version bump at least aligns things with the Quarkus Platform.