### PR TITLE
Remove redundant quarkus-development-mode-spi from camel-quarkus-core

### DIFF
--- a/extensions-core/core/runtime/pom.xml
+++ b/extensions-core/core/runtime/pom.xml
@@ -43,10 +43,6 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc</artifactId>
         </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-development-mode-spi</artifactId>
-        </dependency>
 
         <dependency>
             <groupId>org.apache.camel</groupId>


### PR DESCRIPTION
Seems it was originally added when upgrading to an ancient Quarkus Alpha release.