### PR TITLE
Revert "feat: Promote CSimple extension to stable"

### DIFF
--- a/docs/modules/ROOT/pages/reference/extensions/csimple.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/csimple.adoc
@@ -5,8 +5,8 @@
 :linkattrs:
 :cq-artifact-id: camel-quarkus-csimple
 :cq-native-supported: true
-:cq-status: Stable
-:cq-status-deprecation: Stable
+:cq-status: Preview
+:cq-status-deprecation: Preview
 :cq-description: Compiled Simple language
 :cq-deprecated: false
 :cq-jvm-since: 1.5.0

--- a/extensions/csimple/runtime/pom.xml
+++ b/extensions/csimple/runtime/pom.xml
@@ -33,6 +33,7 @@
     <properties>
         <camel.quarkus.jvmSince>1.5.0</camel.quarkus.jvmSince>
         <camel.quarkus.nativeSince>1.5.0</camel.quarkus.nativeSince>
+        <quarkus.metadata.status>preview</quarkus.metadata.status>
     </properties>
 
     <dependencies>

--- a/extensions/csimple/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/csimple/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,4 +30,4 @@ metadata:
   categories:
   - "integration"
   status:
-  - "stable"
+  - "preview"


### PR DESCRIPTION
Reverts apache/camel-quarkus#8015

Looks like it is not that straightforward. We cannot reliably list all CSimple expressions at build time. It is therefore difficult to ensure the CSimple extension is stable.