### PR TITLE
Use quarkus-micrometer-registry-prometheus instead of the plain io.micrometer dependency

### DIFF
--- a/docs/modules/ROOT/pages/reference/extensions/micrometer.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/micrometer.adoc
@@ -53,8 +53,8 @@ Your application should declare the following dependency or  one of the dependen
 [source,xml]
 ----
 <dependency>
-    <groupId>io.micrometer</groupId>
-    <artifactId>micrometer-registry-prometheus</artifactId>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
 </dependency>
 ----
 

--- a/extensions/micrometer/runtime/src/main/doc/usage.adoc
+++ b/extensions/micrometer/runtime/src/main/doc/usage.adoc
@@ -5,8 +5,8 @@ Your application should declare the following dependency or  one of the dependen
 [source,xml]
 ----
 <dependency>
-    <groupId>io.micrometer</groupId>
-    <artifactId>micrometer-registry-prometheus</artifactId>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
 </dependency>
 ----
 

--- a/integration-tests/micrometer/pom.xml
+++ b/integration-tests/micrometer/pom.xml
@@ -52,8 +52,8 @@
             <artifactId>camel-quarkus-management</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.micrometer</groupId>
-            <artifactId>micrometer-registry-prometheus</artifactId>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
Anticipates a change coming in Quarkus 3.14.2.