### PR TITLE
Remove quarkus-cxf-rt-features-logging since it is deprecated

### DIFF
--- a/extensions/cxf-soap/deployment/pom.xml
+++ b/extensions/cxf-soap/deployment/pom.xml
@@ -42,10 +42,6 @@
             <groupId>io.quarkiverse.cxf</groupId>
             <artifactId>quarkus-cxf-deployment</artifactId>
         </dependency>
-        <dependency>
-            <groupId>io.quarkiverse.cxf</groupId>
-            <artifactId>quarkus-cxf-rt-features-logging-deployment</artifactId>
-        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/cxf-soap/runtime/pom.xml
+++ b/extensions/cxf-soap/runtime/pom.xml
@@ -48,10 +48,6 @@
             <groupId>io.quarkiverse.cxf</groupId>
             <artifactId>quarkus-cxf</artifactId>
         </dependency>
-        <dependency>
-            <groupId>io.quarkiverse.cxf</groupId>
-            <artifactId>quarkus-cxf-rt-features-logging</artifactId>
-        </dependency>
     </dependencies>
 
     <build>

--- a/integration-test-groups/cxf-soap/cxf-soap-ws-trust/pom.xml
+++ b/integration-test-groups/cxf-soap/cxf-soap-ws-trust/pom.xml
@@ -43,10 +43,6 @@
             <groupId>io.quarkiverse.cxf</groupId>
             <artifactId>quarkus-cxf-services-sts</artifactId>
         </dependency>
-        <dependency>
-            <groupId>io.quarkiverse.cxf</groupId>
-            <artifactId>quarkus-cxf-rt-features-logging</artifactId>
-        </dependency>
 
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
... and all functionality was moved to `quarkus-cxf`