### PR TITLE
Remove named DataSource configuration in OpenTelemetryTestResource

### DIFF
--- a/integration-tests/opentelemetry/src/test/java/org/apache/camel/quarkus/component/opentelemetry/it/OpenTelemetryTestResource.java
+++ b/integration-tests/opentelemetry/src/test/java/org/apache/camel/quarkus/component/opentelemetry/it/OpenTelemetryTestResource.java
@@ -27,7 +27,7 @@ public class OpenTelemetryTestResource implements QuarkusTestResourceLifecycleMa
 
     @Override
     public Map<String, String> start() {
-        return Map.of("quarkus.datasource.\"postgres\".devservices.image-name", POSTGRES_IMAGE_NAME);
+        return Map.of("quarkus.datasource.devservices.image-name", POSTGRES_IMAGE_NAME);
     }
 
     @Override


### PR DESCRIPTION
Fixes an issue discovered on `quarkus-main`. Surprised this is working on `main` given the config is wrong.