### PR TITLE
Add Maven Wrapper to source zip

### DIFF
--- a/tooling/descriptors/src.xml
+++ b/tooling/descriptors/src.xml
@@ -45,7 +45,6 @@
         <exclude>**/eclipse-classes/**</exclude>
         <exclude>**/.*</exclude>
         <exclude>**/.github/**</exclude>
-        <exclude>**/.mvn/wrapper/**</exclude>
 
         <exclude>**/surefire*</exclude>
         <exclude>**/svn-commit*</exclude>
@@ -58,15 +57,13 @@
 
         <!-- Eclipse -->
         <exclude>**/.project</exclude>
-        <exclude>**/.classpath]</exclude>
+        <exclude>**/.classpath</exclude>
         <exclude>**/.settings/**</exclude>
 
         <exclude>**/cobertura.ser</exclude>
 
         <exclude>**/node_modules/**</exclude>
         <exclude>**/.flattened-pom.xml</exclude>
-
-        <exclude>**/mvnw**</exclude>
       </excludes>
     </fileSet>
 


### PR DESCRIPTION
The `perf-regression` module attempts to copy the wrapper scripts and supporting files from the project root. So we need them in the source archive.