### PR TITLE
Deprecate kotlin extension #6444

### DIFF
--- a/docs/modules/ROOT/pages/reference/extensions/kotlin.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/kotlin.adoc
@@ -7,15 +7,15 @@
 :cq-artifact-id: camel-quarkus-kotlin
 :cq-native-supported: true
 :cq-status: Stable
-:cq-status-deprecation: Stable
+:cq-status-deprecation: Stable Deprecated
 :cq-description: Write Camel integration routes in Kotlin
-:cq-deprecated: false
+:cq-deprecated: true
 :cq-jvm-since: 1.0.0
 :cq-native-since: 1.0.0
 
 ifeval::[{doc-show-badges} == true]
 [.badges]
-[.badge-key]##JVM since##[.badge-supported]##1.0.0## [.badge-key]##Native since##[.badge-supported]##1.0.0##
+[.badge-key]##JVM since##[.badge-supported]##1.0.0## [.badge-key]##Native since##[.badge-supported]##1.0.0## [.badge-key]##⚠️##[.badge-unsupported]##Deprecated##
 endif::[]
 
 Write Camel integration routes in Kotlin

--- a/extensions/kotlin/runtime/pom.xml
+++ b/extensions/kotlin/runtime/pom.xml
@@ -32,6 +32,7 @@
     <properties>
         <camel.quarkus.jvmSince>1.0.0</camel.quarkus.jvmSince>
         <camel.quarkus.nativeSince>1.0.0</camel.quarkus.nativeSince>
+        <quarkus.metadata.deprecated>true</quarkus.metadata.deprecated>
     </properties>
 
     <dependencies>

--- a/extensions/kotlin/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/kotlin/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,4 @@ metadata:
   - "integration"
   status:
   - "stable"
+  - "deprecated"


### PR DESCRIPTION
I can follow up with some notes in the migration guide about Kotlin extension deprecation (since kotlin-dsl is also deprecated).