### PR TITLE
Test Artemis ConnectionFactory URL with parameters

### DIFF
--- a/integration-tests/jms-artemis-client/src/main/java/org/apache/camel/quarkus/component/jms/artemis/it/JmsArtemisResource.java
+++ b/integration-tests/jms-artemis-client/src/main/java/org/apache/camel/quarkus/component/jms/artemis/it/JmsArtemisResource.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.quarkus.component.jms.artemis.it;
 
+import io.quarkus.arc.ClientProxy;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.jms.ConnectionFactory;
@@ -24,11 +25,13 @@ import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelExecutionException;
 import org.apache.camel.Produce;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.support.CamelContextHelper;
 
 @ApplicationScoped
 @Path("/messaging/jms/artemis")
@@ -50,7 +53,16 @@ public class JmsArtemisResource {
     @Path("/connection/factory")
     @Produces(MediaType.TEXT_PLAIN)
     public String connectionFactoryImplementation() {
-        return connectionFactory.getClass().getName();
+        return ClientProxy.unwrap(connectionFactory).getClass().getName();
+    }
+
+    @GET
+    @Path("/connection/factory/reconnectAttempts")
+    @Produces(MediaType.TEXT_PLAIN)
+    public int connectionFactoryReconnectAttempts() {
+        ConnectionFactory customConnectionFactory = CamelContextHelper.mandatoryLookup(context,
+                "camel-quarkus-custom-connection-factory", ConnectionFactory.class);
+        return ((ActiveMQConnectionFactory) ClientProxy.unwrap(customConnectionFactory)).getReconnectAttempts();
     }
 
     @POST

--- a/integration-tests/jms-artemis-client/src/main/resources/application.properties
+++ b/integration-tests/jms-artemis-client/src/main/resources/application.properties
@@ -18,10 +18,9 @@
 
 quarkus.artemis.devservices.extra-args=--no-autotune --mapped --no-fsync --java-options=-Dbrokerconfig.maxDiskUsage=-1
 
-# Overridden to false via @TestProfile(JmsArtemisDisable.class) for some tests
-# When false, we produce a custom ConnectionFactory via CustomConnectionFactory producer bean
-quarkus.artemis.enabled=true
+# Overridden to true via @TestProfile(JmsArtemisDisable.class) for some tests
+# When true, we produce a custom ConnectionFactory via CustomConnectionFactory producer bean
+artemis.custom.connection-factory.enabled=false
 
-#
 # Only enabled with JmsArtemisPoolingTest
 quarkus.pooled-jms.pooling.enabled=false

--- a/integration-tests/jms-artemis-client/src/test/java/org/apache/camel/quarkus/component/jms/artemis/it/JmsArtemisCustomConnectionFactory.java
+++ b/integration-tests/jms-artemis-client/src/test/java/org/apache/camel/quarkus/component/jms/artemis/it/JmsArtemisCustomConnectionFactory.java
@@ -22,11 +22,12 @@ import java.util.Map;
 
 import io.quarkus.test.junit.QuarkusTestProfile;
 
-public class JmsArtemisDisable implements QuarkusTestProfile {
+public class JmsArtemisCustomConnectionFactory implements QuarkusTestProfile {
     @Override
     public Map<String, String> getConfigOverrides() {
         Map<String, String> props = new HashMap<>();
-        props.put("quarkus.artemis.enabled", "false");
+        props.put("artemis.custom.connection-factory.enabled", "true");
+        props.put("camel.component.jms.connection-factory", "#camel-quarkus-custom-connection-factory");
         return props;
     }
 

--- a/integration-tests/jms-artemis-client/src/test/java/org/apache/camel/quarkus/component/jms/artemis/it/JmsArtemisCustomConnectionFactoryIT.java
+++ b/integration-tests/jms-artemis-client/src/test/java/org/apache/camel/quarkus/component/jms/artemis/it/JmsArtemisCustomConnectionFactoryIT.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.jms.artemis.it;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+class JmsArtemisCustomConnectionFactoryIT extends JmsArtemisCustomConnectionFactory {
+}

--- a/integration-tests/jms-artemis-client/src/test/java/org/apache/camel/quarkus/component/jms/artemis/it/JmsArtemisCustomConnectionFactoryTest.java
+++ b/integration-tests/jms-artemis-client/src/test/java/org/apache/camel/quarkus/component/jms/artemis/it/JmsArtemisCustomConnectionFactoryTest.java
@@ -26,15 +26,16 @@ import org.apache.camel.quarkus.messaging.jms.AbstractJmsMessagingTest;
 import org.apache.camel.quarkus.test.support.activemq.ActiveMQTestResource;
 import org.junit.jupiter.api.Test;
 
+import static org.apache.camel.quarkus.component.jms.artemis.it.CustomConnectionFactory.RECONNECT_ATTEMPTS;
 import static org.hamcrest.Matchers.is;
 
 @QuarkusTest
-@TestProfile(JmsArtemisDisable.class)
+@TestProfile(JmsArtemisCustomConnectionFactory.class)
 @QuarkusTestResource(initArgs = {
         @ResourceArg(name = "modules", value = "quarkus.artemis"),
         @ResourceArg(name = "java-args", value = "-Dbrokerconfig.securityEnabled=false")
 }, value = ActiveMQTestResource.class)
-public class JmsArtemisCustomTest extends AbstractJmsMessagingTest {
+public class JmsArtemisCustomConnectionFactoryTest extends AbstractJmsMessagingTest {
     @Test
     public void connectionFactoryImplementation() {
         RestAssured.get("/messaging/jms/artemis/connection/factory")
@@ -42,4 +43,13 @@ public class JmsArtemisCustomTest extends AbstractJmsMessagingTest {
                 .statusCode(200)
                 .body(is(ActiveMQConnectionFactory.class.getName()));
     }
+
+    @Test
+    public void connectionFactoryReconnectAttemptsConfigured() {
+        RestAssured.get("/messaging/jms/artemis/connection/factory/reconnectAttempts")
+                .then()
+                .statusCode(200)
+                .body(is(String.valueOf(RECONNECT_ATTEMPTS)));
+    }
+
 }

--- a/integration-tests/jms-artemis-client/src/test/java/org/apache/camel/quarkus/component/jms/artemis/it/JmsArtemisTest.java
+++ b/integration-tests/jms-artemis-client/src/test/java/org/apache/camel/quarkus/component/jms/artemis/it/JmsArtemisTest.java
@@ -18,11 +18,11 @@ package org.apache.camel.quarkus.component.jms.artemis.it;
 
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
+import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
 import org.apache.camel.quarkus.messaging.jms.AbstractJmsMessagingTest;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.startsWith;
 
 @QuarkusTest
 class JmsArtemisTest extends AbstractJmsMessagingTest {
@@ -32,7 +32,7 @@ class JmsArtemisTest extends AbstractJmsMessagingTest {
         RestAssured.get("/messaging/jms/artemis/connection/factory")
                 .then()
                 .statusCode(200)
-                .body(startsWith("jakarta.jms.ConnectionFactory"));
+                .body(is(ActiveMQConnectionFactory.class.getName()));
     }
 
     @Test


### PR DESCRIPTION
URLs with parameters require reflective access to the ConnectionFactory methods. So we should have a simple test to check that it works.