### PR TITLE
Fix formatting for Jolokia expose-container-port config docs

### DIFF
--- a/docs/modules/ROOT/pages/reference/extensions/jolokia.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/jolokia.adoc
@@ -10,11 +10,11 @@
 :cq-description: Expose runtime metrics and management operations via JMX with Jolokia
 :cq-deprecated: false
 :cq-jvm-since: 3.19.0
-:cq-native-since: 3.19.0
+:cq-native-since: 3.20.0
 
 ifeval::[{doc-show-badges} == true]
 [.badges]
-[.badge-key]##JVM since##[.badge-supported]##3.19.0## [.badge-key]##Native since##[.badge-supported]##3.19.0##
+[.badge-key]##JVM since##[.badge-supported]##3.19.0## [.badge-key]##Native since##[.badge-supported]##3.20.0##
 endif::[]
 
 Expose runtime metrics and management operations via JMX with Jolokia

--- a/docs/modules/ROOT/pages/reference/extensions/jolokia.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/jolokia.adoc
@@ -280,7 +280,7 @@ Options can be configured like `quarkus.camel.jolokia.additional-properties."deb
 
 a| [[quarkus.camel.jolokia.register-camel-restrictor]]`link:#quarkus.camel.jolokia.register-camel-restrictor[quarkus.camel.jolokia.register-camel-restrictor]`
 
-When {@code true}, a Jolokia restrictor is registered that limits MBean read, write and operation execution to the
+When `true`, a Jolokia restrictor is registered that limits MBean read, write and operation execution to the
 following MBean domains.
 
 * org.apache.camel

--- a/extensions/jolokia/runtime/pom.xml
+++ b/extensions/jolokia/runtime/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <camel.quarkus.jvmSince>3.19.0</camel.quarkus.jvmSince>
-        <camel.quarkus.nativeSince>3.19.0</camel.quarkus.nativeSince>
+        <camel.quarkus.nativeSince>3.20.0</camel.quarkus.nativeSince>
     </properties>
 
     <dependencies>

--- a/extensions/jolokia/runtime/src/main/java/org/apache/camel/quarkus/jolokia/config/JolokiaRuntimeConfig.java
+++ b/extensions/jolokia/runtime/src/main/java/org/apache/camel/quarkus/jolokia/config/JolokiaRuntimeConfig.java
@@ -46,7 +46,7 @@ public interface JolokiaRuntimeConfig {
     Map<String, String> additionalProperties();
 
     /**
-     * When {@code true}, a Jolokia restrictor is registered that limits MBean read, write and operation execution to the
+     * When `true`, a Jolokia restrictor is registered that limits MBean read, write and operation execution to the
      * following MBean domains.
      *
      * * org.apache.camel


### PR DESCRIPTION
I missed this in #7075. 