### PR TITLE
Avoid deploying redundant modules during the release

### DIFF
--- a/docs/modules/ROOT/pages/contributor-guide/release-guide.adoc
+++ b/docs/modules/ROOT/pages/contributor-guide/release-guide.adoc
@@ -58,7 +58,7 @@ $ cd target/checkout
 +
 [source,shell]
 ----
-mvn deploy -Papache-release -DskipTests -Denforcer.skip -Dquarkus.build.skip -Dformatter.skip -Dimpsort.skip -rf :camel-quarkus-openapi-java
+mvn deploy -Dapache-release -DskipTests -Denforcer.skip -Dquarkus.build.skip -Dformatter.skip -Dimpsort.skip -rf :camel-quarkus-openapi-java
 ----
 
 == Close the Apache staging repository

--- a/pom.xml
+++ b/pom.xml
@@ -278,6 +278,8 @@
         <camel-quarkus.extension.finder.strict>true</camel-quarkus.extension.finder.strict>
     </properties>
 
+    <!-- Core modules -->
+    <!-- Any modules that do not need to be deployed during the Maven release, should be added to the 'standard-build' profile below -->
     <modules>
         <module>poms</module>
         <module>tooling</module>
@@ -288,9 +290,6 @@
         <module>catalog</module>
         <module>integration-tests-support</module>
         <module>integration-tests</module>
-        <module>integration-test-groups</module>
-        <module>docs</module>
-        <module>integration-tests-jvm</module>
         <module>test-framework</module>
     </modules>
 
@@ -408,14 +407,13 @@
                     <version>${maven-release-plugin.version}</version>
                     <configuration>
                         <!-- release:prepare config -->
-                        <preparationGoals>clean validate -Pcommit-release-changes "-Dcq.commit.message.prefix=[maven-release-plugin] Prepare release" -N</preparationGoals>
-                        <completionGoals>clean validate -Pcommit-release-changes "-Dcq.commit.message.prefix=[maven-release-plugin] Set next development version" -N</completionGoals>
+                        <preparationGoals>clean validate -Pstandard-build -Pcommit-release-changes "-Dcq.commit.message.prefix=[maven-release-plugin] Prepare release" -N</preparationGoals>
+                        <completionGoals>clean validate -Pstandard-build -Pcommit-release-changes "-Dcq.commit.message.prefix=[maven-release-plugin] Set next development version" -N</completionGoals>
                         <!-- release:perform config -->
-                        <useReleaseProfile>true</useReleaseProfile>
-                        <releaseProfiles>apache-release</releaseProfiles>
+                        <releaseProfiles combine.self="override"/>
                         <goals>deploy</goals>
                         <!-- Both release:prepare and release:perform config -->
-                        <arguments>-DskipTests -Denforcer.skip -Dquarkus.build.skip -Dformatter.skip -Dimpsort.skip</arguments>
+                        <arguments>-Dapache-release -DskipTests -Denforcer.skip -Dquarkus.build.skip -Dformatter.skip -Dimpsort.skip</arguments>
                     </configuration>
                 </plugin>
 
@@ -1055,6 +1053,19 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <id>standard-build</id>
+            <activation>
+                <property>
+                    <name>!apache-release</name>
+                </property>
+            </activation>
+            <modules>
+                <module>docs</module>
+                <module>integration-test-groups</module>
+                <module>integration-tests-jvm</module>
+            </modules>
         </profile>
         <profile>
             <id>apache-release</id>

--- a/tooling/pom.xml
+++ b/tooling/pom.xml
@@ -36,7 +36,6 @@
         <module>maven-plugin</module>
         <module>camel-k-catalog-model</module>
         <module>camel-k-maven-plugin</module>
-        <module>perf-regression</module>
         <module>test-list</module>
     </modules>
 
@@ -54,4 +53,18 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+
+    <profiles>
+        <profile>
+            <id>standard-build</id>
+            <activation>
+                <property>
+                    <name>!apache-release</name>
+                </property>
+            </activation>
+            <modules>
+                <module>perf-regression</module>
+            </modules>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
This shrinks the number of modules deployed at release time from 1435 to 1274.

I ran the full release against a local Nexus instance and the output from both the `release:prepare` and `release:perform` stages was as expected. The list of deployed artifacts is here:

https://gist.github.com/jamesnetherton/f19fcec764d08f59c39933835f3d1dfb

I also tested the release with the Quarkus Platform. It built fine and I ran a small selection of tests, which passed.

WDYT @ppalaga?