### PR TITLE
Remove redundant parentFirstArtifact configuration from js-dsl extension

### DIFF
--- a/extensions/js-dsl/runtime/pom.xml
+++ b/extensions/js-dsl/runtime/pom.xml
@@ -57,16 +57,6 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-extension-maven-plugin</artifactId>
-                <configuration>
-                    <parentFirstArtifacts>
-                        <parentFirstArtifact>org.graalvm.sdk:nativeimage</parentFirstArtifact>
-                        <parentFirstArtifact>org.graalvm.nativeimage:svm</parentFirstArtifact>
-                        <parentFirstArtifact>org.graalvm.truffle:truffle-api</parentFirstArtifact>
-                        <parentFirstArtifact>org.graalvm.js:js</parentFirstArtifact>
-                        <parentFirstArtifact>org.graalvm.regex:regex</parentFirstArtifact>
-                        <parentFirstArtifact>com.ibm.icu:icu4j</parentFirstArtifact>
-                    </parentFirstArtifacts>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This configuration is already part of Quarkus Core.