### PR TITLE
Revert back to QuarkusTestResource

### DIFF
--- a/docs/modules/ROOT/pages/user-guide/testing.adoc
+++ b/docs/modules/ROOT/pages/user-guide/testing.adoc
@@ -131,15 +131,15 @@ public class MyTestResource implements QuarkusTestResourceLifecycleManager {
 }
 ----
 
-The defined test resource needs to be referenced from the test classes with `@WithTestResource` as shown below:
+The defined test resource needs to be referenced from the test classes with `@QuarkusTestResource` as shown below:
 
 [source,java]
 ----
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
-@WithTestResource(MyTestResource.class)
+@QuarkusTestResource(MyTestResource.class)
 class MyTest {
    ...
 }
@@ -206,16 +206,16 @@ public class WireMockTestResource implements QuarkusTestResourceLifecycleManager
 }
 ----
 
-Finally, ensure your test class has the `@WithTestResource` annotation with the appropriate test resource class specified as the value. The WireMock server will be started before all tests are
+Finally, ensure your test class has the `@QuarkusTestResource` annotation with the appropriate test resource class specified as the value. The WireMock server will be started before all tests are
 executed and will be shut down when all tests are finished.
 
 [source,java]
 ----
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
-@WithTestResource(WireMockTestResource.class)
+@QuarkusTestResource(WireMockTestResource.class)
 class MyTest {
    ...
 }

--- a/integration-test-groups/aws2-quarkus-client/aws2-ddb/src/test/java/org/apache/camel/quarkus/component/aws2/ddb/it/Aws2DdbQuarkusClientTest.java
+++ b/integration-test-groups/aws2-quarkus-client/aws2-ddb/src/test/java/org/apache/camel/quarkus/component/aws2/ddb/it/Aws2DdbQuarkusClientTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.camel.quarkus.component.aws2.ddb.it;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import org.apache.camel.quarkus.test.support.aws2.Aws2TestResource;
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.CoreMatchers.is;
 
 @QuarkusTest
-@WithTestResource(Aws2TestResource.class)
+@QuarkusTestResource(Aws2TestResource.class)
 class Aws2DdbQuarkusClientTest {
 
     @Test

--- a/integration-test-groups/aws2/aws2-cw/src/test/java/org/apache/camel/quarkus/component/aws2/cw/it/Aws2CwTest.java
+++ b/integration-test-groups/aws2/aws2-cw/src/test/java/org/apache/camel/quarkus/component/aws2/cw/it/Aws2CwTest.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -44,7 +44,7 @@ import software.amazon.awssdk.services.cloudwatch.model.Statistic;
 import static org.hamcrest.Matchers.is;
 
 @QuarkusTest
-@WithTestResource(Aws2TestResource.class)
+@QuarkusTestResource(Aws2TestResource.class)
 class Aws2CwTest extends BaseAWs2TestSupport {
     private static final Logger LOG = Logger.getLogger(Aws2CwTest.class);
 

--- a/integration-test-groups/aws2/aws2-ddb/src/test/java/org/apache/camel/quarkus/component/aws2/ddb/it/Aws2DdbStreamTest.java
+++ b/integration-test-groups/aws2/aws2-ddb/src/test/java/org/apache/camel/quarkus/component/aws2/ddb/it/Aws2DdbStreamTest.java
@@ -22,7 +22,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -38,7 +38,7 @@ import org.junit.jupiter.api.Test;
 import static org.apache.camel.quarkus.component.aws2.ddb.it.Aws2DdbResource.Table;
 
 @QuarkusTest
-@WithTestResource(Aws2TestResource.class)
+@QuarkusTestResource(Aws2TestResource.class)
 class Aws2DdbStreamTest {
 
     private static final Logger LOG = Logger.getLogger(Aws2DdbStreamTest.class);

--- a/integration-test-groups/aws2/aws2-ddb/src/test/java/org/apache/camel/quarkus/component/aws2/ddb/it/Aws2DdbTest.java
+++ b/integration-test-groups/aws2/aws2-ddb/src/test/java/org/apache/camel/quarkus/component/aws2/ddb/it/Aws2DdbTest.java
@@ -22,7 +22,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -42,7 +42,7 @@ import static org.apache.camel.quarkus.component.aws2.ddb.it.Aws2DdbResource.Tab
 import static org.hamcrest.CoreMatchers.is;
 
 @QuarkusTest
-@WithTestResource(Aws2TestResource.class)
+@QuarkusTestResource(Aws2TestResource.class)
 class Aws2DdbTest extends BaseAWs2TestSupport {
 
     private static final Logger LOG = Logger.getLogger(Aws2DdbTest.class);

--- a/integration-test-groups/aws2/aws2-kinesis/src/test/java/org/apache/camel/quarkus/component/aws2/kinesis/it/Aws2KinesisFirehoseTest.java
+++ b/integration-test-groups/aws2/aws2-kinesis/src/test/java/org/apache/camel/quarkus/component/aws2/kinesis/it/Aws2KinesisFirehoseTest.java
@@ -20,7 +20,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -43,7 +43,7 @@ import software.amazon.awssdk.services.s3.model.ListObjectsResponse;
 import software.amazon.awssdk.services.s3.model.S3Object;
 
 @QuarkusTest
-@WithTestResource(Aws2TestResource.class)
+@QuarkusTestResource(Aws2TestResource.class)
 class Aws2KinesisFirehoseTest extends BaseAWs2TestSupport {
 
     private static final Logger LOG = Logger.getLogger(Aws2KinesisFirehoseTest.class);

--- a/integration-test-groups/aws2/aws2-kinesis/src/test/java/org/apache/camel/quarkus/component/aws2/kinesis/it/Aws2KinesisTest.java
+++ b/integration-test-groups/aws2/aws2-kinesis/src/test/java/org/apache/camel/quarkus/component/aws2/kinesis/it/Aws2KinesisTest.java
@@ -18,7 +18,7 @@ package org.apache.camel.quarkus.component.aws2.kinesis.it;
 
 import java.util.concurrent.TimeUnit;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -33,7 +33,7 @@ import software.amazon.awssdk.services.s3.S3Client;
 
 @DisabledIfEnvironmentVariable(named = "CI", matches = "true", disabledReason = "https://github.com/apache/camel-quarkus/issues/6342")
 @QuarkusTest
-@WithTestResource(Aws2TestResource.class)
+@QuarkusTestResource(Aws2TestResource.class)
 class Aws2KinesisTest extends BaseAWs2TestSupport {
 
     private static final Logger LOG = Logger.getLogger(Aws2KinesisTest.class);

--- a/integration-test-groups/aws2/aws2-lambda/src/test/java/org/apache/camel/quarkus/component/aws2/lambda/it/Aws2LambdaTest.java
+++ b/integration-test-groups/aws2/aws2-lambda/src/test/java/org/apache/camel/quarkus/component/aws2/lambda/it/Aws2LambdaTest.java
@@ -24,7 +24,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -42,7 +42,7 @@ import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @QuarkusTest
-@WithTestResource(Aws2TestResource.class)
+@QuarkusTestResource(Aws2TestResource.class)
 class Aws2LambdaTest extends BaseAWs2TestSupport {
     private static final Logger LOG = Logger.getLogger(Aws2LambdaTest.class);
 

--- a/integration-test-groups/aws2/aws2-s3/src/test/java/org/apache/camel/quarkus/component/aws2/s3/it/Aws2S3Test.java
+++ b/integration-test-groups/aws2/aws2-s3/src/test/java/org/apache/camel/quarkus/component/aws2/s3/it/Aws2S3Test.java
@@ -23,7 +23,7 @@ import java.util.Locale;
 import java.util.UUID;
 import java.util.stream.Stream;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -40,7 +40,7 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @QuarkusTest
-@WithTestResource(Aws2TestResource.class)
+@QuarkusTestResource(Aws2TestResource.class)
 class Aws2S3Test extends BaseAWs2TestSupport {
     private int objects_num_before;
     private int objects_num_after;

--- a/integration-test-groups/aws2/aws2-ses/src/test/java/org/apache/camel/quarkus/component/aws2/ses/it/Aws2SesTest.java
+++ b/integration-test-groups/aws2/aws2-ses/src/test/java/org/apache/camel/quarkus/component/aws2/ses/it/Aws2SesTest.java
@@ -24,7 +24,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -57,7 +57,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 @EnabledIfEnvironmentVariable(named = "AWS_ACCESS_KEY", matches = "[a-zA-Z0-9]+")
 @EnabledIfEnvironmentVariable(named = "MAILSLURP_API_KEY", matches = "[a-zA-Z0-9]+")
 @QuarkusTest
-@WithTestResource(Aws2TestResource.class)
+@QuarkusTestResource(Aws2TestResource.class)
 class Aws2SesTest extends BaseAWs2TestSupport {
     private static final Logger LOG = Logger.getLogger(Aws2SesTest.class);
 

--- a/integration-test-groups/aws2/aws2-sqs-sns/src/test/java/org/apache/camel/quarkus/component/aws2/sns/it/Aws2SqsSnsTest.java
+++ b/integration-test-groups/aws2/aws2-sqs-sns/src/test/java/org/apache/camel/quarkus/component/aws2/sns/it/Aws2SqsSnsTest.java
@@ -19,7 +19,7 @@ package org.apache.camel.quarkus.component.aws2.sns.it;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -35,7 +35,7 @@ import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.core.Is.is;
 
 @QuarkusTest
-@WithTestResource(Aws2TestResource.class)
+@QuarkusTestResource(Aws2TestResource.class)
 class Aws2SqsSnsTest extends BaseAWs2TestSupport {
 
     public Aws2SqsSnsTest() {

--- a/integration-test-groups/aws2/aws2-sqs/src/test/java/org/apache/camel/quarkus/component/aws2/sqs/it/Aws2SqsTest.java
+++ b/integration-test-groups/aws2/aws2-sqs/src/test/java/org/apache/camel/quarkus/component/aws2/sqs/it/Aws2SqsTest.java
@@ -27,7 +27,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -48,7 +48,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
 @QuarkusTest
-@WithTestResource(Aws2TestResource.class)
+@QuarkusTestResource(Aws2TestResource.class)
 class Aws2SqsTest extends BaseAWs2TestSupport {
 
     private static final Logger LOG = Logger.getLogger(Aws2SqsTest.class);

--- a/integration-test-groups/azure/azure-storage-blob/src/test/java/org/apache/camel/quarkus/component/azure/storage/blob/it/AzureStorageBlobIT.java
+++ b/integration-test-groups/azure/azure-storage-blob/src/test/java/org/apache/camel/quarkus/component/azure/storage/blob/it/AzureStorageBlobIT.java
@@ -16,12 +16,12 @@
  */
 package org.apache.camel.quarkus.component.azure.storage.blob.it;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import org.apache.camel.quarkus.test.support.azure.AzureStorageTestResource;
 
 @QuarkusIntegrationTest
-@WithTestResource(AzureStorageTestResource.class)
+@QuarkusTestResource(AzureStorageTestResource.class)
 class AzureStorageBlobIT extends AzureStorageBlobTest {
 
 }

--- a/integration-test-groups/azure/azure-storage-blob/src/test/java/org/apache/camel/quarkus/component/azure/storage/blob/it/AzureStorageBlobTest.java
+++ b/integration-test-groups/azure/azure-storage-blob/src/test/java/org/apache/camel/quarkus/component/azure/storage/blob/it/AzureStorageBlobTest.java
@@ -28,7 +28,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import com.azure.storage.blob.models.BlockListType;
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -55,7 +55,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
 @QuarkusTest
-@WithTestResource(AzureStorageTestResource.class)
+@QuarkusTestResource(AzureStorageTestResource.class)
 class AzureStorageBlobTest {
 
     private static final String BLOB_CONTENT = "Hello Camel Quarkus Azure Blob";

--- a/integration-test-groups/azure/azure-storage-queue/src/test/java/org/apache/camel/quarkus/component/azure/storage/queue/it/AzureStorageQueueIT.java
+++ b/integration-test-groups/azure/azure-storage-queue/src/test/java/org/apache/camel/quarkus/component/azure/storage/queue/it/AzureStorageQueueIT.java
@@ -16,12 +16,12 @@
  */
 package org.apache.camel.quarkus.component.azure.storage.queue.it;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import org.apache.camel.quarkus.test.support.azure.AzureStorageTestResource;
 
 @QuarkusIntegrationTest
-@WithTestResource(AzureStorageTestResource.class)
+@QuarkusTestResource(AzureStorageTestResource.class)
 class AzureStorageQueueIT extends AzureStorageQueueTest {
 
 }

--- a/integration-test-groups/azure/azure-storage-queue/src/test/java/org/apache/camel/quarkus/component/azure/storage/queue/it/AzureStorageQueueTest.java
+++ b/integration-test-groups/azure/azure-storage-queue/src/test/java/org/apache/camel/quarkus/component/azure/storage/queue/it/AzureStorageQueueTest.java
@@ -20,7 +20,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @QuarkusTest
-@WithTestResource(AzureStorageTestResource.class)
+@QuarkusTestResource(AzureStorageTestResource.class)
 class AzureStorageQueueTest {
 
     @Test

--- a/integration-test-groups/cxf-soap/cxf-soap-client/src/test/java/org/apache/camel/quarkus/component/cxf/soap/client/it/CxfSoapClientTest.java
+++ b/integration-test-groups/cxf-soap/cxf-soap-client/src/test/java/org/apache/camel/quarkus/component/cxf/soap/client/it/CxfSoapClientTest.java
@@ -22,7 +22,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import org.eclipse.microprofile.config.ConfigProvider;
@@ -38,7 +38,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
 @QuarkusTest
-@WithTestResource(value = CxfClientTestResource.class, restrictToAnnotatedClass = false)
+@QuarkusTestResource(value = CxfClientTestResource.class)
 class CxfSoapClientTest {
 
     @ParameterizedTest

--- a/integration-test-groups/cxf-soap/cxf-soap-rest/src/test/java/org/apache/camel/quarkus/component/cxf/soap/rest/it/CxfSoapRestTest.java
+++ b/integration-test-groups/cxf-soap/cxf-soap-rest/src/test/java/org/apache/camel/quarkus/component/cxf/soap/rest/it/CxfSoapRestTest.java
@@ -17,7 +17,7 @@
 package org.apache.camel.quarkus.component.cxf.soap.rest.it;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
-@WithTestResource(value = CxfRestTestResource.class, restrictToAnnotatedClass = false)
+@QuarkusTestResource(value = CxfRestTestResource.class)
 class CxfSoapRestTest {
 
     @Test

--- a/integration-test-groups/cxf-soap/cxf-soap-ws-security-client/src/test/java/org/apache/camel/quarkus/component/cxf/soap/wss/client/it/CxfSoapWssClientTest.java
+++ b/integration-test-groups/cxf-soap/cxf-soap-ws-security-client/src/test/java/org/apache/camel/quarkus/component/cxf/soap/wss/client/it/CxfSoapWssClientTest.java
@@ -26,7 +26,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.DisabledOnIntegrationTest;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
@@ -45,7 +45,7 @@ import org.testcontainers.shaded.org.awaitility.Awaitility;
 import static org.hamcrest.Matchers.equalTo;
 
 @QuarkusTest
-@WithTestResource(value = CxfWssClientTestResource.class, restrictToAnnotatedClass = false)
+@QuarkusTestResource(value = CxfWssClientTestResource.class, restrictToAnnotatedClass = false)
 class CxfSoapWssClientTest {
 
     @Test

--- a/integration-test-groups/cxf-soap/cxf-soap-ws-security-server/src/test/java/org/apache/camel/quarkus/component/cxf/soap/wss/server/it/CxfSoapWssServerTest.java
+++ b/integration-test-groups/cxf-soap/cxf-soap-ws-security-server/src/test/java/org/apache/camel/quarkus/component/cxf/soap/wss/server/it/CxfSoapWssServerTest.java
@@ -25,7 +25,7 @@ import javax.security.auth.callback.CallbackHandler;
 import javax.security.auth.callback.UnsupportedCallbackException;
 
 import io.quarkiverse.cxf.test.QuarkusCxfClientTestUtil;
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import org.apache.cxf.endpoint.Client;
@@ -42,7 +42,7 @@ import org.junit.jupiter.api.Test;
 import static io.quarkiverse.cxf.test.QuarkusCxfClientTestUtil.anyNs;
 
 @QuarkusTest
-@WithTestResource(value = CxfWssServerTestResource.class, restrictToAnnotatedClass = false)
+@QuarkusTestResource(value = CxfWssServerTestResource.class)
 class CxfSoapWssServerTest {
 
     @Test

--- a/integration-test-groups/foundation/language/src/test/java/org/apache/camel/quarkus/component/language/it/LanguageTest.java
+++ b/integration-test-groups/foundation/language/src/test/java/org/apache/camel/quarkus/component/language/it/LanguageTest.java
@@ -25,7 +25,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.builder.RequestSpecBuilder;
@@ -46,7 +46,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @QuarkusTest
-@WithTestResource(LanguageTestResource.class)
+@QuarkusTestResource(LanguageTestResource.class)
 class LanguageTest {
 
     @MockServer

--- a/integration-test-groups/http/http/src/test/java/org/apache/camel/quarkus/component/http/http/it/HttpIT.java
+++ b/integration-test-groups/http/http/src/test/java/org/apache/camel/quarkus/component/http/http/it/HttpIT.java
@@ -16,11 +16,11 @@
  */
 package org.apache.camel.quarkus.component.http.http.it;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import org.apache.camel.quarkus.component.http.common.HttpTestResource;
 
 @QuarkusIntegrationTest
-@WithTestResource(HttpTestResource.class)
+@QuarkusTestResource(HttpTestResource.class)
 public class HttpIT extends HttpTest {
 }

--- a/integration-test-groups/http/http/src/test/java/org/apache/camel/quarkus/component/http/http/it/HttpTest.java
+++ b/integration-test-groups/http/http/src/test/java/org/apache/camel/quarkus/component/http/http/it/HttpTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.camel.quarkus.component.http.http.it;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -35,7 +35,7 @@ import static org.hamcrest.Matchers.not;
         @Certificate(name = HttpTestResource.KEYSTORE_NAME, formats = {
                 Format.PKCS12 }, password = HttpTestResource.KEYSTORE_PASSWORD) })
 @QuarkusTest
-@WithTestResource(HttpTestResource.class)
+@QuarkusTestResource(HttpTestResource.class)
 public class HttpTest extends AbstractHttpTest {
     @Override
     public String component() {

--- a/integration-test-groups/http/netty-http/src/test/java/org/apache/camel/quarkus/component/http/netty/it/NettyHttpJaasTest.java
+++ b/integration-test-groups/http/netty-http/src/test/java/org/apache/camel/quarkus/component/http/netty/it/NettyHttpJaasTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.camel.quarkus.component.http.netty.it;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import me.escoffier.certs.Format;
@@ -31,7 +31,7 @@ import org.junit.jupiter.params.provider.CsvSource;
         @Certificate(name = HttpTestResource.KEYSTORE_NAME, formats = {
                 Format.PKCS12 }, password = HttpTestResource.KEYSTORE_PASSWORD) })
 @QuarkusTest
-@WithTestResource(value = NettyHttpJaasTestResource.class, restrictToAnnotatedClass = false)
+@QuarkusTestResource(value = NettyHttpJaasTestResource.class)
 public class NettyHttpJaasTest {
     @ParameterizedTest
     @CsvSource({

--- a/integration-test-groups/http/netty-http/src/test/java/org/apache/camel/quarkus/component/http/netty/it/NettyHttpTest.java
+++ b/integration-test-groups/http/netty-http/src/test/java/org/apache/camel/quarkus/component/http/netty/it/NettyHttpTest.java
@@ -18,7 +18,7 @@ package org.apache.camel.quarkus.component.http.netty.it;
 
 import java.util.List;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.response.Response;
@@ -41,8 +41,8 @@ import static org.hamcrest.Matchers.is;
         @Certificate(name = HttpTestResource.KEYSTORE_NAME, formats = {
                 Format.PKCS12 }, password = HttpTestResource.KEYSTORE_PASSWORD) })
 @QuarkusTest
-@WithTestResource(value = HttpTestResource.class, restrictToAnnotatedClass = false)
-@WithTestResource(value = NettyHttpTestResource.class, restrictToAnnotatedClass = false)
+@QuarkusTestResource(value = HttpTestResource.class)
+@QuarkusTestResource(value = NettyHttpTestResource.class)
 public class NettyHttpTest extends AbstractHttpTest {
     @Override
     public String component() {

--- a/integration-test-groups/http/vertx-http/src/test/java/org/apache/camel/quarkus/component/http/vertx/it/VertxHttpTest.java
+++ b/integration-test-groups/http/vertx-http/src/test/java/org/apache/camel/quarkus/component/http/vertx/it/VertxHttpTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.camel.quarkus.component.http.vertx.it;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import me.escoffier.certs.Format;
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
         @Certificate(name = HttpTestResource.KEYSTORE_NAME, formats = {
                 Format.PKCS12 }, password = HttpTestResource.KEYSTORE_PASSWORD) })
 @QuarkusTest
-@WithTestResource(HttpTestResource.class)
+@QuarkusTestResource(HttpTestResource.class)
 public class VertxHttpTest extends AbstractHttpTest {
     @Override
     public String component() {

--- a/integration-test-groups/mongodb/mongodb-gridfs/src/test/java/org/apache/camel/quarkus/component/mongodb/gridfs/it/MongodbGridfsTest.java
+++ b/integration-test-groups/mongodb/mongodb-gridfs/src/test/java/org/apache/camel/quarkus/component/mongodb/gridfs/it/MongodbGridfsTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.camel.quarkus.component.mongodb.gridfs.it;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -30,7 +30,7 @@ import static org.hamcrest.Matchers.is;
 
 @Disabled("https://github.com/apache/camel-quarkus/issues/6341")
 @QuarkusTest
-@WithTestResource(MongoDbTestResource.class)
+@QuarkusTestResource(MongoDbTestResource.class)
 class MongodbGridfsTest {
 
     @ParameterizedTest

--- a/integration-test-groups/mongodb/mongodb/src/test/java/org/apache/camel/quarkus/component/mongodb/it/MongoDbTest.java
+++ b/integration-test-groups/mongodb/mongodb/src/test/java/org/apache/camel/quarkus/component/mongodb/it/MongoDbTest.java
@@ -25,7 +25,7 @@ import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -53,7 +53,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Disabled("https://github.com/apache/camel-quarkus/issues/6341")
 @QuarkusTest
-@WithTestResource(MongoDbTestResource.class)
+@QuarkusTestResource(MongoDbTestResource.class)
 class MongoDbTest {
     private static final Logger LOG = Logger.getLogger(MongoDbTest.class);
 

--- a/integration-test-groups/xml/jvm/xslt-http/src/test/java/org/apache/camel/quarkus/component/xml/it/XsltHttpTest.java
+++ b/integration-test-groups/xml/jvm/xslt-http/src/test/java/org/apache/camel/quarkus/component/xml/it/XsltHttpTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.camel.quarkus.component.xml.it;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.DisabledOnIntegrationTest;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
-@WithTestResource(XmlHttpTestResource.class)
+@QuarkusTestResource(XmlHttpTestResource.class)
 class XsltHttpTest {
     private static final String BODY = "<mail><subject>Hey</subject><body>Hello world!</body></mail>";
 

--- a/integration-tests-jvm/aws-secrets-manager/src/test/java/org/apache/camel/quarkus/component/aws/secrets/manager/it/AwsSecretsManagerTest.java
+++ b/integration-tests-jvm/aws-secrets-manager/src/test/java/org/apache/camel/quarkus/component/aws/secrets/manager/it/AwsSecretsManagerTest.java
@@ -19,7 +19,7 @@ package org.apache.camel.quarkus.component.aws.secrets.manager.it;
 import java.util.Collections;
 import java.util.Map;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @QuarkusTest
-@WithTestResource(Aws2TestResource.class)
+@QuarkusTestResource(Aws2TestResource.class)
 class AwsSecretsManagerTest {
 
     @Test

--- a/integration-tests-jvm/azure-storage-datalake/src/test/java/org/apache/camel/quarkus/component/azure/storage/datalake/it/AzureStorageDatalakeTest.java
+++ b/integration-tests-jvm/azure-storage-datalake/src/test/java/org/apache/camel/quarkus/component/azure/storage/datalake/it/AzureStorageDatalakeTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.camel.quarkus.component.azure.storage.datalake.it;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import org.apache.camel.quarkus.test.support.azure.AzureStorageTestResource;
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 @EnabledIfEnvironmentVariable(named = "AZURE_STORAGE_ACCOUNT_NAME", matches = ".+")
 @EnabledIfEnvironmentVariable(named = "AZURE_STORAGE_ACCOUNT_KEY", matches = ".+")
 @QuarkusTest
-@WithTestResource(AzureStorageTestResource.class)
+@QuarkusTestResource(AzureStorageTestResource.class)
 class AzureStorageDatalakeTest {
 
     private static final Logger LOG = Logger.getLogger(AzureStorageDatalakeTest.class);

--- a/integration-tests-jvm/couchbase/src/test/java/org/apache/camel/quarkus/component/couchbase/it/CouchbaseDeleteTest.java
+++ b/integration-tests-jvm/couchbase/src/test/java/org/apache/camel/quarkus/component/couchbase/it/CouchbaseDeleteTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.camel.quarkus.component.couchbase.it;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
@@ -27,7 +27,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 
 @QuarkusTest
 @TestHTTPEndpoint(CouchbaseResource.class)
-@WithTestResource(CouchbaseTestResource.class)
+@QuarkusTestResource(CouchbaseTestResource.class)
 @DisabledIfEnvironmentVariable(named = "CI", matches = "true")
 class CouchbaseDeleteTest {
 

--- a/integration-tests-jvm/couchbase/src/test/java/org/apache/camel/quarkus/component/couchbase/it/CouchbasePollTest.java
+++ b/integration-tests-jvm/couchbase/src/test/java/org/apache/camel/quarkus/component/couchbase/it/CouchbasePollTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.camel.quarkus.component.couchbase.it;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
@@ -27,7 +27,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 
 @QuarkusTest
 @TestHTTPEndpoint(CouchbaseResource.class)
-@WithTestResource(CouchbaseTestResource.class)
+@QuarkusTestResource(CouchbaseTestResource.class)
 @DisabledIfEnvironmentVariable(named = "CI", matches = "true")
 public class CouchbasePollTest {
 

--- a/integration-tests-jvm/couchbase/src/test/java/org/apache/camel/quarkus/component/couchbase/it/CouchbaseUpdateTest.java
+++ b/integration-tests-jvm/couchbase/src/test/java/org/apache/camel/quarkus/component/couchbase/it/CouchbaseUpdateTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.camel.quarkus.component.couchbase.it;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.ContentType;
@@ -28,7 +28,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 
 @QuarkusTest
 @TestHTTPEndpoint(CouchbaseResource.class)
-@WithTestResource(CouchbaseTestResource.class)
+@QuarkusTestResource(CouchbaseTestResource.class)
 @DisabledIfEnvironmentVariable(named = "CI", matches = "true")
 public class CouchbaseUpdateTest {
 

--- a/integration-tests-jvm/elasticsearch/src/test/java/org/apache/camel/quarkus/component/elasticsearch/it/ElasticsearchTest.java
+++ b/integration-tests-jvm/elasticsearch/src/test/java/org/apache/camel/quarkus/component/elasticsearch/it/ElasticsearchTest.java
@@ -19,7 +19,7 @@ package org.apache.camel.quarkus.component.elasticsearch.it;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -31,7 +31,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import static org.hamcrest.Matchers.is;
 
 @QuarkusTest
-@WithTestResource(ElasticsearchTestResource.class)
+@QuarkusTestResource(ElasticsearchTestResource.class)
 class ElasticsearchTest {
 
     @AfterEach

--- a/integration-tests-jvm/hashicorp-vault/src/test/java/org/apache/camel/quarkus/component/hashicorp/vault/it/HashicorpVaultTest.java
+++ b/integration-tests-jvm/hashicorp-vault/src/test/java/org/apache/camel/quarkus/component/hashicorp/vault/it/HashicorpVaultTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.camel.quarkus.component.hashicorp.vault.it;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.Test;
@@ -26,7 +26,7 @@ import static org.apache.camel.quarkus.component.hashicorp.vault.it.HashicorpVau
 import static org.hamcrest.Matchers.is;
 
 @QuarkusTest
-@WithTestResource(HashicorpVaultTestResource.class)
+@QuarkusTestResource(HashicorpVaultTestResource.class)
 class HashicorpVaultTest {
     @Test
     void secretCRUD() {

--- a/integration-tests-jvm/redis/src/test/java/org/apache/camel/quarkus/component/redis/it/RedisTest.java
+++ b/integration-tests-jvm/redis/src/test/java/org/apache/camel/quarkus/component/redis/it/RedisTest.java
@@ -18,7 +18,7 @@ package org.apache.camel.quarkus.component.redis.it;
 
 import java.util.concurrent.TimeUnit;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.ContentType;
 import org.junit.jupiter.api.Test;
@@ -29,7 +29,7 @@ import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @QuarkusTest
-@WithTestResource(RedisTestResource.class)
+@QuarkusTestResource(RedisTestResource.class)
 class RedisTest {
 
     @Test

--- a/integration-tests-jvm/snmp/src/test/java/org/apache/camel/quarkus/component/snmp/it/SnmpTest.java
+++ b/integration-tests-jvm/snmp/src/test/java/org/apache/camel/quarkus/component/snmp/it/SnmpTest.java
@@ -19,7 +19,7 @@ package org.apache.camel.quarkus.component.snmp.it;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import org.hamcrest.Matchers;
@@ -38,7 +38,7 @@ import static org.awaitility.Awaitility.await;
  * - poll returns unending stream of responses
  */
 @QuarkusTest
-@WithTestResource(SnmpTestResource.class)
+@QuarkusTestResource(SnmpTestResource.class)
 class SnmpTest {
 
     public static final OID GET_NEXT_OID = new OID(new int[] { 1, 3, 6, 1, 2, 1, 25, 3, 2, 1, 5, 1 });

--- a/integration-tests-jvm/spring-redis/src/test/java/org/apache/camel/quarkus/component/spring/redis/it/SpringRedisTest.java
+++ b/integration-tests-jvm/spring-redis/src/test/java/org/apache/camel/quarkus/component/spring/redis/it/SpringRedisTest.java
@@ -18,14 +18,14 @@ package org.apache.camel.quarkus.component.spring.redis.it;
 
 import java.util.concurrent.TimeUnit;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.shaded.org.awaitility.Awaitility;
 
 @QuarkusTest
-@WithTestResource(SpringRedisTestResource.class)
+@QuarkusTestResource(SpringRedisTestResource.class)
 class SpringRedisTest {
 
     @Test

--- a/integration-tests/activemq/src/test/java/org/apache/camel/quarkus/component/activemq/it/ActiveMQTest.java
+++ b/integration-tests/activemq/src/test/java/org/apache/camel/quarkus/component/activemq/it/ActiveMQTest.java
@@ -16,12 +16,12 @@
  */
 package org.apache.camel.quarkus.component.activemq.it;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import org.apache.camel.quarkus.messaging.jms.AbstractJmsMessagingTest;
 
 @QuarkusTest
-@WithTestResource(ActiveMQTestResource.class)
+@QuarkusTestResource(ActiveMQTestResource.class)
 class ActiveMQTest extends AbstractJmsMessagingTest {
 
 }

--- a/integration-tests/amqp/src/test/java/org/apache/camel/quarkus/component/amqp/it/AmqpPoolingTest.java
+++ b/integration-tests/amqp/src/test/java/org/apache/camel/quarkus/component/amqp/it/AmqpPoolingTest.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.component.amqp.it;
 
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.ResourceArg;
-import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import io.restassured.RestAssured;
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.Matchers.containsString;
 
 @QuarkusTest
-@WithTestResource(initArgs = {
+@QuarkusTestResource(initArgs = {
         @ResourceArg(name = "modules", value = "quarkus.qpid-jms")
 }, value = ActiveMQTestResource.class)
 @TestProfile(JmsPoolingEnabled.class)

--- a/integration-tests/amqp/src/test/java/org/apache/camel/quarkus/component/amqp/it/AmqpTest.java
+++ b/integration-tests/amqp/src/test/java/org/apache/camel/quarkus/component/amqp/it/AmqpTest.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.component.amqp.it;
 
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.ResourceArg;
-import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import org.apache.camel.quarkus.messaging.jms.AbstractJmsMessagingTest;
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.Matchers.containsString;
 
 @QuarkusTest
-@WithTestResource(initArgs = {
+@QuarkusTestResource(initArgs = {
         @ResourceArg(name = "modules", value = "quarkus.qpid-jms")
 }, value = ActiveMQTestResource.class)
 class AmqpTest extends AbstractJmsMessagingTest {

--- a/integration-tests/arangodb/src/test/java/org/apache/camel/quarkus/component/arangodb/it/ArangodbTest.java
+++ b/integration-tests/arangodb/src/test/java/org/apache/camel/quarkus/component/arangodb/it/ArangodbTest.java
@@ -20,7 +20,7 @@ import com.arangodb.ArangoCollection;
 import com.arangodb.ArangoDB;
 import com.arangodb.ArangoDatabase;
 import com.arangodb.entity.BaseDocument;
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -34,7 +34,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 @QuarkusTest
-@WithTestResource(ArangodbTestResource.class)
+@QuarkusTestResource(ArangodbTestResource.class)
 class ArangodbTest {
     protected static final String DATABASE_NAME = "test";
     protected static final String COLLECTION_NAME = "camel";

--- a/integration-tests/as2/src/test/java/org/apache/camel/quarkus/component/as2/it/As2Test.java
+++ b/integration-tests/as2/src/test/java/org/apache/camel/quarkus/component/as2/it/As2Test.java
@@ -21,7 +21,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import org.apache.camel.component.as2.api.entity.AS2MessageDispositionNotificationEntity;
@@ -41,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@WithTestResource(As2TestResource.class)
+@QuarkusTestResource(As2TestResource.class)
 @QuarkusTest
 public class As2Test {
     private static final Logger LOG = LoggerFactory.getLogger(As2Test.class);

--- a/integration-tests/avro-rpc/src/test/java/org/apache/camel/quarkus/component/avro/rpc/it/AvroRpcTestSupport.java
+++ b/integration-tests/avro-rpc/src/test/java/org/apache/camel/quarkus/component/avro/rpc/it/AvroRpcTestSupport.java
@@ -20,7 +20,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.URL;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import org.apache.avro.ipc.HttpTransceiver;
@@ -42,7 +42,7 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@WithTestResource(AvroRpcTestResource.class)
+@QuarkusTestResource(AvroRpcTestResource.class)
 abstract class AvroRpcTestSupport {
 
     private final static String NAME = "Sheldon";

--- a/integration-tests/cassandraql/src/test/java/org/apache/camel/quarkus/component/cassandraql/it/CassandraqlTest.java
+++ b/integration-tests/cassandraql/src/test/java/org/apache/camel/quarkus/component/cassandraql/it/CassandraqlTest.java
@@ -18,7 +18,7 @@ package org.apache.camel.quarkus.component.cassandraql.it;
 
 import java.util.stream.Stream;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import org.hamcrest.Matcher;
@@ -34,7 +34,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 
 @QuarkusTest
-@WithTestResource(CassandraqlTestResource.class)
+@QuarkusTestResource(CassandraqlTestResource.class)
 class CassandraqlTest {
 
     private Employee sheldon = new Employee(1, "Sheldon", "Alpha Centauri");

--- a/integration-tests/consul/src/test/java/org/apache/camel/quarkus/component/consul/it/ConsulTest.java
+++ b/integration-tests/consul/src/test/java/org/apache/camel/quarkus/component/consul/it/ConsulTest.java
@@ -18,7 +18,7 @@ package org.apache.camel.quarkus.component.consul.it;
 
 import java.util.UUID;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.Test;
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.core.Is.is;
 
 @QuarkusTest
-@WithTestResource(ConsulTestResource.class)
+@QuarkusTestResource(ConsulTestResource.class)
 class ConsulTest {
     @Test
     public void basic() {

--- a/integration-tests/couchdb/src/test/java/org/apache/camel/quarkus/component/couchdb/it/CouchdbTest.java
+++ b/integration-tests/couchdb/src/test/java/org/apache/camel/quarkus/component/couchdb/it/CouchdbTest.java
@@ -18,7 +18,7 @@ package org.apache.camel.quarkus.component.couchdb.it;
 
 import java.util.concurrent.TimeUnit;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @QuarkusTest
-@WithTestResource(CouchdbTestResource.class)
+@QuarkusTestResource(CouchdbTestResource.class)
 class CouchdbTest {
 
     @Test

--- a/integration-tests/debezium/src/test/java/org/apache/camel/quarkus/component/debezium/common/it/mongodb/DebeziumMongodbTest.java
+++ b/integration-tests/debezium/src/test/java/org/apache/camel/quarkus/component/debezium/common/it/mongodb/DebeziumMongodbTest.java
@@ -25,7 +25,7 @@ import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.result.DeleteResult;
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import org.apache.camel.quarkus.component.debezium.common.it.AbstractDebeziumTest;
 import org.apache.camel.quarkus.component.debezium.common.it.Type;
@@ -50,7 +50,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 @Disabled("https://github.com/apache/camel-quarkus/issues/6341")
 @QuarkusTest
-@WithTestResource(DebeziumMongodbTestResource.class)
+@QuarkusTestResource(DebeziumMongodbTestResource.class)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class DebeziumMongodbTest extends AbstractDebeziumTest {
     private static MongoClient mongoClient;

--- a/integration-tests/debezium/src/test/java/org/apache/camel/quarkus/component/debezium/common/it/mysql/DebeziumMysqlTest.java
+++ b/integration-tests/debezium/src/test/java/org/apache/camel/quarkus/component/debezium/common/it/mysql/DebeziumMysqlTest.java
@@ -21,7 +21,7 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.Optional;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import org.apache.camel.quarkus.component.debezium.common.it.AbstractDebeziumTest;
 import org.apache.camel.quarkus.component.debezium.common.it.Type;
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
 @QuarkusTest
-@WithTestResource(DebeziumMysqlTestResource.class)
+@QuarkusTestResource(DebeziumMysqlTestResource.class)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class DebeziumMysqlTest extends AbstractDebeziumTest {
     private static Connection connection;

--- a/integration-tests/debezium/src/test/java/org/apache/camel/quarkus/component/debezium/common/it/postgres/DebeziumPostgresTest.java
+++ b/integration-tests/debezium/src/test/java/org/apache/camel/quarkus/component/debezium/common/it/postgres/DebeziumPostgresTest.java
@@ -20,7 +20,7 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import org.apache.camel.quarkus.component.debezium.common.it.AbstractDebeziumTest;
@@ -38,7 +38,7 @@ import org.junit.jupiter.api.TestMethodOrder;
 import static org.hamcrest.Matchers.is;
 
 @QuarkusTest
-@WithTestResource(DebeziumPostgresTestResource.class)
+@QuarkusTestResource(DebeziumPostgresTestResource.class)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class DebeziumPostgresTest extends AbstractDebeziumTest {
     private static final Logger LOG = Logger.getLogger(DebeziumPostgresTest.class);

--- a/integration-tests/debezium/src/test/java/org/apache/camel/quarkus/component/debezium/common/it/sqlserver/DebeziumSqlserverTest.java
+++ b/integration-tests/debezium/src/test/java/org/apache/camel/quarkus/component/debezium/common/it/sqlserver/DebeziumSqlserverTest.java
@@ -21,7 +21,7 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.Optional;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.response.Response;
 import org.apache.camel.quarkus.component.debezium.common.it.AbstractDebeziumTest;
@@ -42,7 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 @QuarkusTest
-@WithTestResource(DebeziumSqlserverTestResource.class)
+@QuarkusTestResource(DebeziumSqlserverTestResource.class)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class DebeziumSqlserverTest extends AbstractDebeziumTest {
     private static final Logger LOG = Logger.getLogger(DebeziumSqlserverTest.class);

--- a/integration-tests/digitalocean/src/test/java/org/apache/camel/quarkus/component/digitalocean/it/DigitaloceanDropletTest.java
+++ b/integration-tests/digitalocean/src/test/java/org/apache/camel/quarkus/component/digitalocean/it/DigitaloceanDropletTest.java
@@ -24,7 +24,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -41,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SuppressWarnings("unchecked")
 @QuarkusTest
-@WithTestResource(DigitaloceanTestResource.class)
+@QuarkusTestResource(DigitaloceanTestResource.class)
 public class DigitaloceanDropletTest {
     static final long timeout = 5;
     static TimeUnit timeoutUnit = TimeUnit.SECONDS;

--- a/integration-tests/digitalocean/src/test/java/org/apache/camel/quarkus/component/digitalocean/it/DigitaloceanTest.java
+++ b/integration-tests/digitalocean/src/test/java/org/apache/camel/quarkus/component/digitalocean/it/DigitaloceanTest.java
@@ -21,7 +21,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -39,7 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SuppressWarnings("unchecked")
 @QuarkusTest
-@WithTestResource(DigitaloceanTestResource.class)
+@QuarkusTestResource(DigitaloceanTestResource.class)
 class DigitaloceanTest {
     static String publicKey;
     @MockServer

--- a/integration-tests/elasticsearch-rest-client/src/test/java/org/apache/camel/quarkus/component/elasticsearch/rest/client/it/ElasticsearchRestClientTest.java
+++ b/integration-tests/elasticsearch-rest-client/src/test/java/org/apache/camel/quarkus/component/elasticsearch/rest/client/it/ElasticsearchRestClientTest.java
@@ -20,7 +20,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -38,7 +38,7 @@ import static org.hamcrest.Matchers.is;
                 Format.PKCS12 }, password = ElasticsearchRestTestResource.KEYSTORE_PASSWORD)
 }, docker = true)
 @QuarkusTest
-@WithTestResource(ElasticsearchRestTestResource.class)
+@QuarkusTestResource(ElasticsearchRestTestResource.class)
 class ElasticsearchRestClientTest {
 
     @AfterEach

--- a/integration-tests/fhir/src/test/java/org/apache/camel/quarkus/component/fhir/it/FhirDstu2Hl7OrgTest.java
+++ b/integration-tests/fhir/src/test/java/org/apache/camel/quarkus/component/fhir/it/FhirDstu2Hl7OrgTest.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.component.fhir.it;
 
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.ResourceArg;
-import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
@@ -27,7 +27,7 @@ import org.apache.camel.quarkus.test.EnabledIf;
 import static org.hamcrest.Matchers.is;
 
 @QuarkusTest
-@WithTestResource(value = FhirTestResource.class, initArgs = @ResourceArg(name = "fhirVersion", value = "DSTU2_HL7ORG"))
+@QuarkusTestResource(value = FhirTestResource.class, initArgs = @ResourceArg(name = "fhirVersion", value = "DSTU2_HL7ORG"))
 @TestHTTPEndpoint(FhirDstu2Hl7OrgResource.class)
 @EnabledIf(Dstu2Hl7OrgEnabled.class)
 class FhirDstu2Hl7OrgTest extends AbstractFhirTest {

--- a/integration-tests/fhir/src/test/java/org/apache/camel/quarkus/component/fhir/it/FhirDstu2Test.java
+++ b/integration-tests/fhir/src/test/java/org/apache/camel/quarkus/component/fhir/it/FhirDstu2Test.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.component.fhir.it;
 
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.ResourceArg;
-import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
@@ -27,7 +27,7 @@ import org.apache.camel.quarkus.test.EnabledIf;
 import static org.hamcrest.Matchers.is;
 
 @QuarkusTest
-@WithTestResource(value = FhirTestResource.class, initArgs = @ResourceArg(name = "fhirVersion", value = "DSTU2"))
+@QuarkusTestResource(value = FhirTestResource.class, initArgs = @ResourceArg(name = "fhirVersion", value = "DSTU2"))
 @TestHTTPEndpoint(FhirDstu2Resource.class)
 @EnabledIf(Dstu2Enabled.class)
 class FhirDstu2Test extends AbstractFhirTest {

--- a/integration-tests/fhir/src/test/java/org/apache/camel/quarkus/component/fhir/it/FhirDstu2_1Test.java
+++ b/integration-tests/fhir/src/test/java/org/apache/camel/quarkus/component/fhir/it/FhirDstu2_1Test.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.component.fhir.it;
 
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.ResourceArg;
-import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Disabled;
 import static org.hamcrest.Matchers.is;
 
 @QuarkusTest
-@WithTestResource(value = FhirTestResource.class, initArgs = @ResourceArg(name = "fhirVersion", value = "DSTU2_1"))
+@QuarkusTestResource(value = FhirTestResource.class, initArgs = @ResourceArg(name = "fhirVersion", value = "DSTU2_1"))
 @TestHTTPEndpoint(FhirDstu2_1Resource.class)
 @EnabledIf(Dstu2_1Enabled.class)
 @Disabled("https://github.com/hapifhir/hapi-fhir-jpaserver-starter/issues/335")

--- a/integration-tests/fhir/src/test/java/org/apache/camel/quarkus/component/fhir/it/FhirDstu3Test.java
+++ b/integration-tests/fhir/src/test/java/org/apache/camel/quarkus/component/fhir/it/FhirDstu3Test.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.component.fhir.it;
 
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.ResourceArg;
-import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
@@ -27,7 +27,7 @@ import org.apache.camel.quarkus.test.EnabledIf;
 import static org.hamcrest.Matchers.is;
 
 @QuarkusTest
-@WithTestResource(value = FhirTestResource.class, initArgs = @ResourceArg(name = "fhirVersion", value = "DSTU3"))
+@QuarkusTestResource(value = FhirTestResource.class, initArgs = @ResourceArg(name = "fhirVersion", value = "DSTU3"))
 @TestHTTPEndpoint(FhirDstu3Resource.class)
 @EnabledIf(Dstu3Enabled.class)
 class FhirDstu3Test extends AbstractFhirTest {

--- a/integration-tests/fhir/src/test/java/org/apache/camel/quarkus/component/fhir/it/FhirR4Test.java
+++ b/integration-tests/fhir/src/test/java/org/apache/camel/quarkus/component/fhir/it/FhirR4Test.java
@@ -16,15 +16,15 @@
  */
 package org.apache.camel.quarkus.component.fhir.it;
 
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.ResourceArg;
-import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
 import org.apache.camel.quarkus.component.fhir.it.util.R4Enabled;
 import org.apache.camel.quarkus.test.EnabledIf;
 
 @QuarkusTest
-@WithTestResource(value = FhirTestResource.class, initArgs = @ResourceArg(name = "fhirVersion", value = "R4"))
+@QuarkusTestResource(value = FhirTestResource.class, initArgs = @ResourceArg(name = "fhirVersion", value = "R4"))
 @TestHTTPEndpoint(FhirR4Resource.class)
 @EnabledIf(R4Enabled.class)
 class FhirR4Test extends AbstractFhirTest {

--- a/integration-tests/fhir/src/test/java/org/apache/camel/quarkus/component/fhir/it/FhirR5Test.java
+++ b/integration-tests/fhir/src/test/java/org/apache/camel/quarkus/component/fhir/it/FhirR5Test.java
@@ -16,15 +16,15 @@
  */
 package org.apache.camel.quarkus.component.fhir.it;
 
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.ResourceArg;
-import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
 import org.apache.camel.quarkus.component.fhir.it.util.R5Enabled;
 import org.apache.camel.quarkus.test.EnabledIf;
 
 @QuarkusTest
-@WithTestResource(value = FhirTestResource.class, initArgs = @ResourceArg(name = "fhirVersion", value = "R5"))
+@QuarkusTestResource(value = FhirTestResource.class, initArgs = @ResourceArg(name = "fhirVersion", value = "R5"))
 @TestHTTPEndpoint(FhirR5Resource.class)
 @EnabledIf(R5Enabled.class)
 class FhirR5Test extends AbstractFhirTest {

--- a/integration-tests/file/src/test/java/org/apache/camel/quarkus/component/file/it/FileTest.java
+++ b/integration-tests/file/src/test/java/org/apache/camel/quarkus/component/file/it/FileTest.java
@@ -25,7 +25,7 @@ import java.nio.file.StandardCopyOption;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -74,7 +74,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Linked to https://github.com/apache/camel-quarkus/issues/3584
  */
 @QuarkusTest
-@WithTestResource(value = FileTestResource.class, restrictToAnnotatedClass = false)
+@QuarkusTestResource(value = FileTestResource.class)
 class FileTest {
 
     @Test

--- a/integration-tests/ftp/src/test/java/org/apache/camel/quarkus/component/ftp/it/FtpTest.java
+++ b/integration-tests/ftp/src/test/java/org/apache/camel/quarkus/component/ftp/it/FtpTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.camel.quarkus.component.ftp.it;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.CoreMatchers.is;
 
 @QuarkusTest
-@WithTestResource(FtpTestResource.class)
+@QuarkusTestResource(FtpTestResource.class)
 class FtpTest {
     @Test
     public void testFtpComponent() {

--- a/integration-tests/ftp/src/test/java/org/apache/camel/quarkus/component/ftps/it/FtpsTest.java
+++ b/integration-tests/ftp/src/test/java/org/apache/camel/quarkus/component/ftps/it/FtpsTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.camel.quarkus.component.ftps.it;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -34,7 +34,7 @@ import static org.hamcrest.CoreMatchers.is;
                 Format.PKCS12 }, password = "password") })
 @Disabled //https://github.com/apache/camel-quarkus/issues/4089
 @QuarkusTest
-@WithTestResource(FtpsTestResource.class)
+@QuarkusTestResource(FtpsTestResource.class)
 class FtpsTest {
     static final String CERTIFICATE_KEYSTORE_FILE = CertificatesUtil.keystoreFile("ftp", "p12");
 

--- a/integration-tests/ftp/src/test/java/org/apache/camel/quarkus/component/sftp/it/SftpTest.java
+++ b/integration-tests/ftp/src/test/java/org/apache/camel/quarkus/component/sftp/it/SftpTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.camel.quarkus.component.sftp.it;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -33,7 +33,7 @@ import static org.hamcrest.CoreMatchers.is;
         @Certificate(name = "ftp", formats = {
                 Format.PKCS12 }, password = "password") })
 @QuarkusTest
-@WithTestResource(SftpTestResource.class)
+@QuarkusTestResource(SftpTestResource.class)
 class SftpTest {
 
     @Test

--- a/integration-tests/geocoder/src/test/java/org/apache/camel/quarkus/component/geocoder/it/GeocoderGoogleTest.java
+++ b/integration-tests/geocoder/src/test/java/org/apache/camel/quarkus/component/geocoder/it/GeocoderGoogleTest.java
@@ -17,7 +17,7 @@
 package org.apache.camel.quarkus.component.geocoder.it;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
@@ -33,7 +33,7 @@ import static org.hamcrest.Matchers.hasKey;
 
 @QuarkusTest
 @TestHTTPEndpoint(GeocoderGoogleResource.class)
-@WithTestResource(GeocoderTestResource.class)
+@QuarkusTestResource(GeocoderTestResource.class)
 class GeocoderGoogleTest {
 
     @MockServer

--- a/integration-tests/geocoder/src/test/java/org/apache/camel/quarkus/component/geocoder/it/GeocoderNominationTest.java
+++ b/integration-tests/geocoder/src/test/java/org/apache/camel/quarkus/component/geocoder/it/GeocoderNominationTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.camel.quarkus.component.geocoder.it;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
@@ -27,7 +27,7 @@ import static org.hamcrest.Matchers.notNullValue;
 
 @QuarkusTest
 @TestHTTPEndpoint(GeocoderNominationResource.class)
-@WithTestResource(GeocoderTestResource.class)
+@QuarkusTestResource(GeocoderTestResource.class)
 public class GeocoderNominationTest {
 
     /**

--- a/integration-tests/github/src/test/java/org/apache/camel/quarkus/component/github/it/GithubTest.java
+++ b/integration-tests/github/src/test/java/org/apache/camel/quarkus/component/github/it/GithubTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.camel.quarkus.component.github.it;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.Test;
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.Matchers.containsString;
 
 @QuarkusTest
-@WithTestResource(GithubTestResource.class)
+@QuarkusTestResource(GithubTestResource.class)
 class GithubTest {
 
     @Test

--- a/integration-tests/google-bigquery/src/test/java/org/apache/camel/quarkus/component/google/bigquery/it/GoogleBigqueryTest.java
+++ b/integration-tests/google-bigquery/src/test/java/org/apache/camel/quarkus/component/google/bigquery/it/GoogleBigqueryTest.java
@@ -34,7 +34,7 @@ import com.google.cloud.bigquery.Job;
 import com.google.cloud.bigquery.JobInfo;
 import com.google.cloud.bigquery.QueryJobConfiguration;
 import com.google.cloud.bigquery.TableResult;
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
@@ -52,8 +52,8 @@ import static org.hamcrest.Matchers.is;
 
 @QuarkusTest
 @TestHTTPEndpoint(GoogleBigqueryResource.class)
-@WithTestResource(GoogleBigqueryWiremockTestResource.class)
-@WithTestResource(GoogleCloudTestResource.class)
+@QuarkusTestResource(GoogleBigqueryWiremockTestResource.class)
+@QuarkusTestResource(GoogleCloudTestResource.class)
 class GoogleBigqueryTest {
 
     @GoogleProperty(name = "project.id")

--- a/integration-tests/google-pubsub/src/test/java/org/apache/camel/quarkus/component/google/pubsub/it/GooglePubsubTest.java
+++ b/integration-tests/google-pubsub/src/test/java/org/apache/camel/quarkus/component/google/pubsub/it/GooglePubsubTest.java
@@ -20,7 +20,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import org.apache.camel.component.google.pubsub.GooglePubsubConstants;
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 import static org.awaitility.Awaitility.await;
 
 @QuarkusTest
-@WithTestResource(GoogleCloudTestResource.class)
+@QuarkusTestResource(GoogleCloudTestResource.class)
 class GooglePubsubTest {
     private static final Logger LOG = Logger.getLogger(GooglePubsubTest.class);
 

--- a/integration-tests/google-storage/src/test/java/org/apache/camel/quarkus/component/google/storage/it/GoogleStorageTest.java
+++ b/integration-tests/google-storage/src/test/java/org/apache/camel/quarkus/component/google/storage/it/GoogleStorageTest.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -47,7 +47,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
 
 @QuarkusTest
-@WithTestResource(GoogleStorageTestResource.class)
+@QuarkusTestResource(GoogleStorageTestResource.class)
 class GoogleStorageTest {
     private static final Logger log = LoggerFactory.getLogger(GoogleStorageTest.class);
 

--- a/integration-tests/grpc/src/test/java/org/apache/camel/quarkus/component/grpc/it/GrpcTest.java
+++ b/integration-tests/grpc/src/test/java/org/apache/camel/quarkus/component/grpc/it/GrpcTest.java
@@ -29,7 +29,7 @@ import io.grpc.StatusRuntimeException;
 import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NettyChannelBuilder;
 import io.grpc.stub.StreamObserver;
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.path.json.JsonPath;
@@ -74,7 +74,7 @@ import static org.junit.jupiter.api.Assertions.fail;
         @Certificate(name = "grpc", formats = { Format.PEM })
 })
 @QuarkusTest
-@WithTestResource(GrpcServerTestResource.class)
+@QuarkusTestResource(GrpcServerTestResource.class)
 class GrpcTest {
 
     private static final String GRPC_TEST_PING_VALUE = "PING";

--- a/integration-tests/hazelcast/src/test/java/org/apache/camel/quarkus/component/hazelcast/it/HazelcastAtomicTest.java
+++ b/integration-tests/hazelcast/src/test/java/org/apache/camel/quarkus/component/hazelcast/it/HazelcastAtomicTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.camel.quarkus.component.hazelcast.it;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
@@ -26,7 +26,7 @@ import static org.hamcrest.Matchers.equalTo;
 
 @QuarkusTest
 @TestHTTPEndpoint(HazelcastAtomicResource.class)
-@WithTestResource(HazelcastTestResource.class)
+@QuarkusTestResource(HazelcastTestResource.class)
 class HazelcastAtomicTest {
     @Test
     public void testAtomicLong() {

--- a/integration-tests/hazelcast/src/test/java/org/apache/camel/quarkus/component/hazelcast/it/HazelcastIdempotentTest.java
+++ b/integration-tests/hazelcast/src/test/java/org/apache/camel/quarkus/component/hazelcast/it/HazelcastIdempotentTest.java
@@ -20,7 +20,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
@@ -33,7 +33,7 @@ import static org.awaitility.Awaitility.await;
 
 @QuarkusTest
 @TestHTTPEndpoint(HazelcastIdempotentResource.class)
-@WithTestResource(HazelcastTestResource.class)
+@QuarkusTestResource(HazelcastTestResource.class)
 public class HazelcastIdempotentTest {
 
     @SuppressWarnings("unchecked")

--- a/integration-tests/hazelcast/src/test/java/org/apache/camel/quarkus/component/hazelcast/it/HazelcastInstanceTest.java
+++ b/integration-tests/hazelcast/src/test/java/org/apache/camel/quarkus/component/hazelcast/it/HazelcastInstanceTest.java
@@ -19,7 +19,7 @@ package org.apache.camel.quarkus.component.hazelcast.it;
 import java.util.concurrent.TimeUnit;
 
 import com.hazelcast.core.HazelcastInstance;
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
@@ -29,7 +29,7 @@ import static org.awaitility.Awaitility.await;
 
 @QuarkusTest
 @TestHTTPEndpoint(HazelcastInstanceResource.class)
-@WithTestResource(HazelcastTestResource.class)
+@QuarkusTestResource(HazelcastTestResource.class)
 public class HazelcastInstanceTest {
 
     @Test

--- a/integration-tests/hazelcast/src/test/java/org/apache/camel/quarkus/component/hazelcast/it/HazelcastListTest.java
+++ b/integration-tests/hazelcast/src/test/java/org/apache/camel/quarkus/component/hazelcast/it/HazelcastListTest.java
@@ -20,7 +20,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
@@ -33,7 +33,7 @@ import static org.hamcrest.Matchers.equalTo;
 
 @QuarkusTest
 @TestHTTPEndpoint(HazelcastListResource.class)
-@WithTestResource(HazelcastTestResource.class)
+@QuarkusTestResource(HazelcastTestResource.class)
 public class HazelcastListTest {
 
     @SuppressWarnings("unchecked")

--- a/integration-tests/hazelcast/src/test/java/org/apache/camel/quarkus/component/hazelcast/it/HazelcastMapTest.java
+++ b/integration-tests/hazelcast/src/test/java/org/apache/camel/quarkus/component/hazelcast/it/HazelcastMapTest.java
@@ -20,7 +20,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
@@ -34,7 +34,7 @@ import static org.hamcrest.Matchers.equalTo;
 
 @QuarkusTest
 @TestHTTPEndpoint(HazelcastMapResource.class)
-@WithTestResource(HazelcastTestResource.class)
+@QuarkusTestResource(HazelcastTestResource.class)
 public class HazelcastMapTest {
 
     @SuppressWarnings("unchecked")

--- a/integration-tests/hazelcast/src/test/java/org/apache/camel/quarkus/component/hazelcast/it/HazelcastMultimapTest.java
+++ b/integration-tests/hazelcast/src/test/java/org/apache/camel/quarkus/component/hazelcast/it/HazelcastMultimapTest.java
@@ -20,7 +20,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
@@ -36,7 +36,7 @@ import static org.hamcrest.Matchers.hasSize;
 
 @QuarkusTest
 @TestHTTPEndpoint(HazelcastMultimapResource.class)
-@WithTestResource(HazelcastTestResource.class)
+@QuarkusTestResource(HazelcastTestResource.class)
 public class HazelcastMultimapTest {
 
     @SuppressWarnings("unchecked")

--- a/integration-tests/hazelcast/src/test/java/org/apache/camel/quarkus/component/hazelcast/it/HazelcastPolicyTest.java
+++ b/integration-tests/hazelcast/src/test/java/org/apache/camel/quarkus/component/hazelcast/it/HazelcastPolicyTest.java
@@ -20,7 +20,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
@@ -32,7 +32,7 @@ import static org.awaitility.Awaitility.await;
 
 @QuarkusTest
 @TestHTTPEndpoint(HazelcastPolicyResource.class)
-@WithTestResource(HazelcastTestResource.class)
+@QuarkusTestResource(HazelcastTestResource.class)
 public class HazelcastPolicyTest {
 
     @SuppressWarnings("unchecked")

--- a/integration-tests/hazelcast/src/test/java/org/apache/camel/quarkus/component/hazelcast/it/HazelcastQueueTest.java
+++ b/integration-tests/hazelcast/src/test/java/org/apache/camel/quarkus/component/hazelcast/it/HazelcastQueueTest.java
@@ -20,7 +20,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
@@ -35,7 +35,7 @@ import static org.hamcrest.Matchers.hasSize;
 
 @QuarkusTest
 @TestHTTPEndpoint(HazelcastQueueResource.class)
-@WithTestResource(HazelcastTestResource.class)
+@QuarkusTestResource(HazelcastTestResource.class)
 public class HazelcastQueueTest {
     @Test
     public void testQueue() {

--- a/integration-tests/hazelcast/src/test/java/org/apache/camel/quarkus/component/hazelcast/it/HazelcastReplicatedmapTest.java
+++ b/integration-tests/hazelcast/src/test/java/org/apache/camel/quarkus/component/hazelcast/it/HazelcastReplicatedmapTest.java
@@ -20,7 +20,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
@@ -35,7 +35,7 @@ import static org.hamcrest.Matchers.equalTo;
 
 @QuarkusTest
 @TestHTTPEndpoint(HazelcastReplicatedMapResource.class)
-@WithTestResource(HazelcastTestResource.class)
+@QuarkusTestResource(HazelcastTestResource.class)
 public class HazelcastReplicatedmapTest {
 
     @Test

--- a/integration-tests/hazelcast/src/test/java/org/apache/camel/quarkus/component/hazelcast/it/HazelcastRingbufferTest.java
+++ b/integration-tests/hazelcast/src/test/java/org/apache/camel/quarkus/component/hazelcast/it/HazelcastRingbufferTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.camel.quarkus.component.hazelcast.it;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.ContentType;
@@ -27,7 +27,7 @@ import static org.hamcrest.Matchers.equalTo;
 
 @QuarkusTest
 @TestHTTPEndpoint(HazelcastRingbufferResource.class)
-@WithTestResource(HazelcastTestResource.class)
+@QuarkusTestResource(HazelcastTestResource.class)
 public class HazelcastRingbufferTest {
     @Test
     public void testRingBuffer() {

--- a/integration-tests/hazelcast/src/test/java/org/apache/camel/quarkus/component/hazelcast/it/HazelcastSedaTest.java
+++ b/integration-tests/hazelcast/src/test/java/org/apache/camel/quarkus/component/hazelcast/it/HazelcastSedaTest.java
@@ -19,7 +19,7 @@ package org.apache.camel.quarkus.component.hazelcast.it;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
@@ -31,7 +31,7 @@ import static org.awaitility.Awaitility.await;
 
 @QuarkusTest
 @TestHTTPEndpoint(HazelcastSedaResource.class)
-@WithTestResource(HazelcastTestResource.class)
+@QuarkusTestResource(HazelcastTestResource.class)
 public class HazelcastSedaTest {
     @Test
     public void testSedaFifo() {

--- a/integration-tests/hazelcast/src/test/java/org/apache/camel/quarkus/component/hazelcast/it/HazelcastSetTest.java
+++ b/integration-tests/hazelcast/src/test/java/org/apache/camel/quarkus/component/hazelcast/it/HazelcastSetTest.java
@@ -20,7 +20,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
@@ -32,7 +32,7 @@ import static org.awaitility.Awaitility.await;
 
 @QuarkusTest
 @TestHTTPEndpoint(HazelcastSetResource.class)
-@WithTestResource(HazelcastTestResource.class)
+@QuarkusTestResource(HazelcastTestResource.class)
 public class HazelcastSetTest {
 
     @SuppressWarnings("unchecked")

--- a/integration-tests/hazelcast/src/test/java/org/apache/camel/quarkus/component/hazelcast/it/HazelcastTopicTest.java
+++ b/integration-tests/hazelcast/src/test/java/org/apache/camel/quarkus/component/hazelcast/it/HazelcastTopicTest.java
@@ -19,7 +19,7 @@ package org.apache.camel.quarkus.component.hazelcast.it;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
@@ -31,7 +31,7 @@ import static org.awaitility.Awaitility.await;
 
 @QuarkusTest
 @TestHTTPEndpoint(HazelcastTopicResource.class)
-@WithTestResource(HazelcastTestResource.class)
+@QuarkusTestResource(HazelcastTestResource.class)
 public class HazelcastTopicTest {
     @Test
     public void testTopic() {

--- a/integration-tests/hl7/src/test/java/org/apache/camel/quarkus/component/hl7/it/Hl7Test.java
+++ b/integration-tests/hl7/src/test/java/org/apache/camel/quarkus/component/hl7/it/Hl7Test.java
@@ -29,7 +29,7 @@ import ca.uhn.hl7v2.parser.ParserConfiguration;
 import ca.uhn.hl7v2.parser.UnexpectedSegmentBehaviourEnum;
 import ca.uhn.hl7v2.validation.ValidationContext;
 import ca.uhn.hl7v2.validation.impl.ValidationContextFactory;
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -43,7 +43,7 @@ import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.is;
 
 @QuarkusTest
-@WithTestResource(Hl7TestResource.class)
+@QuarkusTestResource(Hl7TestResource.class)
 class Hl7Test {
 
     private static final String PID_MESSAGE = readPidFile();

--- a/integration-tests/infinispan/src/test/java/org/apache/camel/quarkus/component/infinispan/InfinispanTest.java
+++ b/integration-tests/infinispan/src/test/java/org/apache/camel/quarkus/component/infinispan/InfinispanTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.camel.quarkus.component.infinispan;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import org.apache.camel.quarkus.component.infinispan.common.InfinispanCommonTest;
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.Matchers.is;
 
 @QuarkusTest
-@WithTestResource(InfinispanServerTestResource.class)
+@QuarkusTestResource(InfinispanServerTestResource.class)
 public class InfinispanTest extends InfinispanCommonTest {
     public void inspect() {
         String hosts = ConfigProvider.getConfig().getValue("camel.component.infinispan.hosts", String.class);

--- a/integration-tests/influxdb/src/test/java/org/apache/camel/quarkus/component/influxdb/it/InfluxdbTest.java
+++ b/integration-tests/influxdb/src/test/java/org/apache/camel/quarkus/component/influxdb/it/InfluxdbTest.java
@@ -19,7 +19,7 @@ package org.apache.camel.quarkus.component.influxdb.it;
 import java.util.HashMap;
 import java.util.Map;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @QuarkusTest
-@WithTestResource(InfluxdbTestResource.class)
+@QuarkusTestResource(InfluxdbTestResource.class)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class InfluxdbTest {
 

--- a/integration-tests/jfr/src/test/java/org/apache/camel/quarkus/component/jfr/it/JfrTest.java
+++ b/integration-tests/jfr/src/test/java/org/apache/camel/quarkus/component/jfr/it/JfrTest.java
@@ -18,7 +18,7 @@ package org.apache.camel.quarkus.component.jfr.it;
 
 import java.io.File;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.Test;
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @QuarkusTest
-@WithTestResource(JfrTestResource.class)
+@QuarkusTestResource(JfrTestResource.class)
 class JfrTest {
 
     @Test

--- a/integration-tests/jira/src/test/java/org/apache/camel/quarkus/component/jira/it/JiraTest.java
+++ b/integration-tests/jira/src/test/java/org/apache/camel/quarkus/component/jira/it/JiraTest.java
@@ -30,7 +30,7 @@ import com.atlassian.jira.rest.client.api.domain.Issue;
 import com.atlassian.jira.rest.client.api.domain.IssueLink;
 import com.atlassian.jira.rest.client.api.domain.Resolution;
 import com.atlassian.jira.rest.client.api.domain.Worklog;
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -50,7 +50,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @QuarkusTest
-@WithTestResource(JiraTestResource.class)
+@QuarkusTestResource(JiraTestResource.class)
 public class JiraTest {
 
     private static final String ISSUE_ATTACHMENT = "Camel Quarkus Test Issue Attachment";

--- a/integration-tests/jms-artemis-client/src/test/java/org/apache/camel/quarkus/component/jms/artemis/it/JmsArtemisCustomTest.java
+++ b/integration-tests/jms-artemis-client/src/test/java/org/apache/camel/quarkus/component/jms/artemis/it/JmsArtemisCustomTest.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.component.jms.artemis.it;
 
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.ResourceArg;
-import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import io.restassured.RestAssured;
@@ -30,7 +30,7 @@ import static org.hamcrest.Matchers.is;
 
 @QuarkusTest
 @TestProfile(JmsArtemisDisable.class)
-@WithTestResource(initArgs = {
+@QuarkusTestResource(initArgs = {
         @ResourceArg(name = "modules", value = "quarkus.artemis"),
         @ResourceArg(name = "java-args", value = "-Dbrokerconfig.securityEnabled=false")
 }, value = ActiveMQTestResource.class)

--- a/integration-tests/jms-ibmmq-client/src/test/java/org/apache/camel/quarkus/component/jms/ibmmq/it/IBMMQPoolingTest.java
+++ b/integration-tests/jms-ibmmq-client/src/test/java/org/apache/camel/quarkus/component/jms/ibmmq/it/IBMMQPoolingTest.java
@@ -19,7 +19,7 @@ package org.apache.camel.quarkus.component.jms.ibmmq.it;
 
 import java.lang.reflect.Method;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import io.restassured.RestAssured;
@@ -35,7 +35,7 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import static org.hamcrest.Matchers.is;
 
 @QuarkusTest
-@WithTestResource(IBMMQTestResource.class)
+@QuarkusTestResource(IBMMQTestResource.class)
 @EnabledIfSystemProperty(named = "ibm.mq.container.license", matches = "accept")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @TestProfile(JmsPoolingEnabled.class)

--- a/integration-tests/jms-ibmmq-client/src/test/java/org/apache/camel/quarkus/component/jms/ibmmq/it/IBMMQTest.java
+++ b/integration-tests/jms-ibmmq-client/src/test/java/org/apache/camel/quarkus/component/jms/ibmmq/it/IBMMQTest.java
@@ -18,7 +18,7 @@ package org.apache.camel.quarkus.component.jms.ibmmq.it;
 
 import java.lang.reflect.Method;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import org.apache.camel.quarkus.component.jms.ibmmq.support.IBMMQDestinations;
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import static org.hamcrest.Matchers.is;
 
 @QuarkusTest
-@WithTestResource(IBMMQTestResource.class)
+@QuarkusTestResource(IBMMQTestResource.class)
 @EnabledIfSystemProperty(named = "ibm.mq.container.license", matches = "accept")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class IBMMQTest extends AbstractJmsMessagingTest {

--- a/integration-tests/jms-ibmmq-client/src/test/java/org/apache/camel/quarkus/component/jms/ibmmq/it/IBMMQXATest.java
+++ b/integration-tests/jms-ibmmq-client/src/test/java/org/apache/camel/quarkus/component/jms/ibmmq/it/IBMMQXATest.java
@@ -17,7 +17,7 @@
 
 package org.apache.camel.quarkus.component.jms.ibmmq.it;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import io.restassured.RestAssured;
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import static org.hamcrest.core.Is.is;
 
 @QuarkusTest
-@WithTestResource(IBMMQTestResource.class)
+@QuarkusTestResource(IBMMQTestResource.class)
 @EnabledIfSystemProperty(named = "ibm.mq.container.license", matches = "accept")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @TestProfile(JmsXAEnabled.class)

--- a/integration-tests/jms-qpid-amqp-client/src/test/java/org/apache/camel/quarkus/component/jms/qpid/it/JmsQpidPoolingTest.java
+++ b/integration-tests/jms-qpid-amqp-client/src/test/java/org/apache/camel/quarkus/component/jms/qpid/it/JmsQpidPoolingTest.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.component.jms.qpid.it;
 
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.ResourceArg;
-import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import io.restassured.RestAssured;
@@ -29,7 +29,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
 @QuarkusTest
-@WithTestResource(initArgs = {
+@QuarkusTestResource(initArgs = {
         @ResourceArg(name = "modules", value = "quarkus.qpid-jms") }, value = ActiveMQTestResource.class)
 @TestProfile(JmsPoolingEnabled.class)
 class JmsQpidPoolingTest extends AbstractJmsMessagingTest {

--- a/integration-tests/jms-qpid-amqp-client/src/test/java/org/apache/camel/quarkus/component/jms/qpid/it/JmsQpidTest.java
+++ b/integration-tests/jms-qpid-amqp-client/src/test/java/org/apache/camel/quarkus/component/jms/qpid/it/JmsQpidTest.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.component.jms.qpid.it;
 
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.ResourceArg;
-import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import org.apache.camel.quarkus.messaging.jms.AbstractJmsMessagingTest;
@@ -28,7 +28,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
 @QuarkusTest
-@WithTestResource(initArgs = {
+@QuarkusTestResource(initArgs = {
         @ResourceArg(name = "modules", value = "quarkus.qpid-jms") }, value = ActiveMQTestResource.class)
 class JmsQpidTest extends AbstractJmsMessagingTest {
 

--- a/integration-tests/jsch/src/test/java/org/apache/camel/quarkus/component/jsch/it/JschTest.java
+++ b/integration-tests/jsch/src/test/java/org/apache/camel/quarkus/component/jsch/it/JschTest.java
@@ -19,7 +19,7 @@ package org.apache.camel.quarkus.component.jsch.it;
 import java.io.IOException;
 import java.nio.file.Path;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.Test;
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.io.TempDir;
 import static org.hamcrest.CoreMatchers.is;
 
 @QuarkusTest
-@WithTestResource(JschTestResource.class)
+@QuarkusTestResource(JschTestResource.class)
 class JschTest {
 
     @Test

--- a/integration-tests/jt400/src/test/java/org/apache/camel/quarkus/component/jt400/it/Jt400Test.java
+++ b/integration-tests/jt400/src/test/java/org/apache/camel/quarkus/component/jt400/it/Jt400Test.java
@@ -20,7 +20,7 @@ import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
 import com.ibm.as400.access.QueuedMessage;
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import org.apache.camel.component.jt400.Jt400Constants;
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
 @QuarkusTest
 @EnabledIfEnvironmentVariable(named = "JT400_URL", matches = ".+")
-@WithTestResource(Jt400TestResource.class)
+@QuarkusTestResource(Jt400TestResource.class)
 public class Jt400Test {
     private static final Logger LOGGER = Logger.getLogger(Jt400Test.class);
 

--- a/integration-tests/jta/src/test/java/org/apache/camel/quarkus/component/jta/it/JtaTest.java
+++ b/integration-tests/jta/src/test/java/org/apache/camel/quarkus/component/jta/it/JtaTest.java
@@ -23,7 +23,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.UUID;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.h2.H2DatabaseTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
@@ -37,7 +37,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import static org.hamcrest.Matchers.is;
 
 @QuarkusTest
-@WithTestResource(H2DatabaseTestResource.class)
+@QuarkusTestResource(H2DatabaseTestResource.class)
 class JtaTest {
 
     @Test

--- a/integration-tests/kafka-oauth/src/test/java/org/apache/camel/quarkus/kafka/oauth/it/KafkaTest.java
+++ b/integration-tests/kafka-oauth/src/test/java/org/apache/camel/quarkus/kafka/oauth/it/KafkaTest.java
@@ -18,7 +18,7 @@ package org.apache.camel.quarkus.kafka.oauth.it;
 
 import java.util.concurrent.TimeUnit;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.Test;
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 import static org.awaitility.Awaitility.await;
 
 @QuarkusTest
-@WithTestResource(KafkaKeycloakTestResource.class)
+@QuarkusTestResource(KafkaKeycloakTestResource.class)
 public class KafkaTest {
 
     @Test

--- a/integration-tests/kafka-sasl-ssl/src/test/java/org/apache/camel/quarkus/kafka/sasl/KafkaSaslSslTest.java
+++ b/integration-tests/kafka-sasl-ssl/src/test/java/org/apache/camel/quarkus/kafka/sasl/KafkaSaslSslTest.java
@@ -18,7 +18,7 @@ package org.apache.camel.quarkus.kafka.sasl;
 
 import java.util.UUID;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.path.json.JsonPath;
@@ -34,7 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
                 Format.PKCS12 }, password = KafkaSaslSslTestResource.KAFKA_KEYSTORE_PASSWORD)
 }, baseDir = KafkaSaslSslTestResource.CERTS_BASEDIR, docker = true)
 @QuarkusTest
-@WithTestResource(KafkaSaslSslTestResource.class)
+@QuarkusTestResource(KafkaSaslSslTestResource.class)
 public class KafkaSaslSslTest {
 
     @Test

--- a/integration-tests/kafka-sasl/src/test/java/org/apache/camel/quarkus/kafka/sasl/KafkaSaslBindingTest.java
+++ b/integration-tests/kafka-sasl/src/test/java/org/apache/camel/quarkus/kafka/sasl/KafkaSaslBindingTest.java
@@ -18,7 +18,7 @@ package org.apache.camel.quarkus.kafka.sasl;
 
 import java.util.UUID;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.path.json.JsonPath;
@@ -29,7 +29,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 @DisabledIfFipsMode
 @QuarkusTest
-@WithTestResource(KafkaSaslTestResource.class)
+@QuarkusTestResource(KafkaSaslTestResource.class)
 public class KafkaSaslBindingTest {
 
     @Test

--- a/integration-tests/kafka-ssl/src/test/java/org/apache/camel/quarkus/kafka/ssl/KafkaSslTest.java
+++ b/integration-tests/kafka-ssl/src/test/java/org/apache/camel/quarkus/kafka/ssl/KafkaSslTest.java
@@ -19,7 +19,7 @@ package org.apache.camel.quarkus.kafka.ssl;
 import java.lang.reflect.AnnotatedElement;
 import java.util.UUID;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.path.json.JsonPath;
@@ -36,7 +36,7 @@ import static org.hamcrest.Matchers.is;
                 Format.PKCS12 }, password = KafkaSslTestResource.KAFKA_KEYSTORE_PASSWORD)
 }, docker = true)
 @QuarkusTest
-@WithTestResource(KafkaSslTestResource.class)
+@QuarkusTestResource(KafkaSslTestResource.class)
 public class KafkaSslTest {
 
     @Test

--- a/integration-tests/kafka/src/test/java/org/apache/camel/quarkus/component/kafka/it/CamelKafkaHealthCheckTest.java
+++ b/integration-tests/kafka/src/test/java/org/apache/camel/quarkus/component/kafka/it/CamelKafkaHealthCheckTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.camel.quarkus.component.kafka.it;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import io.restassured.RestAssured;
@@ -31,7 +31,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
 @QuarkusTest
-@WithTestResource(KafkaTestResource.class)
+@QuarkusTestResource(KafkaTestResource.class)
 @TestProfile(KafkaHealthCheckProfile.class)
 public class CamelKafkaHealthCheckTest {
 

--- a/integration-tests/kafka/src/test/java/org/apache/camel/quarkus/component/kafka/it/CamelKafkaTest.java
+++ b/integration-tests/kafka/src/test/java/org/apache/camel/quarkus/component/kafka/it/CamelKafkaTest.java
@@ -19,7 +19,7 @@ package org.apache.camel.quarkus.component.kafka.it;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -35,7 +35,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @QuarkusTest
-@WithTestResource(KafkaTestResource.class)
+@QuarkusTestResource(KafkaTestResource.class)
 public class CamelKafkaTest {
 
     @Test

--- a/integration-tests/knative/src/test/java/org/apache/camel/quarkus/component/knative/producer/it/KnativeProducerTest.java
+++ b/integration-tests/knative/src/test/java/org/apache/camel/quarkus/component/knative/producer/it/KnativeProducerTest.java
@@ -18,7 +18,7 @@ package org.apache.camel.quarkus.component.knative.producer.it;
 
 import java.util.concurrent.TimeUnit;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @TestProfile(KnativeProducerTestProfile.class)
 @QuarkusTest
 @TestHTTPEndpoint(KnativeProducerResource.class)
-@WithTestResource(KnativeTestResource.class)
+@QuarkusTestResource(KnativeTestResource.class)
 public class KnativeProducerTest {
     @Test
     void inspect() {

--- a/integration-tests/kubernetes/src/test/java/org/apache/camel/quarkus/component/kubernetes/it/KubernetesTest.java
+++ b/integration-tests/kubernetes/src/test/java/org/apache/camel/quarkus/component/kubernetes/it/KubernetesTest.java
@@ -20,7 +20,7 @@ import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.kubernetes.client.KubernetesServerTestResource;
 import io.quarkus.test.kubernetes.client.KubernetesTestServer;
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.Matchers.is;
 
 @QuarkusTest
-@WithTestResource(KubernetesServerTestResource.class)
+@QuarkusTestResource(KubernetesServerTestResource.class)
 public class KubernetesTest {
 
     @KubernetesTestServer

--- a/integration-tests/kudu/src/test/java/org/apache/camel/quarkus/component/kudu/it/KuduTest.java
+++ b/integration-tests/kudu/src/test/java/org/apache/camel/quarkus/component/kudu/it/KuduTest.java
@@ -18,7 +18,7 @@ package org.apache.camel.quarkus.component.kudu.it;
 
 import java.util.Map;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -38,7 +38,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@WithTestResource(KuduTestResource.class)
+@QuarkusTestResource(KuduTestResource.class)
 @QuarkusTest
 class KuduTest {
     private static final Logger LOG = Logger.getLogger(KuduTest.class);

--- a/integration-tests/langchain4j-chat/src/test/java/org/apache/camel/quarkus/component/langchain4j/chat/it/LangChain4jChatTest.java
+++ b/integration-tests/langchain4j-chat/src/test/java/org/apache/camel/quarkus/component/langchain4j/chat/it/LangChain4jChatTest.java
@@ -16,13 +16,13 @@
  */
 package org.apache.camel.quarkus.component.langchain4j.chat.it;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
-@WithTestResource(OllamaTestResource.class)
+@QuarkusTestResource(OllamaTestResource.class)
 class LangChain4jChatTest {
 
     @Test

--- a/integration-tests/lra/src/test/java/org/apache/camel/quarkus/component/lra/it/LraTest.java
+++ b/integration-tests/lra/src/test/java/org/apache/camel/quarkus/component/lra/it/LraTest.java
@@ -18,7 +18,7 @@ package org.apache.camel.quarkus.component.lra.it;
 
 import java.util.concurrent.TimeUnit;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.Assertions;
@@ -29,7 +29,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import static org.awaitility.Awaitility.await;
 
 @QuarkusTest
-@WithTestResource(LraTestResource.class)
+@QuarkusTestResource(LraTestResource.class)
 class LraTest {
 
     @Test

--- a/integration-tests/lumberjack/src/test/java/org/apache/camel/quarkus/component/lumberjack/it/LumberjackTest.java
+++ b/integration-tests/lumberjack/src/test/java/org/apache/camel/quarkus/component/lumberjack/it/LumberjackTest.java
@@ -18,7 +18,7 @@ package org.apache.camel.quarkus.component.lumberjack.it;
 
 import java.util.List;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
@@ -37,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
                 Format.JKS }, password = "changeit") })
 @QuarkusTest
 @TestHTTPEndpoint(LumberjackResource.class)
-@WithTestResource(LumberjackTestResource.class)
+@QuarkusTestResource(LumberjackTestResource.class)
 class LumberjackTest {
 
     static final int VERSION_V2 = '2';

--- a/integration-tests/mail/src/test/java/org/apache/camel/quarkus/component/mail/MailTest.java
+++ b/integration-tests/mail/src/test/java/org/apache/camel/quarkus/component/mail/MailTest.java
@@ -30,7 +30,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -62,7 +62,7 @@ import static org.hamcrest.Matchers.is;
                 Format.PKCS12 }, password = MailTestResource.KEYSTORE_PASSWORD)
 }, docker = true)
 @QuarkusTest
-@WithTestResource(MailTestResource.class)
+@QuarkusTestResource(MailTestResource.class)
 public class MailTest {
     static final String GREENMAIL_CERTIFICATE_STORE_FILE = CertificatesUtil.keystoreFile("greenmail", "p12");
     private static final Pattern DELIMITER_PATTERN = Pattern.compile("\r\n[^\r\n]+");

--- a/integration-tests/master-openshift/src/test/java/org/apache/camel/quarkus/component/master/it/MasterOpenShiftTest.java
+++ b/integration-tests/master-openshift/src/test/java/org/apache/camel/quarkus/component/master/it/MasterOpenShiftTest.java
@@ -26,7 +26,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 import io.fabric8.openshift.client.server.mock.OpenShiftServer;
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.kubernetes.client.OpenShiftTestServer;
 import io.restassured.RestAssured;
@@ -45,7 +45,7 @@ import org.zeroturnaround.exec.StartedProcess;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.emptyString;
 
-@WithTestResource(MasterOpenShiftTestResource.class)
+@QuarkusTestResource(MasterOpenShiftTestResource.class)
 @QuarkusTest
 class MasterOpenShiftTest {
 

--- a/integration-tests/minio/src/test/java/org/apache/camel/quarkus/component/minio/it/MinioTest.java
+++ b/integration-tests/minio/src/test/java/org/apache/camel/quarkus/component/minio/it/MinioTest.java
@@ -30,7 +30,7 @@ import io.minio.MakeBucketArgs;
 import io.minio.MinioClient;
 import io.minio.PutObjectArgs;
 import io.minio.errors.MinioException;
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -46,7 +46,7 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.startsWith;
 
 @QuarkusTest
-@WithTestResource(MinioTestResource.class)
+@QuarkusTestResource(MinioTestResource.class)
 class MinioTest {
     private static final long PART_SIZE = 50 * 1024 * 1024;
 

--- a/integration-tests/mllp/src/test/java/org/apache/camel/quarkus/component/mllp/it/MllpTest.java
+++ b/integration-tests/mllp/src/test/java/org/apache/camel/quarkus/component/mllp/it/MllpTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.camel.quarkus.component.mllp.it;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.Test;
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.Matchers.containsString;
 
 @QuarkusTest
-@WithTestResource(MllpTestResource.class)
+@QuarkusTestResource(MllpTestResource.class)
 class MllpTest {
 
     private static final String HL7_MESSAGE = "MSH|^~\\&|REQUESTING|ICE|INHOUSE|RTH00|20210331095020||ORM^O01|1|D|2.3|||AL|NE||\r"

--- a/integration-tests/mybatis/src/test/java/org/apache/camel/quarkus/component/mybatis/it/MyBatisConsumerTest.java
+++ b/integration-tests/mybatis/src/test/java/org/apache/camel/quarkus/component/mybatis/it/MyBatisConsumerTest.java
@@ -20,7 +20,7 @@ package org.apache.camel.quarkus.component.mybatis.it;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.h2.H2DatabaseTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
@@ -33,7 +33,7 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.is;
 
 @QuarkusTest
-@WithTestResource(H2DatabaseTestResource.class)
+@QuarkusTestResource(H2DatabaseTestResource.class)
 public class MyBatisConsumerTest {
 
     @Test

--- a/integration-tests/mybatis/src/test/java/org/apache/camel/quarkus/component/mybatis/it/MyBatisTest.java
+++ b/integration-tests/mybatis/src/test/java/org/apache/camel/quarkus/component/mybatis/it/MyBatisTest.java
@@ -22,7 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.h2.H2DatabaseTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.Matchers.equalTo;
 
 @QuarkusTest
-@WithTestResource(H2DatabaseTestResource.class)
+@QuarkusTestResource(H2DatabaseTestResource.class)
 public class MyBatisTest {
     @Test
     public void tests() {

--- a/integration-tests/nats/src/test/java/org/apache/camel/quarkus/component/nats/it/NatsTest.java
+++ b/integration-tests/nats/src/test/java/org/apache/camel/quarkus/component/nats/it/NatsTest.java
@@ -18,7 +18,7 @@ package org.apache.camel.quarkus.component.nats.it;
 
 import java.util.concurrent.TimeUnit;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.Header;
 import me.escoffier.certs.Format;
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @TestCertificates(certificates = {
         @Certificate(name = "nats", formats = {
                 Format.PKCS12, Format.PEM }, password = "password") })
-@WithTestResource(NatsTestResource.class)
+@QuarkusTestResource(NatsTestResource.class)
 @QuarkusTest
 class NatsTest {
 

--- a/integration-tests/netty/src/test/java/org/apache/camel/quarkus/component/netty/tcp/NettyTcpTest.java
+++ b/integration-tests/netty/src/test/java/org/apache/camel/quarkus/component/netty/tcp/NettyTcpTest.java
@@ -18,7 +18,7 @@ package org.apache.camel.quarkus.component.netty.tcp;
 
 import java.io.IOException;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import me.escoffier.certs.Format;
@@ -32,7 +32,7 @@ import static org.hamcrest.Matchers.is;
         @Certificate(name = "netty", formats = {
                 Format.PKCS12 }, password = "changeit") })
 @QuarkusTest
-@WithTestResource(value = NettyTcpTestResource.class, restrictToAnnotatedClass = false)
+@QuarkusTestResource(value = NettyTcpTestResource.class)
 class NettyTcpTest {
 
     @Test

--- a/integration-tests/netty/src/test/java/org/apache/camel/quarkus/component/netty/udp/NettyUdpTest.java
+++ b/integration-tests/netty/src/test/java/org/apache/camel/quarkus/component/netty/udp/NettyUdpTest.java
@@ -18,7 +18,7 @@ package org.apache.camel.quarkus.component.netty.udp;
 
 import java.io.IOException;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import me.escoffier.certs.Format;
@@ -32,7 +32,7 @@ import static org.hamcrest.Matchers.is;
         @Certificate(name = "netty", formats = {
                 Format.PKCS12 }, password = "changeit") })
 @QuarkusTest
-@WithTestResource(value = NettyUdpTestResource.class, restrictToAnnotatedClass = false)
+@QuarkusTestResource(value = NettyUdpTestResource.class)
 class NettyUdpTest {
 
     @Test

--- a/integration-tests/nitrite/src/test/java/org/apache/camel/quarkus/component/nitrite/it/NitriteTest.java
+++ b/integration-tests/nitrite/src/test/java/org/apache/camel/quarkus/component/nitrite/it/NitriteTest.java
@@ -18,7 +18,7 @@ package org.apache.camel.quarkus.component.nitrite.it;
 
 import java.util.GregorianCalendar;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.TestMethodOrder;
 import static org.hamcrest.core.Is.is;
 
 @QuarkusTest
-@WithTestResource(NitriteTestResource.class)
+@QuarkusTestResource(NitriteTestResource.class)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class NitriteTest {
 

--- a/integration-tests/oaipmh/src/test/java/org/apache/camel/quarkus/component/oaipmh/it/OaipmhTest.java
+++ b/integration-tests/oaipmh/src/test/java/org/apache/camel/quarkus/component/oaipmh/it/OaipmhTest.java
@@ -18,7 +18,7 @@ package org.apache.camel.quarkus.component.oaipmh.it;
 
 import java.util.concurrent.TimeUnit;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import me.escoffier.certs.Format;
 import me.escoffier.certs.junit5.Certificate;
@@ -34,7 +34,7 @@ import static org.hamcrest.Matchers.is;
         @Certificate(name = "oaipmh", formats = {
                 Format.PKCS12 }, password = MockOaipmhServer.PASSWORD) })
 @QuarkusTest
-@WithTestResource(OaipmhTestResource.class)
+@QuarkusTestResource(OaipmhTestResource.class)
 class OaipmhTest {
 
     @Test

--- a/integration-tests/olingo4/src/test/java/org/apache/camel/quarkus/component/olingo4/it/Olingo4Test.java
+++ b/integration-tests/olingo4/src/test/java/org/apache/camel/quarkus/component/olingo4/it/Olingo4Test.java
@@ -18,7 +18,7 @@ package org.apache.camel.quarkus.component.olingo4.it;
 
 import java.io.IOException;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -37,7 +37,7 @@ import static org.apache.camel.quarkus.component.olingo4.it.Olingo4Resource.TEST
 import static org.hamcrest.core.Is.is;
 
 @QuarkusTest
-@WithTestResource(TrustStoreResource.class)
+@QuarkusTestResource(TrustStoreResource.class)
 class Olingo4Test {
 
     private static String sessionId;

--- a/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenstackCinderSnapshotTest.java
+++ b/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenstackCinderSnapshotTest.java
@@ -16,14 +16,14 @@
  */
 package org.apache.camel.quarkus.component.openstack.it;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.post;
 
 @QuarkusTest
-@WithTestResource(OpenStackTestResource.class)
+@QuarkusTestResource(OpenStackTestResource.class)
 class OpenstackCinderSnapshotTest {
 
     @Test

--- a/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenstackCinderVolumeTest.java
+++ b/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenstackCinderVolumeTest.java
@@ -16,14 +16,14 @@
  */
 package org.apache.camel.quarkus.component.openstack.it;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.post;
 
 @QuarkusTest
-@WithTestResource(OpenStackTestResource.class)
+@QuarkusTestResource(OpenStackTestResource.class)
 class OpenstackCinderVolumeTest {
 
     @Test

--- a/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenstackGlanceTest.java
+++ b/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenstackGlanceTest.java
@@ -16,14 +16,14 @@
  */
 package org.apache.camel.quarkus.component.openstack.it;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.post;
 
 @QuarkusTest
-@WithTestResource(OpenStackTestResource.class)
+@QuarkusTestResource(OpenStackTestResource.class)
 class OpenstackGlanceTest {
 
     @Test

--- a/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenstackKeystoneDomainTest.java
+++ b/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenstackKeystoneDomainTest.java
@@ -16,14 +16,14 @@
  */
 package org.apache.camel.quarkus.component.openstack.it;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.post;
 
 @QuarkusTest
-@WithTestResource(OpenStackTestResource.class)
+@QuarkusTestResource(OpenStackTestResource.class)
 class OpenstackKeystoneDomainTest {
 
     @Test

--- a/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenstackKeystoneGroupTest.java
+++ b/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenstackKeystoneGroupTest.java
@@ -16,14 +16,14 @@
  */
 package org.apache.camel.quarkus.component.openstack.it;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.post;
 
 @QuarkusTest
-@WithTestResource(OpenStackTestResource.class)
+@QuarkusTestResource(OpenStackTestResource.class)
 class OpenstackKeystoneGroupTest {
 
     @Test

--- a/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenstackKeystoneProjectTest.java
+++ b/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenstackKeystoneProjectTest.java
@@ -16,14 +16,14 @@
  */
 package org.apache.camel.quarkus.component.openstack.it;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.post;
 
 @QuarkusTest
-@WithTestResource(OpenStackTestResource.class)
+@QuarkusTestResource(OpenStackTestResource.class)
 class OpenstackKeystoneProjectTest {
 
     @Test

--- a/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenstackKeystoneRegionTest.java
+++ b/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenstackKeystoneRegionTest.java
@@ -16,14 +16,14 @@
  */
 package org.apache.camel.quarkus.component.openstack.it;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.post;
 
 @QuarkusTest
-@WithTestResource(OpenStackTestResource.class)
+@QuarkusTestResource(OpenStackTestResource.class)
 class OpenstackKeystoneRegionTest {
 
     @Test

--- a/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenstackKeystoneUserTest.java
+++ b/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenstackKeystoneUserTest.java
@@ -16,14 +16,14 @@
  */
 package org.apache.camel.quarkus.component.openstack.it;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.post;
 
 @QuarkusTest
-@WithTestResource(OpenStackTestResource.class)
+@QuarkusTestResource(OpenStackTestResource.class)
 class OpenstackKeystoneUserTest {
 
     @Test

--- a/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenstackNeutronNetworkTest.java
+++ b/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenstackNeutronNetworkTest.java
@@ -16,14 +16,14 @@
  */
 package org.apache.camel.quarkus.component.openstack.it;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.post;
 
 @QuarkusTest
-@WithTestResource(OpenStackTestResource.class)
+@QuarkusTestResource(OpenStackTestResource.class)
 class OpenstackNeutronNetworkTest {
 
     @Test

--- a/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenstackNeutronPortTest.java
+++ b/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenstackNeutronPortTest.java
@@ -16,14 +16,14 @@
  */
 package org.apache.camel.quarkus.component.openstack.it;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.post;
 
 @QuarkusTest
-@WithTestResource(OpenStackTestResource.class)
+@QuarkusTestResource(OpenStackTestResource.class)
 class OpenstackNeutronPortTest {
 
     @Test

--- a/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenstackNeutronSubnetTest.java
+++ b/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenstackNeutronSubnetTest.java
@@ -16,14 +16,14 @@
  */
 package org.apache.camel.quarkus.component.openstack.it;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.post;
 
 @QuarkusTest
-@WithTestResource(OpenStackTestResource.class)
+@QuarkusTestResource(OpenStackTestResource.class)
 class OpenstackNeutronSubnetTest {
 
     @Test

--- a/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenstackNovaFlavorTest.java
+++ b/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenstackNovaFlavorTest.java
@@ -16,14 +16,14 @@
  */
 package org.apache.camel.quarkus.component.openstack.it;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.post;
 
 @QuarkusTest
-@WithTestResource(OpenStackTestResource.class)
+@QuarkusTestResource(OpenStackTestResource.class)
 class OpenstackNovaFlavorTest {
 
     @Test

--- a/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenstackNovaServerTest.java
+++ b/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenstackNovaServerTest.java
@@ -16,14 +16,14 @@
  */
 package org.apache.camel.quarkus.component.openstack.it;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.post;
 
 @QuarkusTest
-@WithTestResource(OpenStackTestResource.class)
+@QuarkusTestResource(OpenStackTestResource.class)
 class OpenstackNovaServerTest {
 
     @Test

--- a/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenstackSwiftContainerTest.java
+++ b/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenstackSwiftContainerTest.java
@@ -16,14 +16,14 @@
  */
 package org.apache.camel.quarkus.component.openstack.it;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.post;
 
 @QuarkusTest
-@WithTestResource(OpenStackTestResource.class)
+@QuarkusTestResource(OpenStackTestResource.class)
 class OpenstackSwiftContainerTest {
 
     @Test

--- a/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenstackSwiftObjectTest.java
+++ b/integration-tests/openstack/src/test/java/org/apache/camel/quarkus/component/openstack/it/OpenstackSwiftObjectTest.java
@@ -16,14 +16,14 @@
  */
 package org.apache.camel.quarkus.component.openstack.it;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.post;
 
 @QuarkusTest
-@WithTestResource(OpenStackTestResource.class)
+@QuarkusTestResource(OpenStackTestResource.class)
 class OpenstackSwiftObjectTest {
 
     @Test

--- a/integration-tests/opentelemetry/src/test/java/org/apache/camel/quarkus/component/opentelemetry/it/OpenTelemetryTest.java
+++ b/integration-tests/opentelemetry/src/test/java/org/apache/camel/quarkus/component/opentelemetry/it/OpenTelemetryTest.java
@@ -21,7 +21,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import io.opentelemetry.api.trace.SpanKind;
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.AfterEach;
@@ -33,7 +33,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@WithTestResource(OpenTelemetryTestResource.class)
+@QuarkusTestResource(OpenTelemetryTestResource.class)
 @QuarkusTest
 class OpenTelemetryTest {
 

--- a/integration-tests/paho-mqtt5/src/test/java/org/apache/camel/quarkus/component/paho/mqtt5/it/PahoMqtt5Test.java
+++ b/integration-tests/paho-mqtt5/src/test/java/org/apache/camel/quarkus/component/paho/mqtt5/it/PahoMqtt5Test.java
@@ -16,7 +16,7 @@
  */
 package org.apache.camel.quarkus.component.paho.mqtt5.it;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -34,7 +34,7 @@ import static org.hamcrest.core.Is.is;
                 Format.PKCS12, Format.PEM }, password = PahoMqtt5Resource.KEYSTORE_PASSWORD)
 }, docker = true)
 @QuarkusTest
-@WithTestResource(PahoMqtt5TestResource.class)
+@QuarkusTestResource(PahoMqtt5TestResource.class)
 class PahoMqtt5Test {
 
     @ParameterizedTest

--- a/integration-tests/paho/src/test/java/org/apache/camel/quarkus/component/paho/it/PahoTest.java
+++ b/integration-tests/paho/src/test/java/org/apache/camel/quarkus/component/paho/it/PahoTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.camel.quarkus.component.paho.it;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -36,7 +36,7 @@ import static org.hamcrest.core.StringRegularExpression.matchesRegex;
                 Format.PKCS12, Format.PEM }, password = PahoResource.KEYSTORE_PASSWORD)
 }, docker = true)
 @QuarkusTest
-@WithTestResource(PahoTestResource.class)
+@QuarkusTestResource(PahoTestResource.class)
 class PahoTest {
 
     @ParameterizedTest

--- a/integration-tests/pg-replication-slot/src/test/java/org/apache/camel/quarkus/component/pg/replication/slot/it/PgReplicationSlotTest.java
+++ b/integration-tests/pg-replication-slot/src/test/java/org/apache/camel/quarkus/component/pg/replication/slot/it/PgReplicationSlotTest.java
@@ -23,7 +23,7 @@ import java.sql.Statement;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.ContentType;
 import org.eclipse.microprofile.config.ConfigProvider;
@@ -39,7 +39,7 @@ import static org.apache.camel.quarkus.component.pg.replication.slot.it.PgReplic
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@WithTestResource(PgReplicationSlotTestResource.class)
+@QuarkusTestResource(PgReplicationSlotTestResource.class)
 @QuarkusTest
 class PgReplicationSlotTest {
 

--- a/integration-tests/pgevent/src/test/java/org/apache/camel/quarkus/component/pgevent/it/PgeventTest.java
+++ b/integration-tests/pgevent/src/test/java/org/apache/camel/quarkus/component/pgevent/it/PgeventTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.camel.quarkus.component.pgevent.it;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.Matchers.equalTo;
 
 @QuarkusTest
-@WithTestResource(PgEventTestResource.class)
+@QuarkusTestResource(PgEventTestResource.class)
 @TestHTTPEndpoint(PgeventResource.class)
 class PgeventTest {
 

--- a/integration-tests/pinecone/src/test/java/org/apache/camel/quarkus/component/pinecone/it/PineconeTest.java
+++ b/integration-tests/pinecone/src/test/java/org/apache/camel/quarkus/component/pinecone/it/PineconeTest.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.Optional;
 
 import io.pinecone.clients.Pinecone;
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -38,7 +38,7 @@ import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.openapitools.client.model.IndexModelStatus.StateEnum.READY;
 
-@WithTestResource(PineconeTestResource.class)
+@QuarkusTestResource(PineconeTestResource.class)
 @QuarkusTest
 class PineconeTest {
     private static Pinecone pinecone;

--- a/integration-tests/platform-http-proxy-ssl/src/test/java/org.apache.camel.quarkus.component.platform.http.proxy.ssl.it/ProxySslTest.java
+++ b/integration-tests/platform-http-proxy-ssl/src/test/java/org.apache.camel.quarkus.component.platform.http.proxy.ssl.it/ProxySslTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.camel.quarkus.component.platform.http.proxy.ssl.it;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -32,7 +32,7 @@ import static org.hamcrest.Matchers.equalTo;
         @Certificate(name = "proxy-ssl", formats = {
                 Format.PKCS12 }, password = "changeit") })
 @QuarkusTest
-@WithTestResource(PlatformHttpSSLTestResource.class)
+@QuarkusTestResource(PlatformHttpSSLTestResource.class)
 public class ProxySslTest {
     @Test
     void test() {

--- a/integration-tests/platform-http-proxy/src/test/java/org/apache/camel/quarkus/component/platform/http/proxy/it/ProxyTest.java
+++ b/integration-tests/platform-http-proxy/src/test/java/org/apache/camel/quarkus/component/platform/http/proxy/it/ProxyTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.camel.quarkus.component.platform.http.proxy.it;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -26,7 +26,7 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
 
 @QuarkusTest
-@WithTestResource(PlatformHttpTestResource.class)
+@QuarkusTestResource(PlatformHttpTestResource.class)
 public class ProxyTest {
     @Test
     void testProxy() {

--- a/integration-tests/pubnub/src/test/java/org/apache/camel/quarkus/component/pubnub/it/PubnubTest.java
+++ b/integration-tests/pubnub/src/test/java/org/apache/camel/quarkus/component/pubnub/it/PubnubTest.java
@@ -17,7 +17,7 @@
 package org.apache.camel.quarkus.component.pubnub.it;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import org.apache.camel.quarkus.test.wiremock.MockServer;
@@ -31,7 +31,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.matchesPattern;
 
 @QuarkusTest
-@WithTestResource(PubnubTestResource.class)
+@QuarkusTestResource(PubnubTestResource.class)
 class PubnubTest {
 
     @MockServer

--- a/integration-tests/qdrant/src/test/java/org/apache/camel/quarkus/component/qdrant/it/QdrantTest.java
+++ b/integration-tests/qdrant/src/test/java/org/apache/camel/quarkus/component/qdrant/it/QdrantTest.java
@@ -16,14 +16,14 @@
  */
 package org.apache.camel.quarkus.component.qdrant.it;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.Matchers.is;
 
-@WithTestResource(QdrantTestResource.class)
+@QuarkusTestResource(QdrantTestResource.class)
 @QuarkusTest
 class QdrantTest {
 

--- a/integration-tests/quartz-clustered/src/test/java/org/apache/camel/quarkus/component/quartz/it/QuartzClusteredTest.java
+++ b/integration-tests/quartz-clustered/src/test/java/org/apache/camel/quarkus/component/quartz/it/QuartzClusteredTest.java
@@ -22,7 +22,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.concurrent.TimeUnit;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import org.apache.camel.quarkus.test.support.process.QuarkusProcessExecutor;
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.zeroturnaround.exec.StartedProcess;
 
-@WithTestResource(QuartzClusteredTestResource.class)
+@QuarkusTestResource(QuartzClusteredTestResource.class)
 @QuarkusTest
 class QuartzClusteredTest {
 

--- a/integration-tests/salesforce/src/test/java/org/apache/camel/quarkus/component/salesforce/SalesforceTest.java
+++ b/integration-tests/salesforce/src/test/java/org/apache/camel/quarkus/component/salesforce/SalesforceTest.java
@@ -20,7 +20,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.path.json.JsonPath;
@@ -40,7 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @QuarkusTest
-@WithTestResource(SalesforceTestResource.class)
+@QuarkusTestResource(SalesforceTestResource.class)
 class SalesforceTest {
 
     @Test

--- a/integration-tests/sap-netweaver/src/test/java/org/apache/camel/quarkus/component/sap/netweaver/it/SapNetweaverTest.java
+++ b/integration-tests/sap-netweaver/src/test/java/org/apache/camel/quarkus/component/sap/netweaver/it/SapNetweaverTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.camel.quarkus.component.sap.netweaver.it;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import org.eclipse.microprofile.config.ConfigProvider;
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.Matchers.containsString;
 
 @QuarkusTest
-@WithTestResource(SapNetweaverTestResource.class)
+@QuarkusTestResource(SapNetweaverTestResource.class)
 class SapNetweaverTest {
 
     @Test

--- a/integration-tests/servicenow/src/test/java/org/apache/camel/quarkus/component/servicenow/it/ServicenowTest.java
+++ b/integration-tests/servicenow/src/test/java/org/apache/camel/quarkus/component/servicenow/it/ServicenowTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.camel.quarkus.component.servicenow.it;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.Matchers.matchesPattern;
 
 @QuarkusTest
-@WithTestResource(ServicenowTestResource.class)
+@QuarkusTestResource(ServicenowTestResource.class)
 class ServicenowTest {
 
     @Test

--- a/integration-tests/sjms-qpid-amqp-client/src/test/java/org/apache/camel/quarkus/component/sjms/qpid/it/SjmsQpidTest.java
+++ b/integration-tests/sjms-qpid-amqp-client/src/test/java/org/apache/camel/quarkus/component/sjms/qpid/it/SjmsQpidTest.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.component.sjms.qpid.it;
 
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.ResourceArg;
-import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import org.apache.camel.quarkus.messaging.sjms.AbstractSjmsMessagingTest;
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.Matchers.containsString;
 
 @QuarkusTest
-@WithTestResource(initArgs = {
+@QuarkusTestResource(initArgs = {
         @ResourceArg(name = "modules", value = "quarkus.qpid-jms") }, value = ActiveMQTestResource.class)
 class SjmsQpidTest extends AbstractSjmsMessagingTest {
 

--- a/integration-tests/sjms2-qpid-amqp-client/src/test/java/org/apache/camel/quarkus/component/sjms2/qpid/it/Sjms2QpidTest.java
+++ b/integration-tests/sjms2-qpid-amqp-client/src/test/java/org/apache/camel/quarkus/component/sjms2/qpid/it/Sjms2QpidTest.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.quarkus.component.sjms2.qpid.it;
 
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.ResourceArg;
-import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import org.apache.camel.quarkus.messaging.sjms.AbstractSjmsMessagingTest;
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.Matchers.containsString;
 
 @QuarkusTest
-@WithTestResource(initArgs = {
+@QuarkusTestResource(initArgs = {
         @ResourceArg(name = "modules", value = "quarkus.qpid-jms") }, value = ActiveMQTestResource.class)
 class Sjms2QpidTest extends AbstractSjmsMessagingTest {
 

--- a/integration-tests/slack/src/test/java/org/apache/camel/quarkus/component/slack/it/SlackTest.java
+++ b/integration-tests/slack/src/test/java/org/apache/camel/quarkus/component/slack/it/SlackTest.java
@@ -18,7 +18,7 @@ package org.apache.camel.quarkus.component.slack.it;
 
 import java.util.UUID;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.ContentType;
 import org.eclipse.microprofile.config.ConfigProvider;
@@ -37,7 +37,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
  * SLACK_TOKEN=your-slack-api-access-token
  */
 @QuarkusTest
-@WithTestResource(SlackTestResource.class)
+@QuarkusTestResource(SlackTestResource.class)
 class SlackTest {
 
     @Test

--- a/integration-tests/smb/src/test/java/org/apache/camel/quarkus/component/smb/it/SmbTest.java
+++ b/integration-tests/smb/src/test/java/org/apache/camel/quarkus/component/smb/it/SmbTest.java
@@ -16,13 +16,13 @@
  */
 package org.apache.camel.quarkus.component.smb.it;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
-@WithTestResource(SmbTestResource.class)
+@QuarkusTestResource(SmbTestResource.class)
 public class SmbTest {
 
     @Test

--- a/integration-tests/splunk-hec/src/test/java/org/apache/camel/quarkus/component/splunk/hec/it/SplunkHecTest.java
+++ b/integration-tests/splunk-hec/src/test/java/org/apache/camel/quarkus/component/splunk/hec/it/SplunkHecTest.java
@@ -20,7 +20,7 @@ import java.util.Calendar;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -32,7 +32,7 @@ import org.testcontainers.shaded.org.awaitility.Awaitility;
 import org.testcontainers.shaded.org.hamcrest.core.StringContains;
 
 @QuarkusTest
-@WithTestResource(SplunkTestResource.class)
+@QuarkusTestResource(SplunkTestResource.class)
 class SplunkHecTest {
 
     @Test

--- a/integration-tests/splunk/src/test/java/org/apache/camel/quarkus/component/splunk/it/SplunkTest.java
+++ b/integration-tests/splunk/src/test/java/org/apache/camel/quarkus/component/splunk/it/SplunkTest.java
@@ -25,7 +25,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -43,7 +43,7 @@ import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.is;
 
 @QuarkusTest
-@WithTestResource(SplunkTestResource.class)
+@QuarkusTestResource(SplunkTestResource.class)
 class SplunkTest {
 
     @Test

--- a/integration-tests/spring-rabbitmq/src/test/java/org/apache/camel/quarkus/component/spring/rabbitmq/it/SpringRabbitmqTest.java
+++ b/integration-tests/spring-rabbitmq/src/test/java/org/apache/camel/quarkus/component/spring/rabbitmq/it/SpringRabbitmqTest.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.response.Response;
@@ -47,7 +47,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.is;
 
 @QuarkusTest
-@WithTestResource(SpringRabbitmqTestResource.class)
+@QuarkusTestResource(SpringRabbitmqTestResource.class)
 class SpringRabbitmqTest {
 
     private final static String EXCHANGE_POLLING = "polling";

--- a/integration-tests/ssh/src/test/java/org/apache/camel/quarkus/component/ssh/it/SshTest.java
+++ b/integration-tests/ssh/src/test/java/org/apache/camel/quarkus/component/ssh/it/SshTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.camel.quarkus.component.ssh.it;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @QuarkusTest
-@WithTestResource(SshTestResource.class)
+@QuarkusTestResource(SshTestResource.class)
 class SshTest {
 
     @Test

--- a/integration-tests/syslog/src/test/java/org/apache/camel/quarkus/component/syslog/it/SyslogTest.java
+++ b/integration-tests/syslog/src/test/java/org/apache/camel/quarkus/component/syslog/it/SyslogTest.java
@@ -21,7 +21,7 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -32,7 +32,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
 
 @QuarkusTest
-@WithTestResource(SyslogTestResource.class)
+@QuarkusTestResource(SyslogTestResource.class)
 class SyslogTest {
 
     private static final Map<String, String> SYSLOG_MESSAGES = new HashMap<>() {

--- a/integration-tests/telegram/src/test/java/org/apache/camel/quarkus/component/telegram/it/TelegramTest.java
+++ b/integration-tests/telegram/src/test/java/org/apache/camel/quarkus/component/telegram/it/TelegramTest.java
@@ -22,7 +22,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -48,8 +48,8 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
 
 @QuarkusTest
-@WithTestResource(TrustStoreResource.class)
-@WithTestResource(TelegramTestResource.class)
+@QuarkusTestResource(TrustStoreResource.class)
+@QuarkusTestResource(TelegramTestResource.class)
 public class TelegramTest {
 
     private static final Logger LOG = Logger.getLogger(TelegramTest.class);

--- a/integration-tests/twilio/src/test/java/org/apache/camel/quarkus/component/twilio/it/TwilioTest.java
+++ b/integration-tests/twilio/src/test/java/org/apache/camel/quarkus/component/twilio/it/TwilioTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.camel.quarkus.component.twilio.it;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.Test;
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  *
  * https://www.twilio.com/docs/iam/test-credentials
  */
-@WithTestResource(TwilioTestResource.class)
+@QuarkusTestResource(TwilioTestResource.class)
 @QuarkusTest
 class TwilioTest {
 

--- a/integration-tests/validator/src/test/java/org/apache/camel/quarkus/component/validator/it/ValidatorTest.java
+++ b/integration-tests/validator/src/test/java/org/apache/camel/quarkus/component/validator/it/ValidatorTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.camel.quarkus.component.validator.it;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -26,7 +26,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import static org.hamcrest.Matchers.containsString;
 
 @QuarkusTest
-@WithTestResource(ValidatorTestResource.class)
+@QuarkusTestResource(ValidatorTestResource.class)
 class ValidatorTest {
 
     @ParameterizedTest

--- a/integration-tests/weather/src/test/java/org/apache/camel/quarkus/component/weather/it/WeatherTest.java
+++ b/integration-tests/weather/src/test/java/org/apache/camel/quarkus/component/weather/it/WeatherTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.camel.quarkus.component.weather.it;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.Test;
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
 
-@WithTestResource(WeatherTestResource.class)
+@QuarkusTestResource(WeatherTestResource.class)
 @QuarkusTest
 class WeatherTest {
 

--- a/integration-tests/xchange/src/test/java/org/apache/camel/quarkus/component/xchange/it/XchangeTest.java
+++ b/integration-tests/xchange/src/test/java/org/apache/camel/quarkus/component/xchange/it/XchangeTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.camel.quarkus.component.xchange.it;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.Test;
@@ -31,8 +31,8 @@ import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.not;
 
 @QuarkusTest
-@WithTestResource(XchangeBinanceTestResource.class)
-@WithTestResource(XchangeKrakenTestResource.class)
+@QuarkusTestResource(XchangeBinanceTestResource.class)
+@QuarkusTestResource(XchangeKrakenTestResource.class)
 class XchangeTest {
 
     @ParameterizedTest

--- a/integration-tests/zendesk/src/test/java/org/apache/camel/quarkus/component/zendesk/it/ZendeskTest.java
+++ b/integration-tests/zendesk/src/test/java/org/apache/camel/quarkus/component/zendesk/it/ZendeskTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.camel.quarkus.component.zendesk.it;
 
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.Test;
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.CoreMatchers.is;
 
 @QuarkusTest
-@WithTestResource(ZendeskTestResource.class)
+@QuarkusTestResource(ZendeskTestResource.class)
 class ZendeskTest {
 
     @Test

--- a/test-framework/junit5/src/main/java/org/apache/camel/quarkus/test/CamelQuarkusTestSupport.java
+++ b/test-framework/junit5/src/main/java/org/apache/camel/quarkus/test/CamelQuarkusTestSupport.java
@@ -72,7 +72,7 @@ import org.slf4j.LoggerFactory;
  * <a href="https://quarkus.io/guides/getting-started-testing#testing_different_profiles">Quarkus documentation</a> for
  * how you can do
  * that. (Note that
- * <a href="https://quarkus.io/guides/getting-started-testing#quarkus-test-resource">WithTestResource</a>
+ * <a href="https://quarkus.io/guides/getting-started-testing#quarkus-test-resource">QuarkusTestResource</a>
  * has a similar effect.)</li>
  * <li>Camel Quarkus executes the production of beans during the build phase. Because all the tests are
  * build together, exclusion behavior is implemented into {@link CamelQuarkusTestSupport}. If a producer of the specific


### PR DESCRIPTION
Given this comment just landed on the Quarkus 3.14.x branch:

https://github.com/quarkusio/quarkus/blob/3.14/test-framework/common/src/main/java/io/quarkus/test/common/WithTestResource.java#L16-L18

And ongoing discussion:

https://groups.google.com/g/quarkus-dev/c/rS8-WN6b7XQ

I think we should revert back to `QuarkusTestResource` for 3.15.x. We can move forwards on `WithTestResource` for 3.16 and beyond.