### PR TITLE
Fix #8252: Remove incorrect maven-artifact exclusion causing Debezium…

### DIFF
--- a/extensions-support/debezium/deployment/pom.xml
+++ b/extensions-support/debezium/deployment/pom.xml
@@ -41,12 +41,6 @@
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-support-debezium</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.maven</groupId>
-                    <artifactId>maven-artifact</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
This PR addresses the `ClassNotFoundException: org.apache.maven.artifact.versioning.InvalidVersionSpecificationException` encountered during native compilation of Debezium extensions.

The issue was traced to an incorrect exclusion of `maven-artifact` in the [extensions-support/debezium/deployment/pom.xml](cci:7://file:///Users/sanjana./camel-quarkus/extensions-support/debezium/deployment/pom.xml:0:0-0:0). This exclusion prevented essential Maven versioning classes (required by the Debezium engine at build time) from being available to the Quarkus native image generator.

Changes:
- Removed `<exclusion>` for `maven-artifact` in `camel-quarkus-support-debezium-deployment`.

Verification:
- Performed a JVM build (`mvn clean install`) of Debezium support and connector modules (PostgreSQL and Oracle) to ensure no regressions.
- Ref: #8252