### PR TITLE
Pin test report action junit2json package version to 3.1.7

### DIFF
--- a/.github/actions/test-summary-report/action.yaml
+++ b/.github/actions/test-summary-report/action.yaml
@@ -37,7 +37,7 @@ runs:
     - name: Install script dependencies
       shell: bash
       run: |
-        npm install junit2json
+        npm install junit2json@3.1.7
     - name: Generate test summary
       uses: actions/github-script@v7
       with:


### PR DESCRIPTION
Because newly released 3.1.8 is broken.