### PR TITLE
Fixes #8180 wiremock recording should succeed even if url ends with '/'

### DIFF
--- a/integration-tests-support/wiremock/src/main/java/org/apache/camel/quarkus/test/wiremock/WireMockTestResourceLifecycleManager.java
+++ b/integration-tests-support/wiremock/src/main/java/org/apache/camel/quarkus/test/wiremock/WireMockTestResourceLifecycleManager.java
@@ -59,6 +59,10 @@ public abstract class WireMockTestResourceLifecycleManager implements QuarkusTes
 
             if (isRecordingEnabled()) {
                 String recordTargetBaseUrl = getRecordTargetBaseUrl();
+                //url can not end with slash, that would cause recording to fail
+                recordTargetBaseUrl = (recordTargetBaseUrl != null && recordTargetBaseUrl.endsWith("/"))
+                        ? recordTargetBaseUrl.substring(0, recordTargetBaseUrl.length() - 1) : recordTargetBaseUrl;
+
                 if (recordTargetBaseUrl != null) {
                     LOG.infof("Enabling WireMock recording for %s", recordTargetBaseUrl);
                     server.startRecording(recordSpec()


### PR DESCRIPTION
fixes https://github.com/apache/camel-quarkus/issues/8180

Simple fix which makes use of wiremock recording much easier.

<!-- Uncomment and fill this section if your PR is not trivial
[ ] An issue should be filed for the change unless this is a trivial change (fixing a typo or similar). One issue should ideally be fixed by not more than one commit and the other way round, each commit should fix just one issue, without pulling in other changes.
[ ] Each commit in the pull request should have a meaningful and properly spelled subject line and body. Copying the title of the associated issue is typically enough. Please include the issue number in the commit message prefixed by #.
[ ] The pull request description should explain what the pull request does, how, and why. If the info is available in the associated issue or some other external document, a link is enough.
[ ] Phrases like Fix #<issueNumber> or Fixes #<issueNumber> will auto-close the named issue upon merging the pull request. Using them is typically a good idea.
[ ] Please run mvn process-resources -Pformat (and amend the changes if necessary) before sending the pull request.
[ ] Contributor guide is your good friend: https://camel.apache.org/camel-quarkus/latest/contributor-guide.html
-->