### PR TITLE
MySql test does not work on FIPS enabled system

### DIFF
--- a/integration-test-groups/jdbc/mysql/README.adoc
+++ b/integration-test-groups/jdbc/mysql/README.adoc
@@ -1,0 +1,26 @@
+== JDBC MySql tests
+
+=== FIPS
+
+* To execute the tests on FIPS enabled system add `-Dfips` property so that tests will use prooper transformation for the password. Example of usage:
+
+`mvn clean test -Dfips`
+
+* Dev service (MySql docker image) does not start correctly on FIPS enabled system. Please use external database.
+
+To execute the tests against external database, provide the database's connection information by setting environment variables
+
+```
+export MYSQL_JDBC_URL=#jdbc_url
+export MYSQL_JDBC_USERNAME=#username
+export MYSQL_JDBC_PASSWORD=#password
+```
+
+or for windows:
+
+```
+$Env:MYSQL_JDBC_URL = "#jdbc_url"
+$Env:MYSQL_JDBC_USERNAME="#username"
+$Env:MYSQL_JDBC_PASSWORD
+```
+.

--- a/integration-test-groups/jdbc/mysql/pom.xml
+++ b/integration-test-groups/jdbc/mysql/pom.xml
@@ -265,6 +265,45 @@
                 <skipTests>true</skipTests>
             </properties>
         </profile>
+        <profile>
+            <id>fips</id>
+            <activation>
+                <property>
+                    <name>fips</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <quarkus.datasource.mysql.jdbc.additional-jdbc-properties.authenticationPlugins>org.apache.camel.quarkus.component.jdbc.mysql.Sha256FIPSPasswordPlugin</quarkus.datasource.mysql.jdbc.additional-jdbc-properties.authenticationPlugins>
+                                <quarkus.datasource.mysql.jdbc.additional-jdbc-properties.defaultAuthenticationPlugin>cq_fips_plugin</quarkus.datasource.mysql.jdbc.additional-jdbc-properties.defaultAuthenticationPlugin>
+                                <quarkus.datasource.mysql.devservices.enabled>false</quarkus.datasource.mysql.devservices.enabled>
+                                <quarkus.datasource.mysql.username>${env.MYSQL_JDBC_USERNAME}</quarkus.datasource.mysql.username>
+                                <quarkus.datasource.mysql.password>${env.MYSQL_JDBC_PASSWORD}</quarkus.datasource.mysql.password>
+                                <quarkus.datasource.mysql.jdbc.url>${env.MYSQL_JDBC_URL}</quarkus.datasource.mysql.jdbc.url>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <quarkus.datasource.mysql.jdbc.additional-jdbc-properties.authenticationPlugins>org.apache.camel.quarkus.component.jdbc.mysql.Sha256FIPSPasswordPlugin</quarkus.datasource.mysql.jdbc.additional-jdbc-properties.authenticationPlugins>
+                                <quarkus.datasource.mysql.jdbc.additional-jdbc-properties.defaultAuthenticationPlugin>cq_fips_plugin</quarkus.datasource.mysql.jdbc.additional-jdbc-properties.defaultAuthenticationPlugin>
+                                <quarkus.datasource.mysql.devservices.enabled>false</quarkus.datasource.mysql.devservices.enabled>
+                                <quarkus.datasource.mysql.username>${env.MYSQL_JDBC_USERNAME}</quarkus.datasource.mysql.username>
+                                <quarkus.datasource.mysql.password>${env.MYSQL_JDBC_PASSWORD}</quarkus.datasource.mysql.password>
+                                <quarkus.datasource.mysql.jdbc.url>${env.MYSQL_JDBC_URL}</quarkus.datasource.mysql.jdbc.url>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
-
 </project>

--- a/integration-test-groups/jdbc/mysql/src/main/java/org/apache/camel/quarkus/component/jdbc/mysql/Sha256FIPSPasswordPlugin.java
+++ b/integration-test-groups/jdbc/mysql/src/main/java/org/apache/camel/quarkus/component/jdbc/mysql/Sha256FIPSPasswordPlugin.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.jdbc.mysql;
+
+import com.mysql.cj.protocol.a.authentication.Sha256PasswordPlugin;
+
+public class Sha256FIPSPasswordPlugin extends Sha256PasswordPlugin {
+
+    public Sha256FIPSPasswordPlugin() {
+        super();
+    }
+
+    @Override
+    public String getProtocolPluginName() {
+        return "cq_fips_plugin";
+    }
+
+    @Override
+    protected byte[] encryptPassword() {
+        return encryptPassword("RSA/ECB/PKCS1Padding");
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/apache/camel-quarkus/issues/6061

MySql connection contains some security settings (e.g. authenticationPlugins) , where the default value does not work on FIPS system. (More information can be found in this ticket https://github.com/quarkusio/quarkus/issues/32910)

This PR adds a profile for FIPS , wich configures the connection in a way to work on FIPS. The required configuration (like the usage of external database) is described in the README.adoc.

I also created a follow-up ticket - https://github.com/apache/camel-quarkus/issues/6062 - because it sjhould be possible to provide such configuration Out of the box.


<!-- Uncomment and fill this section if your PR is not trivial
[ ] An issue should be filed for the change unless this is a trivial change (fixing a typo or similar). One issue should ideally be fixed by not more than one commit and the other way round, each commit should fix just one issue, without pulling in other changes.
[ ] Each commit in the pull request should have a meaningful and properly spelled subject line and body. Copying the title of the associated issue is typically enough. Please include the issue number in the commit message prefixed by #.
[ ] The pull request description should explain what the pull request does, how, and why. If the info is available in the associated issue or some other external document, a link is enough.
[ ] Phrases like Fix #<issueNumber> or Fixes #<issueNumber> will auto-close the named issue upon merging the pull request. Using them is typically a good idea.
[ ] Please run mvn process-resources -Pformat (and amend the changes if necessary) before sending the pull request.
[ ] Contributor guide is your good friend: https://camel.apache.org/camel-quarkus/latest/contributor-guide.html
-->