### PR TITLE
Log the Camel Quarkus version on startup

### DIFF
--- a/extensions-core/core/deployment/pom.xml
+++ b/extensions-core/core/deployment/pom.xml
@@ -94,6 +94,12 @@
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions-core/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/CamelBootstrapProcessor.java
+++ b/extensions-core/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/CamelBootstrapProcessor.java
@@ -28,6 +28,7 @@ import io.quarkus.runtime.ShutdownContext;
 import org.apache.camel.quarkus.core.CamelBootstrapRecorder;
 import org.apache.camel.quarkus.core.deployment.spi.CamelBootstrapCompletedBuildItem;
 import org.apache.camel.quarkus.core.deployment.spi.CamelRuntimeBuildItem;
+import org.apache.camel.quarkus.core.deployment.util.CamelQuarkusVersion;
 
 class CamelBootstrapProcessor {
     /**
@@ -51,7 +52,7 @@ class CamelBootstrapProcessor {
 
         recorder.addShutdownTask(shutdown, runtime.runtime());
         if (runtime.isAutoStartup()) {
-            recorder.start(runtime.runtime(), commandLineArguments);
+            recorder.start(runtime.runtime(), commandLineArguments, CamelQuarkusVersion.getVersion());
         }
         /* Make sure that Quarkus orders this method before starting to serve HTTP endpoints.
          * Otherwise first requests might reach Camel context in a non-yet-started state. */

--- a/extensions-core/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/util/CamelQuarkusVersion.java
+++ b/extensions-core/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/util/CamelQuarkusVersion.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.core.deployment.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Properties;
+
+import org.jboss.logging.Logger;
+
+public final class CamelQuarkusVersion {
+    private static final String CAMEL_QUARKUS_VERSION_PROPERTIES = "camel-quarkus-version.properties";
+    private static final Logger LOG = Logger.getLogger(CamelQuarkusVersion.class);
+    private static final String VERSION;
+
+    static {
+        Properties versionProps = new Properties();
+        String versionString = "unknown version";
+        try (final InputStream stream = CamelQuarkusVersion.class.getResourceAsStream(CAMEL_QUARKUS_VERSION_PROPERTIES)) {
+            if (stream != null) {
+                try (final InputStreamReader reader = new InputStreamReader(stream, StandardCharsets.UTF_8)) {
+                    versionProps.load(reader);
+                    versionString = versionProps.getProperty("version", versionString);
+                }
+            } else {
+                logUnableToLoadVersionProperties(null);
+            }
+        } catch (IOException e) {
+            logUnableToLoadVersionProperties(e);
+        }
+        VERSION = versionString;
+    }
+
+    static void logUnableToLoadVersionProperties(IOException e) {
+        if (LOG.isDebugEnabled()) {
+            LOG.debugf(e, "Unable to load %s", CAMEL_QUARKUS_VERSION_PROPERTIES);
+        }
+    }
+
+    private CamelQuarkusVersion() {
+        // Utility class
+    }
+
+    public static String getVersion() {
+        return VERSION;
+    }
+}

--- a/extensions-core/core/deployment/src/main/resources/org/apache/camel/quarkus/core/deployment/util/camel-quarkus-version.properties
+++ b/extensions-core/core/deployment/src/main/resources/org/apache/camel/quarkus/core/deployment/util/camel-quarkus-version.properties
@@ -1,0 +1,17 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+version=${project.version}

--- a/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/CamelBootstrapRecorder.java
+++ b/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/CamelBootstrapRecorder.java
@@ -38,10 +38,10 @@ public class CamelBootstrapRecorder {
         });
     }
 
-    public void start(RuntimeValue<CamelRuntime> runtime, Supplier<String[]> arguments) {
+    public void start(RuntimeValue<CamelRuntime> runtime, Supplier<String[]> arguments, String camelQuarkusVersion) {
         try {
             Logger logger = Logger.getLogger(CamelBootstrapRecorder.class);
-            logger.infof("Bootstrap runtime: %s", runtime.getValue().getClass().getName());
+            logger.infof("Apache Camel Quarkus %s is starting", camelQuarkusVersion);
             runtime.getValue().start(arguments.get());
         } catch (Exception e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
I opened this in draft to get some feedback.

For micro release of Quarkus, we may end with something like this in the console logs:

```
INFO  [org.apa.cam.qua.cor.CamelBootstrapRecorder] (main) Apache Camel Quarkus 3.12.0 is starting
...
INFO  [io.quarkus] (main) my-cool-app 1.0.0 on JVM (powered by Quarkus 3.12.3)
```

Do folks think this could be a source of confusion for users? That the CQ version is potentially out of alignment compared to the version of the platform BOM.
