### PR TITLE
Enable vertx-websocket extension to handle Quarkus TLS Registry configuration

### DIFF
--- a/extensions/vertx-websocket/deployment/src/main/java/org/apache/camel/quarkus/component/vertx/websocket/deployment/VertxWebsocketProcessor.java
+++ b/extensions/vertx-websocket/deployment/src/main/java/org/apache/camel/quarkus/component/vertx/websocket/deployment/VertxWebsocketProcessor.java
@@ -16,7 +16,9 @@
  */
 package org.apache.camel.quarkus.component.vertx.websocket.deployment;
 
+import io.quarkus.arc.deployment.SyntheticBeansRuntimeInitBuildItem;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.Consume;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
@@ -38,6 +40,7 @@ class VertxWebsocketProcessor {
     }
 
     @BuildStep
+    @Consume(SyntheticBeansRuntimeInitBuildItem.class)
     @Record(ExecutionTime.RUNTIME_INIT)
     CamelRuntimeBeanBuildItem configureVertxWebsocketComponent(
             VertxBuildItem vertx,

--- a/integration-tests/vertx-websocket/src/test/java/org/apache/camel/quarkus/component/vertx/websocket/it/VertxWebsocketLegacySslIT.java
+++ b/integration-tests/vertx-websocket/src/test/java/org/apache/camel/quarkus/component/vertx/websocket/it/VertxWebsocketLegacySslIT.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.vertx.websocket.it;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+class VertxWebsocketLegacySslIT extends VertxWebsocketLegacySslTest {
+
+}

--- a/integration-tests/vertx-websocket/src/test/java/org/apache/camel/quarkus/component/vertx/websocket/it/VertxWebsocketLegacySslTest.java
+++ b/integration-tests/vertx-websocket/src/test/java/org/apache/camel/quarkus/component/vertx/websocket/it/VertxWebsocketLegacySslTest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.vertx.websocket.it;
+
+import java.util.Map;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import me.escoffier.certs.Format;
+import me.escoffier.certs.junit5.Certificate;
+import org.apache.camel.quarkus.test.support.certificate.TestCertificates;
+
+@TestCertificates(certificates = {
+        @Certificate(name = "vertx-websocket", formats = {
+                Format.PKCS12, Format.PEM }, password = "changeit") })
+@TestProfile(VertxWebsocketLegacySslTest.VertxWebsocketLegacySslTestProfile.class)
+@QuarkusTest
+class VertxWebsocketLegacySslTest extends VertxWebsocketSslTest {
+    public static class VertxWebsocketLegacySslTestProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    "quarkus.http.ssl.certificate.files", "target/certs/vertx-websocket.crt",
+                    "quarkus.http.ssl.certificate.key-files", "target/certs/vertx-websocket.key",
+                    "quarkus.http.insecure-requests", "disabled");
+        }
+    }
+}

--- a/integration-tests/vertx-websocket/src/test/java/org/apache/camel/quarkus/component/vertx/websocket/it/VertxWebsocketTest.java
+++ b/integration-tests/vertx-websocket/src/test/java/org/apache/camel/quarkus/component/vertx/websocket/it/VertxWebsocketTest.java
@@ -42,6 +42,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.matchesPattern;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -88,7 +89,8 @@ class VertxWebsocketTest {
                 .get("/vertx-websocket/invalid/consumer/uri")
                 .then()
                 .statusCode(500)
-                .body(startsWith("Invalid host/port"));
+                .body(matchesPattern(
+                        "Invalid host/port " + hostPort + ".*can only be configured as (localhost|0.0.0.0):" + root.getPort()));
     }
 
     @Test

--- a/integration-tests/vertx-websocket/src/test/java/org/apache/camel/quarkus/component/vertx/websocket/it/VertxWebsocketTlsIT.java
+++ b/integration-tests/vertx-websocket/src/test/java/org/apache/camel/quarkus/component/vertx/websocket/it/VertxWebsocketTlsIT.java
@@ -16,17 +16,9 @@
  */
 package org.apache.camel.quarkus.component.vertx.websocket.it;
 
-import java.util.Map;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-import io.quarkus.test.junit.QuarkusTestProfile;
+@QuarkusIntegrationTest
+class VertxWebsocketTlsIT extends VertxWebsocketTlsTest {
 
-public class VertxWebsocketSslTestProfile implements QuarkusTestProfile {
-
-    @Override
-    public Map<String, String> getConfigOverrides() {
-        return Map.of(
-                "quarkus.http.ssl.certificate.files", "target/certs/vertx-websocket.crt",
-                "quarkus.http.ssl.certificate.key-files", "target/certs/vertx-websocket.key",
-                "quarkus.http.insecure-requests", "disabled");
-    }
 }

--- a/integration-tests/vertx-websocket/src/test/java/org/apache/camel/quarkus/component/vertx/websocket/it/VertxWebsocketTlsNamedConfigIT.java
+++ b/integration-tests/vertx-websocket/src/test/java/org/apache/camel/quarkus/component/vertx/websocket/it/VertxWebsocketTlsNamedConfigIT.java
@@ -19,6 +19,6 @@ package org.apache.camel.quarkus.component.vertx.websocket.it;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest
-class VertxWebsocketSslIT extends VertxWebsocketSslTest {
+class VertxWebsocketTlsNamedConfigIT extends VertxWebsocketTlsNamedConfigTest {
 
 }

--- a/integration-tests/vertx-websocket/src/test/java/org/apache/camel/quarkus/component/vertx/websocket/it/VertxWebsocketTlsNamedConfigTest.java
+++ b/integration-tests/vertx-websocket/src/test/java/org/apache/camel/quarkus/component/vertx/websocket/it/VertxWebsocketTlsNamedConfigTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.vertx.websocket.it;
+
+import java.util.Map;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import me.escoffier.certs.Format;
+import me.escoffier.certs.junit5.Certificate;
+import org.apache.camel.quarkus.test.support.certificate.TestCertificates;
+
+@TestCertificates(certificates = {
+        @Certificate(name = "vertx-websocket", formats = {
+                Format.PKCS12, Format.PEM }, password = "changeit") })
+@TestProfile(VertxWebsocketTlsNamedConfigTest.VertxWebsocketTlsNamedConfigTestProfile.class)
+@QuarkusTest
+class VertxWebsocketTlsNamedConfigTest extends VertxWebsocketSslTest {
+    public static class VertxWebsocketTlsNamedConfigTestProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    "quarkus.tls.https.key-store.pem.0.cert", "target/certs/vertx-websocket.crt",
+                    "quarkus.tls.https.key-store.pem.0.key", "target/certs/vertx-websocket.key",
+                    "quarkus.http.insecure-requests", "disabled",
+                    "quarkus.http.tls-configuration-name", "https");
+        }
+    }
+}

--- a/integration-tests/vertx-websocket/src/test/java/org/apache/camel/quarkus/component/vertx/websocket/it/VertxWebsocketTlsTest.java
+++ b/integration-tests/vertx-websocket/src/test/java/org/apache/camel/quarkus/component/vertx/websocket/it/VertxWebsocketTlsTest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.vertx.websocket.it;
+
+import java.util.Map;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import me.escoffier.certs.Format;
+import me.escoffier.certs.junit5.Certificate;
+import org.apache.camel.quarkus.test.support.certificate.TestCertificates;
+
+@TestCertificates(certificates = {
+        @Certificate(name = "vertx-websocket", formats = {
+                Format.PKCS12, Format.PEM }, password = "changeit") })
+@TestProfile(VertxWebsocketTlsTest.VertxWebsocketTlsTestProfile.class)
+@QuarkusTest
+class VertxWebsocketTlsTest extends VertxWebsocketSslTest {
+    public static class VertxWebsocketTlsTestProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    "quarkus.tls.key-store.pem.0.cert", "target/certs/vertx-websocket.crt",
+                    "quarkus.tls.key-store.pem.0.key", "target/certs/vertx-websocket.key",
+                    "quarkus.http.insecure-requests", "disabled");
+        }
+    }
+}


### PR DESCRIPTION
Relates to #6393.