### PR TITLE
Fix disablement of InfinispanTest.query on JUnit 5.10.1

### DIFF
--- a/integration-tests/infinispan/src/main/java/org/apache/camel/quarkus/component/infinispan/InfinispanRoutes.java
+++ b/integration-tests/infinispan/src/main/java/org/apache/camel/quarkus/component/infinispan/InfinispanRoutes.java
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.camel.quarkus.component.infinispan;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/integration-tests/infinispan/src/test/java/InfinispanTest.java
+++ b/integration-tests/infinispan/src/test/java/InfinispanTest.java
@@ -21,6 +21,7 @@ import io.restassured.RestAssured;
 import org.apache.camel.quarkus.component.infinispan.common.InfinispanCommonTest;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.Matchers.is;
 
@@ -37,8 +38,8 @@ public class InfinispanTest extends InfinispanCommonTest {
     }
 
     @Disabled
+    @Test
     @Override
     public void query() {
-        super.query();
     }
 }

--- a/integration-tests/infinispan/src/test/java/org/apache/camel/quarkus/component/infinispan/InfinispanIT.java
+++ b/integration-tests/infinispan/src/test/java/org/apache/camel/quarkus/component/infinispan/InfinispanIT.java
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.camel.quarkus.component.infinispan;
 
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 

--- a/integration-tests/infinispan/src/test/java/org/apache/camel/quarkus/component/infinispan/InfinispanServerTestResource.java
+++ b/integration-tests/infinispan/src/test/java/org/apache/camel/quarkus/component/infinispan/InfinispanServerTestResource.java
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.camel.quarkus.component.infinispan;
 
 import java.util.Map;
 

--- a/integration-tests/infinispan/src/test/java/org/apache/camel/quarkus/component/infinispan/InfinispanTest.java
+++ b/integration-tests/infinispan/src/test/java/org/apache/camel/quarkus/component/infinispan/InfinispanTest.java
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.camel.quarkus.component.infinispan;
 
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;


### PR DESCRIPTION
Fixes an issue encountered on `quarkus-main` & JUnit 5.10.1