### PR TITLE
[Azure] Fix flaky storage queue crud test

### DIFF
--- a/integration-test-groups/azure/azure-storage-queue/src/main/java/org/apache/camel/quarkus/component/azure/storage/queue/it/AzureStorageQueueResource.java
+++ b/integration-test-groups/azure/azure-storage-queue/src/main/java/org/apache/camel/quarkus/component/azure/storage/queue/it/AzureStorageQueueResource.java
@@ -157,7 +157,8 @@ public class AzureStorageQueueResource {
         return Response.noContent().build();
     }
 
-    @Path("/queue/delete/{id}/{popReceipt}")
+    // popReceipt may contain a slash, so override its regex to "everything"
+    @Path("/queue/delete/{id}/{popReceipt:.*}")
     @DELETE
     public Response deleteMessageById(@PathParam("id") String id, @PathParam("popReceipt") String popReceipt) throws Exception {
         var headers = new HashMap<String, Object>();
@@ -170,7 +171,8 @@ public class AzureStorageQueueResource {
         return Response.noContent().build();
     }
 
-    @Path("/queue/update/{id}/{popReceipt}")
+    // popReceipt may contain a slash, so override its regex to "everything"
+    @Path("/queue/update/{id}/{popReceipt:.*}")
     @POST
     @Consumes(MediaType.TEXT_PLAIN)
     public Response addMessage(@PathParam("id") String id, @PathParam("popReceipt") String popReceipt, String message)

--- a/integration-test-groups/azure/azure-storage-queue/src/test/java/org/apache/camel/quarkus/component/azure/storage/queue/it/AzureStorageQueueTest.java
+++ b/integration-test-groups/azure/azure-storage-queue/src/test/java/org/apache/camel/quarkus/component/azure/storage/queue/it/AzureStorageQueueTest.java
@@ -50,8 +50,8 @@ class AzureStorageQueueTest {
                     .then()
                     .statusCode(201);
 
-            // create 2 messages
-            for (int i = 1; i < 2; i++) {
+            // create messages
+            for (int i = 1; i < 3; i++) {
                 addMessage(message + i);
             }
 
@@ -61,9 +61,9 @@ class AzureStorageQueueTest {
                     .statusCode(200)
                     .body(is(message + "1"));
 
-            // Read 2 messages
+            // Read messages
             List<LinkedHashMap<String, String>> response = null;
-            for (int i = 1; i < 2; i++) {
+            for (int i = 1; i < 3; i++) {
                 response = readMessage();
                 assertNotNull(response);
                 assertEquals(1, response.size());


### PR DESCRIPTION
A real azure service may include a slash in `popReceipt` which then results in 404 as the endpoint path is not matched - this overrides the default regex for popReceipt to capture all, since it is a last element in the path anyway

please also backport to 3.8