### PR TITLE
Move from deprecated StrimziKafkaContainer to StrimziKafkaCluster

### DIFF
--- a/integration-tests-support/kafka/src/main/java/org/apache/camel/quarkus/test/support/kafka/KafkaTestResource.java
+++ b/integration-tests-support/kafka/src/main/java/org/apache/camel/quarkus/test/support/kafka/KafkaTestResource.java
@@ -16,33 +16,39 @@
  */
 package org.apache.camel.quarkus.test.support.kafka;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.function.Function;
 
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
-import io.strimzi.test.container.StrimziKafkaContainer;
+import io.strimzi.test.container.StrimziKafkaCluster;
 import org.eclipse.microprofile.config.ConfigProvider;
+import org.testcontainers.containers.GenericContainer;
 
 public class KafkaTestResource implements QuarkusTestResourceLifecycleManager {
     protected static final String KAFKA_IMAGE_NAME = ConfigProvider.getConfig().getValue("kafka.container.image", String.class);
-    private StrimziKafkaContainer container;
+    private StrimziKafkaCluster container;
 
     @Override
     public Map<String, String> start() {
         try {
-            start(name -> new StrimziKafkaContainer(name));
+            start(name -> new StrimziKafkaCluster.StrimziKafkaClusterBuilder()
+                    .withNumberOfBrokers(1)
+                    .build());
             return Collections.singletonMap("camel.component.kafka.brokers", container.getBootstrapServers());
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
 
-    public String start(Function<String, StrimziKafkaContainer> containerSupplier) {
+    public String start(Function<String, StrimziKafkaCluster> containerSupplier) {
         container = containerSupplier.apply(KAFKA_IMAGE_NAME);
-        container.withLogConsumer(frame -> System.out.print(frame.getUtf8String()))
-                .waitForRunning()
-                .start();
+        Collection<GenericContainer<?>> nodes = container.getNodes();
+        for (GenericContainer<?> genericContainer : nodes) {
+            genericContainer.withLogConsumer(frame -> System.out.print(frame.getUtf8String()));
+        }
+        container.start();
         return container.getBootstrapServers();
     }
 
@@ -60,7 +66,7 @@ public class KafkaTestResource implements QuarkusTestResourceLifecycleManager {
     @Override
     public void inject(TestInjector testInjector) {
         testInjector.injectIntoFields(container,
-                new TestInjector.AnnotatedAndMatchesType(InjectKafka.class, StrimziKafkaContainer.class));
+                new TestInjector.AnnotatedAndMatchesType(InjectKafka.class, StrimziKafkaCluster.class));
     }
 
 }

--- a/integration-tests/kafka/src/test/java/org/apache/camel/quarkus/component/kafka/it/CamelKafkaHealthCheckTest.java
+++ b/integration-tests/kafka/src/test/java/org/apache/camel/quarkus/component/kafka/it/CamelKafkaHealthCheckTest.java
@@ -21,7 +21,7 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
-import io.strimzi.test.container.StrimziKafkaContainer;
+import io.strimzi.test.container.StrimziKafkaCluster;
 import org.apache.camel.quarkus.test.support.kafka.InjectKafka;
 import org.apache.camel.quarkus.test.support.kafka.KafkaTestResource;
 import org.junit.jupiter.api.Test;
@@ -36,7 +36,7 @@ import static org.hamcrest.Matchers.notNullValue;
 public class CamelKafkaHealthCheckTest {
 
     @InjectKafka
-    StrimziKafkaContainer container;
+    StrimziKafkaCluster container;
 
     @Test
     void testHealthCheck() {


### PR DESCRIPTION
StrimziKafkaContainer has been removed in 0.114.0 which was already released in December 2025 even if not yet upgraded on Quarkus side.

Quarkus side was blocked by https://github.com/strimzi/test-container/issues/175 which is fixed on main branch and should be available in strimzi-test-container 0.115.0 which will let Quarkus the opportunity to upgrade

<!-- Uncomment and fill this section if your PR is not trivial
[ ] An issue should be filed for the change unless this is a trivial change (fixing a typo or similar). One issue should ideally be fixed by not more than one commit and the other way round, each commit should fix just one issue, without pulling in other changes.
[ ] Each commit in the pull request should have a meaningful and properly spelled subject line and body. Copying the title of the associated issue is typically enough. Please include the issue number in the commit message prefixed by #.
[ ] The pull request description should explain what the pull request does, how, and why. If the info is available in the associated issue or some other external document, a link is enough.
[ ] Phrases like Fix #<issueNumber> or Fixes #<issueNumber> will auto-close the named issue upon merging the pull request. Using them is typically a good idea.
[ ] Please run mvn process-resources -Pformat (and amend the changes if necessary) before sending the pull request.
[ ] Contributor guide is your good friend: https://camel.apache.org/camel-quarkus/latest/contributor-guide.html
-->