### PR TITLE
[3.15.x] Remove SmallRye Fault Tolerance dependency overrides in microprofile-fault-tolerance test module

### DIFF
--- a/integration-tests/microprofile-fault-tolerance/pom.xml
+++ b/integration-tests/microprofile-fault-tolerance/pom.xml
@@ -30,50 +30,6 @@
     <name>Camel Quarkus :: Integration Tests :: MicroProfile Fault Tolerance</name>
     <description>Integration tests for Camel Quarkus MicroProfile Fault Tolerance extension</description>
 
-    <!-- TODO: Remove this https://github.com/apache/camel-quarkus/issues/7132 -->
-    <properties>
-        <smallrye-fault-tolerance-override.version>6.4.3</smallrye-fault-tolerance-override.version>
-    </properties>
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.smallrye</groupId>
-                <artifactId>smallrye-fault-tolerance</artifactId>
-                <version>${smallrye-fault-tolerance-override.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.smallrye</groupId>
-                <artifactId>smallrye-fault-tolerance-api</artifactId>
-                <version>${smallrye-fault-tolerance-override.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.smallrye</groupId>
-                <artifactId>smallrye-fault-tolerance-core</artifactId>
-                <version>${smallrye-fault-tolerance-override.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.smallrye</groupId>
-                <artifactId>smallrye-fault-tolerance-autoconfig-core</artifactId>
-                <version>${smallrye-fault-tolerance-override.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.smallrye</groupId>
-                <artifactId>smallrye-fault-tolerance-context-propagation</artifactId>
-                <version>${smallrye-fault-tolerance-override.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.smallrye</groupId>
-                <artifactId>smallrye-fault-tolerance-mutiny</artifactId>
-                <version>${smallrye-fault-tolerance-override.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.smallrye</groupId>
-                <artifactId>smallrye-fault-tolerance-vertx</artifactId>
-                <version>${smallrye-fault-tolerance-override.version}</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>


### PR DESCRIPTION
I forgot to do this when I did the upgrade to Quarkus 3.15.5.