### PR TITLE
Do not use Runtime configuration during deployment

### DIFF
--- a/extensions-core/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/CamelBootstrapProcessor.java
+++ b/extensions-core/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/CamelBootstrapProcessor.java
@@ -26,7 +26,6 @@ import io.quarkus.deployment.builditem.ServiceStartBuildItem;
 import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
 import io.quarkus.runtime.ShutdownContext;
 import org.apache.camel.quarkus.core.CamelBootstrapRecorder;
-import org.apache.camel.quarkus.core.CamelRuntimeConfig;
 import org.apache.camel.quarkus.core.deployment.spi.CamelBootstrapCompletedBuildItem;
 import org.apache.camel.quarkus.core.deployment.spi.CamelRuntimeBuildItem;
 import org.apache.camel.quarkus.core.deployment.util.CamelQuarkusVersion;
@@ -40,7 +39,6 @@ class CamelBootstrapProcessor {
      * @param commandLineArguments a reference to the raw command line arguments as they were passed to the application.
      * @param shutdown             a reference to a {@link ShutdownContext} used tor register the Camel's related shutdown
      *                             tasks.
-     * @param camelRuntimeConfig   The {@link CamelRuntimeConfig} instance.
      */
     @BuildStep
     @Record(value = ExecutionTime.RUNTIME_INIT)
@@ -50,12 +48,11 @@ class CamelBootstrapProcessor {
             CamelRuntimeBuildItem runtime,
             RawCommandLineArgumentsBuildItem commandLineArguments,
             ShutdownContextBuildItem shutdown,
-            BuildProducer<ServiceStartBuildItem> serviceStartBuildItems,
-            CamelRuntimeConfig camelRuntimeConfig) {
+            BuildProducer<ServiceStartBuildItem> serviceStartBuildItems) {
 
         recorder.addShutdownTask(shutdown, runtime.runtime());
         if (runtime.isAutoStartup()) {
-            recorder.start(camelRuntimeConfig, runtime.runtime(), commandLineArguments, CamelQuarkusVersion.getVersion());
+            recorder.start(runtime.runtime(), commandLineArguments, CamelQuarkusVersion.getVersion());
         }
         /* Make sure that Quarkus orders this method before starting to serve HTTP endpoints.
          * Otherwise first requests might reach Camel context in a non-yet-started state. */

--- a/extensions-core/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/CamelContextProcessor.java
+++ b/extensions-core/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/CamelContextProcessor.java
@@ -34,7 +34,6 @@ import io.quarkus.runtime.RuntimeValue;
 import org.apache.camel.CamelContext;
 import org.apache.camel.quarkus.core.CamelConfig;
 import org.apache.camel.quarkus.core.CamelContextRecorder;
-import org.apache.camel.quarkus.core.dataformat.CamelDataFormatRuntimeConfig;
 import org.apache.camel.quarkus.core.deployment.spi.CamelBootClockBuildItem;
 import org.apache.camel.quarkus.core.deployment.spi.CamelComponentNameResolverBuildItem;
 import org.apache.camel.quarkus.core.deployment.spi.CamelContextBuildItem;
@@ -196,9 +195,8 @@ public class CamelContextProcessor {
     @BuildStep
     void registerDataFormatLifecycleStrategy(
             CamelContextBuildItem camelContext,
-            CamelDataFormatRuntimeConfig dataFormatConfig,
             CamelContextRecorder recorder) {
-        recorder.registerDataFormatLifecycleStrategy(camelContext.getCamelContext(), dataFormatConfig);
+        recorder.registerDataFormatLifecycleStrategy(camelContext.getCamelContext());
     }
 
     public static final class EventBridgeEnabled implements BooleanSupplier {

--- a/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/CamelBootstrapRecorder.java
+++ b/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/CamelBootstrapRecorder.java
@@ -25,6 +25,12 @@ import org.jboss.logging.Logger;
 
 @Recorder
 public class CamelBootstrapRecorder {
+    private final RuntimeValue<CamelRuntimeConfig> camelRuntimeConfig;
+
+    public CamelBootstrapRecorder(RuntimeValue<CamelRuntimeConfig> camelRuntimeConfig) {
+        this.camelRuntimeConfig = camelRuntimeConfig;
+    }
+
     public void addShutdownTask(ShutdownContext shutdown, RuntimeValue<CamelRuntime> runtime) {
         shutdown.addShutdownTask(new Runnable() {
             @Override
@@ -38,9 +44,9 @@ public class CamelBootstrapRecorder {
         });
     }
 
-    public void start(CamelRuntimeConfig camelRuntimeConfig, RuntimeValue<CamelRuntime> runtime, Supplier<String[]> arguments,
+    public void start(RuntimeValue<CamelRuntime> runtime, Supplier<String[]> arguments,
             String camelQuarkusVersion) {
-        if (camelRuntimeConfig.bootstrap().enabled()) {
+        if (camelRuntimeConfig.getValue().bootstrap().enabled()) {
             try {
                 Logger logger = Logger.getLogger(CamelBootstrapRecorder.class);
                 logger.infof("Apache Camel Quarkus %s is starting", camelQuarkusVersion);

--- a/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/CamelContextRecorder.java
+++ b/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/CamelContextRecorder.java
@@ -50,6 +50,12 @@ import org.eclipse.microprofile.config.ConfigProvider;
 
 @Recorder
 public class CamelContextRecorder {
+    private final RuntimeValue<CamelDataFormatRuntimeConfig> dataFormatConfig;
+
+    public CamelContextRecorder(RuntimeValue<CamelDataFormatRuntimeConfig> dataFormatConfig) {
+        this.dataFormatConfig = dataFormatConfig;
+    }
+
     public RuntimeValue<CamelContext> createContext(
             RuntimeValue<Registry> registry,
             RuntimeValue<TypeConverterRegistry> typeConverterRegistry,
@@ -186,9 +192,9 @@ public class CamelContextRecorder {
         return new RuntimeValue<>(clock);
     }
 
-    public void registerDataFormatLifecycleStrategy(RuntimeValue<CamelContext> context,
-            CamelDataFormatRuntimeConfig dataFormatConfig) {
+    public void registerDataFormatLifecycleStrategy(RuntimeValue<CamelContext> context) {
         CamelContext camelContext = context.getValue();
-        camelContext.addLifecycleStrategy(new CamelQuarkusDataFormatConfigLifecycleStrategy(camelContext, dataFormatConfig));
+        camelContext.addLifecycleStrategy(
+                new CamelQuarkusDataFormatConfigLifecycleStrategy(camelContext, dataFormatConfig.getValue()));
     }
 }

--- a/extensions/jfr/deployment/src/main/java/org/apache/camel/quarkus/component/jfr/deployment/JfrProcessor.java
+++ b/extensions/jfr/deployment/src/main/java/org/apache/camel/quarkus/component/jfr/deployment/JfrProcessor.java
@@ -23,7 +23,6 @@ import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.NativeMonitoringBuildItem;
 import io.quarkus.deployment.pkg.NativeConfig;
 import org.apache.camel.quarkus.component.jfr.CamelJfrRecorder;
-import org.apache.camel.quarkus.component.jfr.RuntimeCamelJfrConfig;
 import org.apache.camel.quarkus.core.deployment.spi.CamelServiceDestination;
 import org.apache.camel.quarkus.core.deployment.spi.CamelServicePatternBuildItem;
 import org.apache.camel.quarkus.core.deployment.spi.RuntimeCamelContextCustomizerBuildItem;
@@ -46,8 +45,8 @@ class JfrProcessor {
 
     @Record(value = ExecutionTime.RUNTIME_INIT)
     @BuildStep
-    RuntimeCamelContextCustomizerBuildItem customizeCamelContext(RuntimeCamelJfrConfig config, CamelJfrRecorder recorder) {
-        return new RuntimeCamelContextCustomizerBuildItem(recorder.createStartupStepRecorder(config));
+    RuntimeCamelContextCustomizerBuildItem customizeCamelContext(CamelJfrRecorder recorder) {
+        return new RuntimeCamelContextCustomizerBuildItem(recorder.createStartupStepRecorder());
     }
 
     @BuildStep

--- a/extensions/jfr/runtime/src/main/java/org/apache/camel/quarkus/component/jfr/CamelJfrRecorder.java
+++ b/extensions/jfr/runtime/src/main/java/org/apache/camel/quarkus/component/jfr/CamelJfrRecorder.java
@@ -24,31 +24,36 @@ import org.apache.camel.startup.jfr.FlightRecorderStartupStepRecorder;
 
 @Recorder
 public class CamelJfrRecorder {
+    private final RuntimeValue<RuntimeCamelJfrConfig> runtimeConfig;
 
-    public RuntimeValue<CamelContextCustomizer> createStartupStepRecorder(RuntimeCamelJfrConfig config) {
+    public CamelJfrRecorder(RuntimeValue<RuntimeCamelJfrConfig> runtimeConfig) {
+        this.runtimeConfig = runtimeConfig;
+    }
+
+    public RuntimeValue<CamelContextCustomizer> createStartupStepRecorder() {
         CamelContextCustomizer flightRecorderCustomizer = new CamelContextCustomizer() {
             @Override
             public void configure(CamelContext camelContext) {
                 FlightRecorderStartupStepRecorder flightRecorder = new FlightRecorderStartupStepRecorder();
 
-                if (config.startupRecorderRecording().isPresent()) {
-                    flightRecorder.setRecording(config.startupRecorderRecording().get());
+                if (runtimeConfig.getValue().startupRecorderRecording().isPresent()) {
+                    flightRecorder.setRecording(runtimeConfig.getValue().startupRecorderRecording().get());
                 }
 
-                if (config.startupRecorderProfile().isPresent()) {
-                    flightRecorder.setRecordingProfile(config.startupRecorderProfile().get());
+                if (runtimeConfig.getValue().startupRecorderProfile().isPresent()) {
+                    flightRecorder.setRecordingProfile(runtimeConfig.getValue().startupRecorderProfile().get());
                 }
 
-                if (config.startupRecorderMaxDepth().isPresent()) {
-                    flightRecorder.setMaxDepth(config.startupRecorderMaxDepth().get());
+                if (runtimeConfig.getValue().startupRecorderMaxDepth().isPresent()) {
+                    flightRecorder.setMaxDepth(runtimeConfig.getValue().startupRecorderMaxDepth().get());
                 }
 
-                if (config.startupRecorderDuration().isPresent()) {
-                    flightRecorder.setStartupRecorderDuration(config.startupRecorderDuration().get());
+                if (runtimeConfig.getValue().startupRecorderDuration().isPresent()) {
+                    flightRecorder.setStartupRecorderDuration(runtimeConfig.getValue().startupRecorderDuration().get());
                 }
 
-                if (config.startupRecorderDir().isPresent()) {
-                    flightRecorder.setRecordingDir(config.startupRecorderDir().get());
+                if (runtimeConfig.getValue().startupRecorderDir().isPresent()) {
+                    flightRecorder.setRecordingDir(runtimeConfig.getValue().startupRecorderDir().get());
                 }
 
                 camelContext.getCamelContextExtension().setStartupStepRecorder(flightRecorder);

--- a/extensions/jolokia/deployment/src/main/java/org/apache/camel/quarkus/jolokia/deployment/JolokiaProcessor.java
+++ b/extensions/jolokia/deployment/src/main/java/org/apache/camel/quarkus/jolokia/deployment/JolokiaProcessor.java
@@ -61,7 +61,6 @@ import jakarta.enterprise.context.ApplicationScoped;
 import org.apache.camel.quarkus.jolokia.CamelQuarkusJolokiaServer;
 import org.apache.camel.quarkus.jolokia.JolokiaRecorder;
 import org.apache.camel.quarkus.jolokia.config.JolokiaBuildTimeConfig;
-import org.apache.camel.quarkus.jolokia.config.JolokiaRuntimeConfig;
 import org.apache.camel.quarkus.jolokia.devmode.DevModeJolokiaServerShutdownListener;
 import org.apache.camel.quarkus.jolokia.restrictor.CamelJolokiaRestrictor;
 import org.apache.camel.util.ObjectHelper;
@@ -88,11 +87,8 @@ public class JolokiaProcessor {
     @Record(ExecutionTime.RUNTIME_INIT)
     JolokiaServerConfigBuildItem createJolokiaServerConfig(
             ApplicationInfoBuildItem applicationInfo,
-            JolokiaBuildTimeConfig buildTimeConfig,
-            JolokiaRuntimeConfig config,
             JolokiaRecorder recorder) {
-        return new JolokiaServerConfigBuildItem(
-                recorder.createJolokiaServerConfig(config, buildTimeConfig.path(), applicationInfo.getName()));
+        return new JolokiaServerConfigBuildItem(recorder.createJolokiaServerConfig(applicationInfo.getName()));
     }
 
     @BuildStep
@@ -108,10 +104,9 @@ public class JolokiaProcessor {
     void startJolokiaServer(
             LaunchModeBuildItem launchMode,
             JolokiaServerBuildItem jolokiaServer,
-            JolokiaRuntimeConfig runtimeConfig,
             BuildProducer<SyntheticBeanBuildItem> syntheticBean,
             JolokiaRecorder recorder) {
-        recorder.startJolokiaServer(jolokiaServer.getRuntimeValue(), runtimeConfig);
+        recorder.startJolokiaServer(jolokiaServer.getRuntimeValue());
 
         SyntheticBeanBuildItem.ExtendedBeanConfigurator beanConfigurator = SyntheticBeanBuildItem
                 .configure(CamelQuarkusJolokiaServer.class)

--- a/extensions/kubernetes-cluster-service/deployment/src/main/java/org/apache/camel/quarkus/component/kubernetes/cluster/deployment/KubernetesClusterServiceProcessor.java
+++ b/extensions/kubernetes-cluster-service/deployment/src/main/java/org/apache/camel/quarkus/component/kubernetes/cluster/deployment/KubernetesClusterServiceProcessor.java
@@ -24,7 +24,6 @@ import io.quarkus.runtime.RuntimeValue;
 import org.apache.camel.component.kubernetes.cluster.KubernetesClusterService;
 import org.apache.camel.quarkus.component.kubernetes.cluster.KubernetesClusterServiceBuildTimeConfig;
 import org.apache.camel.quarkus.component.kubernetes.cluster.KubernetesClusterServiceRecorder;
-import org.apache.camel.quarkus.component.kubernetes.cluster.KubernetesClusterServiceRuntimeConfig;
 import org.apache.camel.quarkus.core.deployment.spi.CamelContextBuildItem;
 import org.apache.camel.quarkus.core.deployment.spi.CamelRuntimeBeanBuildItem;
 import org.apache.camel.support.cluster.RebalancingCamelClusterService;
@@ -36,16 +35,15 @@ class KubernetesClusterServiceProcessor {
     @Consume(CamelContextBuildItem.class)
     CamelRuntimeBeanBuildItem setupKubernetesClusterService(
             KubernetesClusterServiceBuildTimeConfig buildTimeConfig,
-            KubernetesClusterServiceRuntimeConfig runtimeConfig,
             KubernetesClusterServiceRecorder recorder) {
 
         if (buildTimeConfig.rebalancing()) {
             final RuntimeValue<RebalancingCamelClusterService> krcs = recorder
-                    .createKubernetesRebalancingClusterService(runtimeConfig);
+                    .createKubernetesRebalancingClusterService();
             return new CamelRuntimeBeanBuildItem("kubernetesRebalancingClusterService",
                     RebalancingCamelClusterService.class.getName(), krcs);
         } else {
-            final RuntimeValue<KubernetesClusterService> kcs = recorder.createKubernetesClusterService(runtimeConfig);
+            final RuntimeValue<KubernetesClusterService> kcs = recorder.createKubernetesClusterService();
             return new CamelRuntimeBeanBuildItem("kubernetesClusterService", KubernetesClusterService.class.getName(), kcs);
         }
     }

--- a/extensions/kubernetes-cluster-service/runtime/src/main/java/org/apache/camel/quarkus/component/kubernetes/cluster/KubernetesClusterServiceRecorder.java
+++ b/extensions/kubernetes-cluster-service/runtime/src/main/java/org/apache/camel/quarkus/component/kubernetes/cluster/KubernetesClusterServiceRecorder.java
@@ -23,15 +23,19 @@ import org.apache.camel.support.cluster.RebalancingCamelClusterService;
 
 @Recorder
 public class KubernetesClusterServiceRecorder {
+    private final RuntimeValue<KubernetesClusterServiceRuntimeConfig> runtimeConfig;
 
-    public RuntimeValue<KubernetesClusterService> createKubernetesClusterService(KubernetesClusterServiceRuntimeConfig config) {
-        KubernetesClusterService kcs = setupKubernetesClusterServiceFromConfig(config);
+    public KubernetesClusterServiceRecorder(RuntimeValue<KubernetesClusterServiceRuntimeConfig> runtimeConfig) {
+        this.runtimeConfig = runtimeConfig;
+    }
+
+    public RuntimeValue<KubernetesClusterService> createKubernetesClusterService() {
+        KubernetesClusterService kcs = setupKubernetesClusterServiceFromConfig(runtimeConfig.getValue());
         return new RuntimeValue<>(kcs);
     }
 
-    public RuntimeValue<RebalancingCamelClusterService> createKubernetesRebalancingClusterService(
-            KubernetesClusterServiceRuntimeConfig config) {
-        KubernetesClusterService kcs = setupKubernetesClusterServiceFromConfig(config);
+    public RuntimeValue<RebalancingCamelClusterService> createKubernetesRebalancingClusterService() {
+        KubernetesClusterService kcs = setupKubernetesClusterServiceFromConfig(runtimeConfig.getValue());
         RebalancingCamelClusterService rebalancingService = new RebalancingCamelClusterService(kcs,
                 kcs.getRenewDeadlineMillis());
         return new RuntimeValue<>(rebalancingService);

--- a/extensions/ldap/deployment/src/main/java/org/apache/camel/quarkus/component/ldap/deployment/LdapProcessor.java
+++ b/extensions/ldap/deployment/src/main/java/org/apache/camel/quarkus/component/ldap/deployment/LdapProcessor.java
@@ -23,7 +23,6 @@ import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.AllowJNDIBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
-import org.apache.camel.quarkus.component.ldap.CamelLdapConfig;
 import org.apache.camel.quarkus.component.ldap.CamelLdapRecorder;
 import org.apache.camel.quarkus.core.deployment.spi.CamelContextBuildItem;
 
@@ -53,10 +52,9 @@ class LdapProcessor {
     @Record(ExecutionTime.RUNTIME_INIT)
     void createDirContexts(
             CamelContextBuildItem context,
-            CamelLdapRecorder camelLdapRecorder,
-            CamelLdapConfig ldapConfig) {
+            CamelLdapRecorder camelLdapRecorder) {
 
-        camelLdapRecorder.createDirContexts(context.getCamelContext(), ldapConfig);
+        camelLdapRecorder.createDirContexts(context.getCamelContext());
     }
 
 }

--- a/extensions/ldap/runtime/src/main/java/org/apache/camel/quarkus/component/ldap/CamelLdapRecorder.java
+++ b/extensions/ldap/runtime/src/main/java/org/apache/camel/quarkus/component/ldap/CamelLdapRecorder.java
@@ -26,13 +26,18 @@ import org.apache.camel.CamelContext;
 
 @Recorder
 public class CamelLdapRecorder {
+    private final RuntimeValue<CamelLdapConfig> config;
 
-    public void createDirContexts(RuntimeValue<CamelContext> contextRuntimeValue, final CamelLdapConfig config) {
+    public CamelLdapRecorder(RuntimeValue<CamelLdapConfig> config) {
+        this.config = config;
+    }
+
+    public void createDirContexts(RuntimeValue<CamelContext> contextRuntimeValue) {
         CamelContext context = contextRuntimeValue.getValue();
 
-        config.dirContexts().keySet().forEach(contextName -> {
+        config.getValue().dirContexts().keySet().forEach(contextName -> {
 
-            CamelLdapConfig.LdapDirContextConfig dirConfig = config.dirContexts().get(contextName);
+            CamelLdapConfig.LdapDirContextConfig dirConfig = config.getValue().dirContexts().get(contextName);
 
             Hashtable<String, Object> env = new Hashtable<String, Object>();
             dirConfig.initialContextFactory().ifPresent(v -> env.put(Context.INITIAL_CONTEXT_FACTORY, v));


### PR DESCRIPTION
With https://github.com/quarkusio/quarkus/pull/48500, we will disallow the injection of Runtime configuration objects during deployment. The recommended way is to inject it directly into the Recorder, wrapped in a `RuntimeValue`.