### PR TITLE
ci: Upgrade to node 24 test-summary-report action

### DIFF
--- a/.github/actions/test-summary-report/action.yaml
+++ b/.github/actions/test-summary-report/action.yaml
@@ -31,7 +31,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup Node
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@v6
       with:
         node-version: 24
     - name: Install script dependencies


### PR DESCRIPTION
Upgrading to node24 and actions/setup-node@v6

Main changes are for actions/setup-node upgrades are node version and cache mecanism.