### PR TITLE
Ensure quarkus.datasource.db-kind is configured for otel tests

### DIFF
--- a/integration-tests/opentelemetry/src/main/resources/application.properties
+++ b/integration-tests/opentelemetry/src/main/resources/application.properties
@@ -22,5 +22,6 @@
 quarkus.camel.opentelemetry.exclude-patterns = timer:filtered*
 quarkus.otel.bsp.schedule.delay=1
 quarkus.otel.bsp.export.timeout=5s
+quarkus.datasource.db-kind=postgresql
 quarkus.datasource.jdbc.telemetry=true
 quarkus.datasource.devservices.image-name=${postgres.container.image}

--- a/integration-tests/opentelemetry2/src/main/resources/application.properties
+++ b/integration-tests/opentelemetry2/src/main/resources/application.properties
@@ -17,5 +17,6 @@
 quarkus.camel.opentelemetry2.exclude-patterns = timer*
 quarkus.otel.bsp.schedule.delay=1
 quarkus.otel.bsp.export.timeout=5s
+quarkus.datasource.db-kind=postgresql
 quarkus.datasource.jdbc.telemetry=true
 quarkus.datasource.devservices.image-name=${postgres.container.image}


### PR DESCRIPTION
Partial fix for an [issue](https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/Test.20profile.20adding.20build-time-mismatch-at-runtime.3Dfail/with/560767161) that has appeared on the `quarkus-main` branch.