### PR TITLE
Remove dependency references to log4j-jboss-logmanager

### DIFF
--- a/extensions-support/aws2/runtime/pom.xml
+++ b/extensions-support/aws2/runtime/pom.xml
@@ -50,10 +50,6 @@
             <groupId>org.jboss.logmanager</groupId>
             <artifactId>log4j2-jboss-logmanager</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.jboss.logmanager</groupId>
-            <artifactId>log4j-jboss-logmanager</artifactId>
-        </dependency>
     </dependencies>
 
     <build>

--- a/extensions-support/google-pubsub/runtime/pom.xml
+++ b/extensions-support/google-pubsub/runtime/pom.xml
@@ -51,10 +51,6 @@
             <artifactId>log4j2-jboss-logmanager</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.logmanager</groupId>
-            <artifactId>log4j-jboss-logmanager</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.graalvm.sdk</groupId>
             <artifactId>nativeimage</artifactId>
             <scope>provided</scope>

--- a/extensions/google-bigquery/runtime/pom.xml
+++ b/extensions/google-bigquery/runtime/pom.xml
@@ -61,10 +61,6 @@
             <artifactId>log4j2-jboss-logmanager</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.logmanager</groupId>
-            <artifactId>log4j-jboss-logmanager</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-netty</artifactId>
             <exclusions>

--- a/extensions/google-storage/runtime/pom.xml
+++ b/extensions/google-storage/runtime/pom.xml
@@ -56,10 +56,6 @@
             <groupId>org.jboss.logmanager</groupId>
             <artifactId>log4j2-jboss-logmanager</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.jboss.logmanager</groupId>
-            <artifactId>log4j-jboss-logmanager</artifactId>
-        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/qdrant/runtime/pom.xml
+++ b/extensions/qdrant/runtime/pom.xml
@@ -56,10 +56,6 @@
             <groupId>org.jboss.logmanager</groupId>
             <artifactId>log4j2-jboss-logmanager</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.jboss.logmanager</groupId>
-            <artifactId>log4j-jboss-logmanager</artifactId>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Quarkus will no longer manage this dependency starting from 3.32.0. Thus removing it from the codebase.