### PR TITLE
chore: Deployment cleanup and modernization

### DIFF
--- a/extensions-core/core/deployment/src/test/java/org/apache/camel/quarkus/core/deployment/util/PathFilterTest.java
+++ b/extensions-core/core/deployment/src/test/java/org/apache/camel/quarkus/core/deployment/util/PathFilterTest.java
@@ -72,21 +72,22 @@ public class PathFilterTest {
     @Test
     public void pathFilter() {
         PathFilter.Builder builder = new PathFilter.Builder();
-        Stream.of("/foo/bar/*", "moo/mar/*")
-                .forEach(path -> {
-                    if (FileUtil.isWindows()) {
-                        path = path.replace("/", File.pathSeparator);
-                    }
-                    builder.include(path);
-                });
+        List<String> includes = List.of("/foo/bar/*", "moo/mar/*");
+        List<String> excludes = List.of("/foo/baz/*", "moo/maz/*");
 
-        Stream.of("/foo/baz/*", "moo/maz/*")
-                .forEach(path -> {
-                    if (FileUtil.isWindows()) {
-                        path = path.replace("/", File.pathSeparator);
-                    }
-                    builder.exclude(path);
-                });
+        for (String path : includes) {
+            if (FileUtil.isWindows()) {
+                path = path.replace("/", File.pathSeparator);
+            }
+            builder.include(path);
+        }
+
+        for (String path : excludes) {
+            if (FileUtil.isWindows()) {
+                path = path.replace("/", File.pathSeparator);
+            }
+            builder.exclude(path);
+        }
 
         Predicate<Path> predicate = builder
                 .include("/foo/bar/*")


### PR DESCRIPTION
This PR introduces code cleanup in the core deployment module.

**Changes:**
- **CamelNativeImageProcessor.java**: Extracted complex filter logic into a helper method `shouldRegisterConverter`.
- **PathFilterTest.java**: Simplified test logic to reduce code duplication.