### PR TITLE
Switch to org.wiremock:wiremock-standalone

### DIFF
--- a/integration-tests-support/wiremock/pom.xml
+++ b/integration-tests-support/wiremock/pom.xml
@@ -39,8 +39,8 @@
             <artifactId>camel-quarkus-integration-test-support-mock-backend</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock</artifactId>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock-standalone</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>

--- a/integration-tests/oaipmh/pom.xml
+++ b/integration-tests/oaipmh/pom.xml
@@ -68,11 +68,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-servlet</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-integration-test-support</artifactId>
             <scope>test</scope>
@@ -83,13 +78,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock</artifactId>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock-standalone</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.servlet</groupId>
-            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
     </dependencies>
 

--- a/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenStackTestResource.java
+++ b/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenStackTestResource.java
@@ -18,8 +18,6 @@ package org.apache.camel.quarkus.component.openstack.it;
 
 import java.util.Map;
 
-import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
-import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer;
 import org.apache.camel.quarkus.test.wiremock.WireMockTestResourceLifecycleManager;
 
 public class OpenStackTestResource extends WireMockTestResourceLifecycleManager {
@@ -41,10 +39,4 @@ public class OpenStackTestResource extends WireMockTestResourceLifecycleManager 
     protected boolean isMockingEnabled() {
         return true;
     }
-
-    @Override
-    protected void customizeWiremockConfiguration(WireMockConfiguration config) {
-        config.extensions(new ResponseTemplateTransformer(false));
-    }
-
 }

--- a/integration-tests/salesforce/src/test/java/org/apache/camel/quarkus/component/salesforce/SalesforceTestResource.java
+++ b/integration-tests/salesforce/src/test/java/org/apache/camel/quarkus/component/salesforce/SalesforceTestResource.java
@@ -18,8 +18,6 @@ package org.apache.camel.quarkus.component.salesforce;
 
 import java.util.Map;
 
-import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
-import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer;
 import org.apache.camel.quarkus.test.wiremock.WireMockTestResourceLifecycleManager;
 
 public class SalesforceTestResource extends WireMockTestResourceLifecycleManager {
@@ -50,10 +48,4 @@ public class SalesforceTestResource extends WireMockTestResourceLifecycleManager
         }
         return options;
     }
-
-    @Override
-    protected void customizeWiremockConfiguration(WireMockConfiguration config) {
-        config.extensions(new ResponseTemplateTransformer(false));
-    }
-
 }

--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@
         <pdfbox.version>${pdfbox-version}</pdfbox.version>
         <sshd.version>2.10.0</sshd.version><!-- @sync io.quarkus:quarkus-bom:${quarkus.version} dep:org.apache.sshd:sshd-common -->
         <unboundid-ldapsdk.version>6.0.11</unboundid-ldapsdk.version>
-        <wiremock.version>3.0.0-beta-10</wiremock.version>
+        <wiremock.version>3.3.1</wiremock.version>
         <zt-exec.version>1.12</zt-exec.version>
 
         <!-- Tooling dependency versions (keep sorted alphabetically) -->

--- a/poms/bom-test/pom.xml
+++ b/poms/bom-test/pom.xml
@@ -342,8 +342,8 @@
                 </exclusions>
             </dependency>
             <dependency>
-                <groupId>com.github.tomakehurst</groupId>
-                <artifactId>wiremock</artifactId>
+                <groupId>org.wiremock</groupId>
+                <artifactId>wiremock-standalone</artifactId>
                 <version>${wiremock.version}</version>
                 <exclusions>
                     <exclusion>


### PR DESCRIPTION
The main motivation here is to try and help with #5592. With `wiremock-standalone` Jetty is shaded, so we should be less vulnerable to issues from Jetty version upgrades.