### PR TITLE
Reduce log noise from FTP tests

### DIFF
--- a/integration-tests/ftp/src/main/resources/application.properties
+++ b/integration-tests/ftp/src/main/resources/application.properties
@@ -1,0 +1,19 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+# Change to INFO level to get insights about commands run on the FTP server
+quarkus.log.category."org.apache.ftpserver".level = WARNING


### PR DESCRIPTION
Default level causes far too much log spam and makes debugging difficult.