### PR TITLE
[Cassandra] Increase stack size for test container

### DIFF
--- a/integration-tests/cassandraql/src/test/java/org/apache/camel/quarkus/component/cassandraql/it/CassandraqlTestResource.java
+++ b/integration-tests/cassandraql/src/test/java/org/apache/camel/quarkus/component/cassandraql/it/CassandraqlTestResource.java
@@ -49,6 +49,7 @@ public class CassandraqlTestResource implements QuarkusTestResourceLifecycleMana
             container = new CassandraContainer<>(imageName)
                     .withExposedPorts(PORT)
                     .waitingFor(Wait.forLogMessage(".*Created default superuser role.*", 1))
+                    .withEnv("JVM_EXTRA_OPTS", "-Xss448k")
                     .withConfigurationOverride("/cassandra");
 
             container.start();


### PR DESCRIPTION
Trying to run the tests on aarch64 RHEL and the container does not start with:

```
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.

The Java thread stack size specified is too small. Specify at least 448k
```

this is an [issue](https://issues.apache.org/jira/browse/CASSANDRA-15446) in cassandra that is not fixed yet