### PR TITLE
[3.15.x] Replace camel-kamelets-catalog dependency with camel-kamelets in Kamelet extension docs

### DIFF
--- a/docs/modules/ROOT/pages/reference/extensions/kamelet.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/kamelet.adoc
@@ -54,16 +54,32 @@ This extension can preload a set of Kamelets at build time. You must include the
 [id="extensions-kamelet-usage-using-the-kamelet-catalog"]
 === Using the Kamelet Catalog
 
-A set of pre-made Kamelets can be found on the /camel-kamelets/latest[Kamelet Catalog].
+A set of pre-made Kamelets can be found in the Kamelet Catalog.
 To use a Kamelet from the catalog, you need to copy its YAML definition (that you can find https://github.com/apache/camel-kamelets/[in the camel-kamelets repository]) to your project.
 
-Alternatively, you can add a `camel-kamelets-catalog` dependency to your application.
+Alternatively, you can add the `camel-kamelets` dependency to your application.
 
 [source,xml]
 ----
 <dependency>
     <groupId>org.apache.camel.kamelets</groupId>
-    <artifactId>camel-kamelets-catalog</artifactId>
+    <artifactId>camel-kamelets</artifactId>
+</dependency>
+----
+
+If the Kamelet requires the `camel-kamelets-utils` dependency, then this should also be added to your application.
+
+[source,xml]
+----
+<dependency>
+    <groupId>org.apache.camel.kamelets</groupId>
+    <artifactId>camel-kamelets-utils</artifactId>
+    <exclusions>
+        <exclusion>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>*</artifactId>
+        </exclusion>
+    </exclusions>
 </dependency>
 ----
 

--- a/extensions/kamelet/runtime/src/main/doc/usage.adoc
+++ b/extensions/kamelet/runtime/src/main/doc/usage.adoc
@@ -4,16 +4,32 @@ This extension can preload a set of Kamelets at build time. You must include the
 
 === Using the Kamelet Catalog
 
-A set of pre-made Kamelets can be found on the /camel-kamelets/latest[Kamelet Catalog].
+A set of pre-made Kamelets can be found in the Kamelet Catalog.
 To use a Kamelet from the catalog, you need to copy its YAML definition (that you can find https://github.com/apache/camel-kamelets/[in the camel-kamelets repository]) to your project.
 
-Alternatively, you can add a `camel-kamelets-catalog` dependency to your application.
+Alternatively, you can add the `camel-kamelets` dependency to your application.
 
 [source,xml]
 ----
 <dependency>
     <groupId>org.apache.camel.kamelets</groupId>
-    <artifactId>camel-kamelets-catalog</artifactId>
+    <artifactId>camel-kamelets</artifactId>
+</dependency>
+----
+
+If the Kamelet requires the `camel-kamelets-utils` dependency, then this should also be added to your application.
+
+[source,xml]
+----
+<dependency>
+    <groupId>org.apache.camel.kamelets</groupId>
+    <artifactId>camel-kamelets-utils</artifactId>
+    <exclusions>
+        <exclusion>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>*</artifactId>
+        </exclusion>
+    </exclusions>
 </dependency>
 ----
 


### PR DESCRIPTION
Added a mention of `camel-kamelets-utils` since it's still a thing in this release stream.