### PR TITLE
Use hyphenated anchor links for config properties

### DIFF
--- a/docs/modules/ROOT/pages/reference/extensions/cassandraql.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/cassandraql.adoc
@@ -51,7 +51,7 @@ endif::[]
 [id="extensions-cassandraql-configuration-cassandra-aggregation-repository-in-native-mode"]
 === Cassandra aggregation repository in native mode
 
-In order to use Cassandra aggregation repositories like `CassandraAggregationRepository` in native mode, you must xref:extensions/core.adoc#quarkus.camel.native.reflection.serialization-enabled[enable native serialization support].
+In order to use Cassandra aggregation repositories like `CassandraAggregationRepository` in native mode, you must xref:extensions/core.adoc#quarkus-camel-native-reflection-serialization-enabled[enable native serialization support].
 
 In addition, if your exchange bodies are custom types, then they must be registered for serialization by annotating their class declaration with `@RegisterForReflection(serialization = true)`.
 

--- a/docs/modules/ROOT/pages/reference/extensions/cli-connector.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/cli-connector.adoc
@@ -48,7 +48,7 @@ endif::[]
 | Configuration property | Type | Default
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.cli.enabled]]`link:#quarkus.camel.cli.enabled[quarkus.camel.cli.enabled]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-cli-enabled]]`link:#quarkus-camel-cli-enabled[quarkus.camel.cli.enabled]`
 
 Sets whether to enable Camel CLI Connector support.
 | `boolean`

--- a/docs/modules/ROOT/pages/reference/extensions/console.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/console.adoc
@@ -94,19 +94,19 @@ See the configuration overview below for further details about `exposure-mode`.
 | Configuration property | Type | Default
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.console.enabled]]`link:#quarkus.camel.console.enabled[quarkus.camel.console.enabled]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-console-enabled]]`link:#quarkus-camel-console-enabled[quarkus.camel.console.enabled]`
 
 Whether the Camel developer console is enabled.
 | `boolean`
 | `false`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.console.path]]`link:#quarkus.camel.console.path[quarkus.camel.console.path]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-console-path]]`link:#quarkus-camel-console-path[quarkus.camel.console.path]`
 
 The context path under which the Camel developer console is deployed (default `/q/camel/dev-console`).
 | `string`
 | `camel/dev-console`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.console.exposure-mode]]`link:#quarkus.camel.console.exposure-mode[quarkus.camel.console.exposure-mode]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-console-exposure-mode]]`link:#quarkus-camel-console-exposure-mode[quarkus.camel.console.exposure-mode]`
 
 The modes in which the Camel developer console is available. The default `dev-test` enables the developer
 console only in dev mode and test modes.

--- a/docs/modules/ROOT/pages/reference/extensions/core.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/core.adoc
@@ -130,7 +130,7 @@ As such, the class `PropertiesCustomBeanWithSetterInjection` needs to be link:ht
 | Configuration property | Type | Default
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.service.discovery.exclude-patterns]]`link:#quarkus.camel.service.discovery.exclude-patterns[quarkus.camel.service.discovery.exclude-patterns]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-service-discovery-exclude-patterns]]`link:#quarkus-camel-service-discovery-exclude-patterns[quarkus.camel.service.discovery.exclude-patterns]`
 
 A comma-separated list of Ant-path style patterns to match Camel service definition files in the classpath. The
 services defined in the matching files will *not* be discoverable via the **`org.apache.camel.spi.FactoryFinder`
@@ -143,7 +143,7 @@ Example values: `META-INF/services/org/apache/camel/foo/++*++,META-INF/services/
 | List of `string`
 | 
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.service.discovery.include-patterns]]`link:#quarkus.camel.service.discovery.include-patterns[quarkus.camel.service.discovery.include-patterns]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-service-discovery-include-patterns]]`link:#quarkus-camel-service-discovery-include-patterns[quarkus.camel.service.discovery.include-patterns]`
 
 A comma-separated list of Ant-path style patterns to match Camel service definition files in the classpath. The
 services defined in the matching files will be discoverable via the `org.apache.camel.spi.FactoryFinder` mechanism
@@ -156,7 +156,7 @@ Example values: `META-INF/services/org/apache/camel/foo/++*++,META-INF/services/
 | List of `string`
 | 
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.service.registry.exclude-patterns]]`link:#quarkus.camel.service.registry.exclude-patterns[quarkus.camel.service.registry.exclude-patterns]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-service-registry-exclude-patterns]]`link:#quarkus-camel-service-registry-exclude-patterns[quarkus.camel.service.registry.exclude-patterns]`
 
 A comma-separated list of Ant-path style patterns to match Camel service definition files in the classpath. The
 services defined in the matching files will *not* be added to Camel registry during application's static
@@ -169,7 +169,7 @@ Example values: `META-INF/services/org/apache/camel/foo/++*++,META-INF/services/
 | List of `string`
 | 
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.service.registry.include-patterns]]`link:#quarkus.camel.service.registry.include-patterns[quarkus.camel.service.registry.include-patterns]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-service-registry-include-patterns]]`link:#quarkus-camel-service-registry-include-patterns[quarkus.camel.service.registry.include-patterns]`
 
 A comma-separated list of Ant-path style patterns to match Camel service definition files in the classpath. The
 services defined in the matching files will be added to Camel registry during application's static initialization
@@ -182,7 +182,7 @@ Example values: `META-INF/services/org/apache/camel/foo/++*++,META-INF/services/
 | List of `string`
 | 
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.runtime-catalog.components]]`link:#quarkus.camel.runtime-catalog.components[quarkus.camel.runtime-catalog.components]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-runtime-catalog-components]]`link:#quarkus-camel-runtime-catalog-components[quarkus.camel.runtime-catalog.components]`
 
 If `true` the Runtime Camel Catalog embedded in the application will contain JSON schemas of Camel components
 available in the application; otherwise component JSON schemas will not be available in the Runtime Camel Catalog and
@@ -193,7 +193,7 @@ setting this flag to `false` except for making the behavior consistent with nati
 | `boolean`
 | `true`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.runtime-catalog.languages]]`link:#quarkus.camel.runtime-catalog.languages[quarkus.camel.runtime-catalog.languages]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-runtime-catalog-languages]]`link:#quarkus-camel-runtime-catalog-languages[quarkus.camel.runtime-catalog.languages]`
 
 If `true` the Runtime Camel Catalog embedded in the application will contain JSON schemas of Camel languages
 available in the application; otherwise language JSON schemas will not be available in the Runtime Camel Catalog and
@@ -204,7 +204,7 @@ setting this flag to `false` except for making the behavior consistent with nati
 | `boolean`
 | `true`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.runtime-catalog.dataformats]]`link:#quarkus.camel.runtime-catalog.dataformats[quarkus.camel.runtime-catalog.dataformats]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-runtime-catalog-dataformats]]`link:#quarkus-camel-runtime-catalog-dataformats[quarkus.camel.runtime-catalog.dataformats]`
 
 If `true` the Runtime Camel Catalog embedded in the application will contain JSON schemas of Camel data formats
 available in the application; otherwise data format JSON schemas will not be available in the Runtime Camel Catalog
@@ -215,7 +215,7 @@ setting this flag to `false` except for making the behavior consistent with nati
 | `boolean`
 | `true`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.runtime-catalog.devconsoles]]`link:#quarkus.camel.runtime-catalog.devconsoles[quarkus.camel.runtime-catalog.devconsoles]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-runtime-catalog-devconsoles]]`link:#quarkus-camel-runtime-catalog-devconsoles[quarkus.camel.runtime-catalog.devconsoles]`
 
 If `true` the Runtime Camel Catalog embedded in the application will contain JSON schemas of Camel dev consoles
 available in the application; otherwise dev console JSON schemas will not be available in the Runtime Camel Catalog
@@ -226,7 +226,7 @@ setting this flag to `false` except for making the behavior consistent with nati
 | `boolean`
 | `true`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.runtime-catalog.models]]`link:#quarkus.camel.runtime-catalog.models[quarkus.camel.runtime-catalog.models]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-runtime-catalog-models]]`link:#quarkus-camel-runtime-catalog-models[quarkus.camel.runtime-catalog.models]`
 
 If `true` the Runtime Camel Catalog embedded in the application will contain JSON schemas of Camel EIP models
 available in the application; otherwise EIP model JSON schemas will not be available in the Runtime Camel Catalog and
@@ -237,7 +237,7 @@ setting this flag to `false` except for making the behavior consistent with nati
 | `boolean`
 | `true`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.runtime-catalog.transformers]]`link:#quarkus.camel.runtime-catalog.transformers[quarkus.camel.runtime-catalog.transformers]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-runtime-catalog-transformers]]`link:#quarkus-camel-runtime-catalog-transformers[quarkus.camel.runtime-catalog.transformers]`
 
 If `true` the Runtime Camel Catalog embedded in the application will contain JSON schemas of Camel transformers
 available in the application; otherwise transformer JSON schemas will not be available in the Runtime Camel Catalog
@@ -248,13 +248,13 @@ setting this flag to `false` except for making the behavior consistent with nati
 | `boolean`
 | `true`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.routes-discovery.enabled]]`link:#quarkus.camel.routes-discovery.enabled[quarkus.camel.routes-discovery.enabled]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-routes-discovery-enabled]]`link:#quarkus-camel-routes-discovery-enabled[quarkus.camel.routes-discovery.enabled]`
 
 Enable automatic discovery of routes during static initialization.
 | `boolean`
 | `true`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.routes-discovery.exclude-patterns]]`link:#quarkus.camel.routes-discovery.exclude-patterns[quarkus.camel.routes-discovery.exclude-patterns]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-routes-discovery-exclude-patterns]]`link:#quarkus-camel-routes-discovery-exclude-patterns[quarkus.camel.routes-discovery.exclude-patterns]`
 
 Used for exclusive filtering scanning of RouteBuilder classes. The exclusive filtering takes precedence over
 inclusive filtering. The pattern is using Ant-path style pattern. Multiple patterns can be specified separated by
@@ -265,7 +265,7 @@ com/mycompany/bar/++*++,com/mycompany/stuff/++*++
 | List of `string`
 | 
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.routes-discovery.include-patterns]]`link:#quarkus.camel.routes-discovery.include-patterns[quarkus.camel.routes-discovery.include-patterns]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-routes-discovery-include-patterns]]`link:#quarkus-camel-routes-discovery-include-patterns[quarkus.camel.routes-discovery.include-patterns]`
 
 Used for inclusive filtering scanning of RouteBuilder classes. The exclusive filtering takes precedence over
 inclusive filtering. The pattern is using Ant-path style pattern. Multiple patterns can be specified separated by
@@ -276,7 +276,7 @@ com/mycompany/foo/++*++,com/mycompany/stuff/++*++
 | List of `string`
 | 
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.native.reflection.exclude-patterns]]`link:#quarkus.camel.native.reflection.exclude-patterns[quarkus.camel.native.reflection.exclude-patterns]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-native-reflection-exclude-patterns]]`link:#quarkus-camel-native-reflection-exclude-patterns[quarkus.camel.native.reflection.exclude-patterns]`
 
 A comma separated list of Ant-path style patterns to match class names that should be *excluded* from registering for
 reflection. Use the class name format as returned by the `java.lang.Class.getName()` method: package segments
@@ -288,7 +288,7 @@ This option cannot be used to unregister classes which have been registered inte
 | List of `string`
 | 
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.native.reflection.include-patterns]]`link:#quarkus.camel.native.reflection.include-patterns[quarkus.camel.native.reflection.include-patterns]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-native-reflection-include-patterns]]`link:#quarkus-camel-native-reflection-include-patterns[quarkus.camel.native.reflection.include-patterns]`
 
 A comma separated list of Ant-path style patterns to match class names that should be registered for reflection. Use
 the class name format as returned by the `java.lang.Class.getName()` method: package segments delimited by period `.`
@@ -319,7 +319,7 @@ where `my-dep` is a label of your choice to tell Quarkus that `org.my-group` and
 | List of `string`
 | 
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.native.reflection.serialization-enabled]]`link:#quarkus.camel.native.reflection.serialization-enabled[quarkus.camel.native.reflection.serialization-enabled]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-native-reflection-serialization-enabled]]`link:#quarkus-camel-native-reflection-serialization-enabled[quarkus.camel.native.reflection.serialization-enabled]`
 
 If `true`, basic classes are registered for serialization; otherwise basic classes won't be registered automatically
 for serialization in native mode. The list of classes automatically registered for serialization can be found in
@@ -329,26 +329,26 @@ setting this flag to `true` except for making the behavior consistent with nativ
 | `boolean`
 | `false`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.csimple.on-build-time-analysis-failure]]`link:#quarkus.camel.csimple.on-build-time-analysis-failure[quarkus.camel.csimple.on-build-time-analysis-failure]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-csimple-on-build-time-analysis-failure]]`link:#quarkus-camel-csimple-on-build-time-analysis-failure[quarkus.camel.csimple.on-build-time-analysis-failure]`
 
 What to do if it is not possible to extract CSimple expressions from a route definition at build time.
 | `fail`, `warn`, `ignore`
 | `warn`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.expression.on-build-time-analysis-failure]]`link:#quarkus.camel.expression.on-build-time-analysis-failure[quarkus.camel.expression.on-build-time-analysis-failure]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-expression-on-build-time-analysis-failure]]`link:#quarkus-camel-expression-on-build-time-analysis-failure[quarkus.camel.expression.on-build-time-analysis-failure]`
 
 What to do if it is not possible to extract expressions from a route definition at build time.
 | `fail`, `warn`, `ignore`
 | `warn`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.expression.extraction-enabled]]`link:#quarkus.camel.expression.extraction-enabled[quarkus.camel.expression.extraction-enabled]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-expression-extraction-enabled]]`link:#quarkus-camel-expression-extraction-enabled[quarkus.camel.expression.extraction-enabled]`
 
 Indicates whether the expression extraction from the route definitions at build time must be done. If disabled, the
 expressions are compiled at runtime.
 | `boolean`
 | `true`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.event-bridge.enabled]]`link:#quarkus.camel.event-bridge.enabled[quarkus.camel.event-bridge.enabled]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-event-bridge-enabled]]`link:#quarkus-camel-event-bridge-enabled[quarkus.camel.event-bridge.enabled]`
 
 Whether to enable the bridging of Camel events to CDI events.
 
@@ -361,114 +361,114 @@ application.
 | `boolean`
 | `true`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.source-location-enabled]]`link:#quarkus.camel.source-location-enabled[quarkus.camel.source-location-enabled]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-source-location-enabled]]`link:#quarkus-camel-source-location-enabled[quarkus.camel.source-location-enabled]`
 
 Build time configuration options for enable/disable camel source location.
 | `boolean`
 | `false`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.trace.enabled]]`link:#quarkus.camel.trace.enabled[quarkus.camel.trace.enabled]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-trace-enabled]]`link:#quarkus-camel-trace-enabled[quarkus.camel.trace.enabled]`
 
 Enables tracer in your Camel application.
 | `boolean`
 | `false`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.trace.standby]]`link:#quarkus.camel.trace.standby[quarkus.camel.trace.standby]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-trace-standby]]`link:#quarkus-camel-trace-standby[quarkus.camel.trace.standby]`
 
 To set the tracer in standby mode, where the tracer will be installed, but not automatically enabled. The tracer can
 then be enabled explicitly later from Java, JMX or tooling.
 | `boolean`
 | `false`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.trace.backlog-size]]`link:#quarkus.camel.trace.backlog-size[quarkus.camel.trace.backlog-size]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-trace-backlog-size]]`link:#quarkus-camel-trace-backlog-size[quarkus.camel.trace.backlog-size]`
 
 Defines how many of the last messages to keep in the tracer.
 | `int`
 | `1000`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.trace.remove-on-dump]]`link:#quarkus.camel.trace.remove-on-dump[quarkus.camel.trace.remove-on-dump]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-trace-remove-on-dump]]`link:#quarkus-camel-trace-remove-on-dump[quarkus.camel.trace.remove-on-dump]`
 
 Whether all traced messages should be removed when the tracer is dumping. By default, the messages are removed, which
 means that dumping will not contain previous dumped messages.
 | `boolean`
 | `true`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.trace.body-max-chars]]`link:#quarkus.camel.trace.body-max-chars[quarkus.camel.trace.body-max-chars]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-trace-body-max-chars]]`link:#quarkus-camel-trace-body-max-chars[quarkus.camel.trace.body-max-chars]`
 
 To limit the message body to a maximum size in the traced message. Use 0 or negative value to use unlimited size.
 | `int`
 | `131072`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.trace.body-include-streams]]`link:#quarkus.camel.trace.body-include-streams[quarkus.camel.trace.body-include-streams]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-trace-body-include-streams]]`link:#quarkus-camel-trace-body-include-streams[quarkus.camel.trace.body-include-streams]`
 
 Whether to include the message body of stream based messages. If enabled then beware the stream may not be
 re-readable later. See more about Stream Caching.
 | `boolean`
 | `false`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.trace.body-include-files]]`link:#quarkus.camel.trace.body-include-files[quarkus.camel.trace.body-include-files]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-trace-body-include-files]]`link:#quarkus-camel-trace-body-include-files[quarkus.camel.trace.body-include-files]`
 
 Whether to include the message body of file based messages. The overhead is that the file content has to be read from
 the file.
 | `boolean`
 | `true`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.trace.include-exchange-properties]]`link:#quarkus.camel.trace.include-exchange-properties[quarkus.camel.trace.include-exchange-properties]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-trace-include-exchange-properties]]`link:#quarkus-camel-trace-include-exchange-properties[quarkus.camel.trace.include-exchange-properties]`
 
 Whether to include the exchange properties in the traced message.
 | `boolean`
 | `true`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.trace.include-exchange-variables]]`link:#quarkus.camel.trace.include-exchange-variables[quarkus.camel.trace.include-exchange-variables]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-trace-include-exchange-variables]]`link:#quarkus-camel-trace-include-exchange-variables[quarkus.camel.trace.include-exchange-variables]`
 
 Whether to include the exchange variables in the traced message.
 | `boolean`
 | `true`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.trace.include-exception]]`link:#quarkus.camel.trace.include-exception[quarkus.camel.trace.include-exception]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-trace-include-exception]]`link:#quarkus-camel-trace-include-exception[quarkus.camel.trace.include-exception]`
 
 Whether to include the exception in the traced message in case of failed exchange.
 | `boolean`
 | `true`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.trace.trace-rests]]`link:#quarkus.camel.trace.trace-rests[quarkus.camel.trace.trace-rests]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-trace-trace-rests]]`link:#quarkus-camel-trace-trace-rests[quarkus.camel.trace.trace-rests]`
 
 Whether to trace routes that is created from Rest DSL.
 | `boolean`
 | `false`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.trace.trace-templates]]`link:#quarkus.camel.trace.trace-templates[quarkus.camel.trace.trace-templates]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-trace-trace-templates]]`link:#quarkus-camel-trace-trace-templates[quarkus.camel.trace.trace-templates]`
 
 Whether to trace routes that is created from route templates or kamelets.
 | `boolean`
 | `false`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.trace.trace-pattern]]`link:#quarkus.camel.trace.trace-pattern[quarkus.camel.trace.trace-pattern]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-trace-trace-pattern]]`link:#quarkus-camel-trace-trace-pattern[quarkus.camel.trace.trace-pattern]`
 
 Filter for tracing by route or node id.
 | `string`
 | 
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.trace.trace-filter]]`link:#quarkus.camel.trace.trace-filter[quarkus.camel.trace.trace-filter]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-trace-trace-filter]]`link:#quarkus-camel-trace-trace-filter[quarkus.camel.trace.trace-filter]`
 
 Filter for tracing messages.
 | `string`
 | 
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.type-converter.statistics-enabled]]`link:#quarkus.camel.type-converter.statistics-enabled[quarkus.camel.type-converter.statistics-enabled]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-type-converter-statistics-enabled]]`link:#quarkus-camel-type-converter-statistics-enabled[quarkus.camel.type-converter.statistics-enabled]`
 
 Whether type converter statistics are enabled. By default, type converter utilization statistics are disabled. Note
 that enabling statistics incurs a minor performance impact under very heavy load.
 | `boolean`
 | `false`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.main.shutdown.timeout]]`link:#quarkus.camel.main.shutdown.timeout[quarkus.camel.main.shutdown.timeout]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-main-shutdown-timeout]]`link:#quarkus-camel-main-shutdown-timeout[quarkus.camel.main.shutdown.timeout]`
 
 A timeout (with millisecond precision) to wait for `CamelMain++#++stop()` to finish
 | link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[`Duration`] link:#duration-note-anchor-core[icon:question-circle[title=More information about the Duration format]]
 | `PT3S`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.main.arguments.on-unknown]]`link:#quarkus.camel.main.arguments.on-unknown[quarkus.camel.main.arguments.on-unknown]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-main-arguments-on-unknown]]`link:#quarkus-camel-main-arguments-on-unknown[quarkus.camel.main.arguments.on-unknown]`
 
 The action to take when `CamelMain` encounters an unknown argument. fail - Prints the `CamelMain` usage statement and
 throws a `RuntimeException` ignore - Suppresses any warnings and the application startup proceeds as normal warn -
@@ -476,7 +476,7 @@ Prints the `CamelMain` usage statement but allows the application startup to pro
 | `fail`, `warn`, `ignore`
 | `warn`
 
-a| [[quarkus.camel.bootstrap.enabled]]`link:#quarkus.camel.bootstrap.enabled[quarkus.camel.bootstrap.enabled]`
+a| [[quarkus-camel-bootstrap-enabled]]`link:#quarkus-camel-bootstrap-enabled[quarkus.camel.bootstrap.enabled]`
 
 When set to true, the {@link CamelRuntime} will be started automatically.
 | `boolean`

--- a/docs/modules/ROOT/pages/reference/extensions/cxf-soap.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/cxf-soap.adoc
@@ -316,7 +316,7 @@ quarkus.cxf.codegen.wsdl2java.additional-params = -validate
 | Configuration property | Type | Default
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.cxf.class-generation.exclude-patterns]]`link:#quarkus.camel.cxf.class-generation.exclude-patterns[quarkus.camel.cxf.class-generation.exclude-patterns]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-cxf-class-generation-exclude-patterns]]`link:#quarkus-camel-cxf-class-generation-exclude-patterns[quarkus.camel.cxf.class-generation.exclude-patterns]`
 
 For CXF service interfaces to work properly, some ancillary classes (such as request and response wrappers) need to
 be generated at build time. Camel Quarkus lets the `quarkus-cxf` extension to do this for all service interfaces

--- a/docs/modules/ROOT/pages/reference/extensions/debug.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/debug.adoc
@@ -61,13 +61,13 @@ quarkus.camel.debug.enabled=true
 | Configuration property | Type | Default
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.debug.enabled]]`link:#quarkus.camel.debug.enabled[quarkus.camel.debug.enabled]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-debug-enabled]]`link:#quarkus-camel-debug-enabled[quarkus.camel.debug.enabled]`
 
 Set whether to enable Camel debugging support.
 | `boolean`
 | `false`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.debug.suspend]]`link:#quarkus.camel.debug.suspend[quarkus.camel.debug.suspend]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-debug-suspend]]`link:#quarkus-camel-debug-suspend[quarkus.camel.debug.suspend]`
 
 Indicates whether the _suspend mode_ is enabled or not. If `true` the message processing is immediately suspended
 until the method `attach()` is called.

--- a/docs/modules/ROOT/pages/reference/extensions/fhir.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/fhir.adoc
@@ -143,37 +143,37 @@ By default, only FHIR version `R4` is enabled in native mode, since that is also
 | Configuration property | Type | Default
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.fhir.enable-dstu2]]`link:#quarkus.camel.fhir.enable-dstu2[quarkus.camel.fhir.enable-dstu2]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-fhir-enable-dstu2]]`link:#quarkus-camel-fhir-enable-dstu2[quarkus.camel.fhir.enable-dstu2]`
 
 Enable FHIR DSTU2 Specs in native mode.
 | `boolean`
 | `false`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.fhir.enable-dstu2_hl7org]]`link:#quarkus.camel.fhir.enable-dstu2_hl7org[quarkus.camel.fhir.enable-dstu2_hl7org]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-fhir-enable-dstu2_hl7org]]`link:#quarkus-camel-fhir-enable-dstu2_hl7org[quarkus.camel.fhir.enable-dstu2_hl7org]`
 
 Enable FHIR DSTU2_HL7ORG Specs in native mode.
 | `boolean`
 | `false`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.fhir.enable-dstu2_1]]`link:#quarkus.camel.fhir.enable-dstu2_1[quarkus.camel.fhir.enable-dstu2_1]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-fhir-enable-dstu2_1]]`link:#quarkus-camel-fhir-enable-dstu2_1[quarkus.camel.fhir.enable-dstu2_1]`
 
 Enable FHIR DSTU2_1 Specs in native mode.
 | `boolean`
 | `false`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.fhir.enable-dstu3]]`link:#quarkus.camel.fhir.enable-dstu3[quarkus.camel.fhir.enable-dstu3]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-fhir-enable-dstu3]]`link:#quarkus-camel-fhir-enable-dstu3[quarkus.camel.fhir.enable-dstu3]`
 
 Enable FHIR DSTU3 Specs in native mode.
 | `boolean`
 | `false`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.fhir.enable-r4]]`link:#quarkus.camel.fhir.enable-r4[quarkus.camel.fhir.enable-r4]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-fhir-enable-r4]]`link:#quarkus-camel-fhir-enable-r4[quarkus.camel.fhir.enable-r4]`
 
 Enable FHIR R4 Specs in native mode.
 | `boolean`
 | `true`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.fhir.enable-r5]]`link:#quarkus.camel.fhir.enable-r5[quarkus.camel.fhir.enable-r5]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-fhir-enable-r5]]`link:#quarkus-camel-fhir-enable-r5[quarkus.camel.fhir.enable-r5]`
 
 Enable FHIR R5 Specs in native mode.
 | `boolean`

--- a/docs/modules/ROOT/pages/reference/extensions/file-cluster-service.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/file-cluster-service.adoc
@@ -73,44 +73,44 @@ The file cluster service could further be tuned by tweaking `quarkus.camel.clust
 | Configuration property | Type | Default
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.cluster.file.enabled]]`link:#quarkus.camel.cluster.file.enabled[quarkus.camel.cluster.file.enabled]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-cluster-file-enabled]]`link:#quarkus-camel-cluster-file-enabled[quarkus.camel.cluster.file.enabled]`
 
 Whether a File Lock Cluster Service should be automatically configured according to
 'quarkus.camel.cluster.file.++*++' configurations.
 | `boolean`
 | `true`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.cluster.file.id]]`link:#quarkus.camel.cluster.file.id[quarkus.camel.cluster.file.id]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-cluster-file-id]]`link:#quarkus-camel-cluster-file-id[quarkus.camel.cluster.file.id]`
 
 The cluster service ID (defaults to null).
 | `string`
 | 
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.cluster.file.root]]`link:#quarkus.camel.cluster.file.root[quarkus.camel.cluster.file.root]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-cluster-file-root]]`link:#quarkus-camel-cluster-file-root[quarkus.camel.cluster.file.root]`
 
 The root path (defaults to null).
 | `string`
 | 
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.cluster.file.order]]`link:#quarkus.camel.cluster.file.order[quarkus.camel.cluster.file.order]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-cluster-file-order]]`link:#quarkus-camel-cluster-file-order[quarkus.camel.cluster.file.order]`
 
 The service lookup order/priority (defaults to 2147482647).
 | `int`
 | 
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.cluster.file.attributes.-attributes]]`link:#quarkus.camel.cluster.file.attributes.-attributes[quarkus.camel.cluster.file.attributes."attributes"]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-cluster-file-attributes-attributes]]`link:#quarkus-camel-cluster-file-attributes-attributes[quarkus.camel.cluster.file.attributes."attributes"]`
 
 The custom attributes associated to the service (defaults to empty map).
 | `Map<String,String>`
 | 
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.cluster.file.acquire-lock-delay]]`link:#quarkus.camel.cluster.file.acquire-lock-delay[quarkus.camel.cluster.file.acquire-lock-delay]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-cluster-file-acquire-lock-delay]]`link:#quarkus-camel-cluster-file-acquire-lock-delay[quarkus.camel.cluster.file.acquire-lock-delay]`
 
 The time to wait before starting to try to acquire lock (defaults to 1000ms).
 | `string`
 | 
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.cluster.file.acquire-lock-interval]]`link:#quarkus.camel.cluster.file.acquire-lock-interval[quarkus.camel.cluster.file.acquire-lock-interval]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-cluster-file-acquire-lock-interval]]`link:#quarkus-camel-cluster-file-acquire-lock-interval[quarkus.camel.cluster.file.acquire-lock-interval]`
 
 The time to wait between attempts to try to acquire lock (defaults to 10000ms).
 | `string`

--- a/docs/modules/ROOT/pages/reference/extensions/graphql.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/graphql.adoc
@@ -60,7 +60,7 @@ https://quarkus.io/guides/native-and-ssl[Quarkus SSL guide].
 | Configuration property | Type | Default
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.graphql.query-files]]`link:#quarkus.camel.graphql.query-files[quarkus.camel.graphql.query-files]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-graphql-query-files]]`link:#quarkus-camel-graphql-query-files[quarkus.camel.graphql.query-files]`
 
 A comma separated list of paths to files containing GraphQL queries for use by GraphQL endpoints. Query files that
 only need to be accessible from the classpath should be specified on this property. Paths can either be schemeless

--- a/docs/modules/ROOT/pages/reference/extensions/grpc.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/grpc.adoc
@@ -160,7 +160,7 @@ At present there is no support for integrating Camel Quarkus gRPC with Quarkus g
 | Configuration property | Type | Default
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.grpc.service-excludes]]`link:#quarkus.camel.grpc.service-excludes[quarkus.camel.grpc.service-excludes]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-grpc-service-excludes]]`link:#quarkus-camel-grpc-service-excludes[quarkus.camel.grpc.service-excludes]`
 
 Excludes classes from the build time scanning of gRPC service classes.
 This can be useful if there are gRPC services that you want to exclude from participating in Camel gRPC route
@@ -175,7 +175,7 @@ And to exclude all services from two specific packages use:
 | List of `string`
 | 
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.grpc.codegen.enabled]]`link:#quarkus.camel.grpc.codegen.enabled[quarkus.camel.grpc.codegen.enabled]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-grpc-codegen-enabled]]`link:#quarkus-camel-grpc-codegen-enabled[quarkus.camel.grpc.codegen.enabled]`
 
 If `true`, Camel Quarkus gRPC code generation is run for .proto files discovered from the `proto` directory, or from
 dependencies specified in the `scan-for-proto` or `scan-for-imports` options. When `false`, code generation for
@@ -183,7 +183,7 @@ dependencies specified in the `scan-for-proto` or `scan-for-imports` options. Wh
 | `boolean`
 | `true`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.grpc.codegen.scan-for-proto]]`link:#quarkus.camel.grpc.codegen.scan-for-proto[quarkus.camel.grpc.codegen.scan-for-proto]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-grpc-codegen-scan-for-proto]]`link:#quarkus-camel-grpc-codegen-scan-for-proto[quarkus.camel.grpc.codegen.scan-for-proto]`
 
 Camel Quarkus gRPC code generation can scan application dependencies for .proto files to generate Java stubs from
 them. This property sets the scope of the dependencies to scan. Applicable values:
@@ -194,7 +194,7 @@ them. This property sets the scope of the dependencies to scan. Applicable value
 | `string`
 | `none`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.grpc.codegen.scan-for-imports]]`link:#quarkus.camel.grpc.codegen.scan-for-imports[quarkus.camel.grpc.codegen.scan-for-imports]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-grpc-codegen-scan-for-imports]]`link:#quarkus-camel-grpc-codegen-scan-for-imports[quarkus.camel.grpc.codegen.scan-for-imports]`
 
 Camel Quarkus gRPC code generation can scan dependencies for .proto files that can be imported by protos in this
 applications. Applicable values:
@@ -205,13 +205,13 @@ applications. Applicable values:
 | `string`
 | `com.google.protobuf:protobuf-java`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.grpc.codegen.scan-for-proto-includes.-scan-for-proto-includes]]`link:#quarkus.camel.grpc.codegen.scan-for-proto-includes.-scan-for-proto-includes[quarkus.camel.grpc.codegen.scan-for-proto-includes."scan-for-proto-includes"]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-grpc-codegen-scan-for-proto-includes-scan-for-proto-includes]]`link:#quarkus-camel-grpc-codegen-scan-for-proto-includes-scan-for-proto-includes[quarkus.camel.grpc.codegen.scan-for-proto-includes."scan-for-proto-includes"]`
 
 Package path or file glob pattern includes per dependency containing .proto files to be considered for inclusion.
 | `Map<String,List<String>>`
 | 
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.grpc.codegen.scan-for-proto-excludes.-scan-for-proto-excludes]]`link:#quarkus.camel.grpc.codegen.scan-for-proto-excludes.-scan-for-proto-excludes[quarkus.camel.grpc.codegen.scan-for-proto-excludes."scan-for-proto-excludes"]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-grpc-codegen-scan-for-proto-excludes-scan-for-proto-excludes]]`link:#quarkus-camel-grpc-codegen-scan-for-proto-excludes-scan-for-proto-excludes[quarkus.camel.grpc.codegen.scan-for-proto-excludes."scan-for-proto-excludes"]`
 
 Package path or file glob pattern includes per dependency containing .proto files to be considered for exclusion.
 | `Map<String,List<String>>`

--- a/docs/modules/ROOT/pages/reference/extensions/infinispan.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/infinispan.adoc
@@ -121,5 +121,5 @@ public class Routes extends RouteBuilder {
 [id="extensions-infinispan-configuration-camel-infinispan-infinispanremoteaggregationrepository-in-native-mode"]
 === Camel Infinispan `InfinispanRemoteAggregationRepository` in native mode
 
-If you chose to use the `InfinispanRemoteAggregationRepository` in native mode, then you must xref:extensions/core.adoc#quarkus.camel.native.reflection.serialization-enabled[enable native serialization support].
+If you chose to use the `InfinispanRemoteAggregationRepository` in native mode, then you must xref:extensions/core.adoc#quarkus-camel-native-reflection-serialization-enabled[enable native serialization support].
 

--- a/docs/modules/ROOT/pages/reference/extensions/jasypt.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/jasypt.adoc
@@ -199,7 +199,7 @@ you must add the file to `quarkus.native.resources.includes` so that it can be l
 | Configuration property | Type | Default
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.jasypt.enabled]]`link:#quarkus.camel.jasypt.enabled[quarkus.camel.jasypt.enabled]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-jasypt-enabled]]`link:#quarkus-camel-jasypt-enabled[quarkus.camel.jasypt.enabled]`
 
 Setting this option to false will disable Jasypt integration with Quarkus SmallRye configuration. You can however,
 manually configure Jasypt with Camel in the 'classic' way of manually configuring JasyptPropertiesParser and
@@ -207,13 +207,13 @@ PropertiesComponent. Refer to the usage section for more details.
 | `boolean`
 | `true`
 
-a| [[quarkus.camel.jasypt.algorithm]]`link:#quarkus.camel.jasypt.algorithm[quarkus.camel.jasypt.algorithm]`
+a| [[quarkus-camel-jasypt-algorithm]]`link:#quarkus-camel-jasypt-algorithm[quarkus.camel.jasypt.algorithm]`
 
 The algorithm to be used for decryption.
 | `string`
 | `PBEWithMD5AndDES`
 
-a| [[quarkus.camel.jasypt.password]]`link:#quarkus.camel.jasypt.password[quarkus.camel.jasypt.password]`
+a| [[quarkus-camel-jasypt-password]]`link:#quarkus-camel-jasypt-password[quarkus.camel.jasypt.password]`
 
 The master password used by Jasypt for decrypting configuration values. This option supports prefixes which influence
 the master password lookup behaviour.
@@ -223,19 +223,19 @@ environment with the given key.
 | `string`
 | 
 
-a| [[quarkus.camel.jasypt.random-iv-generator-algorithm]]`link:#quarkus.camel.jasypt.random-iv-generator-algorithm[quarkus.camel.jasypt.random-iv-generator-algorithm]`
+a| [[quarkus-camel-jasypt-random-iv-generator-algorithm]]`link:#quarkus-camel-jasypt-random-iv-generator-algorithm[quarkus.camel.jasypt.random-iv-generator-algorithm]`
 
 Configures the Jasypt StandardPBEStringEncryptor with a RandomIvGenerator using the given algorithm.
 | `string`
 | `SHA1PRNG`
 
-a| [[quarkus.camel.jasypt.random-salt-generator-algorithm]]`link:#quarkus.camel.jasypt.random-salt-generator-algorithm[quarkus.camel.jasypt.random-salt-generator-algorithm]`
+a| [[quarkus-camel-jasypt-random-salt-generator-algorithm]]`link:#quarkus-camel-jasypt-random-salt-generator-algorithm[quarkus.camel.jasypt.random-salt-generator-algorithm]`
 
 Configures the Jasypt StandardPBEStringEncryptor with a RandomSaltGenerator using the given algorithm.
 | `string`
 | `SHA1PRNG`
 
-a| [[quarkus.camel.jasypt.configuration-customizer-class-name]]`link:#quarkus.camel.jasypt.configuration-customizer-class-name[quarkus.camel.jasypt.configuration-customizer-class-name]`
+a| [[quarkus-camel-jasypt-configuration-customizer-class-name]]`link:#quarkus-camel-jasypt-configuration-customizer-class-name[quarkus.camel.jasypt.configuration-customizer-class-name]`
 
 The fully qualified class name of an org.apache.camel.quarkus.component.jasypt.JasyptConfigurationCustomizer
 implementation. This provides the optional capability of having full control over the Jasypt configuration.

--- a/docs/modules/ROOT/pages/reference/extensions/jfr.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/jfr.adoc
@@ -81,14 +81,14 @@ In native mode, the native executable can be executed as follows.
 | Configuration property | Type | Default
 
 
-a| [[quarkus.camel.jfr.startup-recorder-dir]]`link:#quarkus.camel.jfr.startup-recorder-dir[quarkus.camel.jfr.startup-recorder-dir]`
+a| [[quarkus-camel-jfr-startup-recorder-dir]]`link:#quarkus-camel-jfr-startup-recorder-dir[quarkus.camel.jfr.startup-recorder-dir]`
 
 Directory to store the recording. By default the current directory will be used. Use false to turn off saving the
 recording to disk.
 | `string`
 | 
 
-a| [[quarkus.camel.jfr.startup-recorder-duration]]`link:#quarkus.camel.jfr.startup-recorder-duration[quarkus.camel.jfr.startup-recorder-duration]`
+a| [[quarkus-camel-jfr-startup-recorder-duration]]`link:#quarkus-camel-jfr-startup-recorder-duration[quarkus.camel.jfr.startup-recorder-duration]`
 
 How long time to run the startup recorder. Use 0 (default) to keep the recorder running until the JVM is exited. Use
 -1 to stop the recorder right after Camel has been started (to only focus on potential Camel startup performance
@@ -97,20 +97,20 @@ auto saved to disk (note: save to disk can be disabled by setting startupRecorde
 | `long`
 | 
 
-a| [[quarkus.camel.jfr.startup-recorder-max-depth]]`link:#quarkus.camel.jfr.startup-recorder-max-depth[quarkus.camel.jfr.startup-recorder-max-depth]`
+a| [[quarkus-camel-jfr-startup-recorder-max-depth]]`link:#quarkus-camel-jfr-startup-recorder-max-depth[quarkus.camel.jfr.startup-recorder-max-depth]`
 
 To filter our sub steps at a maximum depth. Use -1 for no maximum. Use 0 for no sub steps. Use 1 for max 1 sub step,
 and so forth. The default is -1.
 | `int`
 | 
 
-a| [[quarkus.camel.jfr.startup-recorder-profile]]`link:#quarkus.camel.jfr.startup-recorder-profile[quarkus.camel.jfr.startup-recorder-profile]`
+a| [[quarkus-camel-jfr-startup-recorder-profile]]`link:#quarkus-camel-jfr-startup-recorder-profile[quarkus.camel.jfr.startup-recorder-profile]`
 
 To use a specific Java Flight Recorder profile configuration, such as default or profile. The default is default.
 | `string`
 | 
 
-a| [[quarkus.camel.jfr.startup-recorder-recording]]`link:#quarkus.camel.jfr.startup-recorder-recording[quarkus.camel.jfr.startup-recorder-recording]`
+a| [[quarkus-camel-jfr-startup-recorder-recording]]`link:#quarkus-camel-jfr-startup-recorder-recording[quarkus.camel.jfr.startup-recorder-recording]`
 
 To enable Java Flight Recorder to start a recording and automatic dump the recording to disk after startup is
 complete. This requires that camel-jfr is on the classpath. The default is false.

--- a/docs/modules/ROOT/pages/reference/extensions/jolokia.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/jolokia.adoc
@@ -184,19 +184,19 @@ Refer to the Camel Quarkus Management extension xref:reference/extensions/manage
 | Configuration property | Type | Default
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.jolokia.enabled]]`link:#quarkus.camel.jolokia.enabled[quarkus.camel.jolokia.enabled]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-jolokia-enabled]]`link:#quarkus-camel-jolokia-enabled[quarkus.camel.jolokia.enabled]`
 
 Enables Jolokia support.
 | `boolean`
 | `true`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.jolokia.path]]`link:#quarkus.camel.jolokia.path[quarkus.camel.jolokia.path]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-jolokia-path]]`link:#quarkus-camel-jolokia-path[quarkus.camel.jolokia.path]`
 
 The context path that the Jolokia agent is deployed under.
 | `string`
 | `jolokia`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.jolokia.register-management-endpoint]]`link:#quarkus.camel.jolokia.register-management-endpoint[quarkus.camel.jolokia.register-management-endpoint]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-jolokia-register-management-endpoint]]`link:#quarkus-camel-jolokia-register-management-endpoint[quarkus.camel.jolokia.register-management-endpoint]`
 
 Whether to register a Quarkus management endpoint for Jolokia (default `/q/jolokia`).
 When enabled this activates a management endpoint which will be accessible on a path relative to
@@ -207,20 +207,20 @@ have `quarkus-vertx-http` on the application classpath.
 | `boolean`
 | `true`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.jolokia.camel-restrictor-allowed-mbean-domains]]`link:#quarkus.camel.jolokia.camel-restrictor-allowed-mbean-domains[quarkus.camel.jolokia.camel-restrictor-allowed-mbean-domains]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-jolokia-camel-restrictor-allowed-mbean-domains]]`link:#quarkus-camel-jolokia-camel-restrictor-allowed-mbean-domains[quarkus.camel.jolokia.camel-restrictor-allowed-mbean-domains]`
 
 Comma separated list of allowed MBean domains used by `CamelJolokiaRestrictor`.
 | List of `string`
 | `org.apache.camel,java.lang,java.nio`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.jolokia.kubernetes.expose-container-port]]`link:#quarkus.camel.jolokia.kubernetes.expose-container-port[quarkus.camel.jolokia.kubernetes.expose-container-port]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-jolokia-kubernetes-expose-container-port]]`link:#quarkus-camel-jolokia-kubernetes-expose-container-port[quarkus.camel.jolokia.kubernetes.expose-container-port]`
 
 When {@code true} and the quarkus-kubernetes extension is present, a container port named jolokia will
 be added to the generated Kubernetes manifests within the container spec ports definition.
 | `boolean`
 | `true`
 
-a| [[quarkus.camel.jolokia.server.auto-start]]`link:#quarkus.camel.jolokia.server.auto-start[quarkus.camel.jolokia.server.auto-start]`
+a| [[quarkus-camel-jolokia-server-auto-start]]`link:#quarkus-camel-jolokia-server-auto-start[quarkus.camel.jolokia.server.auto-start]`
 
 Whether the Jolokia agent HTTP server should be started automatically.
 When set to `false`, it is the user responsibility to start the server.
@@ -228,7 +228,7 @@ This can be done via `@Inject CamelQuarkusJolokiaServer` and then invoking the `
 | `boolean`
 | `true`
 
-a| [[quarkus.camel.jolokia.server.host]]`link:#quarkus.camel.jolokia.server.host[quarkus.camel.jolokia.server.host]`
+a| [[quarkus-camel-jolokia-server-host]]`link:#quarkus-camel-jolokia-server-host[quarkus.camel.jolokia.server.host]`
 
 The host address to which the Jolokia agent HTTP server should bind to.
 When unspecified, the default is localhost for dev and test mode.
@@ -236,13 +236,13 @@ In prod mode the default is to bind to all interfaces at 0.0.0.0.
 | `string`
 | 
 
-a| [[quarkus.camel.jolokia.server.port]]`link:#quarkus.camel.jolokia.server.port[quarkus.camel.jolokia.server.port]`
+a| [[quarkus-camel-jolokia-server-port]]`link:#quarkus-camel-jolokia-server-port[quarkus.camel.jolokia.server.port]`
 
 The port on which the Jolokia agent HTTP server should listen on.
 | `int`
 | `8778`
 
-a| [[quarkus.camel.jolokia.server.discovery-enabled-mode]]`link:#quarkus.camel.jolokia.server.discovery-enabled-mode[quarkus.camel.jolokia.server.discovery-enabled-mode]`
+a| [[quarkus-camel-jolokia-server-discovery-enabled-mode]]`link:#quarkus-camel-jolokia-server-discovery-enabled-mode[quarkus.camel.jolokia.server.discovery-enabled-mode]`
 
 The mode in which Jolokia agent discovery is enabled. The default `dev-test`, enables discovery only in dev and
 test modes.
@@ -251,26 +251,26 @@ disable agent discovery in all modes.
 | `all`, `dev-test`, `none`
 | `dev-test`
 
-a| [[quarkus.camel.jolokia.kubernetes.client-authentication-enabled]]`link:#quarkus.camel.jolokia.kubernetes.client-authentication-enabled[quarkus.camel.jolokia.kubernetes.client-authentication-enabled]`
+a| [[quarkus-camel-jolokia-kubernetes-client-authentication-enabled]]`link:#quarkus-camel-jolokia-kubernetes-client-authentication-enabled[quarkus.camel.jolokia.kubernetes.client-authentication-enabled]`
 
 Whether to enable Jolokia SSL client authentication in Kubernetes environments.
 Useful for tools such as hawtio to be able to connect with your application.
 | `boolean`
 | `true`
 
-a| [[quarkus.camel.jolokia.kubernetes.service-ca-cert]]`link:#quarkus.camel.jolokia.kubernetes.service-ca-cert[quarkus.camel.jolokia.kubernetes.service-ca-cert]`
+a| [[quarkus-camel-jolokia-kubernetes-service-ca-cert]]`link:#quarkus-camel-jolokia-kubernetes-service-ca-cert[quarkus.camel.jolokia.kubernetes.service-ca-cert]`
 
 Absolute path of the CA certificate Jolokia should use for SSL client authentication.
 | link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/io/File.html[`File`]
 | `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt`
 
-a| [[quarkus.camel.jolokia.kubernetes.client-principal]]`link:#quarkus.camel.jolokia.kubernetes.client-principal[quarkus.camel.jolokia.kubernetes.client-principal]`
+a| [[quarkus-camel-jolokia-kubernetes-client-principal]]`link:#quarkus-camel-jolokia-kubernetes-client-principal[quarkus.camel.jolokia.kubernetes.client-principal]`
 
 The principal which must be given in a client certificate to allow access to Jolokia.
 | `string`
 | 
 
-a| [[quarkus.camel.jolokia.additional-properties.-additional-properties]]`link:#quarkus.camel.jolokia.additional-properties.-additional-properties[quarkus.camel.jolokia.additional-properties."additional-properties"]`
+a| [[quarkus-camel-jolokia-additional-properties-additional-properties]]`link:#quarkus-camel-jolokia-additional-properties-additional-properties[quarkus.camel.jolokia.additional-properties."additional-properties"]`
 
 Arbitrary Jolokia configuration options. These are described at the
 https://jolokia.org/reference/html/manual/agents.html[Jolokia documentation].
@@ -278,7 +278,7 @@ Options can be configured like `quarkus.camel.jolokia.additional-properties."deb
 | `Map<String,String>`
 | 
 
-a| [[quarkus.camel.jolokia.register-camel-restrictor]]`link:#quarkus.camel.jolokia.register-camel-restrictor[quarkus.camel.jolokia.register-camel-restrictor]`
+a| [[quarkus-camel-jolokia-register-camel-restrictor]]`link:#quarkus-camel-jolokia-register-camel-restrictor[quarkus.camel.jolokia.register-camel-restrictor]`
 
 When `true`, a Jolokia restrictor is registered that limits MBean read, write and operation execution to the
 following MBean domains.

--- a/docs/modules/ROOT/pages/reference/extensions/joor.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/joor.adoc
@@ -58,19 +58,19 @@ the one generated at runtime. For this purpose, the next configuration propertie
 | Configuration property | Type | Default
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.joor.single-quotes]]`link:#quarkus.camel.joor.single-quotes[quarkus.camel.joor.single-quotes]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-joor-single-quotes]]`link:#quarkus-camel-joor-single-quotes[quarkus.camel.joor.single-quotes]`
 
 Indicates whether a jOOR expression can use single quotes instead of double quotes.
 | `boolean`
 | `true`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.joor.config-resource]]`link:#quarkus.camel.joor.config-resource[quarkus.camel.joor.config-resource]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-joor-config-resource]]`link:#quarkus-camel-joor-config-resource[quarkus.camel.joor.config-resource]`
 
 The specific location of the configuration of the jOOR language.
 | `string`
 | 
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.joor.compile-at-build-time]]`link:#quarkus.camel.joor.compile-at-build-time[quarkus.camel.joor.compile-at-build-time]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-joor-compile-at-build-time]]`link:#quarkus-camel-joor-compile-at-build-time[quarkus.camel.joor.compile-at-build-time]`
 
 In JVM mode, indicates whether the expressions must be compiled at build time.
 | `boolean`

--- a/docs/modules/ROOT/pages/reference/extensions/kafka.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/kafka.adoc
@@ -67,7 +67,7 @@ This functionality can be disabled with the configuration property `quarkus.kafk
 | Configuration property | Type | Default
 
 
-a| [[quarkus.camel.kafka.kubernetes-service-binding.merge-configuration]]`link:#quarkus.camel.kafka.kubernetes-service-binding.merge-configuration[quarkus.camel.kafka.kubernetes-service-binding.merge-configuration]`
+a| [[quarkus-camel-kafka-kubernetes-service-binding-merge-configuration]]`link:#quarkus-camel-kafka-kubernetes-service-binding-merge-configuration[quarkus.camel.kafka.kubernetes-service-binding.merge-configuration]`
 
 If `true` then any Kafka configuration properties discovered by the Quarkus Kubernetes Service Binding extension (if
 configured) will be merged with those set via Camel Kafka component or endpoint options. If `false` then any Kafka

--- a/docs/modules/ROOT/pages/reference/extensions/kamelet.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/kamelet.adoc
@@ -76,7 +76,7 @@ It's advised to name files containing your custom Kamelet definitions with the e
 | Configuration property | Type | Default
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.kamelet.identifiers]]`link:#quarkus.camel.kamelet.identifiers[quarkus.camel.kamelet.identifiers]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-kamelet-identifiers]]`link:#quarkus-camel-kamelet-identifiers[quarkus.camel.kamelet.identifiers]`
 
 Optional comma separated list of kamelet identifiers to configure for native mode support.
 A kamelet identifier is the Kamelet file name without the `.kamelet.yaml` suffix.

--- a/docs/modules/ROOT/pages/reference/extensions/kubernetes-cluster-service.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/kubernetes-cluster-service.adoc
@@ -70,96 +70,96 @@ The kubernetes cluster service could further be tuned by tweaking `quarkus.camel
 | Configuration property | Type | Default
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.cluster.kubernetes.enabled]]`link:#quarkus.camel.cluster.kubernetes.enabled[quarkus.camel.cluster.kubernetes.enabled]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-cluster-kubernetes-enabled]]`link:#quarkus-camel-cluster-kubernetes-enabled[quarkus.camel.cluster.kubernetes.enabled]`
 
 Whether a Kubernetes Cluster Service should be automatically configured according to
 'quarkus.camel.cluster.kubernetes.++*++' configurations.
 | `boolean`
 | `true`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.cluster.kubernetes.rebalancing]]`link:#quarkus.camel.cluster.kubernetes.rebalancing[quarkus.camel.cluster.kubernetes.rebalancing]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-cluster-kubernetes-rebalancing]]`link:#quarkus-camel-cluster-kubernetes-rebalancing[quarkus.camel.cluster.kubernetes.rebalancing]`
 
 Whether the camel master namespace leaders should be distributed evenly across all the camel contexts in the cluster.
 | `boolean`
 | `true`
 
-a| [[quarkus.camel.cluster.kubernetes.id]]`link:#quarkus.camel.cluster.kubernetes.id[quarkus.camel.cluster.kubernetes.id]`
+a| [[quarkus-camel-cluster-kubernetes-id]]`link:#quarkus-camel-cluster-kubernetes-id[quarkus.camel.cluster.kubernetes.id]`
 
 The cluster service ID (defaults to null).
 | `string`
 | 
 
-a| [[quarkus.camel.cluster.kubernetes.master-url]]`link:#quarkus.camel.cluster.kubernetes.master-url[quarkus.camel.cluster.kubernetes.master-url]`
+a| [[quarkus-camel-cluster-kubernetes-master-url]]`link:#quarkus-camel-cluster-kubernetes-master-url[quarkus.camel.cluster.kubernetes.master-url]`
 
 The URL of the Kubernetes master (read from Kubernetes client properties by default).
 | `string`
 | 
 
-a| [[quarkus.camel.cluster.kubernetes.connection-timeout-millis]]`link:#quarkus.camel.cluster.kubernetes.connection-timeout-millis[quarkus.camel.cluster.kubernetes.connection-timeout-millis]`
+a| [[quarkus-camel-cluster-kubernetes-connection-timeout-millis]]`link:#quarkus-camel-cluster-kubernetes-connection-timeout-millis[quarkus.camel.cluster.kubernetes.connection-timeout-millis]`
 
 The connection timeout in milliseconds to use when making requests to the Kubernetes API server.
 | `int`
 | 
 
-a| [[quarkus.camel.cluster.kubernetes.namespace]]`link:#quarkus.camel.cluster.kubernetes.namespace[quarkus.camel.cluster.kubernetes.namespace]`
+a| [[quarkus-camel-cluster-kubernetes-namespace]]`link:#quarkus-camel-cluster-kubernetes-namespace[quarkus.camel.cluster.kubernetes.namespace]`
 
 The name of the Kubernetes namespace containing the pods and the configmap (autodetected by default).
 | `string`
 | 
 
-a| [[quarkus.camel.cluster.kubernetes.pod-name]]`link:#quarkus.camel.cluster.kubernetes.pod-name[quarkus.camel.cluster.kubernetes.pod-name]`
+a| [[quarkus-camel-cluster-kubernetes-pod-name]]`link:#quarkus-camel-cluster-kubernetes-pod-name[quarkus.camel.cluster.kubernetes.pod-name]`
 
 The name of the current pod (autodetected from container host name by default).
 | `string`
 | 
 
-a| [[quarkus.camel.cluster.kubernetes.jitter-factor]]`link:#quarkus.camel.cluster.kubernetes.jitter-factor[quarkus.camel.cluster.kubernetes.jitter-factor]`
+a| [[quarkus-camel-cluster-kubernetes-jitter-factor]]`link:#quarkus-camel-cluster-kubernetes-jitter-factor[quarkus.camel.cluster.kubernetes.jitter-factor]`
 
 The jitter factor to apply in order to prevent all pods to call Kubernetes APIs in the same instant (defaults to
 1.2).
 | `double`
 | 
 
-a| [[quarkus.camel.cluster.kubernetes.lease-duration-millis]]`link:#quarkus.camel.cluster.kubernetes.lease-duration-millis[quarkus.camel.cluster.kubernetes.lease-duration-millis]`
+a| [[quarkus-camel-cluster-kubernetes-lease-duration-millis]]`link:#quarkus-camel-cluster-kubernetes-lease-duration-millis[quarkus.camel.cluster.kubernetes.lease-duration-millis]`
 
 The default duration of the lease for the current leader (defaults to 15000).
 | `long`
 | 
 
-a| [[quarkus.camel.cluster.kubernetes.renew-deadline-millis]]`link:#quarkus.camel.cluster.kubernetes.renew-deadline-millis[quarkus.camel.cluster.kubernetes.renew-deadline-millis]`
+a| [[quarkus-camel-cluster-kubernetes-renew-deadline-millis]]`link:#quarkus-camel-cluster-kubernetes-renew-deadline-millis[quarkus.camel.cluster.kubernetes.renew-deadline-millis]`
 
 The deadline after which the leader must stop its services because it may have lost the leadership (defaults to
 10000).
 | `long`
 | 
 
-a| [[quarkus.camel.cluster.kubernetes.retry-period-millis]]`link:#quarkus.camel.cluster.kubernetes.retry-period-millis[quarkus.camel.cluster.kubernetes.retry-period-millis]`
+a| [[quarkus-camel-cluster-kubernetes-retry-period-millis]]`link:#quarkus-camel-cluster-kubernetes-retry-period-millis[quarkus.camel.cluster.kubernetes.retry-period-millis]`
 
 The time between two subsequent attempts to check and acquire the leadership. It is randomized using the jitter
 factor (defaults to 2000).
 | `long`
 | 
 
-a| [[quarkus.camel.cluster.kubernetes.order]]`link:#quarkus.camel.cluster.kubernetes.order[quarkus.camel.cluster.kubernetes.order]`
+a| [[quarkus-camel-cluster-kubernetes-order]]`link:#quarkus-camel-cluster-kubernetes-order[quarkus.camel.cluster.kubernetes.order]`
 
 Service lookup order/priority (defaults to 2147482647).
 | `int`
 | 
 
-a| [[quarkus.camel.cluster.kubernetes.resource-name]]`link:#quarkus.camel.cluster.kubernetes.resource-name[quarkus.camel.cluster.kubernetes.resource-name]`
+a| [[quarkus-camel-cluster-kubernetes-resource-name]]`link:#quarkus-camel-cluster-kubernetes-resource-name[quarkus.camel.cluster.kubernetes.resource-name]`
 
 The name of the lease resource used to do optimistic locking (defaults to 'leaders'). The resource name is used as
 prefix when the underlying Kubernetes resource can manage a single lock.
 | `string`
 | 
 
-a| [[quarkus.camel.cluster.kubernetes.lease-resource-type]]`link:#quarkus.camel.cluster.kubernetes.lease-resource-type[quarkus.camel.cluster.kubernetes.lease-resource-type]`
+a| [[quarkus-camel-cluster-kubernetes-lease-resource-type]]`link:#quarkus-camel-cluster-kubernetes-lease-resource-type[quarkus.camel.cluster.kubernetes.lease-resource-type]`
 
 The lease resource type used in Kubernetes, either 'config-map' or 'lease' (defaults to 'lease').
 | `config-map`, `lease`
 | 
 
-a| [[quarkus.camel.cluster.kubernetes.labels.-labels]]`link:#quarkus.camel.cluster.kubernetes.labels.-labels[quarkus.camel.cluster.kubernetes.labels."labels"]`
+a| [[quarkus-camel-cluster-kubernetes-labels-labels]]`link:#quarkus-camel-cluster-kubernetes-labels-labels[quarkus.camel.cluster.kubernetes.labels."labels"]`
 
 The labels key/value used to identify the pods composing the cluster, defaults to empty map.
 | `Map<String,String>`

--- a/docs/modules/ROOT/pages/reference/extensions/micrometer.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/micrometer.adoc
@@ -91,13 +91,13 @@ get created for you.
 | Configuration property | Type | Default
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.metrics.enable-route-policy]]`link:#quarkus.camel.metrics.enable-route-policy[quarkus.camel.metrics.enable-route-policy]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-metrics-enable-route-policy]]`link:#quarkus-camel-metrics-enable-route-policy[quarkus.camel.metrics.enable-route-policy]`
 
 Set whether to enable the MicrometerRoutePolicyFactory for capturing metrics on route processing times.
 | `boolean`
 | `true`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.metrics.enable-message-history]]`link:#quarkus.camel.metrics.enable-message-history[quarkus.camel.metrics.enable-message-history]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-metrics-enable-message-history]]`link:#quarkus-camel-metrics-enable-message-history[quarkus.camel.metrics.enable-message-history]`
 
 Set whether to enable the MicrometerMessageHistoryFactory for capturing metrics on individual route node processing
 times. Depending on the number of configured route nodes, there is the potential to create a large volume of metrics.
@@ -105,13 +105,13 @@ Therefore, this option is disabled by default.
 | `boolean`
 | `false`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.metrics.enable-exchange-event-notifier]]`link:#quarkus.camel.metrics.enable-exchange-event-notifier[quarkus.camel.metrics.enable-exchange-event-notifier]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-metrics-enable-exchange-event-notifier]]`link:#quarkus-camel-metrics-enable-exchange-event-notifier[quarkus.camel.metrics.enable-exchange-event-notifier]`
 
 Set whether to enable the MicrometerExchangeEventNotifier for capturing metrics on exchange processing times.
 | `boolean`
 | `true`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.metrics.base-endpoint-uri-exchange-event-notifier]]`link:#quarkus.camel.metrics.base-endpoint-uri-exchange-event-notifier[quarkus.camel.metrics.base-endpoint-uri-exchange-event-notifier]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-metrics-base-endpoint-uri-exchange-event-notifier]]`link:#quarkus-camel-metrics-base-endpoint-uri-exchange-event-notifier[quarkus.camel.metrics.base-endpoint-uri-exchange-event-notifier]`
 
 Whether to use static or dynamic values for Endpoint Name tags in captured metrics. By default, static values are
 used. When using dynamic tags, then a dynamic to (toD) can compute many different endpoint URIs that,
@@ -119,27 +119,27 @@ can lead to many tags as the URI is dynamic, so use this with care if setting th
 | `boolean`
 | `true`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.metrics.enable-route-event-notifier]]`link:#quarkus.camel.metrics.enable-route-event-notifier[quarkus.camel.metrics.enable-route-event-notifier]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-metrics-enable-route-event-notifier]]`link:#quarkus-camel-metrics-enable-route-event-notifier[quarkus.camel.metrics.enable-route-event-notifier]`
 
 Set whether to enable the MicrometerRouteEventNotifier for capturing metrics on the total number of routes and total
 number of routes running.
 | `boolean`
 | `true`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.metrics.enable-instrumented-thread-pool-factory]]`link:#quarkus.camel.metrics.enable-instrumented-thread-pool-factory[quarkus.camel.metrics.enable-instrumented-thread-pool-factory]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-metrics-enable-instrumented-thread-pool-factory]]`link:#quarkus-camel-metrics-enable-instrumented-thread-pool-factory[quarkus.camel.metrics.enable-instrumented-thread-pool-factory]`
 
 Set whether to gather performance information about Camel Thread Pools by injecting an InstrumentedThreadPoolFactory.
 | `boolean`
 | `false`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.metrics.naming-strategy]]`link:#quarkus.camel.metrics.naming-strategy[quarkus.camel.metrics.naming-strategy]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-metrics-naming-strategy]]`link:#quarkus-camel-metrics-naming-strategy[quarkus.camel.metrics.naming-strategy]`
 
 Controls the naming style to use for metrics. The available values are `default` and `legacy`. `default` uses the
 default Micrometer naming convention. `legacy` uses the legacy camel-case naming style.
 | `default`, `legacy`
 | `default`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.metrics.route-policy-level]]`link:#quarkus.camel.metrics.route-policy-level[quarkus.camel.metrics.route-policy-level]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-metrics-route-policy-level]]`link:#quarkus-camel-metrics-route-policy-level[quarkus.camel.metrics.route-policy-level]`
 
 Sets the level of metrics to capture. The available values are `all` ,`context` and `route`. `all` captures metrics
 for both the camel context and routes. `route` captures metrics for routes only. `context` captures metrics for the
@@ -147,7 +147,7 @@ camel context only.
 | `all`, `context`, `route`
 | `all`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.metrics.route-policy-exclude-pattern]]`link:#quarkus.camel.metrics.route-policy-exclude-pattern[quarkus.camel.metrics.route-policy-exclude-pattern]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-metrics-route-policy-exclude-pattern]]`link:#quarkus-camel-metrics-route-policy-exclude-pattern[quarkus.camel.metrics.route-policy-exclude-pattern]`
 
 Comma separated list of route IDs to exclude from metrics collection.
 | `string`

--- a/docs/modules/ROOT/pages/reference/extensions/microprofile-health.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/microprofile-health.adoc
@@ -82,7 +82,7 @@ Inspects the status of each route and causes the health check status to be `DOWN
 | Configuration property | Type | Default
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.health.enabled]]`link:#quarkus.camel.health.enabled[quarkus.camel.health.enabled]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-health-enabled]]`link:#quarkus-camel-health-enabled[quarkus.camel.health.enabled]`
 
 Set whether to enable Camel health checks
 | `boolean`

--- a/docs/modules/ROOT/pages/reference/extensions/nitrite.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/nitrite.adoc
@@ -48,7 +48,7 @@ endif::[]
 [id="extensions-nitrite-usage"]
 == Usage
 If your persistence objects in native mode implement `java.io.Serializable` and are not automatically registered for serialization,
-you have to register them for serialization. Look into xref:extensions/core.adoc#quarkus.camel.native.reflection.serialization-enabled[documentation]
+you have to register them for serialization. Look into xref:extensions/core.adoc#quarkus-camel-native-reflection-serialization-enabled[documentation]
 to see which classes are registered and how to register other ones.
 
 

--- a/docs/modules/ROOT/pages/reference/extensions/openapi-java.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/openapi-java.adoc
@@ -75,7 +75,7 @@ Also, it can not use CDI injection in the RouteBuilder `configure()` since we ge
 | Configuration property | Type | Default
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.openapi.expose.enabled]]`link:#quarkus.camel.openapi.expose.enabled[quarkus.camel.openapi.expose.enabled]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-openapi-expose-enabled]]`link:#quarkus-camel-openapi-expose-enabled[quarkus.camel.openapi.expose.enabled]`
 
 When set to true, Camel REST DSL OpenAPI specifications are exposed under the Quarkus OpenAPI HTTP endpoint
 (`/q/openapi`). This requires `quarkus-smallrye-openapi` to be added to your application.

--- a/docs/modules/ROOT/pages/reference/extensions/opentelemetry.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/opentelemetry.adoc
@@ -124,7 +124,7 @@ There is more information about CDI instrumentation in the https://quarkus.io/gu
 | Configuration property | Type | Default
 
 
-a| [[quarkus.camel.opentelemetry.encoding]]`link:#quarkus.camel.opentelemetry.encoding[quarkus.camel.opentelemetry.encoding]`
+a| [[quarkus-camel-opentelemetry-encoding]]`link:#quarkus-camel-opentelemetry-encoding[quarkus.camel.opentelemetry.encoding]`
 
 Sets whether header names need to be encoded. Can be useful in situations where OpenTelemetry propagators potentially
 set header name values in formats that are not compatible with the target system. E.g for JMS where the specification
@@ -132,7 +132,7 @@ mandates header names are valid Java identifiers.
 | `boolean`
 | `false`
 
-a| [[quarkus.camel.opentelemetry.exclude-patterns]]`link:#quarkus.camel.opentelemetry.exclude-patterns[quarkus.camel.opentelemetry.exclude-patterns]`
+a| [[quarkus-camel-opentelemetry-exclude-patterns]]`link:#quarkus-camel-opentelemetry-exclude-patterns[quarkus.camel.opentelemetry.exclude-patterns]`
 
 Sets whether to disable tracing for endpoint URIs or Processor ids that match the given comma separated patterns. The
 pattern can take the following forms:
@@ -145,7 +145,7 @@ pattern can take the following forms:
 | `string`
 | 
 
-a| [[quarkus.camel.opentelemetry.trace-processors]]`link:#quarkus.camel.opentelemetry.trace-processors[quarkus.camel.opentelemetry.trace-processors]`
+a| [[quarkus-camel-opentelemetry-trace-processors]]`link:#quarkus-camel-opentelemetry-trace-processors[quarkus.camel.opentelemetry.trace-processors]`
 
 Sets whether to create new OpenTelemetry spans for each Camel Processor. Use the excludePatterns property to filter
 out Processors.

--- a/docs/modules/ROOT/pages/reference/extensions/rest-openapi.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/rest-openapi.adoc
@@ -150,7 +150,7 @@ To set a base path, do any one of the following.
 | Configuration property | Type | Default
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.openapi.codegen.enabled]]`link:#quarkus.camel.openapi.codegen.enabled[quarkus.camel.openapi.codegen.enabled]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-openapi-codegen-enabled]]`link:#quarkus-camel-openapi-codegen-enabled[quarkus.camel.openapi.codegen.enabled]`
 
 If `true`, Camel Quarkus OpenAPI code generation is run for .json and .yaml files discovered from the `openapi`
 directory. When
@@ -158,43 +158,43 @@ directory. When
 | `boolean`
 | `true`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.openapi.codegen.model-package]]`link:#quarkus.camel.openapi.codegen.model-package[quarkus.camel.openapi.codegen.model-package]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-openapi-codegen-model-package]]`link:#quarkus-camel-openapi-codegen-model-package[quarkus.camel.openapi.codegen.model-package]`
 
 The package to use for generated model classes.
 | `string`
 | `org.apache.camel.quarkus`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.openapi.codegen.models]]`link:#quarkus.camel.openapi.codegen.models[quarkus.camel.openapi.codegen.models]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-openapi-codegen-models]]`link:#quarkus-camel-openapi-codegen-models[quarkus.camel.openapi.codegen.models]`
 
 A comma separated list of models to generate. The default is empty list for all models.
 | `string`
 | 
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.openapi.codegen.use-bean-validation]]`link:#quarkus.camel.openapi.codegen.use-bean-validation[quarkus.camel.openapi.codegen.use-bean-validation]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-openapi-codegen-use-bean-validation]]`link:#quarkus-camel-openapi-codegen-use-bean-validation[quarkus.camel.openapi.codegen.use-bean-validation]`
 
 If `true`, use bean validation annotations in the generated model classes.
 | `boolean`
 | `false`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.openapi.codegen.not-null-jackson]]`link:#quarkus.camel.openapi.codegen.not-null-jackson[quarkus.camel.openapi.codegen.not-null-jackson]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-openapi-codegen-not-null-jackson]]`link:#quarkus-camel-openapi-codegen-not-null-jackson[quarkus.camel.openapi.codegen.not-null-jackson]`
 
 If `true`, use NON_NULL Jackson annotation in the generated model classes.
 | `boolean`
 | `false`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.openapi.codegen.ignore-unknown-properties]]`link:#quarkus.camel.openapi.codegen.ignore-unknown-properties[quarkus.camel.openapi.codegen.ignore-unknown-properties]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-openapi-codegen-ignore-unknown-properties]]`link:#quarkus-camel-openapi-codegen-ignore-unknown-properties[quarkus.camel.openapi.codegen.ignore-unknown-properties]`
 
 If `true`, use JsonIgnoreProperties(ignoreUnknown = true) annotation in the generated model classes.
 | `boolean`
 | `false`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.openapi.codegen.additional-properties.-additional-properties]]`link:#quarkus.camel.openapi.codegen.additional-properties.-additional-properties[quarkus.camel.openapi.codegen.additional-properties."additional-properties"]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-openapi-codegen-additional-properties-additional-properties]]`link:#quarkus-camel-openapi-codegen-additional-properties-additional-properties[quarkus.camel.openapi.codegen.additional-properties."additional-properties"]`
 
 Additional properties to be used in the mustache templates.
 | `Map<String,String>`
 | 
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.openapi.codegen.locations]]`link:#quarkus.camel.openapi.codegen.locations[quarkus.camel.openapi.codegen.locations]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-openapi-codegen-locations]]`link:#quarkus-camel-openapi-codegen-locations[quarkus.camel.openapi.codegen.locations]`
 
 A comma separated list of OpenAPI spec locations.
 | `string`

--- a/docs/modules/ROOT/pages/reference/extensions/servlet.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/servlet.adoc
@@ -175,27 +175,27 @@ You will also need to enable serialization for the exception classes that you in
 | Configuration property | Type | Default
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.servlet.url-patterns]]`link:#quarkus.camel.servlet.url-patterns[quarkus.camel.servlet.url-patterns]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-servlet-url-patterns]]`link:#quarkus-camel-servlet-url-patterns[quarkus.camel.servlet.url-patterns]`
 
 A comma separated list of path patterns under which the CamelServlet should be accessible. Example path patterns:
 `/++*++`, `/services/++*++`
 | List of `string`
 | 
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.servlet.servlet-class]]`link:#quarkus.camel.servlet.servlet-class[quarkus.camel.servlet.servlet-class]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-servlet-servlet-class]]`link:#quarkus-camel-servlet-servlet-class[quarkus.camel.servlet.servlet-class]`
 
 A fully qualified name of a servlet class to serve paths that match `url-patterns`
 | `string`
 | `org.apache.camel.component.servlet.CamelHttpTransportServlet`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.servlet.servlet-name]]`link:#quarkus.camel.servlet.servlet-name[quarkus.camel.servlet.servlet-name]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-servlet-servlet-name]]`link:#quarkus-camel-servlet-servlet-name[quarkus.camel.servlet.servlet-name]`
 
 A servletName as it would be defined in a `web.xml` file or in the `jakarta.servlet.annotation.WebServlet++#++name()`
 annotation.
 | `string`
 | `CamelServlet`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.servlet.load-on-startup]]`link:#quarkus.camel.servlet.load-on-startup[quarkus.camel.servlet.load-on-startup]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-servlet-load-on-startup]]`link:#quarkus-camel-servlet-load-on-startup[quarkus.camel.servlet.load-on-startup]`
 
 Sets the loadOnStartup priority on the Servlet. A loadOnStartup is a value greater than or equal to zero, indicates
 to the container the initialization priority of the Servlet. If loadOnStartup is a negative integer, the Servlet is
@@ -203,72 +203,72 @@ initialized lazily.
 | `int`
 | `-1`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.servlet.async]]`link:#quarkus.camel.servlet.async[quarkus.camel.servlet.async]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-servlet-async]]`link:#quarkus-camel-servlet-async[quarkus.camel.servlet.async]`
 
 Enables Camel to benefit from asynchronous Servlet support.
 | `boolean`
 | `false`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.servlet.force-await]]`link:#quarkus.camel.servlet.force-await[quarkus.camel.servlet.force-await]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-servlet-force-await]]`link:#quarkus-camel-servlet-force-await[quarkus.camel.servlet.force-await]`
 
 When set to `true` used in conjunction with `quarkus.camel.servlet.async = true`, this will force route processing to
 run synchronously.
 | `boolean`
 | `false`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.servlet.executor-ref]]`link:#quarkus.camel.servlet.executor-ref[quarkus.camel.servlet.executor-ref]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-servlet-executor-ref]]`link:#quarkus-camel-servlet-executor-ref[quarkus.camel.servlet.executor-ref]`
 
 The name of a bean to configure an optional custom thread pool for handling Camel Servlet processing.
 | `string`
 | 
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.servlet.multipart.location]]`link:#quarkus.camel.servlet.multipart.location[quarkus.camel.servlet.multipart.location]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-servlet-multipart-location]]`link:#quarkus-camel-servlet-multipart-location[quarkus.camel.servlet.multipart.location]`
 
 An absolute path to a directory on the file system to store files temporarily while the parts are processed or
 when the size of the file exceeds the specified file-size-threshold configuration value.
 | `string`
 | `${java.io.tmpdir}`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.servlet.multipart.max-file-size]]`link:#quarkus.camel.servlet.multipart.max-file-size[quarkus.camel.servlet.multipart.max-file-size]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-servlet-multipart-max-file-size]]`link:#quarkus-camel-servlet-multipart-max-file-size[quarkus.camel.servlet.multipart.max-file-size]`
 
 The maximum size allowed in bytes for uploaded files. The default size (-1) allows an unlimited size.
 | `long`
 | `-1`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.servlet.multipart.max-request-size]]`link:#quarkus.camel.servlet.multipart.max-request-size[quarkus.camel.servlet.multipart.max-request-size]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-servlet-multipart-max-request-size]]`link:#quarkus-camel-servlet-multipart-max-request-size[quarkus.camel.servlet.multipart.max-request-size]`
 
 The maximum size allowed in bytes for a multipart/form-data request. The default size (-1) allows an unlimited
 size.
 | `long`
 | `-1`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.servlet.multipart.file-size-threshold]]`link:#quarkus.camel.servlet.multipart.file-size-threshold[quarkus.camel.servlet.multipart.file-size-threshold]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-servlet-multipart-file-size-threshold]]`link:#quarkus-camel-servlet-multipart-file-size-threshold[quarkus.camel.servlet.multipart.file-size-threshold]`
 
 The file size in bytes after which the file will be temporarily stored on disk.
 | `int`
 | `0`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.servlet.-named-servlets-.url-patterns]]`link:#quarkus.camel.servlet.-named-servlets-.url-patterns[quarkus.camel.servlet."named-servlets".url-patterns]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-servlet-named-servlets-url-patterns]]`link:#quarkus-camel-servlet-named-servlets-url-patterns[quarkus.camel.servlet."named-servlets".url-patterns]`
 
 A comma separated list of path patterns under which the CamelServlet should be accessible. Example path patterns:
 `/++*++`, `/services/++*++`
 | List of `string`
 | 
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.servlet.-named-servlets-.servlet-class]]`link:#quarkus.camel.servlet.-named-servlets-.servlet-class[quarkus.camel.servlet."named-servlets".servlet-class]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-servlet-named-servlets-servlet-class]]`link:#quarkus-camel-servlet-named-servlets-servlet-class[quarkus.camel.servlet."named-servlets".servlet-class]`
 
 A fully qualified name of a servlet class to serve paths that match `url-patterns`
 | `string`
 | `org.apache.camel.component.servlet.CamelHttpTransportServlet`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.servlet.-named-servlets-.servlet-name]]`link:#quarkus.camel.servlet.-named-servlets-.servlet-name[quarkus.camel.servlet."named-servlets".servlet-name]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-servlet-named-servlets-servlet-name]]`link:#quarkus-camel-servlet-named-servlets-servlet-name[quarkus.camel.servlet."named-servlets".servlet-name]`
 
 A servletName as it would be defined in a `web.xml` file or in the `jakarta.servlet.annotation.WebServlet++#++name()`
 annotation.
 | `string`
 | `CamelServlet`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.servlet.-named-servlets-.load-on-startup]]`link:#quarkus.camel.servlet.-named-servlets-.load-on-startup[quarkus.camel.servlet."named-servlets".load-on-startup]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-servlet-named-servlets-load-on-startup]]`link:#quarkus-camel-servlet-named-servlets-load-on-startup[quarkus.camel.servlet."named-servlets".load-on-startup]`
 
 Sets the loadOnStartup priority on the Servlet. A loadOnStartup is a value greater than or equal to zero, indicates
 to the container the initialization priority of the Servlet. If loadOnStartup is a negative integer, the Servlet is
@@ -276,46 +276,46 @@ initialized lazily.
 | `int`
 | `-1`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.servlet.-named-servlets-.async]]`link:#quarkus.camel.servlet.-named-servlets-.async[quarkus.camel.servlet."named-servlets".async]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-servlet-named-servlets-async]]`link:#quarkus-camel-servlet-named-servlets-async[quarkus.camel.servlet."named-servlets".async]`
 
 Enables Camel to benefit from asynchronous Servlet support.
 | `boolean`
 | `false`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.servlet.-named-servlets-.force-await]]`link:#quarkus.camel.servlet.-named-servlets-.force-await[quarkus.camel.servlet."named-servlets".force-await]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-servlet-named-servlets-force-await]]`link:#quarkus-camel-servlet-named-servlets-force-await[quarkus.camel.servlet."named-servlets".force-await]`
 
 When set to `true` used in conjunction with `quarkus.camel.servlet.async = true`, this will force route processing to
 run synchronously.
 | `boolean`
 | `false`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.servlet.-named-servlets-.executor-ref]]`link:#quarkus.camel.servlet.-named-servlets-.executor-ref[quarkus.camel.servlet."named-servlets".executor-ref]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-servlet-named-servlets-executor-ref]]`link:#quarkus-camel-servlet-named-servlets-executor-ref[quarkus.camel.servlet."named-servlets".executor-ref]`
 
 The name of a bean to configure an optional custom thread pool for handling Camel Servlet processing.
 | `string`
 | 
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.servlet.-named-servlets-.multipart.location]]`link:#quarkus.camel.servlet.-named-servlets-.multipart.location[quarkus.camel.servlet."named-servlets".multipart.location]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-servlet-named-servlets-multipart-location]]`link:#quarkus-camel-servlet-named-servlets-multipart-location[quarkus.camel.servlet."named-servlets".multipart.location]`
 
 An absolute path to a directory on the file system to store files temporarily while the parts are processed or
 when the size of the file exceeds the specified file-size-threshold configuration value.
 | `string`
 | `${java.io.tmpdir}`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.servlet.-named-servlets-.multipart.max-file-size]]`link:#quarkus.camel.servlet.-named-servlets-.multipart.max-file-size[quarkus.camel.servlet."named-servlets".multipart.max-file-size]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-servlet-named-servlets-multipart-max-file-size]]`link:#quarkus-camel-servlet-named-servlets-multipart-max-file-size[quarkus.camel.servlet."named-servlets".multipart.max-file-size]`
 
 The maximum size allowed in bytes for uploaded files. The default size (-1) allows an unlimited size.
 | `long`
 | `-1`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.servlet.-named-servlets-.multipart.max-request-size]]`link:#quarkus.camel.servlet.-named-servlets-.multipart.max-request-size[quarkus.camel.servlet."named-servlets".multipart.max-request-size]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-servlet-named-servlets-multipart-max-request-size]]`link:#quarkus-camel-servlet-named-servlets-multipart-max-request-size[quarkus.camel.servlet."named-servlets".multipart.max-request-size]`
 
 The maximum size allowed in bytes for a multipart/form-data request. The default size (-1) allows an unlimited
 size.
 | `long`
 | `-1`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.servlet.-named-servlets-.multipart.file-size-threshold]]`link:#quarkus.camel.servlet.-named-servlets-.multipart.file-size-threshold[quarkus.camel.servlet."named-servlets".multipart.file-size-threshold]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-servlet-named-servlets-multipart-file-size-threshold]]`link:#quarkus-camel-servlet-named-servlets-multipart-file-size-threshold[quarkus.camel.servlet."named-servlets".multipart.file-size-threshold]`
 
 The file size in bytes after which the file will be temporarily stored on disk.
 | `int`

--- a/docs/modules/ROOT/pages/reference/extensions/sql.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/sql.adoc
@@ -84,7 +84,7 @@ quarkus.native.resources.includes = queries.sql, sql/*.sql
 [id="extensions-sql-configuration-sql-aggregation-repository-in-native-mode"]
 === SQL aggregation repository in native mode
 
-In order to use SQL aggregation repositories like `JdbcAggregationRepository` in native mode, you must xref:extensions/core.adoc#quarkus.camel.native.reflection.serialization-enabled[enable native serialization support].
+In order to use SQL aggregation repositories like `JdbcAggregationRepository` in native mode, you must xref:extensions/core.adoc#quarkus-camel-native-reflection-serialization-enabled[enable native serialization support].
 
 In addition, if your exchange bodies are custom types, they must be registered for serialization by annotating their class declaration with `@RegisterForReflection(serialization = true)`.
 

--- a/docs/modules/ROOT/pages/reference/extensions/xslt.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/xslt.adoc
@@ -110,19 +110,19 @@ only source of XSLT information at runtime. The XSLT source files may not be inc
 | Configuration property | Type | Default
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.xslt.sources]]`link:#quarkus.camel.xslt.sources[quarkus.camel.xslt.sources]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-xslt-sources]]`link:#quarkus-camel-xslt-sources[quarkus.camel.xslt.sources]`
 
 A comma separated list of templates to compile.
 | List of `string`
 | 
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.xslt.package-name]]`link:#quarkus.camel.xslt.package-name[quarkus.camel.xslt.package-name]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-xslt-package-name]]`link:#quarkus-camel-xslt-package-name[quarkus.camel.xslt.package-name]`
 
 The package name for the generated classes.
 | `string`
 | `org.apache.camel.quarkus.component.xslt.generated`
 
-a|icon:lock[title=Fixed at build time] [[quarkus.camel.xslt.features.-features]]`link:#quarkus.camel.xslt.features.-features[quarkus.camel.xslt.features."features"]`
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-xslt-features-features]]`link:#quarkus-camel-xslt-features-features[quarkus.camel.xslt.features."features"]`
 
 TransformerFactory features.
 | `Map<String,Boolean>`

--- a/extensions/cassandraql/runtime/src/main/doc/configuration.adoc
+++ b/extensions/cassandraql/runtime/src/main/doc/configuration.adoc
@@ -1,5 +1,5 @@
 === Cassandra aggregation repository in native mode
 
-In order to use Cassandra aggregation repositories like `CassandraAggregationRepository` in native mode, you must xref:extensions/core.adoc#quarkus.camel.native.reflection.serialization-enabled[enable native serialization support].
+In order to use Cassandra aggregation repositories like `CassandraAggregationRepository` in native mode, you must xref:extensions/core.adoc#quarkus-camel-native-reflection-serialization-enabled[enable native serialization support].
 
 In addition, if your exchange bodies are custom types, then they must be registered for serialization by annotating their class declaration with `@RegisterForReflection(serialization = true)`.

--- a/extensions/infinispan/runtime/src/main/doc/configuration.adoc
+++ b/extensions/infinispan/runtime/src/main/doc/configuration.adoc
@@ -1,3 +1,3 @@
 === Camel Infinispan `InfinispanRemoteAggregationRepository` in native mode
 
-If you chose to use the `InfinispanRemoteAggregationRepository` in native mode, then you must xref:extensions/core.adoc#quarkus.camel.native.reflection.serialization-enabled[enable native serialization support].
+If you chose to use the `InfinispanRemoteAggregationRepository` in native mode, then you must xref:extensions/core.adoc#quarkus-camel-native-reflection-serialization-enabled[enable native serialization support].

--- a/extensions/nitrite/runtime/src/main/doc/usage.adoc
+++ b/extensions/nitrite/runtime/src/main/doc/usage.adoc
@@ -1,5 +1,5 @@
 If your persistence objects in native mode implement `java.io.Serializable` and are not automatically registered for serialization,
-you have to register them for serialization. Look into xref:extensions/core.adoc#quarkus.camel.native.reflection.serialization-enabled[documentation]
+you have to register them for serialization. Look into xref:extensions/core.adoc#quarkus-camel-native-reflection-serialization-enabled[documentation]
 to see which classes are registered and how to register other ones.
 
 

--- a/extensions/sql/runtime/src/main/doc/configuration.adoc
+++ b/extensions/sql/runtime/src/main/doc/configuration.adoc
@@ -29,6 +29,6 @@ quarkus.native.resources.includes = queries.sql, sql/*.sql
 
 === SQL aggregation repository in native mode
 
-In order to use SQL aggregation repositories like `JdbcAggregationRepository` in native mode, you must xref:extensions/core.adoc#quarkus.camel.native.reflection.serialization-enabled[enable native serialization support].
+In order to use SQL aggregation repositories like `JdbcAggregationRepository` in native mode, you must xref:extensions/core.adoc#quarkus-camel-native-reflection-serialization-enabled[enable native serialization support].
 
 In addition, if your exchange bodies are custom types, they must be registered for serialization by annotating their class declaration with `@RegisterForReflection(serialization = true)`.

--- a/tooling/maven-plugin/src/main/java/org/apache/camel/quarkus/maven/UpdateExtensionDocPageMojo.java
+++ b/tooling/maven-plugin/src/main/java/org/apache/camel/quarkus/maven/UpdateExtensionDocPageMojo.java
@@ -293,7 +293,7 @@ public class UpdateExtensionDocPageMojo extends AbstractDocGeneratorMojo {
                 // Apostrophes.
                 string = string.replaceAll("([a-z])'s([^a-z])", "$1s$2");
                 // Allow only letters, -, _, .
-                string = string.replaceAll("[^\\w-_.]", "-").replaceAll("-{2,}", "-");
+                string = string.replaceAll("[^\\w-_]", "-").replaceAll("-{2,}", "-");
                 // Get rid of any - at the start and end.
                 string = string.replaceAll("-+$", "").replaceAll("^-+", "");
 


### PR DESCRIPTION
Second attempt. I [missed](https://ci-builds.apache.org/job/Camel/job/Camel.website/job/main/1946/cloudbees-pipeline-explorer/) some extension doc references to the `serialization-enabled` property.