### PR TITLE
Run JFR tests only if the JDK supports it

### DIFF
--- a/integration-tests/jfr/src/test/java/org/apache/camel/quarkus/component/jfr/it/JfrTest.java
+++ b/integration-tests/jfr/src/test/java/org/apache/camel/quarkus/component/jfr/it/JfrTest.java
@@ -17,19 +17,29 @@
 package org.apache.camel.quarkus.component.jfr.it;
 
 import java.io.File;
+import java.io.IOException;
+import java.text.ParseException;
 
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
+import jdk.jfr.Configuration;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 @QuarkusTest
 @QuarkusTestResource(JfrTestResource.class)
 class JfrTest {
+
+    @BeforeEach
+    public void beforeEach() {
+        assumeTrue(isFlightRecorderAvailable(), "Flight recorder is not available");
+    }
 
     @Test
     public void testflightRecorderRecording() {
@@ -43,5 +53,14 @@ class JfrTest {
 
         String fileName = recordings[0];
         assertTrue(fileName.matches("camel-recording[0-9]+\\.jfr"));
+    }
+
+    static boolean isFlightRecorderAvailable() {
+        try {
+            Configuration.getConfiguration("default");
+            return true;
+        } catch (IOException | ParseException e) {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
Relates to https://github.com/apache/camel-quarkus/pull/8257. Seems the Semeru releases available with the `setup-java` action do not support JFR. You get `Flight Recorder is not supported on this VM`.