### PR TITLE
chore: modernize collection usage in multiple extensions

### DIFF
--- a/extensions/aws2-kinesis/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/kinesis/deployment/JakartaEnablement.java
+++ b/extensions/aws2-kinesis/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/kinesis/deployment/JakartaEnablement.java
@@ -17,7 +17,6 @@
 package org.apache.camel.quarkus.component.aws2.kinesis.deployment;
 
 import java.nio.ByteBuffer;
-import java.util.Collections;
 import java.util.Map;
 
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
@@ -69,8 +68,8 @@ public class JakartaEnablement {
             //N.B. we enable only this single transformation of package renames, not the full set of capabilities of Eclipse Transformer;
             //this might need tailoring if the same idea gets applied to a different context.
             ctx = new ActionContextImpl(logger,
-                    new SelectionRuleImpl(logger, Collections.emptyMap(), Collections.emptyMap()),
-                    new SignatureRuleImpl(logger, renames, null, null, null, null, null, Collections.emptyMap()));
+                    new SelectionRuleImpl(logger, Map.of(), Map.of()),
+                    new SignatureRuleImpl(logger, renames, null, null, null, null, null, Map.of()));
         }
 
         byte[] transform(final String name, final byte[] bytes) {

--- a/extensions/csimple/deployment/src/main/java/org/apache/camel/quarkus/component/csimple/deployment/CSimpleProcessor.java
+++ b/extensions/csimple/deployment/src/main/java/org/apache/camel/quarkus/component/csimple/deployment/CSimpleProcessor.java
@@ -25,7 +25,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -264,15 +263,16 @@ class CSimpleProcessor {
                 projectDir.resolve("src/main/java").toFile(),
                 csimpleClassesDir.toFile(),
                 StandardCharsets.UTF_8.name(),
-                Collections.emptyMap(),
+                Map.of(),
                 CamelSupport.COMPILATION_JVM_TARGET,
                 null,
                 null,
-                Collections.emptyList(),
-                Collections.emptyList(),
+
+                List.of(),
+                List.of(),
                 null,
-                Collections.emptySet(),
-                Collections.emptyList(),
+                Set.of(),
+                List.of(),
                 null);
     }
 

--- a/extensions/grpc/deployment/src/main/java/org/apache/camel/quarkus/component/grpc/deployment/GrpcProcessor.java
+++ b/extensions/grpc/deployment/src/main/java/org/apache/camel/quarkus/component/grpc/deployment/GrpcProcessor.java
@@ -18,9 +18,9 @@ package org.apache.camel.quarkus.component.grpc.deployment;
 
 import java.lang.reflect.Modifier;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.google.api.client.json.GenericJson;
@@ -73,7 +73,7 @@ class GrpcProcessor {
 
     @BuildStep
     CamelGrpcServiceExcludesBuildItem camelGrpcServiceExcludes(GrpcBuildTimeConfig config) {
-        return new CamelGrpcServiceExcludesBuildItem(config.serviceExcludes().orElse(Collections.emptySet()));
+        return new CamelGrpcServiceExcludesBuildItem(config.serviceExcludes().orElse(Set.of()));
     }
 
     @BuildStep

--- a/extensions/jira/deployment/src/main/java/org/apache/camel/quarkus/component/jira/deployment/JakartaEnablement.java
+++ b/extensions/jira/deployment/src/main/java/org/apache/camel/quarkus/component/jira/deployment/JakartaEnablement.java
@@ -17,7 +17,6 @@
 package org.apache.camel.quarkus.component.jira.deployment;
 
 import java.nio.ByteBuffer;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -98,8 +97,8 @@ public class JakartaEnablement {
             //N.B. we enable only this single transformation of package renames, not the full set of capabilities of Eclipse Transformer;
             //this might need tailoring if the same idea gets applied to a different context.
             ctx = new ActionContextImpl(logger,
-                    new SelectionRuleImpl(logger, Collections.emptyMap(), Collections.emptyMap()),
-                    new SignatureRuleImpl(logger, renames, null, null, null, null, null, Collections.emptyMap()));
+                    new SelectionRuleImpl(logger, Map.of(), Map.of()),
+                    new SignatureRuleImpl(logger, renames, null, null, null, null, null, Map.of()));
         }
 
         byte[] transform(final String name, final byte[] bytes) {

--- a/extensions/jolokia/deployment/src/main/java/org/apache/camel/quarkus/jolokia/deployment/JolokiaProcessor.java
+++ b/extensions/jolokia/deployment/src/main/java/org/apache/camel/quarkus/jolokia/deployment/JolokiaProcessor.java
@@ -18,7 +18,6 @@ package org.apache.camel.quarkus.jolokia.deployment;
 
 import java.io.IOException;
 import java.nio.file.Files;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.BooleanSupplier;
@@ -224,7 +223,7 @@ public class JolokiaProcessor {
             BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
             BuildProducer<NativeImageResourceBuildItem> nativeImageResource) {
 
-        Set<String> jolokiaServiceIncludes = Collections.singleton("META-INF/jolokia/*");
+        Set<String> jolokiaServiceIncludes = Set.of("META-INF/jolokia/*");
         PathFilter pathFilter = PathFilter.forIncludes(jolokiaServiceIncludes);
 
         Set<ResolvedDependency> jolokiaDependencies = curateOutcome.getApplicationModel()

--- a/extensions/smb/deployment/src/main/java/org/apache/camel/quarkus/component/smb/deployment/JakartaEnablement.java
+++ b/extensions/smb/deployment/src/main/java/org/apache/camel/quarkus/component/smb/deployment/JakartaEnablement.java
@@ -17,7 +17,6 @@
 package org.apache.camel.quarkus.component.smb.deployment;
 
 import java.nio.ByteBuffer;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -78,8 +77,8 @@ public class JakartaEnablement {
             //N.B. we enable only this single transformation of package renames, not the full set of capabilities of Eclipse Transformer;
             //this might need tailoring if the same idea gets applied to a different context.
             ctx = new ActionContextImpl(logger,
-                    new SelectionRuleImpl(logger, Collections.emptyMap(), Collections.emptyMap()),
-                    new SignatureRuleImpl(logger, renames, null, null, null, null, null, Collections.emptyMap()));
+                    new SelectionRuleImpl(logger, Map.of(), Map.of()),
+                    new SignatureRuleImpl(logger, renames, null, null, null, null, null, Map.of()));
         }
 
         byte[] transform(final String name, final byte[] bytes) {

--- a/extensions/xslt/deployment/src/main/java/org/apache/camel/quarkus/component/xslt/deployment/XsltProcessor.java
+++ b/extensions/xslt/deployment/src/main/java/org/apache/camel/quarkus/component/xslt/deployment/XsltProcessor.java
@@ -20,7 +20,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -91,7 +90,7 @@ class XsltProcessor {
         final Set<String> translets = new LinkedHashSet<>();
         try {
             final BuildTimeUriResolver resolver = new BuildTimeUriResolver();
-            for (String uri : config.sources().orElse(Collections.emptyList())) {
+            for (String uri : config.sources().orElse(List.of())) {
                 ResolutionResult resolvedUri = resolver.resolve(uri);
                 uriResolverEntries.produce(resolvedUri.toBuildItem());
 


### PR DESCRIPTION
This PR continues the effort to modernize the codebase by replacing older `Collections` utility methods with their Java 9+ immutable equivalents.

## Changes:
- Replaced Collections.emptyList(), Collections.emptySet(), and Collections.emptyMap() with List.of(), Set.of(), and Map.of().
- Replaced Collections.singleton() with Set.of().
- Removed unused imports in affected files.

## Affected Extensions:

- `camel-quarkus-csimple`
- `camel-quarkus-xslt`
- `camel-quarkus-smb`
- `camel-quarkus-aws2-kinesis`
- `camel-quarkus-jira`
- `camel-quarkus-jolokia`
- `camel-quarkus-grpc`