### PR TITLE
Remove spring-rabbitmq limitations

### DIFF
--- a/docs/modules/ROOT/pages/reference/extensions/spring-rabbitmq.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/spring-rabbitmq.adoc
@@ -43,16 +43,3 @@ Or add the coordinates to your existing project:
 ifeval::[{doc-show-user-guide-link} == true]
 Check the xref:user-guide/index.adoc[User guide] for more information about writing Camel Quarkus applications.
 endif::[]
-
-[id="extensions-spring-rabbitmq-camel-quarkus-limitations"]
-== Camel Quarkus limitations
-
-You can use this extension without any special configuration in JVM mode.
-
-In native mode you need to add
-[source,shell]
-----
-quarkus.native.additional-build-args = -H:+InlineBeforeAnalysis
-----
-to your `application.properties`. This is to allow inlining of some static methods that would otherwise cause build failures (see this https://github.com/oracle/graal/issues/2594[GraalVM issue]).
-

--- a/extensions/spring-rabbitmq/runtime/src/main/doc/limitations.adoc
+++ b/extensions/spring-rabbitmq/runtime/src/main/doc/limitations.adoc
@@ -1,8 +1,0 @@
-You can use this extension without any special configuration in JVM mode.
-
-In native mode you need to add
-[source,shell]
-----
-quarkus.native.additional-build-args = -H:+InlineBeforeAnalysis
-----
-to your `application.properties`. This is to allow inlining of some static methods that would otherwise cause build failures (see this https://github.com/oracle/graal/issues/2594[GraalVM issue]).


### PR DESCRIPTION
Remove limitations docs as per https://github.com/quarkusio/quarkus/issues/19446 the option is enabled by default (see current https://github.com/graalvm/graalvm-community-jdk21u/blob/vm-23.1.8/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/phases/InlineBeforeAnalysis.java#L58).