### PR TITLE
[CXF] Fix exception message expectation on windows

### DIFF
--- a/integration-test-groups/cxf-soap/cxf-soap-ws-security-client/src/test/java/org/apache/camel/quarkus/component/cxf/soap/wss/client/it/CxfSoapWssClientTest.java
+++ b/integration-test-groups/cxf-soap/cxf-soap-ws-security-client/src/test/java/org/apache/camel/quarkus/component/cxf/soap/wss/client/it/CxfSoapWssClientTest.java
@@ -43,7 +43,6 @@ import org.junit.jupiter.api.Test;
 import org.testcontainers.shaded.org.awaitility.Awaitility;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
 
 @QuarkusTest
 @QuarkusTestResource(CxfWssClientTestResource.class)
@@ -116,7 +115,7 @@ class CxfSoapWssClientTest {
                 //always fails because there is no server implementation
                 createSayHelloWrongClient().sayHelloWrong("Sheldon");
             } catch (SOAPFaultException e) {
-                return "Connection refused".equals(e.getMessage());
+                return e.getMessage() != null && e.getMessage().toLowerCase().contains("connection refused");
             }
             //can not happen (client does not work)
             return false;


### PR DESCRIPTION
please also backport to 3.8

on windows, the exception message is `Connection refused: no further information`, so it didn't match the expectation