### PR TITLE
Load Java DSL routes in a predicatable order

### DIFF
--- a/extensions-core/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/CamelProcessor.java
+++ b/extensions-core/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/CamelProcessor.java
@@ -404,6 +404,7 @@ class CamelProcessor {
                 .filter(ci -> ((ci.flags() & (Modifier.ABSTRACT | Modifier.PUBLIC)) == Modifier.PUBLIC))
                 .map(ClassInfo::name)
                 .filter(pathFilter)
+                .sorted()
                 .map(CamelRoutesBuilderClassBuildItem::new)
                 .collect(Collectors.toList());
     }


### PR DESCRIPTION
Loosely related to #6842. We should load Java routes in a predictable order like `camel-main`. Currently the load order on CQ is potentially different each time the augmentation phase runs.