### PR TITLE
Remove redundant localstack container PROVIDER_OVERRIDE_CLOUDWATCH environment variable

### DIFF
--- a/integration-tests-support/aws2/src/test/java/org/apache/camel/quarkus/test/support/aws2/Aws2TestResource.java
+++ b/integration-tests-support/aws2/src/test/java/org/apache/camel/quarkus/test/support/aws2/Aws2TestResource.java
@@ -87,7 +87,6 @@ public final class Aws2TestResource implements QuarkusTestResourceLifecycleManag
             LocalStackContainer localstack = new LocalStackContainer(imageName)
                     .withServices(services);
             localstack.withEnv("LS_LOG", localstackLogLevel);
-            localstack.withEnv("PROVIDER_OVERRIDE_CLOUDWATCH", "v1");
             localstack.withEnv("AWS_ACCESS_KEY_ID", "testAccessKeyId"); //has to be longer then `test`, to work on FIPS systems
             localstack.withEnv("AWS_SECRET_ACCESS_KEY", "testSecretKeyId");
             localstack.withLogConsumer(new Slf4jLogConsumer(LOG));


### PR DESCRIPTION
I think this is why #8151 is failing.