### PR TITLE
Move swagger-codegen dependencies to rest-openapi deployment module

### DIFF
--- a/extensions-support/swagger/runtime/pom.xml
+++ b/extensions-support/swagger/runtime/pom.xml
@@ -56,14 +56,6 @@
             <artifactId>swagger-parser</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.swagger.codegen.v3</groupId>
-            <artifactId>swagger-codegen-generators</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.swagger.codegen.v3</groupId>
-            <artifactId>swagger-codegen</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.graalvm.sdk</groupId>
             <artifactId>nativeimage</artifactId>
             <scope>provided</scope>

--- a/extensions/rest-openapi/deployment/pom.xml
+++ b/extensions/rest-openapi/deployment/pom.xml
@@ -46,6 +46,14 @@
             <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-support-swagger-deployment</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.swagger.codegen.v3</groupId>
+            <artifactId>swagger-codegen-generators</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.swagger.codegen.v3</groupId>
+            <artifactId>swagger-codegen</artifactId>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
AFAIK they were added to support rest-openapi codegen. Thus they are only required at build time.