### PR TITLE
Upgrade Quarkus to 3.22.0

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -31,7 +31,7 @@ asciidoc:
     camel-version: 4.11.0 # replace ${camel.version}
     camel-docs-version: next
     camel-quarkus-version: 3.22.0 # replace ${camel-quarkus.version}
-    quarkus-version: 3.22.0.CR1 # replace ${quarkus.version}
+    quarkus-version: 3.22.0 # replace ${quarkus.version}
     graalvm-version: 23.1.2 # replace ${graalvm.version}
     graalvm-docs-version: jdk21 # replace ${graalvm-docs.version}
     mapstruct-version: 1.6.3 # replace ${mapstruct.version}

--- a/integration-test-groups/azure/azure-servicebus/src/test/java/org/apache/camel/quarkus/component/azure/servicebus/it/AzureServiceBusTest.java
+++ b/integration-test-groups/azure/azure-servicebus/src/test/java/org/apache/camel/quarkus/component/azure/servicebus/it/AzureServiceBusTest.java
@@ -41,7 +41,9 @@ import org.jboss.logging.Logger;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
@@ -84,19 +86,8 @@ class AzureServiceBusTest {
         }
     }
 
-    @Test
-    //quick workaround because of https://github.com/apache/camel-quarkus/issues/7274
-    void produceConsumeMessage() {
-        //do not use @MethodSource and run the tests directly
-        produceConsumeOptions().forEach(args -> {
-            LOG.infof("Starting configuration", args);
-            produceConsumeMessage((String) args.get()[0], (AmqpTransportType) args.get()[1], (String) args.get()[2]);
-        });
-    }
-
-    // te be returned once workaround is not necessary https://github.com/apache/camel-quarkus/issues/7274
-    //    @ParameterizedTest
-    //    @MethodSource("produceConsumeOptions")
+    @ParameterizedTest
+    @MethodSource("produceConsumeOptions")
     void produceConsumeMessage(
             String destinationType,
             AmqpTransportType transportType,

--- a/integration-tests-support/aws2/src/test/java/org/apache/camel/quarkus/test/support/aws2/BaseAWs2TestSupport.java
+++ b/integration-tests-support/aws2/src/test/java/org/apache/camel/quarkus/test/support/aws2/BaseAWs2TestSupport.java
@@ -18,7 +18,6 @@ package org.apache.camel.quarkus.test.support.aws2;
 
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -87,7 +86,6 @@ public abstract class BaseAWs2TestSupport {
     }
 
     //test can be executed only if mock backend is used and no defaultCredentialsprovider is defined in the system
-    @Disabled("https://github.com/apache/camel-quarkus/issues/7274")
     @ExtendWith(Aws2DefaultCredentialsProviderAvailabilityCondition.class)
     @Test
     public void failingDefaultCredentialsProviderTest() {

--- a/integration-tests-support/certificate-generator/src/main/java/org/apache/camel/quarkus/test/support/certificate/TestCertificateGenerationExtension.java
+++ b/integration-tests-support/certificate-generator/src/main/java/org/apache/camel/quarkus/test/support/certificate/TestCertificateGenerationExtension.java
@@ -108,16 +108,10 @@ public class TestCertificateGenerationExtension implements BeforeAllCallback {
     }
 
     private Optional<String> resolveDockerHost(ExtensionContext extensionContext) {
-        ClassLoader origTCCL = Thread.currentThread().getContextClassLoader();
-        try {
-            Thread.currentThread().setContextClassLoader(extensionContext.getTestClass().get().getClassLoader());
-            String dockerHost = DockerClientFactory.instance().dockerHostIpAddress();
-            if (!dockerHost.equals("localhost") && !dockerHost.equals("127.0.0.1")) {
-                return Optional.of(dockerHost);
-            }
-            return Optional.empty();
-        } finally {
-            Thread.currentThread().setContextClassLoader(origTCCL);
+        String dockerHost = DockerClientFactory.instance().dockerHostIpAddress();
+        if (!dockerHost.equals("localhost") && !dockerHost.equals("127.0.0.1")) {
+            return Optional.of(dockerHost);
         }
+        return Optional.empty();
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <quarkiverse-minio.version>3.8.1</quarkiverse-minio.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/minio/quarkus-minio-parent/ -->
         <quarkiverse-mybatis.version>2.3.2</quarkiverse-mybatis.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/mybatis/quarkus-mybatis-parent/ -->
         <quarkiverse-pooled-jms.version>2.8.0</quarkiverse-pooled-jms.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/messaginghub/quarkus-pooled-jms-parent/ -->
-        <quarkus.version>3.22.0.CR1</quarkus.version><!-- https://repo1.maven.org/maven2/io/quarkus/quarkus-bom/ -->
+        <quarkus.version>3.22.0</quarkus.version><!-- https://repo1.maven.org/maven2/io/quarkus/quarkus-bom/ -->
         <quarkus-hazelcast-client.version>4.0.0</quarkus-hazelcast-client.version><!-- https://repo1.maven.org/maven2/com/hazelcast/quarkus-hazelcast-client-bom/ -->
         <quarkus-qpid-jms.version>2.8.0</quarkus-qpid-jms.version><!-- This should be in sync with quarkus-platform https://repo1.maven.org/maven2/org/amqphub/quarkus/quarkus-qpid-jms-bom/ -->
 

--- a/poms/bom/pom.xml
+++ b/poms/bom/pom.xml
@@ -349,6 +349,10 @@
                         <groupId>org.checkerframework</groupId>
                         <artifactId>checker-qual</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>org.jetbrains.kotlin</groupId>
+                        <artifactId>kotlin-stdlib-common</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>
@@ -7011,11 +7015,23 @@
                 <groupId>com.squareup.okio</groupId>
                 <artifactId>okio-fakefilesystem-jvm</artifactId>
                 <version>${okio.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.jetbrains.kotlin</groupId>
+                        <artifactId>kotlin-stdlib-common</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>com.squareup.okio</groupId>
                 <artifactId>okio-jvm</artifactId>
                 <version>${okio.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.jetbrains.kotlin</groupId>
+                        <artifactId>kotlin-stdlib-common</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>com.squareup.retrofit2</groupId>
@@ -7561,6 +7577,12 @@
                 <groupId>org.jetbrains.kotlinx</groupId>
                 <artifactId>kotlinx-serialization-core-jvm</artifactId>
                 <version>${kotlinx.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.jetbrains.kotlin</groupId>
+                        <artifactId>kotlin-stdlib-common</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.jolokia</groupId>

--- a/poms/bom/src/main/generated/flattened-full-pom.xml
+++ b/poms/bom/src/main/generated/flattened-full-pom.xml
@@ -273,6 +273,10 @@
             <groupId>org.checkerframework</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
             <artifactId>checker-qual</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
           </exclusion>
+          <exclusion>
+            <groupId>org.jetbrains.kotlin</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+            <artifactId>kotlin-stdlib-common</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
@@ -6912,11 +6916,23 @@
         <groupId>com.squareup.okio</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>okio-fakefilesystem-jvm</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <version>3.6.0</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+        <exclusions>
+          <exclusion>
+            <groupId>org.jetbrains.kotlin</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+            <artifactId>kotlin-stdlib-common</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>com.squareup.okio</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>okio-jvm</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <version>3.6.0</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+        <exclusions>
+          <exclusion>
+            <groupId>org.jetbrains.kotlin</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+            <artifactId>kotlin-stdlib-common</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>com.squareup.retrofit2</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
@@ -7462,6 +7478,12 @@
         <groupId>org.jetbrains.kotlinx</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>kotlinx-serialization-core-jvm</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <version>1.4.0</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+        <exclusions>
+          <exclusion>
+            <groupId>org.jetbrains.kotlin</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+            <artifactId>kotlin-stdlib-common</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.jolokia</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->

--- a/poms/bom/src/main/generated/flattened-reduced-pom.xml
+++ b/poms/bom/src/main/generated/flattened-reduced-pom.xml
@@ -273,6 +273,10 @@
             <groupId>org.checkerframework</groupId>
             <artifactId>checker-qual</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib-common</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
@@ -6887,11 +6891,23 @@
         <groupId>com.squareup.okio</groupId>
         <artifactId>okio-fakefilesystem-jvm</artifactId>
         <version>3.6.0</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib-common</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>com.squareup.okio</groupId>
         <artifactId>okio-jvm</artifactId>
         <version>3.6.0</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib-common</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>com.squareup.retrofit2</groupId>
@@ -7402,6 +7418,12 @@
         <groupId>org.jetbrains.kotlinx</groupId>
         <artifactId>kotlinx-serialization-core-jvm</artifactId>
         <version>1.4.0</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib-common</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.jolokia</groupId>

--- a/poms/bom/src/main/generated/flattened-reduced-verbose-pom.xml
+++ b/poms/bom/src/main/generated/flattened-reduced-verbose-pom.xml
@@ -273,6 +273,10 @@
             <groupId>org.checkerframework</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
             <artifactId>checker-qual</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
           </exclusion>
+          <exclusion>
+            <groupId>org.jetbrains.kotlin</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+            <artifactId>kotlin-stdlib-common</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
@@ -6887,11 +6891,23 @@
         <groupId>com.squareup.okio</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>okio-fakefilesystem-jvm</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <version>3.6.0</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+        <exclusions>
+          <exclusion>
+            <groupId>org.jetbrains.kotlin</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+            <artifactId>kotlin-stdlib-common</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>com.squareup.okio</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>okio-jvm</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <version>3.6.0</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+        <exclusions>
+          <exclusion>
+            <groupId>org.jetbrains.kotlin</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+            <artifactId>kotlin-stdlib-common</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>com.squareup.retrofit2</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
@@ -7402,6 +7418,12 @@
         <groupId>org.jetbrains.kotlinx</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>kotlinx-serialization-core-jvm</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <version>1.4.0</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+        <exclusions>
+          <exclusion>
+            <groupId>org.jetbrains.kotlin</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+            <artifactId>kotlin-stdlib-common</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.jolokia</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->

--- a/tooling/enforcer-rules/camel-quarkus-banned-dependencies.xml
+++ b/tooling/enforcer-rules/camel-quarkus-banned-dependencies.xml
@@ -53,6 +53,7 @@
                 <exclude>org.apache.geronimo.specs:geronimo-jta_1.1_spec</exclude><!-- use jakarta.transaction:jakarta.transaction-api instead -->
                 <exclude>org.apache.geronimo.specs:geronimo-jta_1.2_spec</exclude><!-- use jakarta.transaction:jakarta.transaction-api instead -->
                 <exclude>org.glassfish.main.transaction:javax.transaction</exclude><!-- use jakarta.transaction:jakarta.transaction-api instead -->
+                <exclude>org.jetbrains.kotlin:kotlin-stdlib-common</exclude><!-- Deprecated and since Kotlin 2.1.x no JAR artifact exists and replace kotlin-stdlib compatibility is unknown -->
                 <exclude>xml-apis:xml-apis</exclude><!-- Rely on JAXP APIs available in the JDK -->
             </excludes>
         </bannedDependencies>


### PR DESCRIPTION
This reverts some test class loading hacks added in 3.22.0.CR1.

Also, not sure how this went unnoticed, but Quarkus bumped Kotlin to 2.1.20 some weeks back. This causes dependency convergence check issues for `org.jetbrains.kotlin:kotlin-stdlib-common`.

That dependency is deprecated and there's no longer a JAR for it. Its replacement is supposedly `org.jetbrains.kotlin:kotlin-stdlib` but that's not guaranteed to be backwards compatible.

So I've just banned & excluded the `kotlin-stdlib-common` everywhere.

I am expecting some things to potentially fail. Lets see.
