### PR TITLE
Remove redundant debezium-sqlserver & debezium-mysql test profiles

### DIFF
--- a/integration-test-groups/debezium/mssql/pom.xml
+++ b/integration-test-groups/debezium/mssql/pom.xml
@@ -31,17 +31,10 @@
     <name>Camel Quarkus :: Integration Tests :: Debezium MSSQL</name>
     <description>Integration tests for Debezium - MSSQL Database</description>
 
-    <properties>
-        <sqlserver.EULA.accepted>true</sqlserver.EULA.accepted>
-        <!-- You are required to accept an EULA for SQL container image. We cannot do it by default for legal reasons. -->
-        <!-- See https://camel.apache.org/camel-quarkus/latest/extensions/debezium-sqlserver.html#_integration-testing for more details -->
-        <sqlserver.EULA>src/test/resources/container-license-acceptance.txt</sqlserver.EULA>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
-            <artifactId>camel-quarkus-debezium-mongodb</artifactId>
+            <artifactId>camel-quarkus-debezium-sqlserver</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -55,9 +48,13 @@
             <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-integration-tests-support-debezium</artifactId>
         </dependency>
+        <!-- Required since it's excluded from the runtime classpath by default -->
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+        </dependency>
 
         <!-- test dependencies -->
-
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-integration-tests-support-debezium</artifactId>
@@ -102,6 +99,15 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+                <filtering>true</filtering>
+            </testResource>
+        </testResources>
+    </build>
+
     <profiles>
         <!-- https://github.com/apache/camel-quarkus/issues/4638
         <profile>
@@ -133,20 +139,6 @@
         </profile>
         -->
         <profile>
-            <id>sqlserver</id>
-            <activation>
-                <file>
-                    <exists>${sqlserver.EULA}</exists>
-                </file>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>org.apache.camel.quarkus</groupId>
-                    <artifactId>camel-quarkus-debezium-sqlserver</artifactId>
-                </dependency>
-            </dependencies>
-        </profile>
-        <profile>
             <id>virtualDependencies</id>
             <activation>
                 <property>
@@ -157,7 +149,7 @@
                 <!-- The following dependencies guarantee that this module is built after them. You can update them by running `mvn process-resources -Pformat -N` from the source tree root directory -->
                 <dependency>
                     <groupId>org.apache.camel.quarkus</groupId>
-                    <artifactId>camel-quarkus-debezium-mongodb-deployment</artifactId>
+                    <artifactId>camel-quarkus-debezium-sqlserver-deployment</artifactId>
                     <version>${project.version}</version>
                     <type>pom</type>
                     <scope>test</scope>

--- a/integration-test-groups/debezium/mssql/src/test/resources/container-license-acceptance.txt
+++ b/integration-test-groups/debezium/mssql/src/test/resources/container-license-acceptance.txt
@@ -1,0 +1,1 @@
+${sql-server.container.image}

--- a/integration-test-groups/debezium/mysql/pom.xml
+++ b/integration-test-groups/debezium/mysql/pom.xml
@@ -34,7 +34,7 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
-            <artifactId>camel-quarkus-debezium-mongodb</artifactId>
+            <artifactId>camel-quarkus-debezium-mysql</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -49,8 +49,13 @@
             <artifactId>camel-quarkus-integration-tests-support-debezium</artifactId>
         </dependency>
 
-        <!-- test dependencies -->
+        <!-- Required since it's excluded from the runtime classpath by default -->
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+        </dependency>
 
+        <!-- test dependencies -->
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-integration-tests-support-debezium</artifactId>
@@ -126,26 +131,6 @@
         </profile>
         -->
         <profile>
-            <id>mysqlDriver</id>
-            <activation>
-                <property>
-                    <name>mysql.driver.file</name>
-                </property>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>org.apache.camel.quarkus</groupId>
-                    <artifactId>camel-quarkus-debezium-mysql</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>com.mysql</groupId>
-                    <artifactId>mysql-connector-j</artifactId>
-                    <scope>system</scope>
-                    <systemPath>${mysql.driver.file}</systemPath>
-                </dependency>
-            </dependencies>
-        </profile>
-        <profile>
             <id>virtualDependencies</id>
             <activation>
                 <property>
@@ -156,7 +141,7 @@
                 <!-- The following dependencies guarantee that this module is built after them. You can update them by running `mvn process-resources -Pformat -N` from the source tree root directory -->
                 <dependency>
                     <groupId>org.apache.camel.quarkus</groupId>
-                    <artifactId>camel-quarkus-debezium-mongodb-deployment</artifactId>
+                    <artifactId>camel-quarkus-debezium-mysql-deployment</artifactId>
                     <version>${project.version}</version>
                     <type>pom</type>
                     <scope>test</scope>

--- a/integration-tests/debezium-grouped/pom.xml
+++ b/integration-tests/debezium-grouped/pom.xml
@@ -43,17 +43,24 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
-            <artifactId>camel-quarkus-debezium-postgres</artifactId>
+            <artifactId>camel-quarkus-debezium-mongodb</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
-            <artifactId>camel-quarkus-debezium-mongodb</artifactId>
+            <artifactId>camel-quarkus-debezium-mysql</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-debezium-oracle</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-debezium-postgres</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-debezium-sqlserver</artifactId>
+        </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy</artifactId>
@@ -62,14 +69,17 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy-jackson</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-integration-tests-support-debezium</artifactId>
         </dependency>
+        <!-- Required since it's excluded from the runtime classpath by default -->
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+        </dependency>
 
         <!-- test dependencies -->
-
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-integration-tests-support-debezium</artifactId>
@@ -159,6 +169,12 @@
     </dependencies>
 
     <build>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+                <filtering>true</filtering>
+            </testResource>
+        </testResources>
         <plugins>
             <plugin>
                 <groupId>org.codehaus.gmavenplus</groupId>
@@ -217,40 +233,6 @@
         </profile>
         -->
         <profile>
-            <id>mysqlDriver</id>
-            <activation>
-                <property>
-                    <name>mysql.driver.file</name>
-                </property>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>org.apache.camel.quarkus</groupId>
-                    <artifactId>camel-quarkus-debezium-mysql</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>com.mysql</groupId>
-                    <artifactId>mysql-connector-j</artifactId>
-                    <scope>system</scope>
-                    <systemPath>${mysql.driver.file}</systemPath>
-                </dependency>
-            </dependencies>
-        </profile>
-        <profile>
-            <id>sqlserver</id>
-            <activation>
-                <file>
-                    <exists>${sqlserver.EULA}</exists>
-                </file>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>org.apache.camel.quarkus</groupId>
-                    <artifactId>camel-quarkus-debezium-sqlserver</artifactId>
-                </dependency>
-            </dependencies>
-        </profile>
-        <profile>
             <id>virtualDependencies</id>
             <activation>
                 <property>
@@ -262,6 +244,19 @@
                 <dependency>
                     <groupId>org.apache.camel.quarkus</groupId>
                     <artifactId>camel-quarkus-debezium-mongodb-deployment</artifactId>
+                    <version>${project.version}</version>
+                    <type>pom</type>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-debezium-mysql-deployment</artifactId>
                     <version>${project.version}</version>
                     <type>pom</type>
                     <scope>test</scope>
@@ -288,6 +283,19 @@
                 <dependency>
                     <groupId>org.apache.camel.quarkus</groupId>
                     <artifactId>camel-quarkus-debezium-oracle-deployment</artifactId>
+                    <version>${project.version}</version>
+                    <type>pom</type>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-debezium-sqlserver-deployment</artifactId>
                     <version>${project.version}</version>
                     <type>pom</type>
                     <scope>test</scope>


### PR DESCRIPTION
The test profiles in Debezium MySQL & MSSQL modules were unnecessary and screw up the build, depending on the options you use.