### PR TITLE
Configure Protostream annotation processor for maven-compiler-plugin in infnispan-common test module

### DIFF
--- a/integration-tests/infinispan-common/pom.xml
+++ b/integration-tests/infinispan-common/pom.xml
@@ -88,6 +88,18 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.infinispan.protostream</groupId>
+                            <artifactId>protostream-processor</artifactId>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>io.smallrye</groupId>
                 <artifactId>jandex-maven-plugin</artifactId>
                 <executions>


### PR DESCRIPTION
Fixes #7893
