### PR TITLE
Deprecate camel-quarkus-langchain4j extension

### DIFF
--- a/docs/modules/ROOT/pages/reference/extensions/langchain4j.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/langchain4j.adoc
@@ -6,15 +6,15 @@
 :cq-artifact-id: camel-quarkus-langchain4j
 :cq-native-supported: true
 :cq-status: Experimental
-:cq-status-deprecation: Experimental
+:cq-status-deprecation: Experimental Deprecated
 :cq-description: LangChain4j high level api usage with Camel Quarkus
-:cq-deprecated: false
+:cq-deprecated: true
 :cq-jvm-since: 3.16.0
 :cq-native-since: 3.16.0
 
 ifeval::[{doc-show-badges} == true]
 [.badges]
-[.badge-key]##JVM since##[.badge-supported]##3.16.0## [.badge-key]##Native since##[.badge-supported]##3.16.0##
+[.badge-key]##JVM since##[.badge-supported]##3.16.0## [.badge-key]##Native since##[.badge-supported]##3.16.0## [.badge-key]##⚠️##[.badge-unsupported]##Deprecated##
 endif::[]
 
 LangChain4j high level api usage with Camel Quarkus

--- a/extensions/langchain4j/runtime/pom.xml
+++ b/extensions/langchain4j/runtime/pom.xml
@@ -34,6 +34,7 @@
         <camel.quarkus.jvmSince>3.16.0</camel.quarkus.jvmSince>
         <camel.quarkus.nativeSince>3.16.0</camel.quarkus.nativeSince>
         <quarkus.metadata.status>experimental</quarkus.metadata.status>
+        <quarkus.metadata.deprecated>true</quarkus.metadata.deprecated>
     </properties>
 
     <dependencies>

--- a/extensions/langchain4j/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/langchain4j/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,4 @@ metadata:
   - "integration"
   status:
   - "experimental"
+  - "deprecated"


### PR DESCRIPTION
Reasoning explained in #7586 & #7587.