### PR TITLE
[Tests] FTP: Use restrictions to bypass cert setup issues

### DIFF
--- a/integration-tests/ftp/src/test/java/org/apache/camel/quarkus/component/ftp/it/FtpTest.java
+++ b/integration-tests/ftp/src/test/java/org/apache/camel/quarkus/component/ftp/it/FtpTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.CoreMatchers.is;
 
 @QuarkusTest
-@QuarkusTestResource(FtpTestResource.class)
+@QuarkusTestResource(value = FtpTestResource.class, restrictToAnnotatedClass = true)
 class FtpTest {
     @Test
     public void testFtpComponent() {

--- a/integration-tests/ftp/src/test/java/org/apache/camel/quarkus/component/ftps/it/FtpsTest.java
+++ b/integration-tests/ftp/src/test/java/org/apache/camel/quarkus/component/ftps/it/FtpsTest.java
@@ -34,7 +34,7 @@ import static org.hamcrest.CoreMatchers.is;
                 Format.PKCS12 }, password = "password") })
 @Disabled //https://github.com/apache/camel-quarkus/issues/4089
 @QuarkusTest
-@QuarkusTestResource(FtpsTestResource.class)
+@QuarkusTestResource(value = FtpsTestResource.class, restrictToAnnotatedClass = true)
 class FtpsTest {
     static final String CERTIFICATE_KEYSTORE_FILE = CertificatesUtil.keystoreFile("ftp", "p12");
 

--- a/integration-tests/ftp/src/test/java/org/apache/camel/quarkus/component/ftps/it/FtpsTestResource.java
+++ b/integration-tests/ftp/src/test/java/org/apache/camel/quarkus/component/ftps/it/FtpsTestResource.java
@@ -30,12 +30,6 @@ public class FtpsTestResource extends FtpTestResource {
 
     @Override
     protected ListenerFactory createListenerFactory(int port) {
-        //do not create a factory if keystore file does not exists
-        //because the test is disabled, but the test resource is "activated", this condition prevents the failure
-        //for the FtpTest
-        if (!Path.of(FtpsTest.CERTIFICATE_KEYSTORE_FILE).toFile().exists()) {
-            return null;
-        }
 
         SslConfigurationFactory sslConfigFactory = new SslConfigurationFactory();
         sslConfigFactory.setKeystoreFile(Path.of(FtpsTest.CERTIFICATE_KEYSTORE_FILE).toFile());


### PR DESCRIPTION
Currently both `FtpTestResource` and `FtpsTestResource` are instantiated before the first test runs.

The current method did not work when executing only the native tests (`-Pnative -Dtest="\!*" -Dsurefire.failIfNoSpecifiedTests=false`) without jvm tests. When running with `-Pnative` only (so jvm tests first, then native), the problem did not occur, as the `FtpsIT` did not actually use the certificates defined in `FtpsTest`, but reused the certificates generated by the invocation of `SftpTest` in jvm mode.

When running with `-Pnative -Dtest="\!*" -Dsurefire.failIfNoSpecifiedTests=false`, the "workflow" without this change was:
1. start running FtpIT
2. instantiate FtpTestResource
3. instantiate SftpTestResource
4. run FtpIT
5. start running FtpsIT
6. generate certificates needed for SftpTestResource, but that is already initialized

With this change, the order is:
1. start running FtpIT
2. instantiate FtpTestResource
3. run FtpIT
4. start running FtpsIT
5. generate certificates needed for SftpTestResource
6. instantiate SftpTestResource

please also backport to 3.8 when merged