### PR TITLE
chore: modernize List usage and minor style fixes

### DIFF
--- a/extensions/grpc/codegen/src/main/java/org/apache/camel/quarkus/grpc/codegen/CamelQuarkusGrpcCodegenProvider.java
+++ b/extensions/grpc/codegen/src/main/java/org/apache/camel/quarkus/grpc/codegen/CamelQuarkusGrpcCodegenProvider.java
@@ -22,7 +22,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -43,8 +42,6 @@ import io.smallrye.common.cpu.CPU;
 import io.smallrye.common.os.OS;
 import org.eclipse.microprofile.config.Config;
 import org.jboss.logging.Logger;
-
-import static java.util.Arrays.asList;
 
 /**
  * Custom {@link CodeGenProvider} for Camel Quarkus gRPC. Based on the original Quarkus gRPC implementation:
@@ -153,7 +150,7 @@ public class CamelQuarkusGrpcCodegenProvider implements CodeGenProvider {
                     command.add(String.format("-I=%s", escapeWhitespace(protoDir)));
                 }
 
-                command.addAll(asList("--plugin=protoc-gen-grpc=" + executables.grpc,
+                command.addAll(List.of("--plugin=protoc-gen-grpc=" + executables.grpc,
                         "--grpc_out=" + outDir,
                         "--java_out=" + outDir));
                 command.addAll(protoFiles);
@@ -218,7 +215,7 @@ public class CamelQuarkusGrpcCodegenProvider implements CodeGenProvider {
         }
         boolean scanAll = "all".equalsIgnoreCase(scanDependencies);
 
-        List<String> dependenciesToScan = asList(scanDependencies.split(","));
+        List<String> dependenciesToScan = List.of(scanDependencies.split(","));
 
         ApplicationModel appModel = context.applicationModel();
         List<Path> protoFilesFromDependencies = new ArrayList<>();
@@ -263,7 +260,7 @@ public class CamelQuarkusGrpcCodegenProvider implements CodeGenProvider {
         }
 
         boolean scanAll = "all".equals(scanForImports.toLowerCase(Locale.getDefault()));
-        List<String> dependenciesToScan = Arrays.asList(scanForImports.split(","));
+        List<String> dependenciesToScan = List.of(scanForImports.split(","));
 
         Set<String> importDirectories = new HashSet<>();
         ApplicationModel appModel = context.applicationModel();

--- a/extensions/mapstruct/deployment/src/main/java/org/apache/camel/quarkus/component/mapstruct/deployment/MapStructProcessor.java
+++ b/extensions/mapstruct/deployment/src/main/java/org/apache/camel/quarkus/component/mapstruct/deployment/MapStructProcessor.java
@@ -17,7 +17,6 @@
 package org.apache.camel.quarkus.component.mapstruct.deployment;
 
 import java.lang.reflect.Modifier;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -93,7 +92,7 @@ class MapStructProcessor {
 
         if (mapperPackageName.isPresent()) {
             String packages = StringUtils.deleteWhitespace(mapperPackageName.get());
-            mapperPackages.addAll(Arrays.asList(packages.split(",")));
+            mapperPackages.addAll(List.of(packages.split(",")));
         } else {
             // Fallback on auto discovery
             combinedIndex.getIndex()

--- a/extensions/splunk/deployment/src/main/java/org/apache/camel/quarkus/component/splunk/deployment/SplunkProcessor.java
+++ b/extensions/splunk/deployment/src/main/java/org/apache/camel/quarkus/component/splunk/deployment/SplunkProcessor.java
@@ -17,7 +17,6 @@
 package org.apache.camel.quarkus.component.splunk.deployment;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import com.splunk.HttpService;
@@ -71,7 +70,7 @@ class SplunkProcessor {
 
     @BuildStep
     List<ReflectiveClassBuildItem> reflectiveClasses() {
-        return Arrays.asList(ReflectiveClassBuildItem.builder(Index.class.getName()).constructors().build(),
+        return List.of(ReflectiveClassBuildItem.builder(Index.class.getName()).constructors().build(),
                 ReflectiveClassBuildItem.builder(SavedSearch.class.getName()).constructors().build(),
                 ReflectiveClassBuildItem.builder(Input.class.getName()).constructors().build(),
                 ReflectiveClassBuildItem.builder(Service.class.getName()).constructors().build());

--- a/extensions/ssh/deployment/src/main/java/org/apache/camel/quarkus/component/ssh/deployment/SshProcessor.java
+++ b/extensions/ssh/deployment/src/main/java/org/apache/camel/quarkus/component/ssh/deployment/SshProcessor.java
@@ -19,7 +19,7 @@ package org.apache.camel.quarkus.component.ssh.deployment;
 import java.security.KeyFactory;
 import java.security.KeyPairGenerator;
 import java.security.Signature;
-import java.util.Arrays;
+import java.util.List;
 
 import javax.crypto.KeyAgreement;
 import javax.crypto.Mac;
@@ -68,7 +68,7 @@ class SshProcessor {
 
     @BuildStep
     void sessionProxy(BuildProducer<NativeImageProxyDefinitionBuildItem> proxiesProducer) {
-        for (String s : Arrays.asList(
+        for (String s : List.of(
                 SessionListener.class.getName(),
                 ChannelListener.class.getName(),
                 PortForwardingEventListener.class.getName())) {

--- a/integration-test-groups/debezium/mongodb/src/test/java/org/apache/camel/quarkus/component/debezium/common/it/mongodb/DebeziumMongodbTestResource.java
+++ b/integration-test-groups/debezium/mongodb/src/test/java/org/apache/camel/quarkus/component/debezium/common/it/mongodb/DebeziumMongodbTestResource.java
@@ -48,7 +48,7 @@ public class DebeziumMongodbTestResource extends AbstractDebeziumTestResource<Ge
         super(Type.mongodb);
     }
 
-    private final Network net = Network.newNetwork();;
+    private final Network net = Network.newNetwork();
 
     @Override
     protected GenericContainer<?> createContainer() {


### PR DESCRIPTION
I was looking through the codebase and noticed a few places where we could use `List.of` instead of `Arrays.asList` for better consistency and conciseness.

I also spotted a double semicolon in a test file and some unused imports, so I cleaned those up while I was at it.