### PR TITLE
[3.15.x] Upgrade to Quarkus CXF 3.15.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <optaplanner.version>9.37.0.Final</optaplanner.version><!-- This should be in sync with quarkus-platform https://repo1.maven.org/maven2/org/optaplanner/optaplanner-quarkus/ -->
         <quarkiverse-amazonservices.version>2.18.1</quarkiverse-amazonservices.version><!-- This should be in sync with quarkus-platform https://repo1.maven.org/maven2/io/quarkiverse/amazonservices/quarkus-amazon-services-parent/ -->
         <quarkiverse-artemis.version>3.4.2</quarkiverse-artemis.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/artemis/quarkus-artemis-parent/ -->
-        <quarkiverse-cxf.version>3.15.2</quarkiverse-cxf.version><!-- This should be in sync with quarkus-platform https://repo1.maven.org/maven2/io/quarkiverse/cxf/quarkus-cxf-parent/ -->
+        <quarkiverse-cxf.version>3.15.3</quarkiverse-cxf.version><!-- This should be in sync with quarkus-platform https://repo1.maven.org/maven2/io/quarkiverse/cxf/quarkus-cxf-parent/ -->
         <quarkiverse-freemarker.version>1.1.0</quarkiverse-freemarker.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/freemarker/quarkus-freemarker-parent/ -->
         <quarkiverse-groovy.version>3.14.1</quarkiverse-groovy.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/groovy/quarkus-groovy-parent/ -->
         <quarkiverse-jackson-jq.version>2.1.0</quarkiverse-jackson-jq.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/jackson-jq/quarkus-jackson-jq-parent/ -->

--- a/poms/bom/pom.xml
+++ b/poms/bom/pom.xml
@@ -32,6 +32,7 @@
         <!-- This property is kept in sync with project.version by the release plugin -->
         <!-- Do not change to project.version because otherwise the end user apps having our BOM as parent (rather than importing it) will stop working -->
         <camel-quarkus.version>3.15.2-SNAPSHOT</camel-quarkus.version>
+        <allow-findbugs>true</allow-findbugs>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -7629,6 +7630,7 @@
                                 </bannedDependencyResource>
                                 <bannedDependencyResource>
                                     <location>${maven.multiModuleProjectDirectory}/tooling/enforcer-rules/camel-quarkus-banned-dependencies.xml</location>
+                                    <xsltLocation>${project.build.directory}/enforcer-rules/allow-findbugs.xsl</xsltLocation>
                                 </bannedDependencyResource>
                                 <bannedDependencyResource>
                                     <location>${maven.multiModuleProjectDirectory}/tooling/enforcer-rules/camel-quarkus-banned-dependencies-spring.xml</location>

--- a/poms/bom/src/main/generated/flattened-full-pom.xml
+++ b/poms/bom/src/main/generated/flattened-full-pom.xml
@@ -7503,513 +7503,507 @@
         <version>3.13.1</version><!-- org.apache:apache:33 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-rt-features-logging</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-rt-features-logging</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-rt-features-metrics</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-rt-features-metrics</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-rt-frontend-jaxws</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-rt-frontend-jaxws</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
         <exclusions>
           <exclusion>
-            <groupId>org.ow2.asm</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-            <artifactId>asm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+            <groupId>org.ow2.asm</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+            <artifactId>asm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-rt-transports-http</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-rt-transports-http</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-rt-transports-http-hc5</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-rt-transports-http-hc5</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
         <exclusions>
           <exclusion>
-            <groupId>org.slf4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-            <artifactId>jcl-over-slf4j</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+            <groupId>org.slf4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+            <artifactId>jcl-over-slf4j</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-rt-ws-mex</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-rt-ws-mex</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-rt-ws-security</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-rt-ws-security</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-rt-ws-rm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-rt-ws-rm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-rt-wsdl</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-rt-wsdl</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
         <exclusions>
           <exclusion>
-            <groupId>org.ow2.asm</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-            <artifactId>asm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+            <groupId>org.ow2.asm</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+            <artifactId>asm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.services.sts</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-services-sts-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.cxf.services.sts</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-services-sts-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-xjc-boolean</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-xjc-boolean</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-xjc-dv</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-xjc-dv</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-xjc-javadoc</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-xjc-javadoc</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-xjc-pl</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-xjc-pl</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-xjc-ts</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-xjc-ts</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-xjc-wsdlextension</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-xjc-wsdlextension</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.xjc-utils</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-xjc-runtime</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.cxf.xjc-utils</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-xjc-runtime</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.santuario</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>xmlsec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.0.4</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.santuario</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>xmlsec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.0.4</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>quarkus-cxf</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.15.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>quarkus-cxf</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.15.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>quarkus-cxf-axiom-api-stub</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.15.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>quarkus-cxf-axiom-api-stub</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.15.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>quarkus-cxf-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.15.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>quarkus-cxf-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.15.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>quarkus-cxf-integration-tracing-opentelemetry</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.15.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>quarkus-cxf-integration-tracing-opentelemetry</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.15.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>quarkus-cxf-integration-tracing-opentelemetry-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.15.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>quarkus-cxf-rt-features-logging</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.15.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>quarkus-cxf-rt-features-logging-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.15.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>quarkus-cxf-rt-features-metrics</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.15.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>quarkus-cxf-rt-features-metrics-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.15.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>quarkus-cxf-rt-transports-http-hc5</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.15.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>quarkus-cxf-rt-transports-http-hc5-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.15.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>quarkus-cxf-rt-ws-security</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.15.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>quarkus-cxf-rt-ws-security-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.15.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>quarkus-cxf-bc-stub</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.15.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>quarkus-cxf-rt-ws-rm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.15.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>quarkus-cxf-rt-ws-rm-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.15.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>quarkus-cxf-saaj</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.15.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>quarkus-cxf-saaj-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.15.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>quarkus-cxf-santuario-xmlsec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.15.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>quarkus-cxf-santuario-xmlsec-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.15.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>quarkus-cxf-services-sts</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.15.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>quarkus-cxf-services-sts-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.15.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>quarkus-cxf-vertx-client</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.15.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>quarkus-cxf-woodstox</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.15.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>quarkus-cxf-woodstox-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.15.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>quarkus-cxf-xjc-plugins</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.15.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>quarkus-cxf-xjc-plugins-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.15.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.woodstox</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>woodstox-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>7.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>com.sun.xml.fastinfoset</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>FastInfoset</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>2.1.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
         <exclusions>
           <exclusion>
-            <groupId>com.google.code.findbugs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-            <artifactId>jsr305</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+            <groupId>javax.xml</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+            <artifactId>jsr173</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+          </exclusion>
+          <exclusion>
+            <groupId>javax.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+            <artifactId>jsr173_api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>quarkus-cxf-integration-tracing-opentelemetry-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.15.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>quarkus-cxf-rt-features-logging</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.15.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>quarkus-cxf-rt-features-logging-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.15.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>quarkus-cxf-rt-features-metrics</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.15.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>quarkus-cxf-rt-features-metrics-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.15.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>quarkus-cxf-rt-transports-http-hc5</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.15.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>quarkus-cxf-rt-transports-http-hc5-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.15.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>quarkus-cxf-rt-ws-security</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.15.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>quarkus-cxf-rt-ws-security-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.15.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>quarkus-cxf-bc-stub</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.15.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>quarkus-cxf-rt-ws-rm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.15.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>quarkus-cxf-rt-ws-rm-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.15.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>quarkus-cxf-saaj</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.15.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>quarkus-cxf-saaj-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.15.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>quarkus-cxf-santuario-xmlsec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.15.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>quarkus-cxf-santuario-xmlsec-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.15.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>quarkus-cxf-services-sts</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.15.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>quarkus-cxf-services-sts-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.15.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>quarkus-cxf-vertx-client</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.15.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>quarkus-cxf-woodstox</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.15.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>quarkus-cxf-woodstox-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.15.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>quarkus-cxf-xjc-plugins</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.15.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>quarkus-cxf-xjc-plugins-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.15.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.woodstox</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>woodstox-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>7.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>com.sun.xml.fastinfoset</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>FastInfoset</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>2.1.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>com.sun.xml.messaging.saaj</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>saaj-impl</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>2.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
         <exclusions>
           <exclusion>
-            <groupId>javax.xml</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-            <artifactId>jsr173</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-          </exclusion>
-          <exclusion>
-            <groupId>javax.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-            <artifactId>jsr173_api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+            <groupId>com.sun.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+            <artifactId>jakarta.activation</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>com.sun.xml.messaging.saaj</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>saaj-impl</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>2.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.httpcomponents.client5</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>httpclient5</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>5.2.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents.core5</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>httpcore5</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>5.2.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents.core5</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>httpcore5-h2</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>5.2.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>wss4j-bindings</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.0.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>wss4j-policy</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.0.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>wss4j-ws-security-common</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.0.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
         <exclusions>
           <exclusion>
-            <groupId>com.sun.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-            <artifactId>jakarta.activation</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+            <groupId>io.dropwizard.metrics</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+            <artifactId>metrics-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.httpcomponents.client5</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>httpclient5</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>5.2.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>wss4j-ws-security-dom</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.0.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.httpcomponents.core5</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>httpcore5</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>5.2.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>wss4j-ws-security-policy-stax</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.0.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.httpcomponents.core5</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>httpcore5-h2</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>5.2.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>wss4j-ws-security-stax</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.0.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>wss4j-bindings</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.0.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.neethi</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>neethi</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.2.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>wss4j-policy</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.0.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.codehaus.woodstox</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>stax2-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.2.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>wss4j-ws-security-common</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.0.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.ehcache</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>ehcache</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.10.8</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <classifier>jakarta</classifier><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
         <exclusions>
           <exclusion>
-            <groupId>io.dropwizard.metrics</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-            <artifactId>metrics-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+            <groupId>javax.cache</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+            <artifactId>cache-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>wss4j-ws-security-dom</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.0.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.glassfish.jaxb</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>jaxb-runtime</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>wss4j-ws-security-policy-stax</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.0.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.glassfish.jaxb</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>jaxb-xjc</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>wss4j-ws-security-stax</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.0.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.jasypt</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>jasypt</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>1.9.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.neethi</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>neethi</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.2.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.jvnet.mimepull</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>mimepull</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>1.10.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>org.codehaus.woodstox</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>stax2-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.2.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>jakarta.jws</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>jakarta.jws-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>org.ehcache</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>ehcache</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.10.8</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <classifier>jakarta</classifier><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>jakarta.mail</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>jakarta.mail-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>2.1.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>jakarta.xml.soap</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>jakarta.xml.soap-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>2.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
         <exclusions>
           <exclusion>
-            <groupId>javax.cache</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-            <artifactId>cache-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+            <groupId>com.sun.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+            <artifactId>jakarta.activation</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.glassfish.jaxb</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>jaxb-runtime</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>jakarta.xml.ws</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>jakarta.xml.ws-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>org.glassfish.jaxb</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>jaxb-xjc</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>wsdl4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>wsdl4j</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>1.6.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>org.jasypt</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>jasypt</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>1.9.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-integration-tracing-opentelemetry</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>org.jvnet.mimepull</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>mimepull</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>1.10.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-rt-bindings-soap</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>jakarta.jws</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>jakarta.jws-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-rt-bindings-xml</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>jakarta.mail</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>jakarta.mail-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>2.1.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-rt-databinding-jaxb</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>jakarta.xml.soap</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>jakarta.xml.soap-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>2.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-rt-frontend-simple</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-rt-management</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-rt-rs-json-basic</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-rt-rs-security-jose</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-rt-security-saml</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-rt-ws-addr</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-rt-ws-policy</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-rt-security</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-tools-common</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-tools-java2ws</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
         <exclusions>
           <exclusion>
-            <groupId>com.sun.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-            <artifactId>jakarta.activation</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+            <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+            <artifactId>cxf-rt-databinding-aegis</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+            <artifactId>cxf-rt-javascript</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>jakarta.xml.ws</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>jakarta.xml.ws-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-tools-validator</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>wsdl4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>wsdl4j</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>1.6.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-tools-wsdlto-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-integration-tracing-opentelemetry</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-tools-wsdlto-databinding-jaxb</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-rt-bindings-soap</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-rt-bindings-xml</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-rt-databinding-jaxb</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-rt-frontend-simple</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-rt-management</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-rt-rs-json-basic</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-rt-rs-security-jose</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-rt-security-saml</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-rt-ws-addr</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-rt-ws-policy</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-rt-security</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-tools-common</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-tools-java2ws</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <exclusions>
-          <exclusion>
-            <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-            <artifactId>cxf-rt-databinding-aegis</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-          </exclusion>
-          <exclusion>
-            <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-            <artifactId>cxf-rt-javascript</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-tools-validator</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-tools-wsdlto-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-tools-wsdlto-databinding-jaxb</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-tools-wsdlto-frontend-jaxws</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-tools-wsdlto-frontend-jaxws</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
         <groupId>org.apache.groovy</groupId><!-- org.apache.groovy:groovy-bom:4.0.21 -->

--- a/poms/bom/src/main/generated/flattened-reduced-pom.xml
+++ b/poms/bom/src/main/generated/flattened-reduced-pom.xml
@@ -7538,143 +7538,137 @@
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf</artifactId>
-        <version>3.15.2</version>
+        <version>3.15.3</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-axiom-api-stub</artifactId>
-        <version>3.15.2</version>
+        <version>3.15.3</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-deployment</artifactId>
-        <version>3.15.2</version>
+        <version>3.15.3</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-integration-tracing-opentelemetry</artifactId>
-        <version>3.15.2</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-          </exclusion>
-        </exclusions>
+        <version>3.15.3</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-integration-tracing-opentelemetry-deployment</artifactId>
-        <version>3.15.2</version>
+        <version>3.15.3</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-features-logging</artifactId>
-        <version>3.15.2</version>
+        <version>3.15.3</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-features-logging-deployment</artifactId>
-        <version>3.15.2</version>
+        <version>3.15.3</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-features-metrics</artifactId>
-        <version>3.15.2</version>
+        <version>3.15.3</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-features-metrics-deployment</artifactId>
-        <version>3.15.2</version>
+        <version>3.15.3</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-transports-http-hc5</artifactId>
-        <version>3.15.2</version>
+        <version>3.15.3</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-transports-http-hc5-deployment</artifactId>
-        <version>3.15.2</version>
+        <version>3.15.3</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-ws-security</artifactId>
-        <version>3.15.2</version>
+        <version>3.15.3</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-ws-security-deployment</artifactId>
-        <version>3.15.2</version>
+        <version>3.15.3</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-bc-stub</artifactId>
-        <version>3.15.2</version>
+        <version>3.15.3</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-ws-rm</artifactId>
-        <version>3.15.2</version>
+        <version>3.15.3</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-ws-rm-deployment</artifactId>
-        <version>3.15.2</version>
+        <version>3.15.3</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-saaj</artifactId>
-        <version>3.15.2</version>
+        <version>3.15.3</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-saaj-deployment</artifactId>
-        <version>3.15.2</version>
+        <version>3.15.3</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-santuario-xmlsec</artifactId>
-        <version>3.15.2</version>
+        <version>3.15.3</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-santuario-xmlsec-deployment</artifactId>
-        <version>3.15.2</version>
+        <version>3.15.3</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-services-sts</artifactId>
-        <version>3.15.2</version>
+        <version>3.15.3</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-services-sts-deployment</artifactId>
-        <version>3.15.2</version>
+        <version>3.15.3</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-vertx-client</artifactId>
-        <version>3.15.2</version>
+        <version>3.15.3</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-woodstox</artifactId>
-        <version>3.15.2</version>
+        <version>3.15.3</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-woodstox-deployment</artifactId>
-        <version>3.15.2</version>
+        <version>3.15.3</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-xjc-plugins</artifactId>
-        <version>3.15.2</version>
+        <version>3.15.3</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-xjc-plugins-deployment</artifactId>
-        <version>3.15.2</version>
+        <version>3.15.3</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.woodstox</groupId>

--- a/poms/bom/src/main/generated/flattened-reduced-verbose-pom.xml
+++ b/poms/bom/src/main/generated/flattened-reduced-verbose-pom.xml
@@ -7423,513 +7423,507 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-rt-features-logging</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-rt-features-logging</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-rt-features-metrics</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-rt-features-metrics</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-rt-frontend-jaxws</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-rt-frontend-jaxws</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
         <exclusions>
           <exclusion>
-            <groupId>org.ow2.asm</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-            <artifactId>asm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+            <groupId>org.ow2.asm</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+            <artifactId>asm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-rt-transports-http</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-rt-transports-http</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-rt-transports-http-hc5</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-rt-transports-http-hc5</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
         <exclusions>
           <exclusion>
-            <groupId>org.slf4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-            <artifactId>jcl-over-slf4j</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+            <groupId>org.slf4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+            <artifactId>jcl-over-slf4j</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-rt-ws-mex</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-rt-ws-mex</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-rt-ws-security</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-rt-ws-security</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-rt-ws-rm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-rt-ws-rm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-rt-wsdl</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-rt-wsdl</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
         <exclusions>
           <exclusion>
-            <groupId>org.ow2.asm</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-            <artifactId>asm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+            <groupId>org.ow2.asm</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+            <artifactId>asm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.services.sts</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-services-sts-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.cxf.services.sts</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-services-sts-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-xjc-boolean</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-xjc-boolean</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-xjc-dv</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-xjc-dv</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-xjc-javadoc</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-xjc-javadoc</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-xjc-pl</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-xjc-pl</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-xjc-ts</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-xjc-ts</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-xjc-wsdlextension</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-xjc-wsdlextension</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.xjc-utils</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-xjc-runtime</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.cxf.xjc-utils</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-xjc-runtime</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.santuario</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>xmlsec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.0.4</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.santuario</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>xmlsec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.0.4</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>quarkus-cxf</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.15.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>quarkus-cxf</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.15.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>quarkus-cxf-axiom-api-stub</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.15.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>quarkus-cxf-axiom-api-stub</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.15.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>quarkus-cxf-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.15.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>quarkus-cxf-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.15.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>quarkus-cxf-integration-tracing-opentelemetry</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.15.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>quarkus-cxf-integration-tracing-opentelemetry</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.15.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>quarkus-cxf-integration-tracing-opentelemetry-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.15.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>quarkus-cxf-rt-features-logging</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.15.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>quarkus-cxf-rt-features-logging-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.15.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>quarkus-cxf-rt-features-metrics</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.15.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>quarkus-cxf-rt-features-metrics-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.15.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>quarkus-cxf-rt-transports-http-hc5</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.15.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>quarkus-cxf-rt-transports-http-hc5-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.15.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>quarkus-cxf-rt-ws-security</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.15.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>quarkus-cxf-rt-ws-security-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.15.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>quarkus-cxf-bc-stub</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.15.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>quarkus-cxf-rt-ws-rm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.15.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>quarkus-cxf-rt-ws-rm-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.15.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>quarkus-cxf-saaj</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.15.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>quarkus-cxf-saaj-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.15.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>quarkus-cxf-santuario-xmlsec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.15.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>quarkus-cxf-santuario-xmlsec-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.15.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>quarkus-cxf-services-sts</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.15.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>quarkus-cxf-services-sts-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.15.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>quarkus-cxf-vertx-client</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.15.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>quarkus-cxf-woodstox</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.15.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>quarkus-cxf-woodstox-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.15.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>quarkus-cxf-xjc-plugins</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.15.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>quarkus-cxf-xjc-plugins-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.15.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.woodstox</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>woodstox-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>7.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>com.sun.xml.fastinfoset</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>FastInfoset</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>2.1.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
         <exclusions>
           <exclusion>
-            <groupId>com.google.code.findbugs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-            <artifactId>jsr305</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+            <groupId>javax.xml</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+            <artifactId>jsr173</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+          </exclusion>
+          <exclusion>
+            <groupId>javax.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+            <artifactId>jsr173_api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>quarkus-cxf-integration-tracing-opentelemetry-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.15.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>quarkus-cxf-rt-features-logging</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.15.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>quarkus-cxf-rt-features-logging-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.15.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>quarkus-cxf-rt-features-metrics</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.15.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>quarkus-cxf-rt-features-metrics-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.15.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>quarkus-cxf-rt-transports-http-hc5</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.15.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>quarkus-cxf-rt-transports-http-hc5-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.15.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>quarkus-cxf-rt-ws-security</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.15.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>quarkus-cxf-rt-ws-security-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.15.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>quarkus-cxf-bc-stub</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.15.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>quarkus-cxf-rt-ws-rm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.15.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>quarkus-cxf-rt-ws-rm-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.15.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>quarkus-cxf-saaj</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.15.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>quarkus-cxf-saaj-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.15.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>quarkus-cxf-santuario-xmlsec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.15.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>quarkus-cxf-santuario-xmlsec-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.15.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>quarkus-cxf-services-sts</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.15.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>quarkus-cxf-services-sts-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.15.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>quarkus-cxf-vertx-client</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.15.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>quarkus-cxf-woodstox</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.15.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>quarkus-cxf-woodstox-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.15.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>quarkus-cxf-xjc-plugins</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.15.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>quarkus-cxf-xjc-plugins-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.15.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.woodstox</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>woodstox-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>7.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>com.sun.xml.fastinfoset</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>FastInfoset</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>2.1.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>com.sun.xml.messaging.saaj</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>saaj-impl</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>2.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
         <exclusions>
           <exclusion>
-            <groupId>javax.xml</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-            <artifactId>jsr173</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-          </exclusion>
-          <exclusion>
-            <groupId>javax.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-            <artifactId>jsr173_api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+            <groupId>com.sun.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+            <artifactId>jakarta.activation</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>com.sun.xml.messaging.saaj</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>saaj-impl</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>2.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.httpcomponents.client5</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>httpclient5</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>5.2.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents.core5</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>httpcore5</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>5.2.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents.core5</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>httpcore5-h2</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>5.2.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>wss4j-bindings</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.0.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>wss4j-policy</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.0.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>wss4j-ws-security-common</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.0.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
         <exclusions>
           <exclusion>
-            <groupId>com.sun.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-            <artifactId>jakarta.activation</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+            <groupId>io.dropwizard.metrics</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+            <artifactId>metrics-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.httpcomponents.client5</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>httpclient5</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>5.2.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>wss4j-ws-security-dom</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.0.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.httpcomponents.core5</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>httpcore5</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>5.2.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>wss4j-ws-security-policy-stax</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.0.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.httpcomponents.core5</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>httpcore5-h2</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>5.2.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>wss4j-ws-security-stax</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.0.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>wss4j-bindings</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.0.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.neethi</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>neethi</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.2.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>wss4j-policy</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.0.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.codehaus.woodstox</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>stax2-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.2.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>wss4j-ws-security-common</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.0.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.ehcache</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>ehcache</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.10.8</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <classifier>jakarta</classifier><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
         <exclusions>
           <exclusion>
-            <groupId>io.dropwizard.metrics</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-            <artifactId>metrics-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+            <groupId>javax.cache</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+            <artifactId>cache-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>wss4j-ws-security-dom</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.0.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.glassfish.jaxb</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>jaxb-runtime</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>wss4j-ws-security-policy-stax</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.0.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.glassfish.jaxb</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>jaxb-xjc</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>wss4j-ws-security-stax</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.0.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.jasypt</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>jasypt</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>1.9.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.neethi</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>neethi</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.2.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.jvnet.mimepull</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>mimepull</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>1.10.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>org.codehaus.woodstox</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>stax2-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.2.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>jakarta.jws</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>jakarta.jws-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>org.ehcache</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>ehcache</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.10.8</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <classifier>jakarta</classifier><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>jakarta.mail</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>jakarta.mail-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>2.1.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>jakarta.xml.soap</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>jakarta.xml.soap-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>2.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
         <exclusions>
           <exclusion>
-            <groupId>javax.cache</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-            <artifactId>cache-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+            <groupId>com.sun.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+            <artifactId>jakarta.activation</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.glassfish.jaxb</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>jaxb-runtime</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>jakarta.xml.ws</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>jakarta.xml.ws-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>3.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>org.glassfish.jaxb</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>jaxb-xjc</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>wsdl4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>wsdl4j</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>1.6.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>org.jasypt</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>jasypt</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>1.9.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-integration-tracing-opentelemetry</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>org.jvnet.mimepull</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>mimepull</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>1.10.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-rt-bindings-soap</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>jakarta.jws</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>jakarta.jws-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.0.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-rt-bindings-xml</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>jakarta.mail</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>jakarta.mail-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>2.1.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-rt-databinding-jaxb</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>jakarta.xml.soap</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>jakarta.xml.soap-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>2.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-rt-frontend-simple</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-rt-management</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-rt-rs-json-basic</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-rt-rs-security-jose</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-rt-security-saml</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-rt-ws-addr</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-rt-ws-policy</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-rt-security</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-tools-common</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+      </dependency>
+      <dependency>
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-tools-java2ws</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
         <exclusions>
           <exclusion>
-            <groupId>com.sun.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-            <artifactId>jakarta.activation</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+            <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+            <artifactId>cxf-rt-databinding-aegis</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+            <artifactId>cxf-rt-javascript</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>jakarta.xml.ws</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>jakarta.xml.ws-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>3.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-tools-validator</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>wsdl4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>wsdl4j</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>1.6.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-tools-wsdlto-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-integration-tracing-opentelemetry</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-tools-wsdlto-databinding-jaxb</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-rt-bindings-soap</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-rt-bindings-xml</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-rt-databinding-jaxb</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-rt-frontend-simple</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-rt-management</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-rt-rs-json-basic</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-rt-rs-security-jose</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-rt-security-saml</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-rt-ws-addr</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-rt-ws-policy</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-rt-security</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-tools-common</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-tools-java2ws</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <exclusions>
-          <exclusion>
-            <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-            <artifactId>cxf-rt-databinding-aegis</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-          </exclusion>
-          <exclusion>
-            <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-            <artifactId>cxf-rt-javascript</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-tools-validator</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-tools-wsdlto-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-tools-wsdlto-databinding-jaxb</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-      </dependency>
-      <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <artifactId>cxf-tools-wsdlto-frontend-jaxws</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
-        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <artifactId>cxf-tools-wsdlto-frontend-jaxws</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
+        <version>4.0.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.15.3 -->
       </dependency>
       <dependency>
         <groupId>org.apache.groovy</groupId><!-- org.apache.groovy:groovy-bom:4.0.21 -->


### PR DESCRIPTION
If there is enough agreement for this variant (cf. https://github.com/apache/camel-quarkus/pull/6781 ) then we either need to port the first `Allow findbugs...` commit to main or stop banning findbugs there. 