### PR TITLE
Remove io.quarkiverse.amazonservices:quarkus-amazon-services-bom from camel-quarkus-bom-test

### DIFF
--- a/poms/bom-test/pom.xml
+++ b/poms/bom-test/pom.xml
@@ -49,13 +49,6 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
-                <groupId>io.quarkiverse.amazonservices</groupId>
-                <artifactId>quarkus-amazon-services-bom</artifactId>
-                <version>${quarkiverse-amazonservices.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
                 <groupId>io.quarkiverse.artemis</groupId>
                 <artifactId>quarkus-artemis-bom</artifactId>
                 <version>${quarkiverse-artemis.version}</version>

--- a/tooling/internal-dependency-management/pom.xml
+++ b/tooling/internal-dependency-management/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.camel.quarkus</groupId>
+        <artifactId>camel-quarkus-tooling</artifactId>
+        <version>3.26.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>camel-quarkus-internal-dependency-management</artifactId>
+    <packaging>pom</packaging>
+
+    <name>Camel Quarkus :: Tooling :: Internal Dependency Management</name>
+    <description>Pseudo dependency management module so that Dependabot can auto update version properties required by other properties using the @sync tag</description>
+
+    <!-- The following dependencies are defined only to enable Dependabot to auto-update version properties in the root pom.xml. Primarily for things that @sync properties depend on -->
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkiverse.amazonservices</groupId>
+            <artifactId>quarkus-amazon-services-bom</artifactId>
+            <version>${quarkiverse-amazonservices.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/tooling/pom.xml
+++ b/tooling/pom.xml
@@ -61,6 +61,7 @@
                 </property>
             </activation>
             <modules>
+                <module>internal-dependency-management</module>
                 <module>perf-regression</module>
             </modules>
         </profile>


### PR DESCRIPTION
Relates to #7304.

@ppalaga WDYT? I added a `tooling/internal-dependency-management` module as a place where stuff can get added purely for Dependabot updates if needed.