### PR TITLE
Ensure MasterTest waits for follower process to shut down

### DIFF
--- a/integration-tests/master/src/test/java/org/apache/camel/quarkus/component/master/it/MasterTest.java
+++ b/integration-tests/master/src/test/java/org/apache/camel/quarkus/component/master/it/MasterTest.java
@@ -72,7 +72,7 @@ class MasterTest {
             });
         } finally {
             if (process != null && process.getProcess().isAlive()) {
-                process.getProcess().destroy();
+                quarkusProcessExecutor.destroy();
             }
         }
     }


### PR DESCRIPTION
Fixes a race condition I observed in #8125 Windows testing.