### PR TITLE
Disable Nitrite native integration tests #8246

### DIFF
--- a/integration-tests/nitrite/pom.xml
+++ b/integration-tests/nitrite/pom.xml
@@ -79,6 +79,9 @@
                                     <goal>integration-test</goal>
                                     <goal>verify</goal>
                                 </goals>
+                                <configuration>
+                                    <skipTests>true</skipTests>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>


### PR DESCRIPTION
This PR disables the native integration tests for the `camel-quarkus-nitrite` extension.

As reported in #8246, the native build for Nitrite is currently failing with multiple `NoClassDefFoundError`s. Since the `camel-nitrite` component is deprecated and investigating deep native compilation issues provides low value for a deprecated extension, this PR disables the native test execution to unblock the build.

Fixes #8246