### PR TITLE
Add camel-quarkus-support-httpclient5 to keycloak extension

### DIFF
--- a/extensions/keycloak/deployment/pom.xml
+++ b/extensions/keycloak/deployment/pom.xml
@@ -36,6 +36,10 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-support-httpclient5-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-keycloak</artifactId>
         </dependency>
         <!-- Use Quarkus Keycloak Admin Client deployment extension -->

--- a/extensions/keycloak/runtime/pom.xml
+++ b/extensions/keycloak/runtime/pom.xml
@@ -42,6 +42,10 @@
             <artifactId>camel-quarkus-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-support-httpclient5</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-keycloak</artifactId>
         </dependency>


### PR DESCRIPTION
Required because `httpclient5` is a dependency of the Camel component & I've seen sporadic native build failures related to `BrotliInputStream`.

```
org.apache.camel.quarkus:camel-quarkus-integration-test-keycloak:jar:3.31.0-SNAPSHOT
\- org.apache.camel.quarkus:camel-quarkus-keycloak:jar:3.31.0-SNAPSHOT:compile
   \- org.apache.camel:camel-keycloak:jar:4.17.0:compile
      \- org.apache.httpcomponents.client5:httpclient5:jar:5.5.1:compile
```