### PR TITLE
Enable java-joor-dsl & jsh-dsl tests on Windows

### DIFF
--- a/integration-tests/java-joor-dsl/src/test/java/org/apache/camel/quarkus/dsl/java/joor/JavaJoorDslTest.java
+++ b/integration-tests/java-joor-dsl/src/test/java/org/apache/camel/quarkus/dsl/java/joor/JavaJoorDslTest.java
@@ -21,12 +21,9 @@ import io.restassured.RestAssured;
 import org.apache.camel.dsl.java.joor.JavaRoutesBuilderLoader;
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 
-@DisabledOnOs(value = OS.WINDOWS, disabledReason = "https://github.com/apache/camel-quarkus/issues/5872")
 @QuarkusTest
 class JavaJoorDslTest {
 

--- a/integration-tests/jsh-dsl/src/test/java/org/apache/camel/quarkus/dsl/jsh/JshDslTest.java
+++ b/integration-tests/jsh-dsl/src/test/java/org/apache/camel/quarkus/dsl/jsh/JshDslTest.java
@@ -21,10 +21,7 @@ import io.restassured.RestAssured;
 import org.apache.camel.dsl.jsh.JshRoutesBuilderLoader;
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 
-@DisabledOnOs(value = OS.WINDOWS, disabledReason = "https://github.com/apache/camel-quarkus/issues/5873")
 @QuarkusTest
 class JshDslTest {
 


### PR DESCRIPTION
They seem to be passing for me on Windows after the upgrade to Quarkus 3.9.0.CR2.