### PR TITLE
Add option to skip sanity-checks script execution

### DIFF
--- a/tooling/scripts/sanity-checks.groovy
+++ b/tooling/scripts/sanity-checks.groovy
@@ -20,11 +20,17 @@ import java.nio.file.Paths
 
 
 // check bad dependencies
+final Boolean skip = Boolean.getBoolean("sanity-checks.skip")
 final List<String> badDeps = []
 final File pomXml = new File(project.basedir, "pom.xml")
 
 final Path treeRootDir = Paths.get(System.getProperty('maven.multiModuleProjectDirectory'))
 final Path relativePomPath = treeRootDir.relativize(pomXml.toPath().normalize())
+
+if (skip) {
+    println "Sanity checks are disabled"
+    return
+}
 
 if (pomXml.exists()) {
     def pomXmlProject = new XmlParser().parseText(pomXml.getText('UTF-8'))


### PR DESCRIPTION
I find this useful when I want to do quick experiments and not have the build fail due to checks on Maven version properties etc. 