### PR TITLE
[3.27.x] Disable NATS TLS testing due to #7771

### DIFF
--- a/integration-tests/nats/src/test/java/org/apache/camel/quarkus/component/nats/it/NatsTest.java
+++ b/integration-tests/nats/src/test/java/org/apache/camel/quarkus/component/nats/it/NatsTest.java
@@ -21,9 +21,6 @@ import java.util.concurrent.TimeUnit;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.Header;
-import io.smallrye.certs.Format;
-import io.smallrye.certs.junit5.Certificate;
-import org.apache.camel.quarkus.test.support.certificate.TestCertificates;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
@@ -31,9 +28,10 @@ import static io.restassured.RestAssured.given;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@TestCertificates(certificates = {
-        @Certificate(name = "nats", formats = {
-                Format.PKCS12, Format.PEM }, password = "password") })
+// TODO: Restore TLS tests - https://github.com/apache/camel-quarkus/issues/7771
+//@TestCertificates(certificates = {
+//        @Certificate(name = "nats", formats = {
+//                Format.PKCS12, Format.PEM }, password = "password") })
 @QuarkusTestResource(NatsTestResource.class)
 @QuarkusTest
 class NatsTest {

--- a/integration-tests/nats/src/test/java/org/apache/camel/quarkus/component/nats/it/NatsTestResource.java
+++ b/integration-tests/nats/src/test/java/org/apache/camel/quarkus/component/nats/it/NatsTestResource.java
@@ -55,12 +55,13 @@ public class NatsTestResource implements QuarkusTestResourceLifecycleManager {
         noAuthContainer = noAuthContainer(properties);
         tokenAuthContainer = tokenAuthContainer(properties);
 
-        if ("true".equals(System.getenv("ENABLE_TLS_TESTS"))) {
-            LOG.info("TLS tests enabled so starting the TLS auth container");
-            tlsAuthContainer = tlsAuthContainer(properties);
-        } else {
-            LOG.info("TLS tests NOT enabled, so NOT starting the TLS auth container");
-        }
+        // TODO: Restore TLS tests - https://github.com/apache/camel-quarkus/issues/7771
+        //        if ("true".equals(System.getenv("ENABLE_TLS_TESTS"))) {
+        //            LOG.info("TLS tests enabled so starting the TLS auth container");
+        //            tlsAuthContainer = tlsAuthContainer(properties);
+        //        } else {
+        //            LOG.info("TLS tests NOT enabled, so NOT starting the TLS auth container");
+        //        }
 
         LOG.info("Properties: {}", properties);
 


### PR DESCRIPTION
In anticipation of BouncyCastle getting upgraded to 1.82 in Quarkus 3.27.1.