### PR TITLE
Remove workaround management dump

### DIFF
--- a/integration-tests/management/src/main/java/org/apache/camel/quarkus/component/management/it/ManagementResource.java
+++ b/integration-tests/management/src/main/java/org/apache/camel/quarkus/component/management/it/ManagementResource.java
@@ -18,6 +18,7 @@ package org.apache.camel.quarkus.component.management.it;
 
 import java.lang.management.ManagementFactory;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Set;
 
 import javax.management.MBeanServer;
@@ -73,6 +74,33 @@ public class ManagementResource {
         ObjectInstance mbean = getMBean(name);
         if (mbean != null) {
             return String.valueOf(getMBeanServer().invoke(mbean.getObjectName(), operation, new Object[] {}, new String[] {}));
+        }
+        return null;
+    }
+
+    @POST
+    @Path("/invokeXml")
+    @Produces(MediaType.APPLICATION_XML)
+    public String invokeMBeanXmlOperation(@QueryParam("name") String name, @QueryParam("operation") String operation,
+            @QueryParam("paramValues") List<String> paramValues, @QueryParam("paramTypes") List<String> paramTypes)
+            throws Exception {
+        Object[] values = new Object[paramValues.size()];
+        String[] types = new String[paramTypes.size()];
+
+        for (int i = 0; i < paramValues.size(); i++) {
+            String valueStr = paramValues.get(i);
+            String typeStr = paramTypes.get(i);
+
+            switch (typeStr) {
+            case "boolean":
+                values[i] = Boolean.parseBoolean(valueStr);
+                break;
+            }
+            types[i] = typeStr;
+        }
+        ObjectInstance mbean = getMBean(name);
+        if (mbean != null) {
+            return String.valueOf(getMBeanServer().invoke(mbean.getObjectName(), operation, values, types));
         }
         return null;
     }

--- a/integration-tests/management/src/main/java/org/apache/camel/quarkus/component/management/it/Routes.java
+++ b/integration-tests/management/src/main/java/org/apache/camel/quarkus/component/management/it/Routes.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.quarkus.component.management.it;
 
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
 import org.apache.camel.builder.RouteBuilder;
 
 public class Routes extends RouteBuilder {
@@ -24,6 +26,21 @@ public class Routes extends RouteBuilder {
         getContext().setDebugging(false);
 
         from("direct:start").routeId("hello").setBody().constant("Hello World");
+
+        from("direct:step").routeId("hellostep").step("hellostep")
+                .doTry()
+                .setBody().constant("Hello Step")
+                .process(new Processor() {
+                    @Override
+                    public void process(Exchange exchange) throws Exception {
+                        // not used processor, just to be able to call `doFinally`
+                    }
+                })
+                .doFinally()
+                .id("trystep")
+                .end()
+                .stop()
+                .id("stopstep");
 
         from("direct:count").routeId("count")
                 .bean(ManagedCounter.class, "increment").id("counter");


### PR DESCRIPTION
After removing workaround for #7054 , i've hit issue 

```
Caused by: org.graalvm.nativeimage.MissingReflectionRegistrationError: The program tried to reflectively access the proxy class inheriting [org.apache.camel.api.management.mbean.ManagedStepMBean] without it being registered for runtime reflection. Add [org.apache.camel.api.management.mbean.ManagedStepMBean] to the dynamic-proxy metadata to solve this problem. Note: The order of interfaces used to create proxies matters. See https://www.graalvm.org/latest/reference-manual/native-image/metadata/#dynamic-proxy for help.
```
which is caused by this reflective call https://github.com/apache/camel/blob/camel-4.13.0/core/camel-management/src/main/java/org/apache/camel/management/mbean/ManagedRoute.java#L594.

The problem why this class was not registered automatically is that the interface https://github.com/apache/camel/blob/camel-4.13.0/core/camel-management-api/src/main/java/org/apache/camel/api/management/mbean/ManagedStepMBean.java#L19 doesn't have any annotation.
There are two more interfaces `ManagedDoFinallyMBean`, `ManagedStopMBean` which don't have annotations, but those are not used anywhere. But to be sure for future, i've added two more tests to cover the area.