### PR TITLE
Miscellaneous documentation tidy-ups

### DIFF
--- a/docs/modules/ROOT/pages/contributor-guide/release-guide.adoc
+++ b/docs/modules/ROOT/pages/contributor-guide/release-guide.adoc
@@ -391,7 +391,7 @@ It should be the case most of the time.
 In this case, right after the newest Quarkus Platform becomes available on https://repo1.maven.org/maven2/io/quarkus/platform/quarkus-bom/[Maven Central]:
 
 * Make sure all https://github.com/apache/camel-quarkus-examples/pulls[PRs] against `camel-quarkus-main` branch are merged.
-* Since Camel Quarkus 2.3.0, the examples should use Quarkus Platform BOMs in the `main` branch. To set it do the following:
+* The examples should use Quarkus Platform BOMs in the `main` branch. To set it do the following:
 +
 [source,shell]
 ----

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -22,10 +22,7 @@ This enables users to take advantage of the performance benefits, https://quarku
 and the https://quarkus.io/container-first[container first ethos] that Quarkus provides.
 
 Camel Quarkus provides xref:reference/index.adoc[Quarkus extensions] for many of the Camel components.
-
-Camel Quarkus also takes advantage of the many performance improvements made in Camel 3, which results in a lower memory footprint, less reliance on reflection (which is good for native application support) and faster startup times.
-
-You can xref:user-guide/defining-camel-routes.adoc[define Camel routes] using the Java DSL, XML, Kotlin, Groovy, YAML or JavaScript.
+You can xref:user-guide/defining-camel-routes.adoc[define Camel routes] using the Java DSL, XML, YAML and other languages.
 
 == Where to go next?
 

--- a/docs/modules/ROOT/pages/user-guide/cdi.adoc
+++ b/docs/modules/ROOT/pages/user-guide/cdi.adoc
@@ -127,7 +127,6 @@ public class MyBean {
 
 If you are used to `@org.apache.camel.EndpointInject` and `@org.apache.camel.Produce` from
 xref:manual::pojo-producing.adoc[plain Camel] or from Camel on SpringBoot, you can continue using them on Quarkus too.
-This is supported since Camel Quarkus 2.0.0.
 
 The following use cases are supported by `org.apache.camel.quarkus:camel-quarkus-core`:
 
@@ -274,7 +273,7 @@ Do not hesitate to https://github.com/apache/camel-quarkus/issues[file an issue]
 
 === `@Consume`
 
-Since Camel Quarkus 2.0.0, the `camel-quarkus-bean` artifact brings support for `@org.apache.camel.Consume`
+The `camel-quarkus-bean` artifact brings support for `@org.apache.camel.Consume`
 - see the xref:manual::pojo-consuming.adoc[Pojo consuming] section of Camel documentation.
 
 Declaring a class like the following

--- a/docs/modules/ROOT/pages/user-guide/command-mode.adoc
+++ b/docs/modules/ROOT/pages/user-guide/command-mode.adoc
@@ -138,7 +138,7 @@ Having the above in place, we can call the application with the `-Dgreeted.subje
 
 [source,shell]
 ----
-$ java -Dgreeted.subject=Joe -jar target/*-runner.jar
+$ java -Dgreeted.subject=Joe -jar target/quarkus-app/quarkus-run.jar
 2020-07-15 11:42:18,770 INFO  [org.apa.cam.qua.cor.CamelBootstrapRecorder] (main) bootstrap runtime: org.apache.camel.quarkus.main.CamelMainRuntime
 2020-07-15 11:42:18,816 INFO  [org.apa.cam.mai.BaseMainSupport] (main) Auto-configuration summary:
 2020-07-15 11:42:18,816 INFO  [org.apa.cam.mai.BaseMainSupport] (main)  camel.main.durationMaxMessages=1

--- a/docs/modules/ROOT/pages/user-guide/defining-camel-routes.adoc
+++ b/docs/modules/ROOT/pages/user-guide/defining-camel-routes.adoc
@@ -24,7 +24,7 @@ public class TimerRoute extends RouteBuilder {
 
 === Endpoint DSL
 
-Since Camel 3.0, you can use fluent builders also for defining Camel endpoints.
+You can use fluent builders for defining Camel endpoints.
 The following is equivalent with the previous example:
 
 [source,java]
@@ -53,10 +53,17 @@ It is also possible to include Java DSL routes from other JARs by adding them as
 
 == XML DSL
 
-In order to configure Camel routes, rests or templates in XML, you must add a Camel XML parser dependency to the classpath.
-Since Camel Quarkus 1.8.0, `xref:reference/extensions/xml-io-dsl.adoc[camel-quarkus-xml-io-dsl]` is the best choice.
+In order to configure Camel routes, rests or templates in XML, you must add the `camel-quarkus-xml-io-dsl` dependency to the classpath.
 
-With Camel Main, you can set a property that points to the location of resources XML files such as routes, xref:manual::rest-dsl.adoc[REST DSL] and xref:manual::route-template.adoc[Route templates]:
+[source,xml]
+----
+<dependency>
+    <groupId>org.apache.camel.quarkus</groupId>
+    <artifactId>camel-quarkus-xml-io-dsl</artifactId>
+</dependency>
+----
+
+With Camel Main, you can set a property that points to the location of XML files such as routes, xref:manual::rest-dsl.adoc[REST DSL] and xref:manual::route-template.adoc[Route templates]:
 
 [source,properties]
 ----
@@ -132,6 +139,14 @@ The route XML should be in the simplified version like:
 == YAML DSL
 
 To configure routes with YAML, you must add the `camel-quarkus-yaml-dsl` dependency to the classpath.
+
+[source,xml]
+----
+<dependency>
+    <groupId>org.apache.camel.quarkus</groupId>
+    <artifactId>camel-quarkus-yaml-dsl</artifactId>
+</dependency>
+----
 
 With Camel Main, you can set a property that points to the location of YAML files containing routes, xref:manual::rest-dsl.adoc[REST DSL] and xref:manual::route-template.adoc[Route templates] definitions:
 


### PR DESCRIPTION
Removes many of  the '`since Camel / Camel Quarkus x.x.x release`' statements from the user guide as they are like old news now and potentially confusing.
 