### PR TITLE
Remove ssr-dom-shim dependency override

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,6 @@
         <snakeyaml-engine.version>${snakeyaml-engine-version}</snakeyaml-engine.version><!-- Resolve conflict between camel-snakeyaml & kubernetes-client -->
         <spring.version>${spring-version}</spring.version>
         <spring.data.redis.version>${spring-data-redis-version}</spring.data.redis.version>
-        <ssr-dom-shim.version>1.1.2-pre.1</ssr-dom-shim.version><!-- Resolves conflict brought by Quarkus-vertx-http-dev-ui-resources - quick solution -->
         <tablesaw.version>0.43.1</tablesaw.version>
         <threetenbp.version>1.6.0</threetenbp.version>
         <xalan.version>2.7.2</xalan.version><!-- Xalan should be removed as is in Camel, but it is not possible. https://github.com/apache/camel-quarkus/issues/4065-->

--- a/poms/bom/pom.xml
+++ b/poms/bom/pom.xml
@@ -6783,11 +6783,6 @@
                 <version>${mybatis.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.mvnpm.at.lit-labs</groupId>
-                <artifactId>ssr-dom-shim</artifactId>
-                <version>${ssr-dom-shim.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.optaplanner</groupId>
                 <artifactId>optaplanner-quarkus</artifactId>
                 <version>${optaplanner.version}</version>

--- a/poms/bom/src/main/generated/flattened-full-pom.xml
+++ b/poms/bom/src/main/generated/flattened-full-pom.xml
@@ -6706,11 +6706,6 @@
         <version>3.5.15</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
       </dependency>
       <dependency>
-        <groupId>org.mvnpm.at.lit-labs</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <artifactId>ssr-dom-shim</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <version>1.1.2-pre.1</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-      </dependency>
-      <dependency>
         <groupId>org.optaplanner</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>optaplanner-quarkus</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <version>9.37.0.Final</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
@@ -22718,6 +22713,12 @@
         <groupId>org.mockito</groupId><!-- io.quarkus:quarkus-bom:3.0.0.Final -->
         <artifactId>mockito-inline</artifactId><!-- io.quarkus:quarkus-bom:3.0.0.Final -->
         <version>5.2.0</version><!-- io.quarkus:quarkus-bom:3.0.0.Final -->
+      </dependency>
+      <dependency>
+        <groupId>org.mvnpm.at.lit-labs</groupId><!-- io.quarkus:quarkus-bom:3.0.0.Final -->
+        <artifactId>ssr-dom-shim</artifactId><!-- io.quarkus:quarkus-bom:3.0.0.Final -->
+        <version>1.1.0</version><!-- io.quarkus:quarkus-bom:3.0.0.Final -->
+        <scope>runtime</scope><!-- io.quarkus:quarkus-bom:3.0.0.Final -->
       </dependency>
       <dependency>
         <groupId>org.mvnpm.at.lit</groupId><!-- io.quarkus:quarkus-bom:3.0.0.Final -->

--- a/poms/bom/src/main/generated/flattened-reduced-pom.xml
+++ b/poms/bom/src/main/generated/flattened-reduced-pom.xml
@@ -6606,11 +6606,6 @@
         <version>3.5.15</version>
       </dependency>
       <dependency>
-        <groupId>org.mvnpm.at.lit-labs</groupId>
-        <artifactId>ssr-dom-shim</artifactId>
-        <version>1.1.2-pre.1</version>
-      </dependency>
-      <dependency>
         <groupId>org.optaplanner</groupId>
         <artifactId>optaplanner-quarkus</artifactId>
         <version>9.37.0.Final</version>

--- a/poms/bom/src/main/generated/flattened-reduced-verbose-pom.xml
+++ b/poms/bom/src/main/generated/flattened-reduced-verbose-pom.xml
@@ -6606,11 +6606,6 @@
         <version>3.5.15</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
       </dependency>
       <dependency>
-        <groupId>org.mvnpm.at.lit-labs</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <artifactId>ssr-dom-shim</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <version>1.1.2-pre.1</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-      </dependency>
-      <dependency>
         <groupId>org.optaplanner</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>optaplanner-quarkus</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <version>9.37.0.Final</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->


### PR DESCRIPTION
I believe the dependency mess for ssr-dom-shim and its friends was resolved on the Quarkus side.