### PR TITLE
Fix auto label workflow GraphQL query

### DIFF
--- a/.github/workflows/label-issue.yaml
+++ b/.github/workflows/label-issue.yaml
@@ -137,7 +137,7 @@ jobs:
             // Check to see if labels already exist, and if not, create them so we can set the color
             const labelQuery = `{
               repository(owner: "${context.repo.owner}", name: "${context.repo.repo}") {
-                labels(first: 50, query: "name: ${Array.from(labels).join(' ')}") {
+                labels(first: 50, query: "name: ${Array.from(labels).join(' || ')}") {
                   nodes {
                     name
                   }


### PR DESCRIPTION
Something must have changed in the GitHub API that broke the auto label workflow.

This should get it working again.