### PR TITLE
chore: replace string concatenation with parameterized logging

### DIFF
--- a/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/main/CamelMain.java
+++ b/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/main/CamelMain.java
@@ -145,7 +145,7 @@ public final class CamelMain extends MainCommandLineSupport implements HasCamelC
                     camelTemplate = null;
                 }
             } catch (Exception e) {
-                LOG.debug("Error stopping camelTemplate due " + e.getMessage() + ". This exception is ignored.", e);
+                LOG.debug("Error stopping camelTemplate due {}. This exception is ignored.", e.getMessage(), e);
             }
 
             beforeStop();


### PR DESCRIPTION
This is a minor cleanup PR to improve logging efficiency and readability. I've replaced string concatenation with SLF4J-style parameterized logging (using `{}`).

This approach is preferred as it avoids the overhead of constructing the long log string if the debug/info level isn't actually enabled at runtime. It also helps keep the logging style consistent across the codebase.
Verified that the logging output remains exactly the same!