### PR TITLE
Link to Camel 4.8.x documentation

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -29,7 +29,7 @@ asciidoc:
 
     # Project versions
     camel-version: 4.8.0 # replace ${camel.version}
-    camel-docs-version: next
+    camel-docs-version: 4.8.x
     camel-quarkus-version: 3.16.0 # replace ${camel-quarkus.version}
     quarkus-version: 3.15.1 # replace ${quarkus.version}
     graalvm-version: 23.1.2 # replace ${graalvm.version}
@@ -39,7 +39,7 @@ asciidoc:
     target-maven-version: 3.9.8 # replace ${target-maven-version}
 
     # Attributes used in xrefs to other Antora components
-    cq-camel-components: next@components
+    cq-camel-components: components
     doc-link-icon-lock: "icon:lock"
     quarkus-examples-version: latest
 


### PR DESCRIPTION
We'll need to switch back to `next` when we eventually merge `camel-main` for Camel 4.9.0.