### PR TITLE
Move all classpath resource glob tests to a dedicated test method

### DIFF
--- a/integration-test-groups/foundation/core/src/test/java/org/apache/camel/quarkus/core/CoreTest.java
+++ b/integration-test-groups/foundation/core/src/test/java/org/apache/camel/quarkus/core/CoreTest.java
@@ -157,7 +157,22 @@ public class CoreTest {
                 .then()
                 .body(endsWith("include-pattern-folder/included.txt"));
 
-        // Classpath globbing
+        // Resource that does not exist
+        RestAssured.given()
+                .queryParam("path", "sub-resources-folder/invalid")
+                .get("/core/resource/resolve")
+                .then()
+                .body(emptyOrNullString());
+    }
+
+    @Test
+    void classpathPackageScanDirectoryGlob() {
+        // TODO: Remove this suppression of test execution in the Quarkus Platform
+        // https://github.com/apache/camel-quarkus/issues/7312
+        Path moduleDir = Paths.get("").toAbsolutePath().getFileName();
+
+        Assumptions.assumeFalse(moduleDir.toString().equals("camel-quarkus-integration-test-foundation-grouped"));
+
         RestAssured.given()
                 .queryParam("path", "sub-resources-folder/**")
                 .get("/core/resource/resolve")
@@ -181,21 +196,6 @@ public class CoreTest {
                 .body(
                         containsString("sub-resources-folder/foo/bar/test-1.txt"),
                         containsString("sub-resources-folder/foo/bar/test-2.txt"));
-
-        // Resource that does not exist
-        RestAssured.given()
-                .queryParam("path", "sub-resources-folder/invalid")
-                .get("/core/resource/resolve")
-                .then()
-                .body(emptyOrNullString());
-    }
-
-    @Test
-    void classpathPackageScanDirectoryStartGlob() {
-        // TODO: Remove this suppression of test execution in the Quarkus Platform
-        // https://github.com/apache/camel-quarkus/issues/7312
-        Path moduleDir = Paths.get("").toAbsolutePath().getFileName();
-        Assumptions.assumeFalse(moduleDir.toString().equals("camel-quarkus-integration-test-foundation-grouped"));
 
         RestAssured.given()
                 .queryParam("path", "**/*.txt")


### PR DESCRIPTION
Relates to https://github.com/apache/camel-quarkus/issues/7312.