### PR TITLE
fix: Use previous oracle-free image (deprecated) for Debezium-oracle tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -257,7 +257,7 @@
         <nats.container.image>mirror.gcr.io/nats:2.10.18</nats.container.image>
         <opensearch.container.image>mirror.gcr.io/opensearchproject/opensearch:2.9.0</opensearch.container.image>
         <openssh-server.container.image>mirror.gcr.io/linuxserver/openssh-server:version-9.7_p1-r4</openssh-server.container.image>
-        <oracle-debezium.container.image>mirror.gcr.io/gvenzl/oracle-free:23-slim-faststart</oracle-debezium.container.image>
+        <oracle-debezium.container.image>mirror.gcr.io/gvenzl/oracle-free:23.9-slim-faststart</oracle-debezium.container.image>
         <pinecone.container.image>ghcr.io/pinecone-io/pinecone-local:v0.7.0</pinecone.container.image>
         <postgres.container.image>mirror.gcr.io/postgres:15.0</postgres.container.image>
         <postgres-debezium.container.image>mirror.gcr.io/debezium/postgres:15-alpine</postgres-debezium.container.image>


### PR DESCRIPTION
Closes #7941 

Rollback to 23.9 version as it is the last Oracle 23ai version. Latest image is Oracle 26ai version
