### PR TITLE
Remove logging of testcontainers configuration

### DIFF
--- a/integration-tests-jvm/elasticsearch/src/test/java/org/apache/camel/quarkus/component/elasticsearch/it/ElasticsearchTestResource.java
+++ b/integration-tests-jvm/elasticsearch/src/test/java/org/apache/camel/quarkus/component/elasticsearch/it/ElasticsearchTestResource.java
@@ -26,7 +26,6 @@ import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.utility.TestcontainersConfiguration;
 
 public class ElasticsearchTestResource implements QuarkusTestResourceLifecycleManager {
 
@@ -41,8 +40,6 @@ public class ElasticsearchTestResource implements QuarkusTestResourceLifecycleMa
 
     @Override
     public Map<String, String> start() {
-        LOGGER.info(TestcontainersConfiguration.getInstance().toString());
-
         try {
             container = new GenericContainer<>(ELASTICSEARCH_IMAGE)
                     .withExposedPorts(ELASTICSEARCH_PORT)

--- a/integration-tests-jvm/redis/src/test/java/org/apache/camel/quarkus/component/redis/it/RedisTestResource.java
+++ b/integration-tests-jvm/redis/src/test/java/org/apache/camel/quarkus/component/redis/it/RedisTestResource.java
@@ -26,7 +26,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.utility.TestcontainersConfiguration;
 
 public class RedisTestResource implements QuarkusTestResourceLifecycleManager {
     private static final Logger LOG = LoggerFactory.getLogger(RedisTestResource.class);
@@ -37,8 +36,6 @@ public class RedisTestResource implements QuarkusTestResourceLifecycleManager {
 
     @Override
     public Map<String, String> start() {
-        LOG.info(TestcontainersConfiguration.getInstance().toString());
-
         try {
             container = new GenericContainer(REDIS_IMAGE).withExposedPorts(REDIS_PORT).waitingFor(Wait.forListeningPort());
             container.start();

--- a/integration-tests-support/kafka/src/main/java/org/apache/camel/quarkus/test/support/kafka/KafkaTestResource.java
+++ b/integration-tests-support/kafka/src/main/java/org/apache/camel/quarkus/test/support/kafka/KafkaTestResource.java
@@ -25,7 +25,6 @@ import io.strimzi.test.container.StrimziKafkaContainer;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testcontainers.utility.TestcontainersConfiguration;
 
 public class KafkaTestResource implements QuarkusTestResourceLifecycleManager {
     protected static final String KAFKA_IMAGE_NAME = ConfigProvider.getConfig().getValue("kafka.container.image", String.class);
@@ -35,8 +34,6 @@ public class KafkaTestResource implements QuarkusTestResourceLifecycleManager {
 
     @Override
     public Map<String, String> start() {
-        LOGGER.info(TestcontainersConfiguration.getInstance().toString());
-
         try {
             start(name -> new StrimziKafkaContainer(name));
 
@@ -47,7 +44,6 @@ public class KafkaTestResource implements QuarkusTestResourceLifecycleManager {
     }
 
     public String start(Function<String, StrimziKafkaContainer> containerSupplier) {
-        LOGGER.info(TestcontainersConfiguration.getInstance().toString());
         container = containerSupplier.apply(KAFKA_IMAGE_NAME);
 
         /* Added container startup logging because of https://github.com/apache/camel-quarkus/issues/2461 */

--- a/integration-tests-support/mongodb/src/main/java/org/apache/camel/quarkus/test/support/mongodb/MongoDbTestResource.java
+++ b/integration-tests-support/mongodb/src/main/java/org/apache/camel/quarkus/test/support/mongodb/MongoDbTestResource.java
@@ -34,7 +34,6 @@ import org.testcontainers.containers.Container;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.utility.TestcontainersConfiguration;
 
 import static org.apache.camel.quarkus.test.support.mongodb.MongoDbTestSupportUtils.getMongoScriptExecutable;
 
@@ -49,8 +48,6 @@ public class MongoDbTestResource implements QuarkusTestResourceLifecycleManager 
 
     @Override
     public Map<String, String> start() {
-        LOGGER.info(TestcontainersConfiguration.getInstance().toString());
-
         try {
             container = new GenericContainer(MONGO_IMAGE)
                     .withExposedPorts(MONGODB_PORT)

--- a/integration-tests/activemq/src/test/java/org/apache/camel/quarkus/component/activemq/it/ActiveMQTestResource.java
+++ b/integration-tests/activemq/src/test/java/org/apache/camel/quarkus/component/activemq/it/ActiveMQTestResource.java
@@ -27,7 +27,6 @@ import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.utility.TestcontainersConfiguration;
 
 public class ActiveMQTestResource implements QuarkusTestResourceLifecycleManager {
     private static final Logger LOGGER = LoggerFactory.getLogger(ActiveMQTestResource.class);
@@ -39,8 +38,6 @@ public class ActiveMQTestResource implements QuarkusTestResourceLifecycleManager
 
     @Override
     public Map<String, String> start() {
-        LOGGER.info(TestcontainersConfiguration.getInstance().toString());
-
         try {
             container = new GenericContainer<>(ACTIVEMQ_IMAGE)
                     .withExposedPorts(TCP_PORT)

--- a/integration-tests/arangodb/src/test/java/org/apache/camel/quarkus/component/arangodb/it/ArangodbTestResource.java
+++ b/integration-tests/arangodb/src/test/java/org/apache/camel/quarkus/component/arangodb/it/ArangodbTestResource.java
@@ -26,7 +26,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.utility.TestcontainersConfiguration;
 
 public class ArangodbTestResource implements QuarkusTestResourceLifecycleManager {
 
@@ -39,8 +38,6 @@ public class ArangodbTestResource implements QuarkusTestResourceLifecycleManager
 
     @Override
     public Map<String, String> start() {
-        LOGGER.info(TestcontainersConfiguration.getInstance().toString());
-
         try {
             container = new GenericContainer<>(ARANGO_IMAGE)
                     .withExposedPorts(PORT_DEFAULT)

--- a/integration-tests/cassandraql/src/test/java/org/apache/camel/quarkus/component/cassandraql/it/CassandraqlTestResource.java
+++ b/integration-tests/cassandraql/src/test/java/org/apache/camel/quarkus/component/cassandraql/it/CassandraqlTestResource.java
@@ -33,7 +33,6 @@ import org.slf4j.LoggerFactory;
 import org.testcontainers.cassandra.CassandraContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
-import org.testcontainers.utility.TestcontainersConfiguration;
 
 public class CassandraqlTestResource implements QuarkusTestResourceLifecycleManager {
     private static final Logger LOGGER = LoggerFactory.getLogger(CassandraqlTestResource.class);
@@ -45,7 +44,6 @@ public class CassandraqlTestResource implements QuarkusTestResourceLifecycleMana
 
     @Override
     public Map<String, String> start() {
-        LOGGER.info(TestcontainersConfiguration.getInstance().toString());
         try {
             DockerImageName imageName = DockerImageName.parse(DOCKER_IMAGE_NAME).asCompatibleSubstituteFor("cassandra");
             container = new CassandraContainer(imageName)

--- a/integration-tests/consul/src/test/java/org/apache/camel/quarkus/component/consul/it/ConsulTestResource.java
+++ b/integration-tests/consul/src/test/java/org/apache/camel/quarkus/component/consul/it/ConsulTestResource.java
@@ -26,7 +26,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.utility.TestcontainersConfiguration;
 
 public class ConsulTestResource implements QuarkusTestResourceLifecycleManager {
     private static final Logger LOGGER = LoggerFactory.getLogger(ConsulTestResource.class);
@@ -37,8 +36,6 @@ public class ConsulTestResource implements QuarkusTestResourceLifecycleManager {
 
     @Override
     public Map<String, String> start() {
-        LOGGER.info(TestcontainersConfiguration.getInstance().toString());
-
         try {
             container = new GenericContainer(CONTAINER_IMAGE)
                     .withExposedPorts(CONTAINER_PORT)

--- a/integration-tests/debezium/src/test/java/org/apache/camel/quarkus/component/debezium/common/it/AbstractDebeziumTestResource.java
+++ b/integration-tests/debezium/src/test/java/org/apache/camel/quarkus/component/debezium/common/it/AbstractDebeziumTestResource.java
@@ -26,7 +26,6 @@ import org.apache.camel.util.CollectionHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.utility.TestcontainersConfiguration;
 
 /**
  * Abstract parent for debezium test resources.
@@ -56,7 +55,6 @@ public abstract class AbstractDebeziumTestResource<T extends GenericContainer<?>
 
     @Override
     public Map<String, String> start() {
-        LOGGER.info(TestcontainersConfiguration.getInstance().toString());
         try {
             storeFile = Files.createTempFile(getClass().getSimpleName() + "-store-", "");
 

--- a/integration-tests/influxdb/src/test/java/org/apache/camel/quarkus/component/influxdb/it/InfluxdbTestResource.java
+++ b/integration-tests/influxdb/src/test/java/org/apache/camel/quarkus/component/influxdb/it/InfluxdbTestResource.java
@@ -26,7 +26,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.utility.TestcontainersConfiguration;
 
 public class InfluxdbTestResource implements QuarkusTestResourceLifecycleManager {
     public static final Logger LOGGER = LoggerFactory.getLogger(InfluxdbTestResource.class);
@@ -38,8 +37,6 @@ public class InfluxdbTestResource implements QuarkusTestResourceLifecycleManager
 
     @Override
     public Map<String, String> start() {
-        LOGGER.info(TestcontainersConfiguration.getInstance().toString());
-
         try {
             container = new GenericContainer<>(INFLUXDB_IMAGE)
                     .withExposedPorts(INFLUXDB_PORT)

--- a/integration-tests/kudu/src/test/java/org/apache/camel/quarkus/component/kudu/it/KuduTestResource.java
+++ b/integration-tests/kudu/src/test/java/org/apache/camel/quarkus/component/kudu/it/KuduTestResource.java
@@ -34,7 +34,6 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.utility.TestcontainersConfiguration;
 
 import static org.apache.camel.quarkus.component.kudu.it.KuduInfrastructureTestHelper.DOCKER_HOST;
 import static org.apache.camel.quarkus.component.kudu.it.KuduInfrastructureTestHelper.KUDU_TABLET_NETWORK_ALIAS;
@@ -54,8 +53,6 @@ public class KuduTestResource implements QuarkusTestResourceLifecycleManager {
 
     @Override
     public Map<String, String> start() {
-        LOG.info(TestcontainersConfiguration.getInstance().toString());
-
         Network kuduNetwork = Network.newNetwork();
 
         // Setup the Kudu master server container

--- a/integration-tests/nats/src/test/java/org/apache/camel/quarkus/component/nats/it/NatsTestResource.java
+++ b/integration-tests/nats/src/test/java/org/apache/camel/quarkus/component/nats/it/NatsTestResource.java
@@ -30,7 +30,6 @@ import org.testcontainers.containers.SelinuxContext;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.MountableFile;
-import org.testcontainers.utility.TestcontainersConfiguration;
 
 import static org.apache.camel.quarkus.component.nats.it.NatsConfiguration.NATS_BROKER_URL_BASIC_AUTH_CONFIG_KEY;
 import static org.apache.camel.quarkus.component.nats.it.NatsConfiguration.NATS_BROKER_URL_NO_AUTH_CONFIG_KEY;
@@ -50,8 +49,6 @@ public class NatsTestResource implements QuarkusTestResourceLifecycleManager {
 
     @Override
     public Map<String, String> start() {
-        LOG.info(TestcontainersConfiguration.getInstance().toString());
-
         Map<String, String> properties = new HashMap<>();
 
         basicAuthContainer = basicAuthContainer(properties);

--- a/integration-tests/paho/src/test/java/org/apache/camel/quarkus/component/paho/it/PahoTestResource.java
+++ b/integration-tests/paho/src/test/java/org/apache/camel/quarkus/component/paho/it/PahoTestResource.java
@@ -30,7 +30,6 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.MountableFile;
-import org.testcontainers.utility.TestcontainersConfiguration;
 
 public class PahoTestResource implements QuarkusTestResourceLifecycleManager {
     private static final Logger LOGGER = LoggerFactory.getLogger(PahoTestResource.class);
@@ -45,8 +44,6 @@ public class PahoTestResource implements QuarkusTestResourceLifecycleManager {
 
     @Override
     public Map<String, String> start() {
-        LOGGER.info(TestcontainersConfiguration.getInstance().toString());
-
         try {
             Map<String, String> result = new HashMap<>();
 

--- a/integration-tests/pg-replication-slot/src/test/java/org/apache/camel/quarkus/component/pg/replication/slot/it/PgReplicationSlotTestResource.java
+++ b/integration-tests/pg-replication-slot/src/test/java/org/apache/camel/quarkus/component/pg/replication/slot/it/PgReplicationSlotTestResource.java
@@ -26,7 +26,6 @@ import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.utility.TestcontainersConfiguration;
 
 import static org.apache.camel.quarkus.component.pg.replication.slot.it.PgReplicationSlotRoute.PG_AUTHORITY_CFG_KEY;
 import static org.apache.camel.quarkus.component.pg.replication.slot.it.PgReplicationSlotRoute.PG_DBNAME_CFG_KEY;
@@ -46,8 +45,6 @@ public class PgReplicationSlotTestResource implements QuarkusTestResourceLifecyc
 
     @Override
     public Map<String, String> start() {
-        LOG.info(TestcontainersConfiguration.getInstance().toString());
-
         // Setup the Postgres container with replication enabled
         pgContainer = new GenericContainer<>(POSTGRES_IMAGE).withCommand("postgres -c wal_level=logical")
                 .withExposedPorts(POSTGRES_PORT).withEnv("POSTGRES_USER", POSTGRES_USER)

--- a/integration-tests/qdrant/src/test/java/org/apache/camel/quarkus/component/qdrant/it/QdrantTestResource.java
+++ b/integration-tests/qdrant/src/test/java/org/apache/camel/quarkus/component/qdrant/it/QdrantTestResource.java
@@ -27,7 +27,6 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.qdrant.QdrantContainer;
 import org.testcontainers.utility.DockerImageName;
-import org.testcontainers.utility.TestcontainersConfiguration;
 
 public class QdrantTestResource implements QuarkusTestResourceLifecycleManager {
 
@@ -39,8 +38,6 @@ public class QdrantTestResource implements QuarkusTestResourceLifecycleManager {
 
     @Override
     public Map<String, String> start() {
-        LOG.info(TestcontainersConfiguration.getInstance().toString());
-
         Map<String, String> properties = new HashMap<>();
 
         DockerImageName qdrantImageName = DockerImageName.parse(QDRANT_IMAGE).asCompatibleSubstituteFor("qdrant/qdrant");


### PR DESCRIPTION
Follow up to https://github.com/apache/camel-quarkus/pull/7231. We should do it globally. Dumping the environment JSON to the console doesn't really add anything useful.