### PR TITLE
Use AsciiDoc attribute for langchain4j BOM version in extension code snippets

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -34,6 +34,7 @@ asciidoc:
     quarkus-version: 3.28.2 # replace ${quarkus.version}
     graalvm-version: 23.1.2 # replace ${graalvm.version}
     graalvm-docs-version: jdk21 # replace ${graalvm-docs.version}
+    langchain4j-version: 1.5.0 # replace ${langchain4j.version}
     mapstruct-version: 1.6.3 # replace ${mapstruct.version}
     min-maven-version: 3.8.2 # replace ${min-maven-version}
     target-maven-version: 3.9.11 # replace ${target-maven-version}

--- a/docs/modules/ROOT/pages/reference/extensions/langchain4j-agent.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/langchain4j-agent.adoc
@@ -48,14 +48,14 @@ endif::[]
 == LangChain4j dependency management
 
 In order to ensure alignment across all Quarkus and LangChain4j related dependencies, it is recommended to import the LangChain4j BOM as below:
-[source,xml]
+[source,xml,subs=attributes+]
 ----
 <dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>dev.langchain4j</groupId>
       <artifactId>langchain4j-bom</artifactId>
-      <version>1.5.0</version>
+      <version>{langchain4j-version}</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>

--- a/docs/modules/ROOT/pages/reference/extensions/langchain4j-chat.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/langchain4j-chat.adoc
@@ -48,14 +48,14 @@ endif::[]
 == LangChain4j dependency management
 
 In order to ensure alignment across all Quarkus and LangChain4j related dependencies, it is recommended to import the LangChain4j BOM as below:
-[source,xml]
+[source,xml,subs=attributes+]
 ----
 <dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>dev.langchain4j</groupId>
       <artifactId>langchain4j-bom</artifactId>
-      <version>1.5.0</version>
+      <version>{langchain4j-version}</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>

--- a/docs/modules/ROOT/pages/reference/extensions/langchain4j-embeddings.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/langchain4j-embeddings.adoc
@@ -48,14 +48,14 @@ endif::[]
 == LangChain4j dependency management
 
 In order to ensure alignment across all Quarkus and LangChain4j related dependencies, it is recommended to import the LangChain4j BOM as below:
-[source,xml]
+[source,xml,subs=attributes+]
 ----
 <dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>dev.langchain4j</groupId>
       <artifactId>langchain4j-bom</artifactId>
-      <version>1.5.0</version>
+      <version>{langchain4j-version}</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>

--- a/docs/modules/ROOT/pages/reference/extensions/langchain4j-embeddingstore.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/langchain4j-embeddingstore.adoc
@@ -41,14 +41,14 @@ endif::[]
 == LangChain4j dependency management
 
 In order to ensure alignment across all Quarkus and LangChain4j related dependencies, it is recommended to import the LangChain4j BOM as below:
-[source,xml]
+[source,xml,subs=attributes+]
 ----
 <dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>dev.langchain4j</groupId>
       <artifactId>langchain4j-bom</artifactId>
-      <version>1.5.0</version>
+      <version>{langchain4j-version}</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>

--- a/docs/modules/ROOT/pages/reference/extensions/langchain4j-tokenizer.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/langchain4j-tokenizer.adoc
@@ -48,14 +48,14 @@ endif::[]
 == LangChain4j dependency management
 
 In order to ensure alignment across all Quarkus and LangChain4j related dependencies, it is recommended to import the LangChain4j BOM as below:
-[source,xml]
+[source,xml,subs=attributes+]
 ----
 <dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>dev.langchain4j</groupId>
       <artifactId>langchain4j-bom</artifactId>
-      <version>1.5.0</version>
+      <version>{langchain4j-version}</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>

--- a/docs/modules/ROOT/pages/reference/extensions/langchain4j-tools.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/langchain4j-tools.adoc
@@ -48,14 +48,14 @@ endif::[]
 == LangChain4j dependency management
 
 In order to ensure alignment across all Quarkus and LangChain4j related dependencies, it is recommended to import the LangChain4j BOM as below:
-[source,xml]
+[source,xml,subs=attributes+]
 ----
 <dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>dev.langchain4j</groupId>
       <artifactId>langchain4j-bom</artifactId>
-      <version>1.5.0</version>
+      <version>{langchain4j-version}</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>

--- a/docs/modules/ROOT/pages/reference/extensions/langchain4j-web-search.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/langchain4j-web-search.adoc
@@ -48,14 +48,14 @@ endif::[]
 == LangChain4j dependency management
 
 In order to ensure alignment across all Quarkus and LangChain4j related dependencies, it is recommended to import the LangChain4j BOM as below:
-[source,xml]
+[source,xml,subs=attributes+]
 ----
 <dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>dev.langchain4j</groupId>
       <artifactId>langchain4j-bom</artifactId>
-      <version>1.5.0</version>
+      <version>{langchain4j-version}</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>

--- a/tooling/maven-plugin/src/main/java/org/apache/camel/quarkus/maven/UpdateExtensionDocPageMojo.java
+++ b/tooling/maven-plugin/src/main/java/org/apache/camel/quarkus/maven/UpdateExtensionDocPageMojo.java
@@ -202,7 +202,6 @@ public class UpdateExtensionDocPageMojo extends AbstractDocGeneratorMojo {
         model.put("hasDurationOption", configOptions.stream().anyMatch(ConfigItem::isTypeDuration));
         model.put("hasMemSizeOption", configOptions.stream().anyMatch(ConfigItem::isTypeMemSize));
         model.put("configOptions", configOptions);
-        model.put("langchain4jVersion", project.getProperties().get("langchain4j.version"));
         model.put("humanReadableKind", new TemplateMethodModelEx() {
             @Override
             public Object exec(List arguments) throws TemplateModelException {

--- a/tooling/maven-plugin/src/main/resources/doc-templates/extension-doc-page.adoc
+++ b/tooling/maven-plugin/src/main/resources/doc-templates/extension-doc-page.adoc
@@ -105,14 +105,14 @@ You will also need to enable serialization for the exception classes that you in
 == LangChain4j dependency management
 
 In order to ensure alignment across all Quarkus and LangChain4j related dependencies, it is recommended to import the LangChain4j BOM as below:
-[source,xml]
+[source,xml,subs=attributes+]
 ----
 <dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>dev.langchain4j</groupId>
       <artifactId>langchain4j-bom</artifactId>
-      <version>[=langchain4jVersion]</version>
+      <version>{langchain4j-version}</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>


### PR DESCRIPTION
Makes LangChain4j Dependabot upgrade PRs work properly.

Currently it fails due to the langchain4j extension docs being modified because of the version change. Thus, better to reference something static like an attribute.