### PR TITLE
Upgrade Quarkus to 3.14.1

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -31,7 +31,7 @@ asciidoc:
     camel-version: 4.7.0 # replace ${camel.version}
     camel-docs-version: next
     camel-quarkus-version: 3.15.0 # replace ${camel-quarkus.version}
-    quarkus-version: 3.14.0 # replace ${quarkus.version}
+    quarkus-version: 3.14.1 # replace ${quarkus.version}
     graalvm-version: 23.1.2 # replace ${graalvm.version}
     graalvm-docs-version: jdk21 # replace ${graalvm-docs.version}
     mapstruct-version: 1.5.5.Final # replace ${mapstruct.version}

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <quarkiverse-mybatis.version>2.2.3</quarkiverse-mybatis.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/mybatis/quarkus-mybatis-parent/ -->
         <quarkiverse-pooled-jms.version>2.5.0</quarkiverse-pooled-jms.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/messaginghub/quarkus-pooled-jms-parent/ -->
         <quarkiverse-tika.version>2.0.4</quarkiverse-tika.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/tika/quarkus-tika-parent/ -->
-        <quarkus.version>3.14.0</quarkus.version><!-- https://repo1.maven.org/maven2/io/quarkus/quarkus-bom/ -->
+        <quarkus.version>3.14.1</quarkus.version><!-- https://repo1.maven.org/maven2/io/quarkus/quarkus-bom/ -->
         <quarkus-hazelcast-client.version>4.0.0</quarkus-hazelcast-client.version><!-- https://repo1.maven.org/maven2/com/hazelcast/quarkus-hazelcast-client-bom/ -->
         <quarkus-qpid-jms.version>2.6.1</quarkus-qpid-jms.version><!-- This should be in sync with quarkus-platform https://repo1.maven.org/maven2/org/amqphub/quarkus/quarkus-qpid-jms-bom/ -->
 


### PR DESCRIPTION
Thought it best to start tracking 3.14.x patch releases given it will be the basis for the next Quarkus LTS.