### PR TITLE
chore: Minor code quality cleanups and modernizations in core runtime

### DIFF
--- a/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/FastTypeConverter.java
+++ b/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/FastTypeConverter.java
@@ -29,11 +29,6 @@ public class FastTypeConverter extends DefaultTypeConverter {
     }
 
     @Override
-    protected void doInit() throws Exception {
-        super.doInit();
-    }
-
-    @Override
     public void loadCoreAndFastTypeConverters() throws Exception {
         for (TypeConverterLoader loader : getCamelContext().getRegistry().findByType(TypeConverterLoader.class)) {
             LOG.debug("TypeConverterLoader: {} loading converters", loader);


### PR DESCRIPTION
This PR removes an unnecessary doInit() override in FastTypeConverter that only calls super. 

Based on maintainer feedback, other proposed modernizations (lambdas) have been removed from this PR to avoid potential memory overhead in the Quarkus runtime.