### PR TITLE
ci: Add github workflow to validation documentation on PR

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -45,6 +45,7 @@ on:
       - '.github/workflows/pr-validate.yml'
       - '.github/workflows/quarkus-master-cron.yaml'
       - '.github/workflows/synchronize-dependabot-branch.yaml'
+      - '.github/workflows/pr-doc-validation.yaml'
       - 'docs/antora.yml'
       - 'release-utils/**'
   pull_request:
@@ -73,6 +74,7 @@ on:
       - '.github/workflows/quarkus-lts-ci-build.yaml'
       - '.github/workflows/quarkus-master-cron.yaml'
       - '.github/workflows/synchronize-dependabot-branch.yaml'
+      - '.github/workflows/pr-doc-validation.yaml'
       - 'docs/antora.yml'
       - 'release-utils/**'
 

--- a/.github/workflows/pr-doc-validation.yml
+++ b/.github/workflows/pr-doc-validation.yml
@@ -1,0 +1,60 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: PR doc validation
+on:
+  pull_request:
+    branches:
+      - main
+      - "[0-9]+.[0-9]+.x"
+    paths:
+      - '**.adoc'
+      - '!**/README.adoc'
+
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check-doc:
+    if: github.repository == 'apache/camel-quarkus'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout camel-quarkus repo
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+          submodules: recursive
+          path: camel-quarkus
+      - name: Checkout camel-website repo
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          repository: apache/camel-website
+          path: camel-website
+          ref: main
+
+      - name: Validate documentation
+        shell: bash
+        run: |
+          cd camel-website
+          yarn install
+          cd ../camel-quarkus/docs
+          yarn install
+          ./local-build.sh quick

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -45,6 +45,7 @@ on:
       - '.github/workflows/quarkus-lts-ci-build.yaml'
       - '.github/workflows/quarkus-master-cron.yaml'
       - '.github/workflows/synchronize-dependabot-branch.yaml'
+      - '.github/workflows/pr-doc-validation.yaml'
       - 'docs/antora.yml'
       - 'release-utils/**'
 


### PR DESCRIPTION
Ref #6041 

This is the same workflow as the one added to the apache/camel repository: https://github.com/apache/camel/pull/19650

It validates that any change in the doc is valid with in syntax with using the doc local/partial build https://github.com/apache/camel-quarkus/blob/main/docs/README.adoc in 1 to 3 mn to execute.

It does not execute any advanced check like the dead links for now.