### PR TITLE
Avoid including redundant modules when deploying SNAPSHOTs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,7 +70,7 @@ pipeline {
                 MAVEN_OPTS = "-Xmx4600m"
             }
             steps {
-                sh "./mvnw ${MAVEN_PARAMS} -Dquickly clean deploy"
+                sh "./mvnw ${MAVEN_PARAMS} -Dquickly -pl catalog -am clean deploy"
             }
         }
     }


### PR DESCRIPTION
Prevents uploading all of the itest modules and other stuff that there's not much point in deploying.