### PR TITLE
Replace codegen usage of deprecated Swagger Schema.required attribute with Schema.requiredMode

### DIFF
--- a/extensions/rest-openapi/deployment/src/main/resources/handlebars/Quarkus/pojo.mustache
+++ b/extensions/rest-openapi/deployment/src/main/resources/handlebars/Quarkus/pojo.mustache
@@ -163,7 +163,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#parcela
   @ApiModelProperty({{#example}}example = "{{{example}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}value = "{{{description}}}")
   {{/useOas2}}
   {{^useOas2}}
-  @Schema({{#example}}example = "{{{example}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}description = "{{{description}}}")
+  @Schema({{#example}}example = "{{{example}}}", {{/example}}requiredMode = {{#required}}Schema.RequiredMode.REQUIRED{{/required}}{{^required}}Schema.RequiredMode.NOT_REQUIRED{{/required}}, description = "{{{description}}}")
   {{/useOas2}}
 {{#vendorExtensions.extraAnnotation}}
   {{{vendorExtensions.extraAnnotation}}}


### PR DESCRIPTION
Avoids ugly deprecation warnings on compilation when using rest-openapi codegen.

I opened an issue at the `swagger-codegen-generators` to hopefully get it fixed there eventually.