### PR TITLE
Configure com.google.protobuf.JavaFeaturesProto for runtime initialization in native mode

### DIFF
--- a/extensions/aws2-kinesis/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/kinesis/deployment/Aws2KinesisProcessor.java
+++ b/extensions/aws2-kinesis/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/kinesis/deployment/Aws2KinesisProcessor.java
@@ -36,7 +36,9 @@ class Aws2KinesisProcessor {
 
     @BuildStep
     void runtimeInitializedClasses(BuildProducer<RuntimeInitializedClassBuildItem> runtimeInitializedClass) {
-        Stream.of("software.amazon.awssdk.services.dynamodb.DynamoDbRetryPolicy",
+        Stream.of(
+                "com.google.protobuf.JavaFeaturesProto",
+                "software.amazon.awssdk.services.dynamodb.DynamoDbRetryPolicy",
                 "software.amazon.kinesis.lifecycle.ShutdownTask")
                 .map(RuntimeInitializedClassBuildItem::new)
                 .forEach(runtimeInitializedClass::produce);

--- a/extensions/debezium-oracle/deployment/src/main/java/org/apache/camel/quarkus/component/debezium/oracle/deployment/DebeziumOracleProcessor.java
+++ b/extensions/debezium-oracle/deployment/src/main/java/org/apache/camel/quarkus/component/debezium/oracle/deployment/DebeziumOracleProcessor.java
@@ -27,6 +27,7 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.IndexDependencyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 import oracle.jdbc.driver.OracleDriver;
 
 class DebeziumOracleProcessor {
@@ -54,5 +55,10 @@ class DebeziumOracleProcessor {
     @BuildStep
     void addDependencies(BuildProducer<IndexDependencyBuildItem> indexDependency) {
         indexDependency.produce(new IndexDependencyBuildItem("io.debezium", "debezium-connector-oracle"));
+    }
+
+    @BuildStep
+    RuntimeInitializedClassBuildItem runtimeInitializedClasses() {
+        return new RuntimeInitializedClassBuildItem("com.google.protobuf.JavaFeaturesProto");
     }
 }

--- a/extensions/fhir/deployment/src/main/java/org/apache/camel/quarkus/component/fhir/deployment/FhirProcessor.java
+++ b/extensions/fhir/deployment/src/main/java/org/apache/camel/quarkus/component/fhir/deployment/FhirProcessor.java
@@ -34,6 +34,7 @@ import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBundleBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 import io.quarkus.deployment.pkg.steps.NativeOrNativeSourcesBuild;
 import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.Gizmo;
@@ -134,6 +135,11 @@ final class FhirProcessor {
                 methodCreator.returnValue(stringBuilder.callToString());
             }
         }
+    }
+
+    @BuildStep
+    RuntimeInitializedClassBuildItem runtimeInitializedClasses() {
+        return new RuntimeInitializedClassBuildItem("com.google.protobuf.JavaFeaturesProto");
     }
 
     static final class IsFhirServerAbsent implements BooleanSupplier {

--- a/extensions/google-bigquery/deployment/src/main/java/org/apache/camel/quarkus/component/google/bigquery/deployment/GoogleBigqueryProcessor.java
+++ b/extensions/google-bigquery/deployment/src/main/java/org/apache/camel/quarkus/component/google/bigquery/deployment/GoogleBigqueryProcessor.java
@@ -33,6 +33,7 @@ class GoogleBigqueryProcessor {
     @BuildStep
     public List<RuntimeInitializedClassBuildItem> runtimeInitializedClass() {
         return List.of(
+                new RuntimeInitializedClassBuildItem("com.google.protobuf.JavaFeaturesProto"),
                 new RuntimeInitializedClassBuildItem("org.apache.arrow.memory.BaseAllocator"),
                 new RuntimeInitializedClassBuildItem("org.apache.arrow.memory.DefaultAllocationManagerFactory"),
                 new RuntimeInitializedClassBuildItem("org.apache.arrow.memory.NettyAllocationManager"));

--- a/extensions/google-pubsub/deployment/src/main/java/org/apache/camel/quarkus/component/google/pubsub/deployment/GooglePubsubProcessor.java
+++ b/extensions/google-pubsub/deployment/src/main/java/org/apache/camel/quarkus/component/google/pubsub/deployment/GooglePubsubProcessor.java
@@ -58,6 +58,7 @@ class GooglePubsubProcessor {
     @BuildStep
     void runtimeInitializedClasses(BuildProducer<RuntimeInitializedClassBuildItem> runtimeInitializedClass) {
         Stream.of(
+                "com.google.protobuf.JavaFeaturesProto",
                 "io.grpc.internal.RetriableStream" // Consider moving this to a separate support extension if we need this in multiple top level extensions
         )
                 .map(RuntimeInitializedClassBuildItem::new)

--- a/extensions/google-secret-manager/deployment/src/main/java/org/apache/camel/quarkus/component/google/secret/manager/deployment/GoogleSecretManagerProcessor.java
+++ b/extensions/google-secret-manager/deployment/src/main/java/org/apache/camel/quarkus/component/google/secret/manager/deployment/GoogleSecretManagerProcessor.java
@@ -18,6 +18,7 @@ package org.apache.camel.quarkus.component.google.secret.manager.deployment;
 
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 import org.jboss.logging.Logger;
 
 class GoogleSecretManagerProcessor {
@@ -28,5 +29,10 @@ class GoogleSecretManagerProcessor {
     @BuildStep
     FeatureBuildItem feature() {
         return new FeatureBuildItem(FEATURE);
+    }
+
+    @BuildStep
+    RuntimeInitializedClassBuildItem runtimeInitializedClasses() {
+        return new RuntimeInitializedClassBuildItem("com.google.protobuf.JavaFeaturesProto");
     }
 }

--- a/extensions/google-storage/deployment/src/main/java/org/apache/camel/quarkus/component/google/storage/deployment/GoogleStorageProcessor.java
+++ b/extensions/google-storage/deployment/src/main/java/org/apache/camel/quarkus/component/google/storage/deployment/GoogleStorageProcessor.java
@@ -19,6 +19,7 @@ package org.apache.camel.quarkus.component.google.storage.deployment;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 
 class GoogleStorageProcessor {
 
@@ -32,5 +33,10 @@ class GoogleStorageProcessor {
     @BuildStep
     ExtensionSslNativeSupportBuildItem activateSslNativeSupport() {
         return new ExtensionSslNativeSupportBuildItem(FEATURE);
+    }
+
+    @BuildStep
+    RuntimeInitializedClassBuildItem runtimeInitializedClasses() {
+        return new RuntimeInitializedClassBuildItem("com.google.protobuf.JavaFeaturesProto");
     }
 }

--- a/extensions/kudu/deployment/src/main/java/org/apache/camel/quarkus/component/kudu/deployment/KuduProcessor.java
+++ b/extensions/kudu/deployment/src/main/java/org/apache/camel/quarkus/component/kudu/deployment/KuduProcessor.java
@@ -30,6 +30,7 @@ import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageSecurityProviderBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeReinitializedClassBuildItem;
 
 class KuduProcessor {
@@ -81,5 +82,10 @@ class KuduProcessor {
                 "org.apache.kudu.client.PartitionSchema$BoundsComparator")
                 .map(RuntimeReinitializedClassBuildItem::new)
                 .forEach(runtimeReinitializedClass::produce);
+    }
+
+    @BuildStep
+    RuntimeInitializedClassBuildItem runtimeInitializedClasses() {
+        return new RuntimeInitializedClassBuildItem("com.google.protobuf.JavaFeaturesProto");
     }
 }

--- a/extensions/pinecone/deployment/src/main/java/org/apache/camel/quarkus/component/pinecone/deployment/PineconeProcessor.java
+++ b/extensions/pinecone/deployment/src/main/java/org/apache/camel/quarkus/component/pinecone/deployment/PineconeProcessor.java
@@ -62,5 +62,6 @@ class PineconeProcessor {
     @BuildStep
     void runtimeInitializedClasses(BuildProducer<RuntimeInitializedClassBuildItem> runtimeInitializedClass) {
         runtimeInitializedClass.produce(new RuntimeInitializedClassBuildItem(Configuration.class.getName()));
+        runtimeInitializedClass.produce(new RuntimeInitializedClassBuildItem("com.google.protobuf.JavaFeaturesProto"));
     }
 }

--- a/extensions/protobuf/deployment/src/main/java/org/apache/camel/quarkus/component/protobuf/deployment/ProtobufProcessor.java
+++ b/extensions/protobuf/deployment/src/main/java/org/apache/camel/quarkus/component/protobuf/deployment/ProtobufProcessor.java
@@ -23,6 +23,7 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
 import org.jboss.logging.Logger;
@@ -55,4 +56,8 @@ class ProtobufProcessor {
         }
     }
 
+    @BuildStep
+    RuntimeInitializedClassBuildItem runtimeInitializedClasses() {
+        return new RuntimeInitializedClassBuildItem("com.google.protobuf.JavaFeaturesProto");
+    }
 }

--- a/extensions/qdrant/deployment/src/main/java/org/apache/camel/quarkus/component/qdrant/deployment/QdrantProcessor.java
+++ b/extensions/qdrant/deployment/src/main/java/org/apache/camel/quarkus/component/qdrant/deployment/QdrantProcessor.java
@@ -18,6 +18,7 @@ package org.apache.camel.quarkus.component.qdrant.deployment;
 
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 import org.jboss.logging.Logger;
 
 class QdrantProcessor {
@@ -28,5 +29,10 @@ class QdrantProcessor {
     @BuildStep
     FeatureBuildItem feature() {
         return new FeatureBuildItem(FEATURE);
+    }
+
+    @BuildStep
+    RuntimeInitializedClassBuildItem runtimeInitializedClasses() {
+        return new RuntimeInitializedClassBuildItem("com.google.protobuf.JavaFeaturesProto");
     }
 }

--- a/extensions/weaviate/deployment/src/main/java/org/apache/camel/quarkus/component/weaviate/deployment/WeaviateProcessor.java
+++ b/extensions/weaviate/deployment/src/main/java/org/apache/camel/quarkus/component/weaviate/deployment/WeaviateProcessor.java
@@ -21,6 +21,7 @@ import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.IndexDependencyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 import org.jboss.jandex.IndexView;
 
 class WeaviateProcessor {
@@ -49,5 +50,10 @@ class WeaviateProcessor {
     @BuildStep
     IndexDependencyBuildItem registerDependencyForIndex() {
         return new IndexDependencyBuildItem("io.weaviate", "client");
+    }
+
+    @BuildStep
+    RuntimeInitializedClassBuildItem runtimeInitializedClasses() {
+        return new RuntimeInitializedClassBuildItem("com.google.protobuf.JavaFeaturesProto");
     }
 }


### PR DESCRIPTION
Seeing a lot of sporadic CI failures related to `JavaFeaturesProto`. Hence this less than ideal 'fix'.

I will open an issue to tidy things up after the 3.29.0 release.

I have a PR open with Quarkus to try and move the runtime init config to a better place:

https://github.com/quarkusio/quarkus/pull/50471