### PR TITLE
Make HazelcastInstanceTest wait and verify new cluster member is shutdown

### DIFF
--- a/integration-tests/hazelcast/src/test/java/org/apache/camel/quarkus/component/hazelcast/it/HazelcastListTest.java
+++ b/integration-tests/hazelcast/src/test/java/org/apache/camel/quarkus/component/hazelcast/it/HazelcastListTest.java
@@ -25,7 +25,6 @@ import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.given;
@@ -37,7 +36,6 @@ import static org.hamcrest.Matchers.equalTo;
 @QuarkusTestResource(HazelcastTestResource.class)
 public class HazelcastListTest {
 
-    @Disabled("https://github.com/apache/camel-quarkus/issues/4989")
     @SuppressWarnings("unchecked")
     @Test
     public void testList() {

--- a/integration-tests/hazelcast/src/test/java/org/apache/camel/quarkus/component/hazelcast/it/HazelcastTestResource.java
+++ b/integration-tests/hazelcast/src/test/java/org/apache/camel/quarkus/component/hazelcast/it/HazelcastTestResource.java
@@ -24,11 +24,10 @@ import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 
 public class HazelcastTestResource implements QuarkusTestResourceLifecycleManager {
     private volatile HazelcastInstance member;
-    private static volatile HazelcastInstance member2;
 
     @Override
     public Map<String, String> start() {
-        member = Hazelcast.newHazelcastInstance();
+        member = addMemberToCluster();
         return null;
     }
 
@@ -37,17 +36,12 @@ public class HazelcastTestResource implements QuarkusTestResourceLifecycleManage
         if (member != null) {
             member.shutdown();
         }
-
-        if (member2 != null) {
-            member.shutdown();
-        }
     }
 
     /**
      * this is used to test new instance in the same cluster
      */
-    public static void addMemberToCluster() {
-        member2 = Hazelcast.newHazelcastInstance();
+    public static HazelcastInstance addMemberToCluster() {
+        return Hazelcast.newHazelcastInstance();
     }
-
 }


### PR DESCRIPTION
Pretty much the same fix as #5082 but with verifying the cluster member was shut down.

Hopefully it makes things more stable. I managed 100 JVM mode test runs without failure.