### PR TITLE
Revert upload / download artifact GitHub action upgrade

### DIFF
--- a/.github/workflows/camel-master-cron.yaml
+++ b/.github/workflows/camel-master-cron.yaml
@@ -129,7 +129,7 @@ jobs:
       matrix: ${{ fromJson(needs.initial-mvn-install.outputs.matrix) }}
     steps:
       - name: Download Maven Repo
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: maven-repo
           path: ..
@@ -210,7 +210,7 @@ jobs:
       MAVEN_OPTS: -Xmx3000m
     steps:
       - name: Download Maven Repo
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: maven-repo
           path: ..
@@ -286,7 +286,7 @@ jobs:
       MAVEN_OPTS: -Xmx3000m
     steps:
       - name: Download Maven Repo
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: maven-repo
           path: ..
@@ -343,7 +343,7 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
       - name: Download Maven Repo
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: maven-repo
           path: ..
@@ -372,7 +372,7 @@ jobs:
       MAVEN_OPTS: -Xmx3000m
     steps:
       - name: Download Maven Repo
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: maven-repo
           path: ..
@@ -424,7 +424,7 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
       - name: Download Maven Repo
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: maven-repo
           path: ..
@@ -505,7 +505,7 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
       - name: Download Maven Repo
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: maven-repo
           path: ..

--- a/.github/workflows/camel-master-cron.yaml
+++ b/.github/workflows/camel-master-cron.yaml
@@ -87,7 +87,7 @@ jobs:
           ls -lh ${{ runner.temp }}/maven-repo.tgz
           df -h /
       - name: Persist Maven Repo
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: maven-repo
           path: ${{ runner.temp }}/maven-repo.tgz

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -227,7 +227,7 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
       - name: Download Maven Repo
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: maven-repo
           path: ..
@@ -301,7 +301,7 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
       - name: Download Maven Repo
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: maven-repo
           path: ..
@@ -371,7 +371,7 @@ jobs:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
       - name: Download Maven Repo
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: maven-repo
           path: ..
@@ -413,7 +413,7 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
       - name: Download Maven Repo
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: maven-repo
           path: ..
@@ -458,7 +458,7 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
       - name: Download Maven Repo
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: maven-repo
           path: ..
@@ -496,7 +496,7 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
       - name: Download Maven Repo
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: maven-repo
           path: ..

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -110,7 +110,7 @@ jobs:
             echo "continue-build=true" >> $GITHUB_OUTPUT
           fi
       - name: Upload dependabot changeset
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         if: steps.pre-build-checks.outputs.continue-build == 'false'
         with:
           name: dependabot-pr-changeset
@@ -177,7 +177,7 @@ jobs:
           ls -lh ${{ runner.temp }}/maven-repo.tgz
           df -h /
       - name: Persist Maven Repo
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: maven-repo
           path: ${{ runner.temp }}/maven-repo.tgz

--- a/.github/workflows/quarkus-master-cron.yaml
+++ b/.github/workflows/quarkus-master-cron.yaml
@@ -88,7 +88,7 @@ jobs:
           ls -lh ${{ runner.temp }}/maven-repo.tgz
           df -h /
       - name: Persist Maven Repo
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: maven-repo
           path: ${{ runner.temp }}/maven-repo.tgz

--- a/.github/workflows/quarkus-master-cron.yaml
+++ b/.github/workflows/quarkus-master-cron.yaml
@@ -130,7 +130,7 @@ jobs:
       matrix: ${{ fromJson(needs.initial-mvn-install.outputs.matrix) }}
     steps:
       - name: Download Maven Repo
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: maven-repo
           path: ..
@@ -211,7 +211,7 @@ jobs:
       MAVEN_OPTS: -Xmx3000m
     steps:
       - name: Download Maven Repo
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: maven-repo
           path: ..
@@ -287,7 +287,7 @@ jobs:
       MAVEN_OPTS: -Xmx3000m
     steps:
       - name: Download Maven Repo
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: maven-repo
           path: ..
@@ -344,7 +344,7 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
       - name: Download Maven Repo
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: maven-repo
           path: ..
@@ -373,7 +373,7 @@ jobs:
       MAVEN_OPTS: -Xmx3000m
     steps:
       - name: Download Maven Repo
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: maven-repo
           path: ..
@@ -425,7 +425,7 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
       - name: Download Maven Repo
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: maven-repo
           path: ..
@@ -506,7 +506,7 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
       - name: Download Maven Repo
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: maven-repo
           path: ..


### PR DESCRIPTION
Downloading seems to be very flaky with v4. Some similar reports here:

https://github.com/orgs/community/discussions/81413

Hence restoring build stability for now.