### PR TITLE
Add debugging to test-summary-report action

### DIFF
--- a/.github/actions/test-summary-report/action.yaml
+++ b/.github/actions/test-summary-report/action.yaml
@@ -46,6 +46,9 @@ runs:
           const junit = require('junit2json');
           const testReportGlobPattern = "${{ inputs.test-report-xml-base-dir }}/${{ inputs.test-report-xml-includes }}".replace(/\.+\/+/g, "")
           const summaryData = [];
+          const log = function(message) {
+            console.log(message);
+          };
 
           // Configure test summary table headers
           summaryData.push([
@@ -59,9 +62,14 @@ runs:
           const globber = await glob.create(testReportGlobPattern);
           for await (const reportFile of globber.globGenerator()) {
             const file = fs.readFileSync(reportFile);
+            log(`Found JUnit report: ${reportFile}`);
             const report = junit.parse(file).then((report) => {
+              log(`Report errors: ${report.errors}`);
+              log(`Report failures: ${report.failures}`);
               if (report.errors > 0 || report.failures > 0) {
+                log(`Test case count: ${report.testcase.length}`);
                 report.testcase.forEach((testCase) => {
+                  log(`Test case failure: ${testCase.failure}`);
                   if (testCase.failure !== undefined) {
                     const shortClassName = `<code>${testCase.classname.substring(testCase.classname.lastIndexOf('.') + 1)}</code>`;
                     const className = `<details><summary>${shortClassName}</summary>\n<code>${testCase.classname}</code></details>`;
@@ -75,6 +83,7 @@ runs:
                     if (message.length > 50) {
                       message = `<details><summary>View</summary>\n${message}</details>`;
                     }
+                    log(`Pushing summary detail to summaryData array`);
                     summaryData.push([className, testName, message, details]);
                   }
                 });
@@ -83,7 +92,10 @@ runs:
           }
 
           // Write the summary data if there were test failures
+          log(`summaryData array length: ${summaryData.length}`);
           if (summaryData.length > 1) {
+            log(`Writing summary`);
+            log(summaryData);
             await core.summary
               .addHeading("Test Failures", "3")
               .addTable(summaryData)


### PR DESCRIPTION
I don't see the test summary being visible on `push` events, or for the nightly workflow jobs. Hence adding some debug info to see what's happening.