### PR TITLE
Add resource bundle sun.security.util.resources.security for kudu

### DIFF
--- a/extensions/kudu/deployment/src/main/java/org/apache/camel/quarkus/component/kudu/deployment/KuduProcessor.java
+++ b/extensions/kudu/deployment/src/main/java/org/apache/camel/quarkus/component/kudu/deployment/KuduProcessor.java
@@ -28,6 +28,7 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBundleBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageSecurityProviderBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
@@ -86,5 +87,10 @@ class KuduProcessor {
     @BuildStep
     RuntimeInitializedClassBuildItem runtimeInitializedClasses() {
         return new RuntimeInitializedClassBuildItem("com.google.protobuf.JavaFeaturesProto");
+    }
+
+    @BuildStep
+    NativeImageResourceBundleBuildItem nativeImageResoourceResourceBundles() {
+        return new NativeImageResourceBundleBuildItem("sun.security.util.resources.security");
     }
 }


### PR DESCRIPTION
Required for JDK25 else you see the following on startup:

```
Caused by: java.util.MissingResourceException: Can't find bundle for base name sun.security.util.resources.security, locale en_US
	at java.base@25.0.1/java.util.ResourceBundle.throwMissingResourceException(ResourceBundle.java:2012)
	at java.base@25.0.1/java.util.ResourceBundle.getBundleImpl(ResourceBundle.java:1664)
	at org.graalvm.nativeimage.builder/com.oracle.svm.core.jdk.localization.substitutions.Target_java_util_ResourceBundle$1.get(Target_java_util_ResourceBundle.java:123)
	at org.graalvm.nativeimage.builder/com.oracle.svm.core.jdk.localization.substitutions.Target_java_util_ResourceBundle$1.get(Target_java_util_ResourceBundle.java:120)
	at org.graalvm.nativeimage.builder/com.oracle.svm.core.MissingRegistrationUtils.runIgnoringMissingRegistrations(MissingRegistrationUtils.java:143)
	at java.base@25.0.1/java.util.ResourceBundle.getBundleImpl(ResourceBundle.java:120)
	at java.base@25.0.1/java.util.ResourceBundle.getBundleImpl(ResourceBundle.java:1529)
	at java.base@25.0.1/java.util.ResourceBundle.getBundle(ResourceBundle.java:848)
	at java.base@25.0.1/java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1724)
	at java.base@25.0.1/sun.security.util.ResourcesMgr.getBundle(ResourcesMgr.java:54)
	at java.base@25.0.1/sun.security.util.ResourcesMgr.getString(ResourcesMgr.java:40)
	at java.base@25.0.1/javax.security.auth.login.LoginContext.invoke(LoginContext.java:749)
	at java.base@25.0.1/javax.security.auth.login.LoginContext.login(LoginContext.java:465)
	at org.apache.kudu.util.SecurityUtil.getSubjectFromTicketCacheOrNull(SecurityUtil.java:117)
	at org.apache.kudu.client.SecurityContext.setupSubject(SecurityContext.java:167)
	at org.apache.kudu.client.SecurityContext.<init>(SecurityContext.java:138)
	... 57 more
```