### PR TITLE
Add type check for non-synthetic beans in RuntimeBeanRepository.getReferenceByName

### DIFF
--- a/extensions-core/core/deployment/src/test/java/org/apache/camel/quarkus/core/runtime/CamelRegistryTest.java
+++ b/extensions-core/core/deployment/src/test/java/org/apache/camel/quarkus/core/runtime/CamelRegistryTest.java
@@ -82,6 +82,9 @@ public class CamelRegistryTest {
         assertThat(registry.findByTypeWithName(String.class))
                 .containsEntry("bean-1", "a")
                 .containsEntry("bean-2", "b");
+
+        // Incorrect type lookup should return null
+        assertThat(registry.lookupByNameAndType("bean-1", Integer.class)).isNull();
     }
 
     @ApplicationScoped

--- a/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/RuntimeBeanRepository.java
+++ b/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/RuntimeBeanRepository.java
@@ -157,7 +157,9 @@ public final class RuntimeBeanRepository implements BeanRepository {
                     result = instance.get();
                 }
             } else {
-                result = instance.get();
+                if (type.isInstance(instance.get())) {
+                    result = instance.get();
+                }
             }
         }
 


### PR DESCRIPTION
This aligns `Registry.lookupByNameAndType` behaviour with vanilla Camel. Where if you lookup a named bean using the wrong type, `null` is returned. On CQ, it's been throwing `ClassCastException`. 