### PR TITLE
Further modernization of core deployment and tests

### DIFF
--- a/extensions-core/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/CamelNativeImageProcessor.java
+++ b/extensions-core/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/CamelNativeImageProcessor.java
@@ -183,7 +183,7 @@ public class CamelNativeImageProcessor {
                 .forEach(service -> {
 
                     String packageName = getPackageName(service.type);
-                    String jsonPath = String.format("META-INF/%s/%s.json", packageName.replace('.', '/'), service.name);
+                    String jsonPath = "META-INF/%s/%s.json".formatted(packageName.replace('.', '/'), service.name);
 
                     if (runtimeCatalog.components()
                             && service.path.startsWith(DefaultComponentResolver.RESOURCE_PATH)) {

--- a/extensions-core/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/ConsumeProcessor.java
+++ b/extensions-core/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/ConsumeProcessor.java
@@ -17,9 +17,7 @@
 package org.apache.camel.quarkus.core.deployment;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
@@ -72,7 +70,7 @@ public class ConsumeProcessor {
      * Based on https://docs.jboss.org/cdi/spec/2.0/cdi-spec.html#builtin_scopes
      * the list is not 100% complete, but hopefully it will suffice for our purposes
      */
-    public static final Set<DotName> BEAN_DEFINING_ANNOTATIONS = new HashSet<DotName>(Arrays.asList(
+    public static final Set<DotName> BEAN_DEFINING_ANNOTATIONS = Set.of(
             DotName.createSimple(ApplicationScoped.class.getName()),
             DotName.createSimple(SessionScoped.class.getName()),
             DotName.createSimple(ConversationScoped.class.getName()),
@@ -80,7 +78,7 @@ public class ConsumeProcessor {
             DotName.createSimple(Interceptor.class.getName()),
             DotName.createSimple(Decorator.class.getName()),
             DotName.createSimple(Dependent.class.getName()),
-            DotName.createSimple(Singleton.class.getName())));
+            DotName.createSimple(Singleton.class.getName()));
 
     @BuildStep
     void annotationsTransformers(

--- a/extensions-core/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/spi/CamelServicePatternBuildItem.java
+++ b/extensions-core/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/spi/CamelServicePatternBuildItem.java
@@ -16,10 +16,7 @@
  */
 package org.apache.camel.quarkus.core.deployment.spi;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 
 import io.quarkus.builder.item.MultiBuildItem;
@@ -34,13 +31,13 @@ public final class CamelServicePatternBuildItem extends MultiBuildItem {
     private final List<String> patterns;
 
     public CamelServicePatternBuildItem(CamelServiceDestination destination, boolean include, String... patterns) {
-        this(destination, include, Arrays.asList(patterns));
+        this(destination, include, List.of(patterns));
     }
 
     public CamelServicePatternBuildItem(CamelServiceDestination destination, boolean include, Collection<String> patterns) {
         this.destination = destination;
         this.include = include;
-        this.patterns = Collections.unmodifiableList(new ArrayList<>(patterns));
+        this.patterns = List.copyOf(patterns);
     }
 
     /**

--- a/extensions-core/core/deployment/src/test/java/org/apache/camel/quarkus/core/deployment/main/CamelMainUnknownArgumentWarnTest.java
+++ b/extensions-core/core/deployment/src/test/java/org/apache/camel/quarkus/core/deployment/main/CamelMainUnknownArgumentWarnTest.java
@@ -63,7 +63,7 @@ public class CamelMainUnknownArgumentWarnTest {
 
             String consoleContent = sysout.toString();
             assertTrue(consoleContent
-                    .contains("Unknown option: -foo bar " + String.format("%s...", StringHelper.limitLength(longArg, 97))));
+                    .contains("Unknown option: -foo bar " + "%s...".formatted(StringHelper.limitLength(longArg, 97))));
             assertTrue(consoleContent.contains("Apache Camel Runner takes the following options"));
         } catch (IOException e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
This PR continues the modernisation effort across the core deployment module and associated test files. it adopts Java 17 features like `List.of()`, `Set.of()`, and `String.formatted()` for better consistency.
Key changes:

- Switched to `List.of()` and the more modern `List.copyOf()` in CamelServicePatternBuildItem.
- Modernised ConsumeProcessor to use `Set.of()` for bean annotations.
- Adopted `String.formatted()` in both CamelNativeImageProcessor and test classes.
- Verified all changes pass `check-format` and core deployment unit tests.