### PR TITLE
Add missing QuarkusTestResource annotations to k8s ConfigMap & Secret reload tests

### DIFF
--- a/integration-tests/kubernetes/src/test/java/org/apache/camel/quarkus/component/kubernetes/it/KubernetesConfigMapContextReloadTest.java
+++ b/integration-tests/kubernetes/src/test/java/org/apache/camel/quarkus/component/kubernetes/it/KubernetesConfigMapContextReloadTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.quarkus.component.kubernetes.it;
 import java.time.Duration;
 import java.util.Map;
 
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
@@ -30,6 +31,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.Matchers.is;
 
+@QuarkusTestResource(CamelQuarkusKubernetesServerTestResource.class)
 @TestProfile(KubernetesConfigMapContextReloadTest.KubernetesConfigMapContextReloadTestProfile.class)
 @QuarkusTest
 class KubernetesConfigMapContextReloadTest {

--- a/integration-tests/kubernetes/src/test/java/org/apache/camel/quarkus/component/kubernetes/it/KubernetesSecretContextReloadTest.java
+++ b/integration-tests/kubernetes/src/test/java/org/apache/camel/quarkus/component/kubernetes/it/KubernetesSecretContextReloadTest.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
@@ -34,6 +35,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.Matchers.is;
 
+@QuarkusTestResource(CamelQuarkusKubernetesServerTestResource.class)
 @TestProfile(KubernetesSecretContextReloadTest.KubernetesSecretContextReloadTestProfile.class)
 @QuarkusTest
 class KubernetesSecretContextReloadTest {


### PR DESCRIPTION
For consistency with other tests, also loosely related to https://github.com/quarkusio/quarkus/issues/47477.