### PR TITLE
Avoid importing packages from testcontainers shaded dependencies

### DIFF
--- a/integration-test-groups/azure/azure-storage-datalake/src/test/java/org/apache/camel/quarkus/component/azure/storage/datalake/it/AzureStorageDatalakeTest.java
+++ b/integration-test-groups/azure/azure-storage-datalake/src/test/java/org/apache/camel/quarkus/component/azure/storage/datalake/it/AzureStorageDatalakeTest.java
@@ -34,6 +34,7 @@ import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import org.apache.camel.component.azure.storage.datalake.DataLakeConstants;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.awaitility.Awaitility;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.hamcrest.Matchers;
 import org.jboss.logging.Logger;
@@ -41,7 +42,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.shaded.org.awaitility.Awaitility;
 
 //Disable tests dynamically in beforeEach method, to reflect preferred env name in case they are used (see README.adoc)
 @QuarkusTest

--- a/integration-tests-support/debezium/pom.xml
+++ b/integration-tests-support/debezium/pom.xml
@@ -76,5 +76,9 @@
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/integration-tests-support/debezium/src/test/java/org/apache/camel/quarkus/test/support/debezium/AbstractDebeziumTest.java
+++ b/integration-tests-support/debezium/src/test/java/org/apache/camel/quarkus/test/support/debezium/AbstractDebeziumTest.java
@@ -24,10 +24,10 @@ import java.util.UUID;
 
 import io.restassured.RestAssured;
 import io.restassured.response.Response;
+import org.awaitility.Awaitility;
 import org.hamcrest.Matcher;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.shaded.org.awaitility.Awaitility;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.emptyOrNullString;

--- a/integration-tests/splunk-hec/src/test/java/org/apache/camel/quarkus/component/splunk/hec/it/SplunkHecTest.java
+++ b/integration-tests/splunk-hec/src/test/java/org/apache/camel/quarkus/component/splunk/hec/it/SplunkHecTest.java
@@ -35,7 +35,6 @@ import org.awaitility.Awaitility;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.shaded.org.hamcrest.core.StringContains;
 
 import static org.hamcrest.Matchers.containsString;
 


### PR DESCRIPTION
In preparation for upgrading to Testcontainers 2.x.