### PR TITLE
chore: formatting and list modernization

### DIFF
--- a/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/CamelConfig.java
+++ b/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/CamelConfig.java
@@ -278,7 +278,7 @@ public interface CamelConfig {
          *
          * @asciidoclet
          */
-        Optional<List<String>> includePatterns();
+        public Optional<List<String>> includePatterns();
 
         /**
          * If `true`, basic classes are registered for serialization; otherwise basic classes won't be registered automatically


### PR DESCRIPTION
I was browsing through the core extension code and noticed a few spots where we could tidy things up a bit.
Here is what I changed this time:

- PathFilterTest.java: Swapped a bunch of `Arrays.asList` calls to `List.of.` It makes the test setup a little less verbose and uses the modern immutable lists.

- CamelConfig.java: Dropped a redundant `public` modifier from an interface method just to align with the rest of the file.