### PR TITLE
[Quarkus CXF 3.27.0] Fail the build if there are overlaps between our BOM and Quarkus BOM

### DIFF
--- a/poms/bom/pom.xml
+++ b/poms/bom/pom.xml
@@ -8158,4 +8158,38 @@
             </releases>
         </repository>
     </repositories>
+    <profiles>
+        <profile>
+            <id>full</id>
+            <activation>
+                <property>
+                    <name>!quickly</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.l2x6.cq</groupId>
+                        <artifactId>cq-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <!-- Fails the build if there are overlaps between our BOM and Quarkus BOM -->
+                                <id>bom-overlaps</id>
+                                <goals>
+                                    <goal>bom-overlaps</goal>
+                                </goals>
+                                <phase>test</phase><!-- after process-resources where we flatten the BOM -->
+                                <configuration>
+                                    <baseBomPath>${project.basedir}/src/main/generated/flattened-reduced-pom.xml</baseBomPath>
+                                    <ignoredOverlaps>
+                                        <ignoredOverlap>org.glassfish.jaxb:jaxb-runtime</ignoredOverlap><!-- Comes from quarkus-cxf-bom -->
+                                    </ignoredOverlaps>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
This requires Quarkus CXF 3.27.0.

Older versions will fail with

```
[ERROR] The following artifacts are managed in both BOMs:
[ERROR]  - jakarta.mail:jakarta.mail-api  2.1.3 ❌ 2.1.4
[ERROR]  - org.eclipse.angus:angus-mail ✅ 2.0.4
```
