### PR TITLE
Upgrade Quarkus Amazon Services to 3.13.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <cassandra-quarkus.version>1.3.1</cassandra-quarkus.version><!-- This should be in sync with quarkus-platform https://repo1.maven.org/maven2/com/datastax/oss/quarkus/cassandra-quarkus-bom/ -->
         <debezium.version>3.4.0.Final</debezium.version> <!-- This should be in sync with quarkus-platform https://github.com/quarkusio/quarkus-platform-->
         <optaplanner.version>10.0.0</optaplanner.version><!-- This should be in sync with quarkus-platform https://repo1.maven.org/maven2/org/optaplanner/optaplanner-quarkus/ -->
-        <quarkiverse-amazonservices.version>3.12.1</quarkiverse-amazonservices.version><!-- This should be in sync with quarkus-platform https://repo1.maven.org/maven2/io/quarkiverse/amazonservices/quarkus-amazon-services-parent/ -->
+        <quarkiverse-amazonservices.version>3.13.0</quarkiverse-amazonservices.version><!-- This should be in sync with quarkus-platform https://repo1.maven.org/maven2/io/quarkiverse/amazonservices/quarkus-amazon-services-parent/ -->
         <quarkiverse-artemis.version>3.11.1</quarkiverse-artemis.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/artemis/quarkus-artemis-parent/ -->
         <quarkiverse-batik.version>1.1.0</quarkiverse-batik.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/batik/quarkus-batik-parent/ -->
         <quarkiverse-cxf.version>3.30.0</quarkiverse-cxf.version><!-- This should be in sync with quarkus-platform https://repo1.maven.org/maven2/io/quarkiverse/cxf/quarkus-cxf-parent/ -->
@@ -74,8 +74,8 @@
         <antlr3.version>3.5.2</antlr3.version><!-- Spark, Stringtemplate and probably others -->
         <audience-annotations.version>${yetus-audience-annotations-version}</audience-annotations.version>
         <avro.version>1.12.1</avro.version><!-- @sync io.quarkus:quarkus-bom:${quarkus.version} dep:org.apache.avro:avro -->
-        <awssdk.version>2.37.5</awssdk.version><!-- @sync io.quarkiverse.amazonservices:quarkus-amazon-services-parent:${quarkiverse-amazonservices.version} prop:awssdk.version -->
-        <awscrt.version>0.39.4</awscrt.version><!-- @sync software.amazon.awssdk:aws-sdk-java-pom:${awssdk.version} prop:awscrt.version -->
+        <awssdk.version>2.41.6</awssdk.version><!-- @sync io.quarkiverse.amazonservices:quarkus-amazon-services-parent:${quarkiverse-amazonservices.version} prop:awssdk.version -->
+        <awscrt.version>0.40.3</awscrt.version><!-- @sync software.amazon.awssdk:aws-sdk-java-pom:${awssdk.version} prop:awscrt.version -->
         <assertj.version>3.27.6</assertj.version><!-- @sync io.quarkus:quarkus-build-parent:${quarkus.version} prop:assertj.version -->
         <aws-java-sdk.version>1.11.714</aws-java-sdk.version>
         <azure-sdk-bom.version>${azure-sdk-bom-version}</azure-sdk-bom.version>
@@ -258,7 +258,7 @@
         <kafka.container.image>quay.io/strimzi-test-container/test-container:latest-kafka-4.1.0</kafka.container.image>
         <keycloak.container.image>quay.io/keycloak/keycloak:${keycloak.version}</keycloak.container.image>
         <kudu.container.image>mirror.gcr.io/apache/kudu:1.18.0-ubuntu</kudu.container.image>
-        <localstack.container.image>mirror.gcr.io/localstack/localstack:4.9.2</localstack.container.image>
+        <localstack.container.image>mirror.gcr.io/localstack/localstack:latest</localstack.container.image>
         <lra-coordinator.container.image>quay.io/jbosstm/lra-coordinator:7.0.1.Final-3.8.3</lra-coordinator.container.image>
         <minio.container.image>mirror.gcr.io/minio/minio:RELEASE.2025-07-23T15-54-02Z-cpuv1</minio.container.image>
         <mysql.container.image>mirror.gcr.io/mysql:9.5</mysql.container.image>

--- a/poms/bom/src/main/generated/flattened-full-pom.xml
+++ b/poms/bom/src/main/generated/flattened-full-pom.xml
@@ -8229,22 +8229,22 @@
       <dependency>
         <groupId>software.amazon.awssdk</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>endpoints-spi</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <version>2.37.5</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+        <version>2.41.6</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>http-auth-aws</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <version>2.37.5</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+        <version>2.41.6</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>sdk-core</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <version>2.37.5</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+        <version>2.41.6</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk.crt</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>aws-crt</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <version>0.39.4</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+        <version>0.40.3</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
       </dependency>
       <dependency>
         <groupId>software.amazon.kinesis</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
@@ -8988,154 +8988,154 @@
         <version>4.0.28</version><!-- org.apache.groovy:groovy-bom:4.0.28 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>codegen-lite-maven-plugin</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>codegen-lite-maven-plugin</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>codegen-lite</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>codegen-lite</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>codegen-maven-plugin</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>codegen-maven-plugin</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>codegen</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>codegen</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>annotations</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>annotations</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>arns</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>arns</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>json-utils</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>json-utils</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>third-party-jackson-core</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>third-party-jackson-core</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>third-party-jackson-dataformat-cbor</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>third-party-jackson-dataformat-cbor</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>auth</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>auth</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>aws-core</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>aws-core</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>profiles</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>profiles</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>aws-cbor-protocol</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>aws-cbor-protocol</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>aws-json-protocol</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>aws-json-protocol</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>aws-query-protocol</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>aws-query-protocol</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>aws-xml-protocol</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>aws-xml-protocol</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>smithy-rpcv2-protocol</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>smithy-rpcv2-protocol</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>protocol-core</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>protocol-core</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>regions</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>regions</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>checksums-spi</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>checksums-spi</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>checksums</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>checksums</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>http-auth-spi</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>http-auth-spi</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>http-auth</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>http-auth</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>http-auth-aws-crt</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>http-auth-aws-crt</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>http-auth-aws-eventstream</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>http-auth-aws-eventstream</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>identity-spi</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>identity-spi</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>http-client-spi</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>http-client-spi</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>retries</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>retries</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>retries-spi</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>retries-spi</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>apache-client</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>apache-client</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -9144,2099 +9144,2144 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>apache5-client</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5-PREVIEW</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>apache5-client</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>netty-nio-client</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>netty-nio-client</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>url-connection-client</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>url-connection-client</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>utils</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>utils</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>utils-lite</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>utils-lite</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>cloudwatch-metric-publisher</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>cloudwatch-metric-publisher</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>emf-metric-logging-publisher</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>emf-metric-logging-publisher</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>s3-transfer-manager</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>s3-transfer-manager</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>s3-event-notifications</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>s3-event-notifications</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>aws-crt-client</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>aws-crt-client</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>auth-crt</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>auth-crt</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>iam-policy-builder</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>iam-policy-builder</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>acm</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>acm</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>acmpca</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>acmpca</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>amplify</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>amplify</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>apigateway</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>apigateway</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>apigatewaymanagementapi</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>apigatewaymanagementapi</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>apigatewayv2</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>apigatewayv2</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>applicationautoscaling</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>applicationautoscaling</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>applicationdiscovery</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>applicationdiscovery</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>appmesh</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>appmesh</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>appstream</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>appstream</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>appsync</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>appsync</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>athena</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>athena</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>autoscaling</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>autoscaling</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>autoscalingplans</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>autoscalingplans</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>backup</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>backup</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>batch</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>batch</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>budgets</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>budgets</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>chime</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>chime</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>cloud9</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>cloud9</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>clouddirectory</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>clouddirectory</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>cloudformation</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>cloudformation</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>cloudfront</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>cloudfront</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>cloudhsm</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>cloudhsm</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>cloudhsmv2</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>cloudhsmv2</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>cloudsearch</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>cloudsearch</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>cloudsearchdomain</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>cloudsearchdomain</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>cloudtrail</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>cloudtrail</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>cloudwatch</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>cloudwatch</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>cloudwatchevents</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>cloudwatchevents</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>cloudwatchlogs</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>cloudwatchlogs</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>codebuild</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>codebuild</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>codecommit</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>codecommit</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>codedeploy</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>codedeploy</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>codepipeline</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>codepipeline</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>cognitoidentity</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>cognitoidentity</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>cognitoidentityprovider</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>cognitoidentityprovider</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>cognitosync</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>cognitosync</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>comprehend</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>comprehend</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>comprehendmedical</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>comprehendmedical</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>config</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>config</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>connect</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>connect</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>costandusagereport</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>costandusagereport</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>costexplorer</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>costexplorer</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>databasemigration</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>databasemigration</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>datapipeline</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>datapipeline</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>datasync</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>datasync</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>dax</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>dax</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>devicefarm</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>devicefarm</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>directconnect</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>directconnect</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>directory</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>directory</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>dlm</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>dlm</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>docdb</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>docdb</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>dynamodb</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>dynamodb</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>dynamodb-enhanced</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>dynamodb-enhanced</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>ec2</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>ec2</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>ecr</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>ecr</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>ecs</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>ecs</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>efs</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>efs</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>eks</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>eks</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>elasticache</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>elasticache</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>elasticbeanstalk</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>elasticbeanstalk</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>elasticloadbalancing</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>elasticloadbalancing</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>elasticloadbalancingv2</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>elasticloadbalancingv2</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>elasticsearch</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>elasticsearch</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>elastictranscoder</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>emr</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>emr</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>firehose</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>firehose</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>fms</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>fms</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>fsx</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>fsx</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>gamelift</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>gamelift</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>glacier</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>glacier</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>globalaccelerator</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>globalaccelerator</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>glue</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>glue</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>greengrass</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>greengrass</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>guardduty</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>guardduty</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>health</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>health</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>iam</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>iam</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>inspector</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>inspector</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>iot</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>iot</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>iotanalytics</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>iotanalytics</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>iotdataplane</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>iotdataplane</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>iotjobsdataplane</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>iotjobsdataplane</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>kafka</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>kafka</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>kinesis</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>kinesis</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>kinesisanalytics</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>kinesisanalytics</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>kinesisanalyticsv2</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>kinesisanalyticsv2</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>kinesisvideo</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>kinesisvideo</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>kinesisvideoarchivedmedia</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>kinesisvideoarchivedmedia</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>kinesisvideomedia</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>kinesisvideomedia</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>kms</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>kms</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>lambda</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>lambda</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>lexmodelbuilding</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>lexmodelbuilding</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>lexruntime</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>lexruntime</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>licensemanager</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>licensemanager</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>lightsail</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>lightsail</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>machinelearning</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>machinelearning</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>managedblockchain</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>managedblockchain</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>marketplacecommerceanalytics</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>marketplacecommerceanalytics</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>marketplaceentitlement</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>marketplaceentitlement</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>marketplacemetering</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>marketplacemetering</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>mediaconnect</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>mediaconnect</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>mediaconvert</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>mediaconvert</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>medialive</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>medialive</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>mediapackage</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>mediapackage</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>mediapackagevod</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>mediapackagevod</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>mediastore</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>mediastore</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>mediastoredata</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>mediastoredata</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>mediatailor</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>mediatailor</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>migrationhub</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>migrationhub</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>mq</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>mq</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>mturk</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>mturk</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>neptune</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>neptune</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>organizations</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>organizations</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>pi</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>pi</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>pinpoint</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>pinpoint</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>pinpointemail</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>pinpointemail</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>pinpointsmsvoice</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>pinpointsmsvoice</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>polly</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>polly</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>pricing</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>pricing</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>quicksight</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>quicksight</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>ram</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>ram</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>rds</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>rds</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>rdsdata</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>rdsdata</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>redshift</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>redshift</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>rekognition</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>rekognition</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>resourcegroups</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>resourcegroups</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>resourcegroupstaggingapi</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>resourcegroupstaggingapi</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>route53</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>route53</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>route53domains</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>route53domains</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>route53resolver</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>route53resolver</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>s3</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>s3</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>s3control</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>s3control</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>sagemaker</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>sagemaker</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>sagemakerruntime</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>sagemakerruntime</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>secretsmanager</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>secretsmanager</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>securityhub</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>securityhub</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>serverlessapplicationrepository</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>serverlessapplicationrepository</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>servicecatalog</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>servicecatalog</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>servicediscovery</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>servicediscovery</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>ses</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>ses</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>sfn</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>sfn</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>shield</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>shield</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>signer</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>signer</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>snowball</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>snowball</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>sns</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>sns</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>sqs</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>sqs</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>ssm</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>ssm</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>storagegateway</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>storagegateway</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>sts</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>sts</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>support</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>support</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>swf</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>swf</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>textract</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>textract</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>transcribe</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>transcribe</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>transcribestreaming</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>transcribestreaming</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>transfer</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>transfer</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>translate</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>translate</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>waf</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>waf</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>workdocs</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>workdocs</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>workmail</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>workmail</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>workspaces</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>workspaces</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>xray</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>xray</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>groundstation</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>groundstation</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>iotthingsgraph</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>iotthingsgraph</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>iotevents</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>iotevents</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>ioteventsdata</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>ioteventsdata</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>personalizeruntime</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>personalizeruntime</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>personalize</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>personalize</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>personalizeevents</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>personalizeevents</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>servicequotas</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>servicequotas</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>applicationinsights</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>applicationinsights</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>ec2instanceconnect</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>ec2instanceconnect</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>eventbridge</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>eventbridge</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>lakeformation</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>lakeformation</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>forecast</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>forecast</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>forecastquery</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>forecastquery</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>workmailmessageflow</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>workmailmessageflow</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>codestarnotifications</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>codestarnotifications</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>savingsplans</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>savingsplans</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>sso</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>sso</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>ssooidc</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>ssooidc</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>marketplacecatalog</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>marketplacecatalog</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>sesv2</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>sesv2</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>dataexchange</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>dataexchange</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>migrationhubconfig</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>migrationhubconfig</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>connectparticipant</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>connectparticipant</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>wafv2</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>wafv2</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>appconfig</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>appconfig</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>iotsecuretunneling</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>iotsecuretunneling</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>imagebuilder</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>imagebuilder</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>schemas</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>schemas</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>accessanalyzer</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>accessanalyzer</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>computeoptimizer</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>computeoptimizer</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>networkmanager</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>networkmanager</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>kendra</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>kendra</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>frauddetector</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>frauddetector</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>codegurureviewer</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>codegurureviewer</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>codeguruprofiler</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>codeguruprofiler</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>outposts</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>outposts</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>sagemakera2iruntime</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>sagemakera2iruntime</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>ebs</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>ebs</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>kinesisvideosignaling</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>kinesisvideosignaling</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>detective</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>detective</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>codestarconnections</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>codestarconnections</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>synthetics</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>synthetics</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>iotsitewise</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>iotsitewise</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>macie2</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>macie2</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>codeartifact</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>codeartifact</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>ivs</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>ivs</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>braket</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>braket</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>identitystore</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>identitystore</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>appflow</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>appflow</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>redshiftdata</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>redshiftdata</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>ssoadmin</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>ssoadmin</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>timestreamwrite</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>timestreamwrite</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>timestreamquery</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>timestreamquery</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>s3outposts</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>s3outposts</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>metrics-spi</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>metrics-spi</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>databrew</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>databrew</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>servicecatalogappregistry</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>servicecatalogappregistry</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>networkfirewall</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>networkfirewall</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>mwaa</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>mwaa</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>devopsguru</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>devopsguru</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>sagemakerfeaturestoreruntime</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>sagemakerfeaturestoreruntime</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>appintegrations</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>appintegrations</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>ecrpublic</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>ecrpublic</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>amplifybackend</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>amplifybackend</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>connectcontactlens</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>connectcontactlens</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>customerprofiles</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>customerprofiles</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>emrcontainers</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>emrcontainers</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>sagemakeredge</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>sagemakeredge</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>healthlake</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>healthlake</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>auditmanager</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>auditmanager</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>amp</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>amp</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>greengrassv2</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>greengrassv2</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>iotwireless</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>iotwireless</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>iotdeviceadvisor</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>iotdeviceadvisor</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>location</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>location</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>wellarchitected</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>wellarchitected</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>lexruntimev2</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>lexruntimev2</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>lexmodelsv2</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>lexmodelsv2</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>fis</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>fis</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>mgn</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>mgn</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>lookoutequipment</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>lookoutequipment</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>finspacedata</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>finspacedata</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>finspace</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>finspace</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>ssmincidents</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>ssmincidents</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>ssmcontacts</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>ssmcontacts</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>applicationcostprofiler</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>applicationcostprofiler</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>apprunner</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>apprunner</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>proton</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>proton</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>route53recoveryreadiness</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>route53recoveryreadiness</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>route53recoverycontrolconfig</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>route53recoverycontrolconfig</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>route53recoverycluster</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>route53recoverycluster</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>chimesdkmessaging</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>chimesdkmessaging</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>chimesdkidentity</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>chimesdkidentity</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>snowdevicemanagement</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>snowdevicemanagement</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>memorydb</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>memorydb</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>opensearch</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>opensearch</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>kafkaconnect</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>kafkaconnect</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>wisdom</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>wisdom</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>voiceid</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>voiceid</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>account</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>account</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>cloudcontrol</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>cloudcontrol</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>grafana</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>grafana</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>panorama</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>panorama</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>chimesdkmeetings</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>chimesdkmeetings</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>resiliencehub</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>resiliencehub</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>migrationhubstrategy</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>migrationhubstrategy</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>drs</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>drs</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>appconfigdata</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>appconfigdata</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>migrationhubrefactorspaces</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>migrationhubrefactorspaces</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>inspector2</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>inspector2</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>evidently</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>evidently</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>rum</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>rum</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>rbin</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>rbin</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>iottwinmaker</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>iottwinmaker</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>workspacesweb</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>workspacesweb</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>backupgateway</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>backupgateway</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>amplifyuibuilder</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>amplifyuibuilder</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>keyspaces</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>keyspaces</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>billingconductor</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>billingconductor</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>pinpointsmsvoicev2</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>pinpointsmsvoicev2</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>ivschat</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>ivschat</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>chimesdkmediapipelines</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>chimesdkmediapipelines</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>emrserverless</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>emrserverless</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>m2</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>m2</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>connectcampaigns</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>connectcampaigns</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>redshiftserverless</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>redshiftserverless</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>rolesanywhere</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>rolesanywhere</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>licensemanagerusersubscriptions</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>licensemanagerusersubscriptions</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>supportapp</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>supportapp</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>controltower</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>controltower</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>iotfleetwise</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>iotfleetwise</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>migrationhuborchestrator</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>migrationhuborchestrator</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>connectcases</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>connectcases</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>resourceexplorer2</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>resourceexplorer2</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>scheduler</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>scheduler</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>ssmsap</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>ssmsap</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>chimesdkvoice</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>chimesdkvoice</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>oam</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>oam</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>arczonalshift</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>arczonalshift</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>simspaceweaver</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>simspaceweaver</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>securitylake</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>securitylake</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>opensearchserverless</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>opensearchserverless</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>omics</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>omics</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>docdbelastic</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>docdbelastic</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>sagemakergeospatial</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>sagemakergeospatial</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>pipes</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>pipes</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>codecatalyst</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>codecatalyst</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>sagemakermetrics</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>sagemakermetrics</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>kinesisvideowebrtcstorage</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>kinesisvideowebrtcstorage</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>licensemanagerlinuxsubscriptions</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>licensemanagerlinuxsubscriptions</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>kendraranking</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>kendraranking</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>cleanrooms</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>cleanrooms</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>cloudtraildata</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>cloudtraildata</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>imds</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>imds</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>tnb</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>tnb</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>internetmonitor</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>internetmonitor</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>ivsrealtime</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>ivsrealtime</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>vpclattice</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>vpclattice</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>osis</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>osis</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>mediapackagev2</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>mediapackagev2</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>paymentcryptographydata</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>paymentcryptographydata</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>paymentcryptography</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>paymentcryptography</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>codegurusecurity</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>codegurusecurity</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>verifiedpermissions</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>verifiedpermissions</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>appfabric</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>appfabric</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>medicalimaging</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>medicalimaging</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>entityresolution</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>entityresolution</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>managedblockchainquery</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>managedblockchainquery</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>pcaconnectorad</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>pcaconnectorad</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>neptunedata</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>neptunedata</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>bedrockruntime</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>bedrockruntime</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>bedrock</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>bedrock</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>datazone</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>datazone</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>launchwizard</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>launchwizard</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>trustedadvisor</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>trustedadvisor</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>cloudfrontkeyvaluestore</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>cloudfrontkeyvaluestore</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>inspectorscan</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>inspectorscan</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>costoptimizationhub</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>costoptimizationhub</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>repostspace</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>repostspace</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>bcmdataexports</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>bcmdataexports</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>freetier</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>freetier</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>eksauth</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>eksauth</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>workspacesthinclient</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>workspacesthinclient</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>b2bi</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>b2bi</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>bedrockagentruntime</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>bedrockagentruntime</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>qbusiness</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>qbusiness</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>qconnect</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>qconnect</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>bedrockagent</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>bedrockagent</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>cleanroomsml</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>cleanroomsml</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>marketplacedeployment</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>marketplacedeployment</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>marketplaceagreement</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>marketplaceagreement</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>neptunegraph</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>neptunegraph</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>networkmonitor</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>networkmonitor</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>supplychain</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>supplychain</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>artifact</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>artifact</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>chatbot</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>chatbot</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>timestreaminfluxdb</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>timestreaminfluxdb</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>codeconnections</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>codeconnections</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>deadline</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>deadline</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>controlcatalog</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>controlcatalog</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>route53profiles</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>route53profiles</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>mailmanager</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>mailmanager</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>taxsettings</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>taxsettings</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>applicationsignals</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>applicationsignals</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>pcaconnectorscep</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>pcaconnectorscep</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>qapps</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>qapps</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>ssmquicksetup</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>ssmquicksetup</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>pcs</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>pcs</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>directoryservicedata</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>directoryservicedata</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>marketplacereporting</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>marketplacereporting</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>socialmessaging</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>socialmessaging</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>geoplaces</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>geoplaces</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>geomaps</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>geomaps</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>georoutes</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>georoutes</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>billing</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>billing</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>partnercentralselling</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>partnercentralselling</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>connectcampaignsv2</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>connectcampaignsv2</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>notifications</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>notifications</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>notificationscontacts</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>notificationscontacts</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>bcmpricingcalculator</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>bcmpricingcalculator</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>observabilityadmin</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>observabilityadmin</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>securityir</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>securityir</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>invoicing</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>invoicing</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>networkflowmonitor</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>networkflowmonitor</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>s3tables</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>s3tables</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>dsql</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>dsql</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>bedrockdataautomationruntime</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>bedrockdataautomationruntime</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>bedrockdataautomation</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>bedrockdataautomation</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>backupsearch</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>backupsearch</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>iotmanagedintegrations</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>iotmanagedintegrations</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>gameliftstreams</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>gameliftstreams</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>ssmguiconnect</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>ssmguiconnect</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>evs</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>evs</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>mpa</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>mpa</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>aiops</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>aiops</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>workspacesinstances</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>workspacesinstances</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>keyspacesstreams</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>keyspacesstreams</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>odb</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>odb</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>s3vectors</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>s3vectors</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>bedrockagentcore</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>bedrockagentcore</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>bedrockagentcorecontrol</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>bedrockagentcorecontrol</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>arcregionswitch</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>arcregionswitch</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>bcmrecommendedactions</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>bcmrecommendedactions</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>bcmdashboards</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>bcmdashboards</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>rtbfabric</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>rtbfabric</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>mwaaserverless</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
+      </dependency>
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>signin</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
+      </dependency>
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>partnercentralchannel</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
+      </dependency>
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>computeoptimizerautomation</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
+      </dependency>
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>sagemakerruntimehttp2</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
+      </dependency>
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>partnercentralaccount</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
+      </dependency>
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>route53globalresolver</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
+      </dependency>
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>partnercentralbenefits</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
+      </dependency>
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>novaact</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
+      </dependency>
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>wickr</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
         <groupId>org.apache.qpid</groupId><!-- org.amqphub.quarkus:quarkus-qpid-jms-bom:2.10.0 -->

--- a/poms/bom/src/main/generated/flattened-reduced-pom.xml
+++ b/poms/bom/src/main/generated/flattened-reduced-pom.xml
@@ -8102,22 +8102,22 @@
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>endpoints-spi</artifactId>
-        <version>2.37.5</version>
+        <version>2.41.6</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>http-auth-aws</artifactId>
-        <version>2.37.5</version>
+        <version>2.41.6</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>sdk-core</artifactId>
-        <version>2.37.5</version>
+        <version>2.41.6</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk.crt</groupId>
         <artifactId>aws-crt</artifactId>
-        <version>0.39.4</version>
+        <version>0.40.3</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.kinesis</groupId>
@@ -8723,122 +8723,127 @@
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>annotations</artifactId>
-        <version>2.37.5</version>
+        <version>2.41.6</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>arns</artifactId>
-        <version>2.37.5</version>
+        <version>2.41.6</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>json-utils</artifactId>
-        <version>2.37.5</version>
+        <version>2.41.6</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>third-party-jackson-core</artifactId>
-        <version>2.37.5</version>
+        <version>2.41.6</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>third-party-jackson-dataformat-cbor</artifactId>
-        <version>2.37.5</version>
+        <version>2.41.6</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>auth</artifactId>
-        <version>2.37.5</version>
+        <version>2.41.6</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>aws-core</artifactId>
-        <version>2.37.5</version>
+        <version>2.41.6</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>profiles</artifactId>
-        <version>2.37.5</version>
+        <version>2.41.6</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>aws-cbor-protocol</artifactId>
-        <version>2.37.5</version>
+        <version>2.41.6</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>aws-json-protocol</artifactId>
-        <version>2.37.5</version>
+        <version>2.41.6</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>aws-query-protocol</artifactId>
-        <version>2.37.5</version>
+        <version>2.41.6</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>aws-xml-protocol</artifactId>
-        <version>2.37.5</version>
+        <version>2.41.6</version>
+      </dependency>
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>smithy-rpcv2-protocol</artifactId>
+        <version>2.41.6</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>protocol-core</artifactId>
-        <version>2.37.5</version>
+        <version>2.41.6</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>regions</artifactId>
-        <version>2.37.5</version>
+        <version>2.41.6</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>checksums-spi</artifactId>
-        <version>2.37.5</version>
+        <version>2.41.6</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>checksums</artifactId>
-        <version>2.37.5</version>
+        <version>2.41.6</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>http-auth-spi</artifactId>
-        <version>2.37.5</version>
+        <version>2.41.6</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>http-auth</artifactId>
-        <version>2.37.5</version>
+        <version>2.41.6</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>http-auth-aws-eventstream</artifactId>
-        <version>2.37.5</version>
+        <version>2.41.6</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>identity-spi</artifactId>
-        <version>2.37.5</version>
+        <version>2.41.6</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>http-client-spi</artifactId>
-        <version>2.37.5</version>
+        <version>2.41.6</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>retries</artifactId>
-        <version>2.37.5</version>
+        <version>2.41.6</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>retries-spi</artifactId>
-        <version>2.37.5</version>
+        <version>2.41.6</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>apache-client</artifactId>
-        <version>2.37.5</version>
+        <version>2.41.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -8849,167 +8854,167 @@
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>netty-nio-client</artifactId>
-        <version>2.37.5</version>
+        <version>2.41.6</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>url-connection-client</artifactId>
-        <version>2.37.5</version>
+        <version>2.41.6</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>utils</artifactId>
-        <version>2.37.5</version>
+        <version>2.41.6</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>utils-lite</artifactId>
-        <version>2.37.5</version>
+        <version>2.41.6</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>athena</artifactId>
-        <version>2.37.5</version>
+        <version>2.41.6</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>cloudtrail</artifactId>
-        <version>2.37.5</version>
+        <version>2.41.6</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>cloudwatch</artifactId>
-        <version>2.37.5</version>
+        <version>2.41.6</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>dynamodb</artifactId>
-        <version>2.37.5</version>
+        <version>2.41.6</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>dynamodb-enhanced</artifactId>
-        <version>2.37.5</version>
+        <version>2.41.6</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>ec2</artifactId>
-        <version>2.37.5</version>
+        <version>2.41.6</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>ecs</artifactId>
-        <version>2.37.5</version>
+        <version>2.41.6</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>eks</artifactId>
-        <version>2.37.5</version>
+        <version>2.41.6</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>firehose</artifactId>
-        <version>2.37.5</version>
+        <version>2.41.6</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>glue</artifactId>
-        <version>2.37.5</version>
+        <version>2.41.6</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>iam</artifactId>
-        <version>2.37.5</version>
+        <version>2.41.6</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>kafka</artifactId>
-        <version>2.37.5</version>
+        <version>2.41.6</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>kinesis</artifactId>
-        <version>2.37.5</version>
+        <version>2.41.6</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>kms</artifactId>
-        <version>2.37.5</version>
+        <version>2.41.6</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>lambda</artifactId>
-        <version>2.37.5</version>
+        <version>2.41.6</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>mq</artifactId>
-        <version>2.37.5</version>
+        <version>2.41.6</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>s3</artifactId>
-        <version>2.37.5</version>
+        <version>2.41.6</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>secretsmanager</artifactId>
-        <version>2.37.5</version>
+        <version>2.41.6</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>ses</artifactId>
-        <version>2.37.5</version>
+        <version>2.41.6</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>sns</artifactId>
-        <version>2.37.5</version>
+        <version>2.41.6</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>sqs</artifactId>
-        <version>2.37.5</version>
+        <version>2.41.6</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>sts</artifactId>
-        <version>2.37.5</version>
+        <version>2.41.6</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>translate</artifactId>
-        <version>2.37.5</version>
+        <version>2.41.6</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>eventbridge</artifactId>
-        <version>2.37.5</version>
+        <version>2.41.6</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>metrics-spi</artifactId>
-        <version>2.37.5</version>
+        <version>2.41.6</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>bedrockruntime</artifactId>
-        <version>2.37.5</version>
+        <version>2.41.6</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>bedrock</artifactId>
-        <version>2.37.5</version>
+        <version>2.41.6</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>bedrockagentruntime</artifactId>
-        <version>2.37.5</version>
+        <version>2.41.6</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>bedrockagent</artifactId>
-        <version>2.37.5</version>
+        <version>2.41.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.qpid</groupId>

--- a/poms/bom/src/main/generated/flattened-reduced-verbose-pom.xml
+++ b/poms/bom/src/main/generated/flattened-reduced-verbose-pom.xml
@@ -8102,22 +8102,22 @@
       <dependency>
         <groupId>software.amazon.awssdk</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>endpoints-spi</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <version>2.37.5</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+        <version>2.41.6</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>http-auth-aws</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <version>2.37.5</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+        <version>2.41.6</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>sdk-core</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <version>2.37.5</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+        <version>2.41.6</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk.crt</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>aws-crt</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <version>0.39.4</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+        <version>0.40.3</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
       </dependency>
       <dependency>
         <groupId>software.amazon.kinesis</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
@@ -8721,124 +8721,129 @@
         <version>4.0.28</version><!-- org.apache.groovy:groovy-bom:4.0.28 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>annotations</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>annotations</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>arns</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>arns</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>json-utils</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>json-utils</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>third-party-jackson-core</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>third-party-jackson-core</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>third-party-jackson-dataformat-cbor</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>third-party-jackson-dataformat-cbor</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>auth</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>auth</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>aws-core</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>aws-core</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>profiles</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>profiles</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>aws-cbor-protocol</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>aws-cbor-protocol</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>aws-json-protocol</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>aws-json-protocol</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>aws-query-protocol</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>aws-query-protocol</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>aws-xml-protocol</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>aws-xml-protocol</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>protocol-core</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>smithy-rpcv2-protocol</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>regions</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>protocol-core</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>checksums-spi</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>regions</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>checksums</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>checksums-spi</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>http-auth-spi</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>checksums</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>http-auth</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>http-auth-spi</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>http-auth-aws-eventstream</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>http-auth</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>identity-spi</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>http-auth-aws-eventstream</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>http-client-spi</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>identity-spi</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>retries</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>http-client-spi</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>retries-spi</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>retries</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>apache-client</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>retries-spi</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
+      </dependency>
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>apache-client</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -8847,169 +8852,169 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>netty-nio-client</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>netty-nio-client</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>url-connection-client</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>url-connection-client</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>utils</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>utils</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>utils-lite</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>utils-lite</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>athena</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>athena</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>cloudtrail</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>cloudtrail</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>cloudwatch</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>cloudwatch</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>dynamodb</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>dynamodb</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>dynamodb-enhanced</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>dynamodb-enhanced</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>ec2</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>ec2</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>ecs</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>ecs</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>eks</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>eks</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>firehose</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>firehose</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>glue</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>glue</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>iam</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>iam</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>kafka</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>kafka</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>kinesis</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>kinesis</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>kms</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>kms</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>lambda</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>lambda</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>mq</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>mq</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>s3</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>s3</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>secretsmanager</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>secretsmanager</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>ses</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>ses</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>sns</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>sns</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>sqs</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>sqs</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>sts</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>sts</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>translate</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>translate</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>eventbridge</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>eventbridge</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>metrics-spi</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>metrics-spi</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>bedrockruntime</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>bedrockruntime</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>bedrock</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>bedrock</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>bedrockagentruntime</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>bedrockagentruntime</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
-        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <artifactId>bedrockagent</artifactId><!-- software.amazon.awssdk:bom:2.37.5 -->
-        <version>2.37.5</version><!-- software.amazon.awssdk:bom:2.37.5 -->
+        <groupId>software.amazon.awssdk</groupId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <artifactId>bedrockagent</artifactId><!-- software.amazon.awssdk:bom:2.41.6 -->
+        <version>2.41.6</version><!-- software.amazon.awssdk:bom:2.41.6 -->
       </dependency>
       <dependency>
         <groupId>org.apache.qpid</groupId><!-- org.amqphub.quarkus:quarkus-qpid-jms-bom:2.10.0 -->


### PR DESCRIPTION
This needs a (hopefully) temporary switch to `localstack:latest` for CloudWatch tests due to https://github.com/localstack/localstack/issues/13028.

If folks think it's not a good idea to use `latest`, then I'll disable the problem tests.