### PR TITLE
Validate pull request number from downloaded archive in synchronize-dependabot-branch workflow before attempting to use it

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -125,6 +125,7 @@ jobs:
             else
               mkdir ./dependabot-pr
               echo ${{ github.head_ref }} > ./dependabot-pr/BRANCH_REF
+              echo ${{ github.event.pull_request.head.sha }} > ./dependabot-pr/PR_HEAD_SHA
               echo "$GITHUB_REF" | awk -F / '{print $3}' >  ./dependabot-pr/PR_NUMBER
               git diff -p --binary > ./dependabot-pr/changes.patch
 

--- a/.github/workflows/synchronize-dependabot-branch.yaml
+++ b/.github/workflows/synchronize-dependabot-branch.yaml
@@ -70,14 +70,25 @@ jobs:
             mkdir -p /home/runner/work/dependabot-pr
             unzip -o /home/runner/work/dependabot-pr.zip -d /home/runner/work/dependabot-pr
 
+            PR_HEAD_SHA=$(cat /home/runner/work/dependabot-pr/PR_HEAD_SHA)
+            if [[ ! "${PR_HEAD_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+              exit 1
+            fi
+
+            PR_NUMBER=$(cat /home/runner/work/dependabot-pr/PR_NUMBER)
+            if [[ ! "${PR_NUMBER}" =~ ^[0-9]+$ ]]; then
+              exit 1
+            fi
+
             echo "branch-ref=$(cat /home/runner/work/dependabot-pr/BRANCH_REF)" >> $GITHUB_OUTPUT
-            echo "pr-number=$(cat /home/runner/work/dependabot-pr/PR_NUMBER)" >> $GITHUB_OUTPUT
+            echo "pr-head-sha=${PR_HEAD_SHA}" >> $GITHUB_OUTPUT
+            echo "pr-number=${PR_NUMBER}" >> $GITHUB_OUTPUT
           fi
       - name: Checkout dependabot branch
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        if: steps.setup-dependabot-patches.outputs.branch-ref != ''
+        if: steps.setup-dependabot-patches.outputs.pr-head-sha != ''
         with:
-          ref: ${{ steps.setup-dependabot-patches.outputs.branch-ref }}
+          ref: ${{ steps.setup-dependabot-patches.outputs.pr-head-sha }}
           fetch-depth: 0
       - name: Push changes to dependabot/maven branch
         id: push-changes
@@ -92,7 +103,7 @@ jobs:
 
             git apply ${CHANGES_PATH}
             git commit -am"${COMMIT_MESSAGE}"
-            git push origin ${BRANCH_REF}
+            git push origin HEAD:${{ steps.setup-dependabot-patches.outputs.branch-ref }}
 
             echo "updated=true" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
Synchronize Dependabot Branch GitHub workflow changes:

1. `git checkout` from the original commit SHA on the Dependabot branch

2. Validate the content from the downloaded artifact archive `PR_NUMBER` file. i.e. make sure it only contains a sequence of numbers