### PR TITLE
Remove kotlin-dsl reference from defining camel routes guide

### DIFF
--- a/docs/modules/ROOT/pages/user-guide/defining-camel-routes.adoc
+++ b/docs/modules/ROOT/pages/user-guide/defining-camel-routes.adoc
@@ -221,7 +221,6 @@ camel.main.routes-include-pattern = routes/routes.yaml, routes/rests.yaml, rests
 * xref:reference/extensions/java-joor-dsl.adoc[Java jOOR]
 * xref:reference/extensions/groovy-dsl.adoc[Groovy]
 * xref:reference/extensions/yaml-dsl.adoc[YAML]
-* xref:reference/extensions/kotlin-dsl.adoc[Kotlin]
 * xref:reference/extensions/js-dsl.adoc[JavaScript]
 
 == What's next?


### PR DESCRIPTION
Thought it best to not point users at deprecated stuff.