### PR TITLE
Add workflow to test LTS branches with Quarkus LTS SNAPSHOTs

### DIFF
--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -42,6 +42,7 @@ on:
       - '.github/workflows/generate-sbom-main.yml'
       - '.github/workflows/label-issue.yaml'
       - '.github/workflows/pr-validate.yml'
+      - '.github/workflows/quarkus-lts-ci-build.yaml'
       - '.github/workflows/quarkus-master-cron.yaml'
       - '.github/workflows/synchronize-dependabot-branch.yaml'
       - 'docs/antora.yml'

--- a/.github/workflows/quarkus-lts-ci-build.yaml
+++ b/.github/workflows/quarkus-lts-ci-build.yaml
@@ -15,64 +15,18 @@
 # limitations under the License.
 #
 
-name: Camel Quarkus CI
+name: Camel Quarkus LTS CI
 
 on:
-  push:
-    branches:
-      - main
-      - camel-main
-      - quarkus-main
-      - "[0-9]+.[0-9]+.x"
-    paths-ignore:
-      - '**.adoc'
-      - '**.md'
-      - 'Jenkinsfile'
-      - 'Jenkinsfile.*'
-      - 'KEYS'
-      - 'LICENSE.txt'
-      - 'NOTICE.txt'
-      - 'camel-quarkus-sbom/**'
-      - '.github/*.sh'
-      - '.github/*.yaml'
-      - '.github/*.yml'
-      - '.github/workflows/assign-issue-milestone.yaml'
-      - '.github/workflows/assign-wontfix-issue-milestone.yaml'
-      - '.github/workflows/camel-master-cron.yaml'
-      - '.github/workflows/check-dependency-convergence.yml'
-      - '.github/workflows/generate-sbom-main.yml'
-      - '.github/workflows/label-issue.yaml'
-      - '.github/workflows/pr-validate.yml'
-      - '.github/workflows/quarkus-master-cron.yaml'
-      - '.github/workflows/synchronize-dependabot-branch.yaml'
-      - 'docs/antora.yml'
-  pull_request:
-    branches:
-      - main
-      - camel-main
-      - quarkus-main
-      - "[0-9]+.[0-9]+.x"
-    paths-ignore:
-      - '**.adoc'
-      - '**.md'
-      - 'Jenkinsfile'
-      - 'Jenkinsfile.*'
-      - 'KEYS'
-      - 'LICENSE.txt'
-      - 'NOTICE.txt'
-      - '.github/*.sh'
-      - '.github/*.yaml'
-      - '.github/*.yml'
-      - '.github/workflows/assign-issue-milestone.yaml'
-      - '.github/workflows/assign-wontfix-issue-milestone.yaml'
-      - '.github/workflows/camel-master-cron.yaml'
-      - '.github/workflows/generate-sbom-main.yml'
-      - '.github/workflows/label-issue.yaml'
-      - '.github/workflows/pr-validate.yml'
-      - '.github/workflows/quarkus-lts-ci-build.yaml'
-      - '.github/workflows/quarkus-master-cron.yaml'
-      - '.github/workflows/synchronize-dependabot-branch.yaml'
-      - 'docs/antora.yml'
+  workflow_dispatch:
+    inputs:
+      branch:
+        type: choice
+        description: "The Quarkus maintenance branch to test"
+        options:
+          - "3.20"
+          - "3.15"
+        required: true
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
@@ -83,71 +37,11 @@ env:
   MAVEN_OPTS: -Xmx3000m
   CQ_MAVEN_ARGS: -V -ntp -e -Daether.connector.http.connectionMaxTtl=120
   TESTCONTAINERS_RYUK_DISABLED: true
-  CHECKOUT_REF: ${{ github.event_name == 'pull_request' && github.actor == 'dependabot[bot]' && github.head_ref || '' }}
 
 jobs:
-  pre-build-checks:
+  initial-mvn-install:
     if: github.repository == 'apache/camel-quarkus'
     runs-on: ubuntu-latest
-    outputs:
-      continue-build: ${{ steps.pre-build-checks.outputs.continue-build }}
-      run-checks: ${{ steps.init.outputs.run-checks }}
-    steps:
-      - name: Initialize
-        id: init
-        run: |
-          if [[ "${{ github.event_name }}" == "pull_request" ]] && [[ "${{ github.actor }}" == "dependabot[bot]" ]]; then
-            echo "run-checks=true" >> $GITHUB_OUTPUT
-          else
-            echo "run-checks=false" >> $GITHUB_OUTPUT
-          fi
-      - name: Set up JDK 17
-        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
-        if: steps.init.outputs.run-checks == 'true'
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        if: steps.init.outputs.run-checks == 'true'
-        with:
-          ref: ${{ env.CHECKOUT_REF }}
-          fetch-depth: 0
-      - name: Pre build checks
-        id: pre-build-checks
-        run: |
-          if [[ "${{ steps.init.outputs.run-checks }}" == "true" ]]; then
-            ./mvnw cq:sync-versions -N ${CQ_MAVEN_ARGS}
-            ./mvnw clean install -pl poms/bom -am -Dcq.flatten-bom.format --fail-never ${CQ_MAVEN_ARGS}
-            ./mvnw clean install -f poms/bom ${CQ_MAVEN_ARGS}
-            ./mvnw clean validate -pl docs ${CQ_MAVEN_ARGS}
-
-            if [[ -z "$(git status --porcelain)" ]]; then
-              echo "continue-build=true" >> $GITHUB_OUTPUT
-            else
-              mkdir ./dependabot-pr
-              echo ${{ github.head_ref }} > ./dependabot-pr/BRANCH_REF
-              echo ${{ github.event.pull_request.head.sha }} > ./dependabot-pr/PR_HEAD_SHA
-              echo "$GITHUB_REF" | awk -F / '{print $3}' >  ./dependabot-pr/PR_NUMBER
-              git diff -p --binary > ./dependabot-pr/changes.patch
-
-              echo "continue-build=false" >> $GITHUB_OUTPUT
-            fi
-          else
-            echo "continue-build=true" >> $GITHUB_OUTPUT
-          fi
-      - name: Upload dependabot changeset
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        if: steps.pre-build-checks.outputs.continue-build == 'false'
-        with:
-          name: dependabot-pr-changeset
-          path: dependabot-pr/
-          retention-days: 1
-
-  initial-mvn-install:
-    if: needs.pre-build-checks.outputs.continue-build == 'true'
-    runs-on: ubuntu-latest
-    needs: pre-build-checks
     outputs:
       matrix: ${{ steps.set-native-matrix.outputs.matrix }}
       examples-matrix: ${{ steps.set-examples-matrix.outputs.examples-matrix }}
@@ -163,18 +57,9 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-      - name: Build Camel
-        if: github.ref == 'refs/heads/camel-main' || github.base_ref == 'camel-main'
-        run: |
-          cd ../
-          git clone --depth 1 --branch main https://github.com/apache/camel.git \
-            && cd camel \
-            && echo "Current Camel commit:" $(git rev-parse HEAD) \
-            && ./mvnw ${CQ_MAVEN_ARGS} clean install -Dquickly -T1C
       - name: Build Quarkus
-        if: github.ref == 'refs/heads/quarkus-main' || github.base_ref == 'quarkus-main'
         run: |
-          git clone --depth 1 --branch main https://github.com/quarkusio/quarkus.git \
+          git clone --depth 1 --branch ${{github.event.inputs.branch}} https://github.com/quarkusio/quarkus.git \
             && cd quarkus \
             && echo "Current Quarkus commit:" $(git rev-parse HEAD) \
             && sed -i '/<module>integration-tests<\/module>/d' pom.xml \
@@ -182,8 +67,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: ${{ env.CHECKOUT_REF }}
+          ref: ${{ github.event.inputs.branch }}.x
           fetch-depth: 0
+      - name: Set Quarkus SNAPSHOT Version
+        run: |
+          sed -i 's/<quarkus.version>.*<\/quarkus.version>/<quarkus.version>${{github.event.inputs.branch}}.999-SNAPSHOT<\/quarkus.version>/' pom.xml
       - name: Update extension metadata
         run: |
           ./mvnw -N cq:update-quarkus-metadata ${CQ_MAVEN_ARGS}
@@ -196,7 +84,7 @@ jobs:
       - name: Fail if there are uncommitted changes
         shell: bash
         run: |
-          [[ -z $(git status --porcelain | grep -v antora.yml) ]] || { echo 'There are uncommitted changes'; git status; git diff; exit 1; }
+          [[ -z $(git status --porcelain | grep -v antora.yml) ]] || { echo 'There are uncommitted changes'; git status; git diff; }
       - name: Tar Maven Repo
         shell: bash
         run: |
@@ -226,13 +114,7 @@ jobs:
       - name: Setup Examples Matrix
         id: set-examples-matrix
         run: |
-          EXAMPLES_BRANCH="camel-quarkus-main"
-          if [[ ${GITHUB_REF_NAME} =~ [0-9]+.[0-9]+.x ]]; then
-              EXAMPLES_BRANCH=${GITHUB_REF_NAME}
-          elif [[ ${GITHUB_BASE_REF} =~ [0-9]+.[0-9]+.x ]]; then
-              EXAMPLES_BRANCH=${GITHUB_BASE_REF}
-          fi
-
+          EXAMPLES_BRANCH="${{ github.event.inputs.branch }}.x"
           sudo apt install groovy -y --no-install-recommends
           EXAMPLES_MATRIX=$(groovy -DEXAMPLES_BRANCH=${EXAMPLES_BRANCH} tooling/scripts/generate-examples-matrix.groovy)
           echo "examples-matrix=${EXAMPLES_MATRIX}" >> $GITHUB_OUTPUT
@@ -241,7 +123,6 @@ jobs:
     name: Native Tests - ${{matrix.category}}
     needs: initial-mvn-install
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'JVM')
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.initial-mvn-install.outputs.matrix) }}
@@ -249,8 +130,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: ${{ env.CHECKOUT_REF }}
+          ref: ${{ github.event.inputs.branch }}.x
           fetch-depth: 0
+      - name: Set Quarkus SNAPSHOT Version
+        run: |
+          sed -i 's/<quarkus.version>.*<\/quarkus.version>/<quarkus.version>${{github.event.inputs.branch}}.999-SNAPSHOT<\/quarkus.version>/' pom.xml
       - name: Reclaim Disk Space
         run: .github/reclaim-disk-space.sh
       - name: Set up JDK 17
@@ -315,20 +199,22 @@ jobs:
       - name: Fail if there are uncommitted changes
         shell: bash
         run: |
-          [[ -z $(git status --porcelain) ]] || { echo 'There are uncommitted changes'; git status; git diff; exit 1; }
+          [[ -z $(git status --porcelain) ]] || { echo 'There are uncommitted changes'; git status; git diff; }
 
   functional-extension-tests:
     runs-on: ubuntu-latest
     needs: initial-mvn-install
-    if: github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'JVM')
     env:
       MAVEN_OPTS: -Xmx3000m
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: ${{ env.CHECKOUT_REF }}
+          ref: ${{ github.event.inputs.branch }}.x
           fetch-depth: 0
+      - name: Set Quarkus SNAPSHOT Version
+        run: |
+          sed -i 's/<quarkus.version>.*<\/quarkus.version>/<quarkus.version>${{github.event.inputs.branch}}.999-SNAPSHOT<\/quarkus.version>/' pom.xml
       - name: Set up JDK 17
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
@@ -419,8 +305,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: ${{ env.CHECKOUT_REF }}
+          ref: ${{ github.event.inputs.branch }}.x
           fetch-depth: 0
+      - name: Set Quarkus SNAPSHOT Version
+        run: |
+          sed -i 's/<quarkus.version>.*<\/quarkus.version>/<quarkus.version>${{github.event.inputs.branch}}.999-SNAPSHOT<\/quarkus.version>/' pom.xml
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
@@ -455,7 +344,6 @@ jobs:
     name: Integration Tests Alternative JDK 21 ${{matrix.name}}
     runs-on: ubuntu-latest
     needs: initial-mvn-install
-    if: github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'JVM')
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.initial-mvn-install.outputs.alternate-jvm-matrix) }}
@@ -465,8 +353,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: ${{ env.CHECKOUT_REF }}
+          ref: ${{ github.event.inputs.branch }}.x
           fetch-depth: 0
+      - name: Set Quarkus SNAPSHOT Version
+        run: |
+          sed -i 's/<quarkus.version>.*<\/quarkus.version>/<quarkus.version>${{github.event.inputs.branch}}.999-SNAPSHOT<\/quarkus.version>/' pom.xml
       - name: Reclaim Disk Space
         run: .github/reclaim-disk-space.sh
       - name: Set up JDK 21
@@ -510,15 +401,18 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'windows-latest' ]
-    if: github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'JVM')
     env:
       MAVEN_OPTS: -Xmx3000m
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: ${{ env.CHECKOUT_REF }}
+          ref: ${{ github.event.inputs.branch }}.x
           fetch-depth: 0
+      - name: Set Quarkus SNAPSHOT Version
+        shell: bash
+        run: |
+          sed -i 's/<quarkus.version>.*<\/quarkus.version>/<quarkus.version>${{github.event.inputs.branch}}.999-SNAPSHOT<\/quarkus.version>/' pom.xml
       - name: Set up JDK 17
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
@@ -552,13 +446,10 @@ jobs:
     name: Examples Tests - ${{matrix.name}}
     needs: initial-mvn-install
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'JVM')
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.initial-mvn-install.outputs.examples-matrix) }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Set up JDK 17
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
@@ -583,13 +474,7 @@ jobs:
           EXAMPLE_MODULES: ${{matrix.examples}}
         shell: '/usr/bin/bash {0}'
         run: |
-          EXAMPLES_BRANCH="camel-quarkus-main"
-
-          if [[ ${GITHUB_REF_NAME} =~ [0-9]+.[0-9]+.x ]]; then
-              EXAMPLES_BRANCH=${GITHUB_REF_NAME}
-          elif [[ ${GITHUB_BASE_REF} =~ [0-9]+.[0-9]+.x ]]; then
-              EXAMPLES_BRANCH=${GITHUB_BASE_REF}
-          fi
+          EXAMPLES_BRANCH="${{ github.event.inputs.branch }}.x"
 
           git clone --depth 1 --branch ${EXAMPLES_BRANCH} https://github.com/apache/camel-quarkus-examples.git \
             && cd camel-quarkus-examples \

--- a/docs/modules/ROOT/pages/contributor-guide/ci.adoc
+++ b/docs/modules/ROOT/pages/contributor-guide/ci.adoc
@@ -33,6 +33,16 @@ Sometimes these jobs fail and it is necessary to fix any issues and manually reb
 
 8. Follow the GitHub CI build to verify that the project builds successfully.
 
+=== Quarkus LTS Branch SNAPSHOT Testing
+
+As Quarkus has a regular https://github.com/quarkusio/quarkus/wiki#lts-releases[LTS patch release cycle], it's desirable to test the latest Camel Quarkus LTS branch `SNAPSHOT` with its related Quarkus LTS branch `SNAPSHOT`.
+For convenience, a GitHub workflow exists to perform this testing. 
+
+From the list of https://github.com/apache/camel-quarkus/actions[GitHub workflows], find `Camel Quarkus LTS CI` in the list of pinned workflows on the left side.
+Next, click the `Run workflow` dropdown and select the Quarkus maintenance branch to test. The `Use workflow from` option can be left as the default. Click `Run workflow` to initiate the build.
+
+Review the build results after the workflow finishes. Investigate any failures and if necessary escalate issues to the Quarkus team.
+
 == Builds
 
 https://github.com/apache/camel-quarkus/actions?query=workflow%3A%22Camel+Quarkus+CI%22


### PR DESCRIPTION
At some point I want a single workflow to do CI builds with options to override branches used. But it's a lot more work to reationalize the workflow. So for now I've duplicated and modified the existing `ci-build.yaml`.