### PR TITLE
Add 3.27.x stream to LTS maintenance branch workflow

### DIFF
--- a/.github/workflows/quarkus-lts-ci-build.yaml
+++ b/.github/workflows/quarkus-lts-ci-build.yaml
@@ -24,8 +24,8 @@ on:
         type: choice
         description: "The Quarkus maintenance branch to test"
         options:
+          - "3.27"
           - "3.20"
-          - "3.15"
         required: true
 
 concurrency:


### PR DESCRIPTION
Also removed `3.15` since we probably wont need to test with that stream again.