### PR TITLE
Remove rest-assured groovy exclusions

### DIFF
--- a/integration-tests/groovy/pom.xml
+++ b/integration-tests/groovy/pom.xml
@@ -62,12 +62,6 @@
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.groovy</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Probably a relic of the past. It breaks on `quarkus-main` after Quarkus upgraded `rest-assured`. Hence I'm removing it.