### PR TITLE
Workaround + fixed generator/resolver of bean catalog in maven-plugin

### DIFF
--- a/tooling/maven-plugin/src/main/java/org/apache/camel/quarkus/maven/PrepareCatalogQuarkusMojo.java
+++ b/tooling/maven-plugin/src/main/java/org/apache/camel/quarkus/maven/PrepareCatalogQuarkusMojo.java
@@ -88,7 +88,7 @@ public class PrepareCatalogQuarkusMojo extends AbstractExtensionListMojo {
         final CqCatalog catalog = CqCatalog.findFirstFromClassPath();
         if (extendClassPathCatalog) {
             catalog.store(catalogBaseDir.toPath());
-            catalog.models().forEach(model -> schemesByKind.get(model.getKind()).add(model.getName()));
+            catalog.models().forEach(model -> schemesByKind.get(model.getKind().name()).add(model.getName()));
         }
 
         findExtensions()


### PR DESCRIPTION
fixes https://github.com/apache/camel-quarkus/issues/6553

Workaround to fallback to `beans` catalog from Camel plain catalog. (to avoid typo which is part of 3.15.0 catalog)

<!-- Uncomment and fill this section if your PR is not trivial
[ ] An issue should be filed for the change unless this is a trivial change (fixing a typo or similar). One issue should ideally be fixed by not more than one commit and the other way round, each commit should fix just one issue, without pulling in other changes.
[ ] Each commit in the pull request should have a meaningful and properly spelled subject line and body. Copying the title of the associated issue is typically enough. Please include the issue number in the commit message prefixed by #.
[ ] The pull request description should explain what the pull request does, how, and why. If the info is available in the associated issue or some other external document, a link is enough.
[ ] Phrases like Fix #<issueNumber> or Fixes #<issueNumber> will auto-close the named issue upon merging the pull request. Using them is typically a good idea.
[ ] Please run mvn process-resources -Pformat (and amend the changes if necessary) before sending the pull request.
[ ] Contributor guide is your good friend: https://camel.apache.org/camel-quarkus/latest/contributor-guide.html
-->