### PR TITLE
Make alternative-jdk job a matrix build

### DIFF
--- a/.github/workflows/camel-master-cron.yaml
+++ b/.github/workflows/camel-master-cron.yaml
@@ -36,6 +36,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-native-matrix.outputs.matrix }}
       examples-matrix: ${{ steps.set-examples-matrix.outputs.examples-matrix }}
+      alternate-jvm-matrix: ${{ steps.set-alternate-jvm-matrix.outputs.alternate-jvm-matrix }}
     env:
       MAVEN_OPTS: -Xmx4500m
     steps:
@@ -97,6 +98,15 @@ jobs:
         run: |
           CATEGORIES=$(yq -M -N -I 0 -o=json e 'keys' tooling/scripts/test-categories.yaml | tr '"' "'")
           echo "matrix={'category': ${CATEGORIES}}" >> $GITHUB_OUTPUT
+      - name: Setup Alternate JVM Matrix
+        id: set-alternate-jvm-matrix
+        shell: bash
+        run: |
+          cd integration-tests
+          mvn help:evaluate -Dexpression=project.modules -N -q -DforceStdout | sed -e 's/<[^>]*>//g' -e 's/^[[:space:]]*//' -e '/^$/d' > ${{ runner.temp }}/itest-modules.txt
+          GROUP1_MODULES=$(cat ${{ runner.temp }}/itest-modules.txt | grep -E '^[a-m].*' | tr '\n' ',' | sed 's/,$//')
+          GROUP2_MODULES=$(cat ${{ runner.temp }}/itest-modules.txt | grep -E '^[n-z].*' | tr '\n' ',' | sed 's/,$//')
+          echo "alternate-jvm-matrix={'include': [{'name': 'group-01', 'modules': '${GROUP1_MODULES}'},{'name': 'group-02', 'modules': '${GROUP2_MODULES}'}]}" >> $GITHUB_OUTPUT
       - name: Setup Examples Matrix
         id: set-examples-matrix
         run: |
@@ -138,6 +148,7 @@ jobs:
         run: |
           df -h /
           tar -xzf ../maven-repo.tgz -C ~
+          rm -f ../maven-repo.tgz
           df -h /
       - name: Checkout
         uses: actions/checkout@v4
@@ -219,6 +230,7 @@ jobs:
         run: |
           df -h /
           tar -xzf ../maven-repo.tgz -C ~
+          rm -f ../maven-repo.tgz
           df -h /
       - name: Checkout
         uses: actions/checkout@v4
@@ -295,6 +307,7 @@ jobs:
         run: |
           df -h /
           tar -xzf ../maven-repo.tgz -C ~
+          rm -f ../maven-repo.tgz
           df -h /
       - name: Checkout
         uses: actions/checkout@v4
@@ -327,6 +340,9 @@ jobs:
   integration-tests-alternative-jdk:
     runs-on: ubuntu-latest
     needs: initial-mvn-install
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.initial-mvn-install.outputs.alternate-jvm-matrix) }}
     env:
       MAVEN_OPTS: -Xmx3000m
     steps:
@@ -358,11 +374,16 @@ jobs:
         run: |
           df -h /
           tar -xzf ../maven-repo.tgz -C ~
+          rm -f ../maven-repo.tgz
           df -h /
       - name: cd integration-tests && mvn clean verify
+        shell: bash
+        env:
+          TEST_MODULES: ${{matrix.modules}}
         run: |
           cd integration-tests
           ../mvnw ${CQ_MAVEN_ARGS} ${BRANCH_OPTIONS} \
+            -pl "${TEST_MODULES// /,}" \
             -Dformatter.skip -Dimpsort.skip -Denforcer.skip \
             --fail-at-end \
             clean verify
@@ -386,6 +407,7 @@ jobs:
         shell: bash
         run: |
           tar -xzf ../maven-repo.tgz -C ~
+          rm -f ../maven-repo.tgz
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -439,6 +461,7 @@ jobs:
         run: |
           df -h /
           tar -xzf ../maven-repo.tgz -C ~
+          rm -f ../maven-repo.tgz
           df -h /
       - name: Checkout
         uses: actions/checkout@v4
@@ -520,6 +543,7 @@ jobs:
         run: |
           df -h /
           tar -xzf ../maven-repo.tgz -C ~
+          rm -f ../maven-repo.tgz
           df -h /
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -124,6 +124,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-native-matrix.outputs.matrix }}
       examples-matrix: ${{ steps.set-examples-matrix.outputs.examples-matrix }}
+      alternate-jvm-matrix: ${{ steps.set-alternate-jvm-matrix.outputs.alternate-jvm-matrix }}
     env:
       MAVEN_OPTS: -Xmx4500m
     steps:
@@ -187,6 +188,15 @@ jobs:
         run: |
           CATEGORIES=$(yq -M -N -I 0 -o=json e 'keys' tooling/scripts/test-categories.yaml | tr '"' "'")
           echo "matrix={'category': ${CATEGORIES}}" >> $GITHUB_OUTPUT
+      - name: Setup Alternate JVM Matrix
+        id: set-alternate-jvm-matrix
+        shell: bash
+        run: |
+          cd integration-tests
+          mvn help:evaluate -Dexpression=project.modules -N -q -DforceStdout | sed -e 's/<[^>]*>//g' -e 's/^[[:space:]]*//' -e '/^$/d' > ${{ runner.temp }}/itest-modules.txt
+          GROUP1_MODULES=$(cat ${{ runner.temp }}/itest-modules.txt | grep -E '^[a-m].*' | tr '\n' ',' | sed 's/,$//')
+          GROUP2_MODULES=$(cat ${{ runner.temp }}/itest-modules.txt | grep -E '^[n-z].*' | tr '\n' ',' | sed 's/,$//')
+          echo "alternate-jvm-matrix={'include': [{'name': 'group-01', 'modules': '${GROUP1_MODULES}'},{'name': 'group-02', 'modules': '${GROUP2_MODULES}'}]}" >> $GITHUB_OUTPUT
       - name: Setup Examples Matrix
         id: set-examples-matrix
         run: |
@@ -236,6 +246,7 @@ jobs:
         run: |
           df -h /
           tar -xzf ../maven-repo.tgz -C ~
+          rm -f ../maven-repo.tgz
           df -h /
       - name: Integration Tests
         run: |
@@ -310,6 +321,7 @@ jobs:
         run: |
           df -h /
           tar -xzf ../maven-repo.tgz -C ~
+          rm -f ../maven-repo.tgz
           df -h /
       - name: cd extensions-core && mvn test
         run: |
@@ -380,6 +392,7 @@ jobs:
         run: |
           df -h /
           tar -xzf ../maven-repo.tgz -C ~
+          rm -f ../maven-repo.tgz
           df -h /
       - name: cd integration-tests-jvm && mvn clean test
         run: |
@@ -390,9 +403,13 @@ jobs:
             clean test
 
   integration-tests-alternative-jdk:
+    name: Integration Tests Alternative JDK 21 ${{matrix.name}}
     runs-on: ubuntu-latest
     needs: initial-mvn-install
     if: github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'JVM')
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.initial-mvn-install.outputs.alternate-jvm-matrix) }}
     env:
       MAVEN_OPTS: -Xmx3000m
     steps:
@@ -422,11 +439,16 @@ jobs:
         run: |
           df -h /
           tar -xzf ../maven-repo.tgz -C ~
+          rm -f ../maven-repo.tgz
           df -h /
       - name: cd integration-tests && mvn clean verify
+        shell: bash
+        env:
+          TEST_MODULES: ${{matrix.modules}}
         run: |
           cd integration-tests
           ../mvnw ${CQ_MAVEN_ARGS} ${BRANCH_OPTIONS} \
+            -pl "${TEST_MODULES// /,}" \
             -Dformatter.skip -Dimpsort.skip -Denforcer.skip \
             --fail-at-end \
             clean verify
@@ -466,6 +488,7 @@ jobs:
         shell: bash
         run: |
           tar -xzf ../maven-repo.tgz -C ~
+          rm -f ../maven-repo.tgz
       - name: cd integration-tests && mvn clean verify
         shell: bash
         run: |
@@ -505,6 +528,7 @@ jobs:
         run: |
           df -h /
           tar -xzf ../maven-repo.tgz -C ~
+          rm -f ../maven-repo.tgz
           df -h /
       - name: set CQ_VERSION
         run: echo "CQ_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout -N)" >> $GITHUB_ENV

--- a/.github/workflows/quarkus-master-cron.yaml
+++ b/.github/workflows/quarkus-master-cron.yaml
@@ -36,6 +36,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-native-matrix.outputs.matrix }}
       examples-matrix: ${{ steps.set-examples-matrix.outputs.examples-matrix }}
+      alternate-jvm-matrix: ${{ steps.set-alternate-jvm-matrix.outputs.alternate-jvm-matrix }}
     env:
       MAVEN_OPTS: -Xmx4500m
     steps:
@@ -98,6 +99,15 @@ jobs:
         run: |
           CATEGORIES=$(yq -M -N -I 0 -o=json e 'keys' tooling/scripts/test-categories.yaml | tr '"' "'")
           echo "matrix={'category': ${CATEGORIES}}" >> $GITHUB_OUTPUT
+      - name: Setup Alternate JVM Matrix
+        id: set-alternate-jvm-matrix
+        shell: bash
+        run: |
+          cd integration-tests
+          mvn help:evaluate -Dexpression=project.modules -N -q -DforceStdout | sed -e 's/<[^>]*>//g' -e 's/^[[:space:]]*//' -e '/^$/d' > ${{ runner.temp }}/itest-modules.txt
+          GROUP1_MODULES=$(cat ${{ runner.temp }}/itest-modules.txt | grep -E '^[a-m].*' | tr '\n' ',' | sed 's/,$//')
+          GROUP2_MODULES=$(cat ${{ runner.temp }}/itest-modules.txt | grep -E '^[n-z].*' | tr '\n' ',' | sed 's/,$//')
+          echo "alternate-jvm-matrix={'include': [{'name': 'group-01', 'modules': '${GROUP1_MODULES}'},{'name': 'group-02', 'modules': '${GROUP2_MODULES}'}]}" >> $GITHUB_OUTPUT
       - name: Setup Examples Matrix
         id: set-examples-matrix
         run: |
@@ -139,6 +149,7 @@ jobs:
         run: |
           df -h /
           tar -xzf ../maven-repo.tgz -C ~
+          rm -f ../maven-repo.tgz
           df -h /
       - name: Checkout
         uses: actions/checkout@v4
@@ -220,6 +231,7 @@ jobs:
         run: |
           df -h /
           tar -xzf ../maven-repo.tgz -C ~
+          rm -f ../maven-repo.tgz
           df -h /
       - name: Checkout
         uses: actions/checkout@v4
@@ -296,6 +308,7 @@ jobs:
         run: |
           df -h /
           tar -xzf ../maven-repo.tgz -C ~
+          rm -f ../maven-repo.tgz
           df -h /
       - name: Checkout
         uses: actions/checkout@v4
@@ -328,6 +341,9 @@ jobs:
   integration-tests-alternative-jdk:
     runs-on: ubuntu-latest
     needs: initial-mvn-install
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.initial-mvn-install.outputs.alternate-jvm-matrix) }}
     env:
       MAVEN_OPTS: -Xmx3000m
     steps:
@@ -359,11 +375,16 @@ jobs:
         run: |
           df -h /
           tar -xzf ../maven-repo.tgz -C ~
+          rm -f ../maven-repo.tgz
           df -h /
       - name: cd integration-tests && mvn clean verify
+        shell: bash
+        env:
+          TEST_MODULES: ${{matrix.modules}}
         run: |
           cd integration-tests
           ../mvnw ${CQ_MAVEN_ARGS} ${BRANCH_OPTIONS} \
+            -pl "${TEST_MODULES// /,}" \
             -Dformatter.skip -Dimpsort.skip -Denforcer.skip \
             --fail-at-end \
             clean verify
@@ -387,6 +408,7 @@ jobs:
         shell: bash
         run: |
           tar -xzf ../maven-repo.tgz -C ~
+          rm -f ../maven-repo.tgz
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -440,6 +462,7 @@ jobs:
         run: |
           df -h /
           tar -xzf ../maven-repo.tgz -C ~
+          rm -f ../maven-repo.tgz
           df -h /
       - name: Checkout
         uses: actions/checkout@v4
@@ -521,6 +544,7 @@ jobs:
         run: |
           df -h /
           tar -xzf ../maven-repo.tgz -C ~
+          rm -f ../maven-repo.tgz
           df -h /
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
The `integration-tests-alternative-jdk` CI job has been failing for reasons that I cannot determine. I suspect it's due to running out of disk space. Hence this attempt at reclaiming some space.