### PR TITLE
fix(azure-storage): Shared key credentials type requires credentials …

### DIFF
--- a/integration-test-groups/azure/azure-storage-blob/src/main/java/org/apache/camel/quarkus/component/azure/storage/blob/it/AzureStorageBlobProducers.java
+++ b/integration-test-groups/azure/azure-storage-blob/src/main/java/org/apache/camel/quarkus/component/azure/storage/blob/it/AzureStorageBlobProducers.java
@@ -56,6 +56,7 @@ public class AzureStorageBlobProducers {
     public BlobComponent azureBlobComponentWithManagedClient() {
         BlobConfiguration configuration = new BlobConfiguration();
         configuration.setCredentialType(CredentialType.SHARED_KEY_CREDENTIAL);
+        configuration.setCredentials(azureStorageSharedKeyCredential());
 
         BlobComponent component = new BlobComponent();
         component.setAutowiredEnabled(false);


### PR DESCRIPTION
…to be set

otherwise an exception is thrown in the test:

```
Caused by: org.apache.camel.ResolveEndpointFailedException: Failed to resolve endpoint: azure-storage-blob-managed-client://camelquarkus/camel-quarkus-8e38ce7f-3db4-4848-9d9c-58b081c0328b?autowiredEnabled=false&blobName=test&operation=getBlob due to: When using shared key credential, credentials must be provided.
	at org.apache.camel.impl.engine.AbstractCamelContext.doGetEndpoint(AbstractCamelContext.java:860)
	at org.apache.camel.impl.engine.AbstractCamelContext.getEndpoint(AbstractCamelContext.java:747)
	at org.apache.camel.support.CamelContextHelper.resolveEndpoint(CamelContextHelper.java:128)
	at org.apache.camel.reifier.SendReifier.resolveEndpoint(SendReifier.java:47)
	at org.apache.camel.reifier.SendReifier.createProcessor(SendReifier.java:37)
	at org.apache.camel.reifier.ProcessorReifier.makeProcessor(ProcessorReifier.java:848)
	at org.apache.camel.reifier.ProcessorReifier.addRoutes(ProcessorReifier.java:621)
	at org.apache.camel.reifier.RouteReifier.doCreateRoute(RouteReifier.java:238)
	... 75 more
Caused by: java.lang.IllegalArgumentException: When using shared key credential, credentials must be provided.
	at org.apache.camel.component.azure.storage.blob.BlobComponent.validateConfigurations(BlobComponent.java:102)
	at org.apache.camel.component.azure.storage.blob.BlobComponent.createEndpoint(BlobComponent.java:68)
	at org.apache.camel.support.DefaultComponent.createEndpoint(DefaultComponent.java:171)
	at org.apache.camel.impl.engine.AbstractCamelContext.doGetEndpoint(AbstractCamelContext.java:826)
	... 82 more

```