### PR TITLE
Import langchain4j-bom to align all dev.langchain4j dependencies

### DIFF
--- a/poms/bom/pom.xml
+++ b/poms/bom/pom.xml
@@ -94,6 +94,13 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
+                <groupId>dev.langchain4j</groupId>
+                <artifactId>langchain4j-bom</artifactId>
+                <version>${langchain4j.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
                 <groupId>io.debezium</groupId>
                 <artifactId>debezium-bom</artifactId>
                 <version>${debezium.version}</version>
@@ -7190,27 +7197,6 @@
                 <groupId>commons-validator</groupId>
                 <artifactId>commons-validator</artifactId>
                 <version>${commons-validator.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>dev.langchain4j</groupId>
-                <artifactId>langchain4j</artifactId>
-                <version>${langchain4j.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>dev.langchain4j</groupId>
-                <artifactId>langchain4j-core</artifactId>
-                <version>${langchain4j.version}</version>
-            </dependency>
-            <!-- The following dev.langchain4j dependencies are managed here to prevent debezium-bom overriding them  -->
-            <dependency>
-                <groupId>dev.langchain4j</groupId>
-                <artifactId>langchain4j-embeddings-all-minilm-l6-v2</artifactId>
-                <version>${langchain4j-beta.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>dev.langchain4j</groupId>
-                <artifactId>langchain4j-ollama</artifactId>
-                <version>${langchain4j-rc.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard.metrics</groupId>

--- a/poms/bom/src/main/generated/flattened-full-pom.xml
+++ b/poms/bom/src/main/generated/flattened-full-pom.xml
@@ -7098,26 +7098,6 @@
         <version>1.9.0</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <artifactId>langchain4j</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <version>1.1.0</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-      </dependency>
-      <dependency>
-        <groupId>dev.langchain4j</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <artifactId>langchain4j-core</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <version>1.1.0</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-      </dependency>
-      <dependency>
-        <groupId>dev.langchain4j</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <artifactId>langchain4j-embeddings-all-minilm-l6-v2</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <version>1.1.0-beta7</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-      </dependency>
-      <dependency>
-        <groupId>dev.langchain4j</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <artifactId>langchain4j-ollama</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <version>1.1.0-rc1</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-      </dependency>
-      <dependency>
         <groupId>io.dropwizard.metrics</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>dropwizard-core</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <version>4.2.33</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
@@ -22946,6 +22926,436 @@
         <groupId>com.datastax.oss</groupId><!-- com.datastax.oss:java-driver-bom:4.15.0 -->
         <artifactId>java-driver-shaded-guava</artifactId><!-- com.datastax.oss:java-driver-bom:4.15.0 -->
         <version>25.1-jre-graal-sub-1</version><!-- com.datastax.oss:java-driver-bom:4.15.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-core</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-test</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-http-client</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-http-client-jdk</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-kotlin</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-reactor</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-easy-rag</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-anthropic</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-rc1</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-azure-open-ai</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-rc1</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-bedrock</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-rc1</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-cohere</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-github-models</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-hugging-face</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-jlama</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-jina</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-onnx-scoring</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-local-ai</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-mistral-ai</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-rc1</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-nomic</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-ollama</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-rc1</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-open-ai</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-open-ai-official</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-ovh-ai</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-vertex-ai</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-vertex-ai-gemini</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-google-ai-gemini</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-rc1</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-workers-ai</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-voyage-ai</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-azure-ai-search</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-azure-cosmos-mongo-vcore</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-cassandra</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-chroma</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-coherence</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-couchbase</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-elasticsearch</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-infinispan</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-mariadb</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-mcp</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-milvus</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-mongodb-atlas</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-opensearch</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-pgvector</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-pinecone</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-qdrant</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-tablestore</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-vespa</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-weaviate</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-azure-cosmos-nosql</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-oracle</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-embeddings</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-embeddings-all-minilm-l6-v2</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-embeddings-all-minilm-l6-v2-q</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-embeddings-bge-small-en</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-embeddings-bge-small-en-q</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-embeddings-bge-small-en-v15</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-embeddings-bge-small-en-v15-q</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-embeddings-bge-small-zh</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-embeddings-bge-small-zh-q</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-embeddings-bge-small-zh-v15</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-embeddings-bge-small-zh-v15-q</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-embeddings-e5-small-v2</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-embeddings-e5-small-v2-q</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-code-execution-engine-graalvm-polyglot</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-code-execution-engine-judge0</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-document-loader-amazon-s3</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-document-loader-azure-storage-blob</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-document-loader-github</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-document-loader-selenium</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-document-loader-tencent-cos</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-document-loader-google-cloud-storage</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-document-parser-apache-pdfbox</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-document-parser-apache-poi</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-document-parser-apache-tika</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-document-transformer-jsoup</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-embedding-store-filter-parser-sql</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-web-search-engine-google-custom</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-web-search-engine-tavily</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-web-search-engine-searchapi</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-experimental-sql</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-spring-boot-starter</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-anthropic-spring-boot-starter</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-azure-ai-search-spring-boot-starter</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-azure-open-ai-spring-boot-starter</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-ollama-spring-boot-starter</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-open-ai-spring-boot-starter</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
       </dependency>
       <dependency>
         <groupId>org.apache.kafka</groupId><!-- io.debezium:debezium-bom:3.1.0.Final -->

--- a/poms/bom/src/main/generated/flattened-reduced-pom.xml
+++ b/poms/bom/src/main/generated/flattened-reduced-pom.xml
@@ -7073,16 +7073,6 @@
         <version>1.9.0</version>
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId>
-        <artifactId>langchain4j</artifactId>
-        <version>1.1.0</version>
-      </dependency>
-      <dependency>
-        <groupId>dev.langchain4j</groupId>
-        <artifactId>langchain4j-core</artifactId>
-        <version>1.1.0</version>
-      </dependency>
-      <dependency>
         <groupId>io.minio</groupId>
         <artifactId>minio</artifactId>
         <version>8.5.17</version>
@@ -8879,6 +8869,36 @@
         <groupId>com.datastax.oss</groupId>
         <artifactId>java-driver-shaded-guava</artifactId>
         <version>25.1-jre-graal-sub-1</version>
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId>
+        <artifactId>langchain4j-core</artifactId>
+        <version>1.1.0</version>
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId>
+        <artifactId>langchain4j</artifactId>
+        <version>1.1.0</version>
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId>
+        <artifactId>langchain4j-http-client</artifactId>
+        <version>1.1.0</version>
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId>
+        <artifactId>langchain4j-http-client-jdk</artifactId>
+        <version>1.1.0</version>
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId>
+        <artifactId>langchain4j-hugging-face</artifactId>
+        <version>1.1.0-beta7</version>
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId>
+        <artifactId>langchain4j-open-ai</artifactId>
+        <version>1.1.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.kafka</groupId>

--- a/poms/bom/src/main/generated/flattened-reduced-verbose-pom.xml
+++ b/poms/bom/src/main/generated/flattened-reduced-verbose-pom.xml
@@ -7073,16 +7073,6 @@
         <version>1.9.0</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <artifactId>langchain4j</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <version>1.1.0</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-      </dependency>
-      <dependency>
-        <groupId>dev.langchain4j</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <artifactId>langchain4j-core</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <version>1.1.0</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-      </dependency>
-      <dependency>
         <groupId>io.minio</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>minio</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <version>8.5.17</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
@@ -8879,6 +8869,36 @@
         <groupId>com.datastax.oss</groupId><!-- com.datastax.oss:java-driver-bom:4.15.0 -->
         <artifactId>java-driver-shaded-guava</artifactId><!-- com.datastax.oss:java-driver-bom:4.15.0 -->
         <version>25.1-jre-graal-sub-1</version><!-- com.datastax.oss:java-driver-bom:4.15.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-core</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-http-client</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-http-client-jdk</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-hugging-face</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0-beta7</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <artifactId>langchain4j-open-ai</artifactId><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
+        <version>1.1.0</version><!-- dev.langchain4j:langchain4j-bom:1.1.0 -->
       </dependency>
       <dependency>
         <groupId>org.apache.kafka</groupId><!-- io.debezium:debezium-bom:3.1.0.Final -->


### PR DESCRIPTION
Needed because `debezium-bom` contains old `dev.langchain4j` dependencies and it's not practical to maintain manual overrides for them in the CQ BOM.