### PR TITLE
Test against CouchDB 3.5.0

### DIFF
--- a/integration-tests/couchdb/src/main/java/org/apache/camel/quarkus/component/couchdb/it/CouchDbRoute.java
+++ b/integration-tests/couchdb/src/main/java/org/apache/camel/quarkus/component/couchdb/it/CouchDbRoute.java
@@ -26,15 +26,17 @@ import static org.apache.camel.quarkus.component.couchdb.it.CouchdbTestDocument.
 @ApplicationScoped
 public class CouchDbRoute extends RouteBuilder {
 
-    static final String COUCHDB_ENDPOINT_URI = "couchdb:http://{{camel.couchdb.test.server.authority}}/database";
+    static final String COUCHDB_ENDPOINT_URI = "couchdb:http://{{camel.couchdb.test.server.authority}}/database?username={{camel.couchdb.test.username}}&password={{camel.couchdb.test.password}}";
 
     @Inject
     CouchdbResource resource;
 
     @Override
     public void configure() {
-        from(COUCHDB_ENDPOINT_URI + "?createDatabase=true&heartbeat=100").process(e -> {
-            resource.logEvent(fromJsonObject(e.getIn().getBody(JsonObject.class)));
-        });
+        from(COUCHDB_ENDPOINT_URI
+                + "&createDatabase=true&heartbeat=100")
+                .process(e -> {
+                    resource.logEvent(fromJsonObject(e.getIn().getBody(JsonObject.class)));
+                });
     }
 }

--- a/integration-tests/couchdb/src/test/java/org/apache/camel/quarkus/component/couchdb/it/CouchdbTestResource.java
+++ b/integration-tests/couchdb/src/test/java/org/apache/camel/quarkus/component/couchdb/it/CouchdbTestResource.java
@@ -18,6 +18,7 @@
 package org.apache.camel.quarkus.component.couchdb.it;
 
 import java.util.Map;
+import java.util.UUID;
 
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 import org.apache.camel.util.CollectionHelper;
@@ -40,11 +41,20 @@ public class CouchdbTestResource implements QuarkusTestResourceLifecycleManager 
         LOGGER.info(TestcontainersConfiguration.getInstance().toString());
 
         try {
-            container = new GenericContainer(COUCHDB_IMAGE).withExposedPorts(COUCHDB_PORT).waitingFor(Wait.forListeningPort());
+            final String user = "admin";
+            final String pwd = UUID.randomUUID().toString();
+            container = new GenericContainer(COUCHDB_IMAGE)
+                    .withEnv("COUCHDB_USER", user)
+                    .withEnv("COUCHDB_PASSWORD", pwd)
+                    .withExposedPorts(COUCHDB_PORT)
+                    .waitingFor(Wait.forListeningPort());
             container.start();
 
             final String authority = container.getHost() + ":" + container.getMappedPort(COUCHDB_PORT).toString();
-            return CollectionHelper.mapOf("camel.couchdb.test.server.authority", authority);
+            return CollectionHelper.mapOf(
+                    "camel.couchdb.test.server.authority", authority,
+                    "camel.couchdb.test.username", user,
+                    "camel.couchdb.test.password", pwd);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/pom.xml
+++ b/pom.xml
@@ -237,7 +237,7 @@
         <cassandra.container.image>mirror.gcr.io/cassandra:5.0.2</cassandra.container.image>
         <consul.container.image>mirror.gcr.io/hashicorp/consul:1.19</consul.container.image>
         <couchbase.container.image>mirror.gcr.io/couchbase/server:7.2.5</couchbase.container.image>
-        <couchdb.container.image>mirror.gcr.io/couchdb:2.3.1</couchdb.container.image>
+        <couchdb.container.image>mirror.gcr.io/couchdb:3.5.0</couchdb.container.image>
         <db2.container.image>icr.io/db2_community/db2:12.1.0.0</db2.container.image>
         <eclipse-mosquitto.container.image>mirror.gcr.io/eclipse-mosquitto:2.0.18</eclipse-mosquitto.container.image>
         <elasticsearch.container.image>mirror.gcr.io/elastic/elasticsearch:9.0.2</elasticsearch.container.image>


### PR DESCRIPTION
The original CouchDB 2.3.1 container first hangs and then testcontainers timeout waiting for the port on my machine. 
I hope it is fine to test against the newest container image