### PR TITLE
Avoid usage of VertxHttpConfig runtime configuration for vertx-websocket build time

### DIFF
--- a/extensions/vertx-websocket/deployment/src/main/java/org/apache/camel/quarkus/component/vertx/websocket/deployment/VertxWebsocketProcessor.java
+++ b/extensions/vertx-websocket/deployment/src/main/java/org/apache/camel/quarkus/component/vertx/websocket/deployment/VertxWebsocketProcessor.java
@@ -25,7 +25,6 @@ import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.vertx.deployment.VertxBuildItem;
 import io.quarkus.vertx.http.deployment.VertxWebRouterBuildItem;
-import io.quarkus.vertx.http.runtime.VertxHttpConfig;
 import org.apache.camel.component.vertx.websocket.VertxWebsocketComponent;
 import org.apache.camel.quarkus.component.vertx.websocket.VertxWebsocketRecorder;
 import org.apache.camel.quarkus.core.deployment.spi.CamelRuntimeBeanBuildItem;
@@ -46,10 +45,8 @@ class VertxWebsocketProcessor {
             VertxBuildItem vertx,
             VertxWebRouterBuildItem router,
             LaunchModeBuildItem launchMode,
-            VertxHttpConfig httpConfig,
             VertxWebsocketRecorder recorder) {
         return new CamelRuntimeBeanBuildItem("vertx-websocket", VertxWebsocketComponent.class.getName(),
-                recorder.createVertxWebsocketComponent(vertx.getVertx(), router.getHttpRouter(), launchMode.getLaunchMode(),
-                        httpConfig));
+                recorder.createVertxWebsocketComponent(vertx.getVertx(), router.getHttpRouter(), launchMode.getLaunchMode()));
     }
 }

--- a/extensions/vertx-websocket/runtime/src/main/java/org/apache/camel/quarkus/component/vertx/websocket/VertxWebsocketRecorder.java
+++ b/extensions/vertx-websocket/runtime/src/main/java/org/apache/camel/quarkus/component/vertx/websocket/VertxWebsocketRecorder.java
@@ -49,17 +49,23 @@ public class VertxWebsocketRecorder {
     private static volatile int PORT;
     private static volatile String HOST;
 
+    private final RuntimeValue<VertxHttpConfig> httpConfigRuntimeValue;
+
+    public VertxWebsocketRecorder(RuntimeValue<VertxHttpConfig> httpConfigRuntimeValue) {
+        this.httpConfigRuntimeValue = httpConfigRuntimeValue;
+    }
+
     public RuntimeValue<VertxWebsocketComponent> createVertxWebsocketComponent(
             RuntimeValue<Vertx> vertx,
             RuntimeValue<Router> router,
-            LaunchMode launchMode,
-            VertxHttpConfig httpConfig) {
+            LaunchMode launchMode) {
 
-        boolean sslEnabled = isHttpSeverSecureTransportConfigured(httpConfig);
-        int httpPort = httpConfig.determinePort(launchMode);
-        int httpsPort = httpConfig.determineSslPort(launchMode);
+        VertxHttpConfig vertxHttpConfig = httpConfigRuntimeValue.getValue();
+        boolean sslEnabled = isHttpSeverSecureTransportConfigured(vertxHttpConfig);
+        int httpPort = vertxHttpConfig.determinePort(launchMode);
+        int httpsPort = vertxHttpConfig.determineSslPort(launchMode);
 
-        HOST = httpConfig.host();
+        HOST = vertxHttpConfig.host();
         PORT = sslEnabled ? httpsPort : httpPort;
 
         QuarkusVertxWebsocketComponent component = new QuarkusVertxWebsocketComponent();


### PR DESCRIPTION
Follows on from https://github.com/apache/camel-quarkus/pull/7524