### PR TITLE
[3.20.x] Add ignore option also for service bus test

### DIFF
--- a/integration-test-groups/azure/azure-servicebus/src/main/java/org/apache/camel/quarkus/component/azure/servicebus/it/AzureServiceBusHelper.java
+++ b/integration-test-groups/azure/azure-servicebus/src/main/java/org/apache/camel/quarkus/component/azure/servicebus/it/AzureServiceBusHelper.java
@@ -36,6 +36,13 @@ public final class AzureServiceBusHelper {
 
     public static boolean isAzureIdentityCredentialsAvailable() {
         Config config = ConfigProvider.getConfig();
+
+        Optional<Boolean> disableIdentity = config.getOptionalValue("CAMEL_QUARKUS_DISABLE_IDENTITY_EXCEPT_KEY_VAULT",
+                Boolean.class);
+        if (disableIdentity.isPresent() && disableIdentity.get()) {
+            return false;
+        }
+
         Optional<String> clientId = config.getOptionalValue("azure.client.id", String.class);
         Optional<String> tenantId = config.getOptionalValue("azure.tenant.id", String.class);
         Optional<String> username = config.getOptionalValue("azure.username", String.class);


### PR DESCRIPTION
Just following this PR https://github.com/apache/camel-quarkus/pull/7057
and adding same option for service bus identity which wasn't present in 3.15 