### PR TITLE
Avoid using LaunchMode static method

### DIFF
--- a/extensions/jolokia/runtime/src/main/java/org/apache/camel/quarkus/jolokia/JolokiaRecorder.java
+++ b/extensions/jolokia/runtime/src/main/java/org/apache/camel/quarkus/jolokia/JolokiaRecorder.java
@@ -81,7 +81,7 @@ public class JolokiaRecorder {
         // Configure Jolokia HTTP server host, port & context path
         String host = runtimeConfig.getValue().server().host().orElse(null);
         if (ObjectHelper.isEmpty(host)) {
-            if (LaunchMode.isRemoteDev()) {
+            if (LaunchMode.current().isRemoteDev()) {
                 host = ALL_INTERFACES;
             } else if (LaunchMode.current().isDevOrTest()) {
                 if (!isWSL()) {


### PR DESCRIPTION
It will be made non-static in 3.26 for consistency with the other methods.
While this will raise a warning with earlier version, it will work with both new and old versions.
Note that it is not binary compatible though, so we will need a 3.26 release - which is probably planned anyway.