### PR TITLE
Enable quarkus-maven-plugin extensions

### DIFF
--- a/poms/build-parent-it/pom.xml
+++ b/poms/build-parent-it/pom.xml
@@ -80,6 +80,7 @@
                     <groupId>${quarkus.platform.group-id}</groupId>
                     <artifactId>quarkus-maven-plugin</artifactId>
                     <version>${quarkus.platform.version}</version>
+                    <extensions>true</extensions>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
There's a [change](https://github.com/Sanne/quarkus/commit/c2bc17e7beb0cd38d6b00aa89409dae88db6c07d) coming in Quarkus 3.31.0 that will log a warning on all `quarkus-maven-plugin:build` executions if extensions are not enabled.