### PR TITLE
Exclude faulttolerance package from MicroProfile integration test module javadoc

### DIFF
--- a/integration-tests/microprofile/pom.xml
+++ b/integration-tests/microprofile/pom.xml
@@ -95,6 +95,13 @@
                     </testExcludes>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <excludePackageNames>org.apache.camel.quarkus.component.microprofile.it.faulttolerance</excludePackageNames>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Due to #5995.