### PR TITLE
[3.20.x] Fallback to resolving bean names from @Identifier for RuntimeBeanRepository.findByTypeWithName

### DIFF
--- a/extensions-core/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/CamelRegistryProcessor.java
+++ b/extensions-core/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/CamelRegistryProcessor.java
@@ -28,6 +28,7 @@ import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.ApplicationArchivesBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import org.apache.camel.BindToRegistry;
+import org.apache.camel.quarkus.core.BeanQualifierResolverIdentifier;
 import org.apache.camel.quarkus.core.CamelBeanQualifierResolver;
 import org.apache.camel.quarkus.core.CamelCapabilities;
 import org.apache.camel.quarkus.core.CamelConfig;
@@ -61,9 +62,12 @@ public class CamelRegistryProcessor {
             List<CamelBeanQualifierResolverBuildItem> camelBeanQualifierResolvers,
             CamelRecorder recorder) {
 
-        Map<String, CamelBeanQualifierResolver> beanQualifierResolvers = new HashMap<>();
+        Map<BeanQualifierResolverIdentifier, CamelBeanQualifierResolver> beanQualifierResolvers = new HashMap<>();
         for (CamelBeanQualifierResolverBuildItem resolver : camelBeanQualifierResolvers) {
-            recorder.registerCamelBeanQualifierResolver(resolver.getBeanTypeName(), resolver.getRuntimeValue(),
+            recorder.registerCamelBeanQualifierResolver(
+                    resolver.getBeanTypeName(),
+                    resolver.getBeanName(),
+                    resolver.getRuntimeValue(),
                     beanQualifierResolvers);
         }
 

--- a/extensions-core/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/spi/CamelBeanQualifierResolverBuildItem.java
+++ b/extensions-core/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/spi/CamelBeanQualifierResolverBuildItem.java
@@ -26,9 +26,16 @@ import org.apache.camel.quarkus.core.CamelBeanQualifierResolver;
 public final class CamelBeanQualifierResolverBuildItem extends MultiBuildItem {
     private final RuntimeValue<CamelBeanQualifierResolver> runtimeValue;
     private final Class<?> beanType;
+    private final String beanName;
 
     public CamelBeanQualifierResolverBuildItem(Class<?> beanType, RuntimeValue<CamelBeanQualifierResolver> runtimeValue) {
+        this(beanType, null, runtimeValue);
+    }
+
+    public CamelBeanQualifierResolverBuildItem(Class<?> beanType, String beanName,
+            RuntimeValue<CamelBeanQualifierResolver> runtimeValue) {
         this.beanType = beanType;
+        this.beanName = beanName;
         this.runtimeValue = runtimeValue;
     }
 
@@ -38,6 +45,10 @@ public final class CamelBeanQualifierResolverBuildItem extends MultiBuildItem {
 
     public String getBeanTypeName() {
         return beanType.getName();
+    }
+
+    public String getBeanName() {
+        return beanName;
     }
 
     public RuntimeValue<CamelBeanQualifierResolver> getRuntimeValue() {

--- a/extensions-core/core/deployment/src/test/java/org/apache/camel/quarkus/core/deployment/CamelBeanLookupWithIdentifierTest.java
+++ b/extensions-core/core/deployment/src/test/java/org/apache/camel/quarkus/core/deployment/CamelBeanLookupWithIdentifierTest.java
@@ -19,6 +19,7 @@ package org.apache.camel.quarkus.core.deployment;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.util.Map;
 import java.util.Properties;
 
 import io.quarkus.test.QuarkusUnitTest;
@@ -73,6 +74,14 @@ public class CamelBeanLookupWithIdentifierTest {
         MyIdentifiedBean bean = CamelContextHelper.lookup(context, "my-identifier", MyIdentifiedBean.class);
         assertNotNull(bean);
         assertEquals("Hello World", template.request(String.class));
+    }
+
+    @Test
+    void resolveIdentifierWithName() {
+        Map<String, MyIdentifiedBean> typeWithName = context.getRegistry().findByTypeWithName(MyIdentifiedBean.class);
+        assertNotNull(typeWithName);
+        assertEquals(1, typeWithName.size());
+        assertNotNull(typeWithName.get("my-identifier"));
     }
 
     @Produces

--- a/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/BeanQualifierResolverIdentifier.java
+++ b/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/BeanQualifierResolverIdentifier.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.core;
+
+import java.util.Objects;
+
+public final class BeanQualifierResolverIdentifier {
+    private final String className;
+    private final String beanName;
+
+    BeanQualifierResolverIdentifier(String className, String beanName) {
+        this.className = className;
+        this.beanName = beanName;
+    }
+
+    public static BeanQualifierResolverIdentifier of(String className) {
+        return new BeanQualifierResolverIdentifier(className, null);
+    }
+
+    public static BeanQualifierResolverIdentifier of(String className, String beanName) {
+        return new BeanQualifierResolverIdentifier(className, beanName);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        BeanQualifierResolverIdentifier that = (BeanQualifierResolverIdentifier) o;
+        return Objects.equals(className, that.className) && Objects.equals(beanName, that.beanName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(className, beanName);
+    }
+
+    @Override
+    public String toString() {
+        String result = "class name " + className;
+        if (beanName != null) {
+            result += ", bean name " + beanName;
+        }
+        return result;
+    }
+}

--- a/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/CamelBeanQualifierResolver.java
+++ b/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/CamelBeanQualifierResolver.java
@@ -19,8 +19,36 @@ package org.apache.camel.quarkus.core;
 import java.lang.annotation.Annotation;
 
 /**
- * Abstraction for resolving bean annotation qualifiers
+ * Abstraction for resolving bean annotation qualifiers.
  */
 public interface CamelBeanQualifierResolver {
-    Annotation[] resolveQualifiers();
+    /**
+     * Resolves bean annotation qualifiers.
+     *
+     * @return The resolved bean {@link Annotation} qualifiers
+     */
+    default Annotation[] resolveQualifiers() {
+        return null;
+    }
+
+    /**
+     * Resolves bean annotation qualifiers with the given bean name.
+     *
+     * @param  beanName The name of the bean
+     * @return          The resolved bean {@link Annotation} qualifiers
+     */
+    default Annotation[] resolveAnnotations(String beanName) {
+        return null;
+    }
+
+    /**
+     * Gets the {@link BeanQualifierResolverIdentifier} associated with this {@link CamelBeanQualifierResolver}.
+     *
+     * @param  className The class name of the bean
+     * @param  beanName  The name of the bean. Can be null
+     * @return           The {@link BeanQualifierResolverIdentifier}
+     */
+    default BeanQualifierResolverIdentifier getIdentifier(String className, String beanName) {
+        return BeanQualifierResolverIdentifier.of(className, beanName);
+    }
 }

--- a/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/CamelRecorder.java
+++ b/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/CamelRecorder.java
@@ -51,17 +51,22 @@ import org.apache.camel.support.startup.DefaultStartupStepRecorder;
 public class CamelRecorder {
     public void registerCamelBeanQualifierResolver(
             String className,
+            String beanName,
             RuntimeValue<CamelBeanQualifierResolver> runtimeValue,
-            Map<String, CamelBeanQualifierResolver> beanQualifiers) {
+            Map<BeanQualifierResolverIdentifier, CamelBeanQualifierResolver> beanQualifiers) {
 
-        if (beanQualifiers.containsKey(className)) {
-            throw new RuntimeException("Duplicate CamelBeanQualifierResolver detected for class: " + className);
+        CamelBeanQualifierResolver resolver = runtimeValue.getValue();
+        BeanQualifierResolverIdentifier identifier = resolver.getIdentifier(className, beanName);
+
+        if (beanQualifiers.containsKey(identifier)) {
+            throw new RuntimeException("Duplicate CamelBeanQualifierResolver detected for: " + identifier);
         }
 
-        beanQualifiers.put(className, runtimeValue.getValue());
+        beanQualifiers.put(identifier, resolver);
     }
 
-    public RuntimeValue<Registry> createRegistry(Map<String, CamelBeanQualifierResolver> beanQualifierResolvers) {
+    public RuntimeValue<Registry> createRegistry(
+            Map<BeanQualifierResolverIdentifier, CamelBeanQualifierResolver> beanQualifierResolvers) {
         return new RuntimeValue<>(new RuntimeRegistry(beanQualifierResolvers));
     }
 

--- a/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/RuntimeRegistry.java
+++ b/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/RuntimeRegistry.java
@@ -22,7 +22,7 @@ import io.quarkus.runtime.RuntimeValue;
 import org.apache.camel.support.DefaultRegistry;
 
 public class RuntimeRegistry extends DefaultRegistry {
-    public RuntimeRegistry(Map<String, CamelBeanQualifierResolver> beanQualifierResolvers) {
+    public RuntimeRegistry(Map<BeanQualifierResolverIdentifier, CamelBeanQualifierResolver> beanQualifierResolvers) {
         super(new RuntimeBeanRepository(beanQualifierResolvers));
     }
 

--- a/integration-test-groups/foundation/bean/src/test/java/org/apache/camel/quarkus/component/bean/BeanTest.java
+++ b/integration-test-groups/foundation/bean/src/test/java/org/apache/camel/quarkus/component/bean/BeanTest.java
@@ -246,9 +246,8 @@ public class BeanTest {
         RestAssured.given()
                 .get("/bean/allBeanInstances")
                 .then()
-                .body("size()", is(5))
+                .body("size()", is(4))
                 .body(allOf(
-                        containsString("defaultBean"),
                         containsString("overridingBean"),
                         containsString("bean1"),
                         containsString("bean2"),


### PR DESCRIPTION
Also included f2cdea96fda5500cd4922f6d5d813caba1ca5fa1 to make cherry-picks simpler. It should be fine to have that change backported.