### PR TITLE
Move Quarkus Qpid JMS configuration content to AMQP extension usage section

### DIFF
--- a/docs/modules/ROOT/pages/reference/extensions/amqp.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/amqp.adoc
@@ -47,6 +47,10 @@ endif::[]
 
 [id="extensions-amqp-usage"]
 == Usage
+This extension leverages https://github.com/amqphub/quarkus-qpid-jms/[Quarkus Qpid JMS]. A `ConnectionFactory` bean is created automatically
+and wired into the AMQP component for you. The connection factory can be configured
+via the Quarkus Qpid JMS https://github.com/amqphub/quarkus-qpid-jms#configuration[configuration options].
+
 [id="extensions-amqp-usage-message-mapping-with-org-w3c-dom-node"]
 === Message mapping with `org.w3c.dom.Node`
 
@@ -91,11 +95,3 @@ You will also need to enable serialization for the exception classes that you in
 ----
 @RegisterForReflection(targets = { IllegalStateException.class, MyCustomException.class }, serialization = true)
 ----
-
-[id="extensions-amqp-additional-camel-quarkus-configuration"]
-== Additional Camel Quarkus configuration
-
-The extension leverages the https://github.com/amqphub/quarkus-qpid-jms/[Quarkus Qpid JMS] extension. A ConnectionFactory bean is automatically created
-and wired into the AMQP component for you. The connection factory can be configured
-via the Quarkus Qpid JMS https://github.com/amqphub/quarkus-qpid-jms#configuration[configuration options].
-

--- a/extensions/amqp/runtime/src/main/doc/configuration.adoc
+++ b/extensions/amqp/runtime/src/main/doc/configuration.adoc
@@ -1,3 +1,0 @@
-The extension leverages the https://github.com/amqphub/quarkus-qpid-jms/[Quarkus Qpid JMS] extension. A ConnectionFactory bean is automatically created
-and wired into the AMQP component for you. The connection factory can be configured
-via the Quarkus Qpid JMS https://github.com/amqphub/quarkus-qpid-jms#configuration[configuration options].

--- a/extensions/amqp/runtime/src/main/doc/usage.adoc
+++ b/extensions/amqp/runtime/src/main/doc/usage.adoc
@@ -1,3 +1,7 @@
+This extension leverages https://github.com/amqphub/quarkus-qpid-jms/[Quarkus Qpid JMS]. A `ConnectionFactory` bean is created automatically
+and wired into the AMQP component for you. The connection factory can be configured
+via the Quarkus Qpid JMS https://github.com/amqphub/quarkus-qpid-jms#configuration[configuration options].
+
 === Message mapping with `org.w3c.dom.Node`
 
 The Camel AMQP component supports message mapping between `jakarta.jms.Message` and `org.apache.camel.Message`. When wanting to convert a Camel message body type of `org.w3c.dom.Node`,


### PR DESCRIPTION
So that it's a bit more clear that you can do minimal configuration via Qpid JMS instead of creating custom JMS component configuration, connection factories etc.