### PR TITLE
Revert "Langchain4j-Tokenizer link is component and not others"

### DIFF
--- a/docs/modules/ROOT/pages/reference/extensions/langchain4j-tokenizer.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/langchain4j-tokenizer.adoc
@@ -22,7 +22,7 @@ LangChain4j Tokenizer
 [id="extensions-langchain4j-tokenizer-whats-inside"]
 == What's inside
 
-* xref:{cq-camel-components}:langchain4j-tokenizer-component.adoc[LangChain4j Tokenizer]
+* xref:{cq-camel-components}:others:langchain4j-tokenizer-component.adoc[LangChain4j Tokenizer]
 
 Please refer to the above link for usage and configuration details.
 


### PR DESCRIPTION
Reverts apache/camel-quarkus#7234