### PR TITLE
Mark modules using legacy @ConfigRoot as such

### DIFF
--- a/extensions-core/core/runtime/pom.xml
+++ b/extensions-core/core/runtime/pom.xml
@@ -117,6 +117,9 @@
                             <version>${quarkus.version}</version>
                         </path>
                     </annotationProcessorPaths>
+                    <compilerArgs>
+                        <arg>-AlegacyConfigRoot=true</arg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
         </plugins>

--- a/extensions-jvm/cli-connector/runtime/pom.xml
+++ b/extensions-jvm/cli-connector/runtime/pom.xml
@@ -70,6 +70,9 @@
                             <version>${quarkus.version}</version>
                         </path>
                     </annotationProcessorPaths>
+                    <compilerArgs>
+                        <arg>-AlegacyConfigRoot=true</arg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
         </plugins>

--- a/extensions/cxf-soap/deployment/pom.xml
+++ b/extensions/cxf-soap/deployment/pom.xml
@@ -57,6 +57,9 @@
                             <version>${quarkus.version}</version>
                         </path>
                     </annotationProcessorPaths>
+                    <compilerArgs>
+                        <arg>-AlegacyConfigRoot=true</arg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
         </plugins>

--- a/extensions/debug/runtime/pom.xml
+++ b/extensions/debug/runtime/pom.xml
@@ -67,6 +67,9 @@
                             <version>${quarkus.version}</version>
                         </path>
                     </annotationProcessorPaths>
+                    <compilerArgs>
+                        <arg>-AlegacyConfigRoot=true</arg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
         </plugins>

--- a/extensions/fhir/runtime/pom.xml
+++ b/extensions/fhir/runtime/pom.xml
@@ -91,6 +91,9 @@
                             <version>${quarkus.version}</version>
                         </path>
                     </annotationProcessorPaths>
+                    <compilerArgs>
+                        <arg>-AlegacyConfigRoot=true</arg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
         </plugins>

--- a/extensions/file-cluster-service/runtime/pom.xml
+++ b/extensions/file-cluster-service/runtime/pom.xml
@@ -63,6 +63,9 @@
                             <version>${quarkus.version}</version>
                         </path>
                     </annotationProcessorPaths>
+                    <compilerArgs>
+                        <arg>-AlegacyConfigRoot=true</arg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
         </plugins>

--- a/extensions/graphql/runtime/pom.xml
+++ b/extensions/graphql/runtime/pom.xml
@@ -66,6 +66,9 @@
                             <version>${quarkus.version}</version>
                         </path>
                     </annotationProcessorPaths>
+                    <compilerArgs>
+                        <arg>-AlegacyConfigRoot=true</arg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
         </plugins>

--- a/extensions/grpc/runtime/pom.xml
+++ b/extensions/grpc/runtime/pom.xml
@@ -97,6 +97,9 @@
                             <version>${quarkus.version}</version>
                         </path>
                     </annotationProcessorPaths>
+                    <compilerArgs>
+                        <arg>-AlegacyConfigRoot=true</arg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
         </plugins>

--- a/extensions/jfr/runtime/pom.xml
+++ b/extensions/jfr/runtime/pom.xml
@@ -63,6 +63,9 @@
                             <version>${quarkus.version}</version>
                         </path>
                     </annotationProcessorPaths>
+                    <compilerArgs>
+                        <arg>-AlegacyConfigRoot=true</arg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
         </plugins>

--- a/extensions/joor/runtime/pom.xml
+++ b/extensions/joor/runtime/pom.xml
@@ -67,6 +67,9 @@
                             <version>${quarkus.version}</version>
                         </path>
                     </annotationProcessorPaths>
+                    <compilerArgs>
+                        <arg>-AlegacyConfigRoot=true</arg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
         </plugins>

--- a/extensions/kafka/runtime/pom.xml
+++ b/extensions/kafka/runtime/pom.xml
@@ -71,6 +71,9 @@
                             <version>${quarkus.version}</version>
                         </path>
                     </annotationProcessorPaths>
+                    <compilerArgs>
+                        <arg>-AlegacyConfigRoot=true</arg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
         </plugins>

--- a/extensions/kamelet/runtime/pom.xml
+++ b/extensions/kamelet/runtime/pom.xml
@@ -63,6 +63,9 @@
                             <version>${quarkus.version}</version>
                         </path>
                     </annotationProcessorPaths>
+                    <compilerArgs>
+                        <arg>-AlegacyConfigRoot=true</arg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
         </plugins>

--- a/extensions/kubernetes-cluster-service/runtime/pom.xml
+++ b/extensions/kubernetes-cluster-service/runtime/pom.xml
@@ -75,6 +75,9 @@
                             <version>${quarkus.version}</version>
                         </path>
                     </annotationProcessorPaths>
+                    <compilerArgs>
+                        <arg>-AlegacyConfigRoot=true</arg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
         </plugins>

--- a/extensions/micrometer/runtime/pom.xml
+++ b/extensions/micrometer/runtime/pom.xml
@@ -71,6 +71,9 @@
                             <version>${quarkus.version}</version>
                         </path>
                     </annotationProcessorPaths>
+                    <compilerArgs>
+                        <arg>-AlegacyConfigRoot=true</arg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
         </plugins>

--- a/extensions/microprofile-health/runtime/pom.xml
+++ b/extensions/microprofile-health/runtime/pom.xml
@@ -68,6 +68,9 @@
                             <version>${quarkus.version}</version>
                         </path>
                     </annotationProcessorPaths>
+                    <compilerArgs>
+                        <arg>-AlegacyConfigRoot=true</arg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
         </plugins>

--- a/extensions/openapi-java/deployment/pom.xml
+++ b/extensions/openapi-java/deployment/pom.xml
@@ -91,6 +91,9 @@
                             <version>${quarkus.version}</version>
                         </path>
                     </annotationProcessorPaths>
+                    <compilerArgs>
+                        <arg>-AlegacyConfigRoot=true</arg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
         </plugins>

--- a/extensions/opentelemetry/runtime/pom.xml
+++ b/extensions/opentelemetry/runtime/pom.xml
@@ -77,6 +77,9 @@
                             <version>${quarkus.version}</version>
                         </path>
                     </annotationProcessorPaths>
+                    <compilerArgs>
+                        <arg>-AlegacyConfigRoot=true</arg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
         </plugins>

--- a/extensions/rest-openapi/runtime/pom.xml
+++ b/extensions/rest-openapi/runtime/pom.xml
@@ -70,6 +70,9 @@
                             <version>${quarkus.version}</version>
                         </path>
                     </annotationProcessorPaths>
+                    <compilerArgs>
+                        <arg>-AlegacyConfigRoot=true</arg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
         </plugins>

--- a/extensions/servlet/runtime/pom.xml
+++ b/extensions/servlet/runtime/pom.xml
@@ -68,6 +68,9 @@
                             <version>${quarkus.version}</version>
                         </path>
                     </annotationProcessorPaths>
+                    <compilerArgs>
+                        <arg>-AlegacyConfigRoot=true</arg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
         </plugins>

--- a/extensions/xslt/runtime/pom.xml
+++ b/extensions/xslt/runtime/pom.xml
@@ -66,6 +66,9 @@
                             <version>${quarkus.version}</version>
                         </path>
                     </annotationProcessorPaths>
+                    <compilerArgs>
+                        <arg>-AlegacyConfigRoot=true</arg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
The new extension annotation processor coming with 3.14 requires that you mark the modules using the legacy @ConfigRoot approach (i.e. without @ConfigMapping) with a specific annotation processor parameter.

This is important for the generation of the config documentation (which is enabled by default).

This can be merged pre-3.14 update but will result in a warning when building. With the advantage of having the build with main passing.

I think I have marked all of them but in any case, if you have an error, you now know what to do.

Fixes https://github.com/quarkusio/quarkus/issues/42417