### PR TITLE
Fix jms-artemis-ra module name

### DIFF
--- a/integration-tests/jms-artemis-ra/pom.xml
+++ b/integration-tests/jms-artemis-ra/pom.xml
@@ -26,7 +26,7 @@
         <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
-    <artifactId>camel-quarkus-integration-test-jms-artemis-jms-ra</artifactId>
+    <artifactId>camel-quarkus-integration-test-jms-artemis-ra</artifactId>
     <name>Camel Quarkus :: Integration Tests :: JMS Artemis RA Connector</name>
     <description>Integration tests for Camel Quarkus JMS extension with the Quarkus Artemis JMS RA Connector</description>
 


### PR DESCRIPTION
Test is failing on maven build phase because it cannot find camel-quarkus-integration-test-jms-artemis-ra module.