### PR TITLE
Refactor: Modernize Stream API usage in AWS2 extensions and Opensearch tests

### DIFF
--- a/extensions/aws2-athena/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/athena/deployment/Aws2AthenaProcessor.java
+++ b/extensions/aws2-athena/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/athena/deployment/Aws2AthenaProcessor.java
@@ -17,7 +17,6 @@
 package org.apache.camel.quarkus.component.aws2.athena.deployment;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -55,7 +54,7 @@ class Aws2AthenaProcessor {
         List<String> knownInterceptorImpls = combinedIndexBuildItem.getIndex()
                 .getAllKnownImplementations(EXECUTION_INTERCEPTOR_NAME)
                 .stream()
-                .map(c -> c.name().toString()).collect(Collectors.toList());
+                .map(c -> c.name().toString()).toList();
 
         reflectiveClasses.produce(
                 ReflectiveClassBuildItem.builder(knownInterceptorImpls.toArray(new String[knownInterceptorImpls.size()]))

--- a/extensions/aws2-cw/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/cw/deployment/Aws2CwProcessor.java
+++ b/extensions/aws2-cw/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/cw/deployment/Aws2CwProcessor.java
@@ -17,7 +17,6 @@
 package org.apache.camel.quarkus.component.aws2.cw.deployment;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -55,7 +54,7 @@ class Aws2CwProcessor {
         List<String> knownInterceptorImpls = combinedIndexBuildItem.getIndex()
                 .getAllKnownImplementations(EXECUTION_INTERCEPTOR_NAME)
                 .stream()
-                .map(c -> c.name().toString()).collect(Collectors.toList());
+                .map(c -> c.name().toString()).toList();
 
         reflectiveClasses.produce(
                 ReflectiveClassBuildItem.builder(knownInterceptorImpls.toArray(new String[knownInterceptorImpls.size()]))

--- a/extensions/aws2-ddb/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/ddb/deployment/Aws2DdbProcessor.java
+++ b/extensions/aws2-ddb/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/ddb/deployment/Aws2DdbProcessor.java
@@ -17,7 +17,6 @@
 package org.apache.camel.quarkus.component.aws2.ddb.deployment;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -56,7 +55,7 @@ class Aws2DdbProcessor {
         List<String> knownInterceptorImpls = combinedIndexBuildItem.getIndex()
                 .getAllKnownImplementations(EXECUTION_INTERCEPTOR_NAME)
                 .stream()
-                .map(c -> c.name().toString()).collect(Collectors.toList());
+                .map(c -> c.name().toString()).toList();
 
         reflectiveClasses.produce(
                 ReflectiveClassBuildItem.builder(knownInterceptorImpls.toArray(new String[knownInterceptorImpls.size()]))

--- a/extensions/aws2-ec2/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/ec2/deployment/Aws2Ec2Processor.java
+++ b/extensions/aws2-ec2/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/ec2/deployment/Aws2Ec2Processor.java
@@ -17,7 +17,6 @@
 package org.apache.camel.quarkus.component.aws2.ec2.deployment;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -55,7 +54,7 @@ class Aws2Ec2Processor {
         List<String> knownInterceptorImpls = combinedIndexBuildItem.getIndex()
                 .getAllKnownImplementations(EXECUTION_INTERCEPTOR_NAME)
                 .stream()
-                .map(c -> c.name().toString()).collect(Collectors.toList());
+                .map(c -> c.name().toString()).toList();
 
         reflectiveClasses.produce(
                 ReflectiveClassBuildItem.builder(knownInterceptorImpls.toArray(new String[knownInterceptorImpls.size()]))

--- a/extensions/aws2-ecs/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/ecs/deployment/Aws2EcsProcessor.java
+++ b/extensions/aws2-ecs/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/ecs/deployment/Aws2EcsProcessor.java
@@ -17,7 +17,6 @@
 package org.apache.camel.quarkus.component.aws2.ecs.deployment;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -54,7 +53,7 @@ class Aws2EcsProcessor {
         List<String> knownInterceptorImpls = combinedIndexBuildItem.getIndex()
                 .getAllKnownImplementations(EXECUTION_INTERCEPTOR_NAME)
                 .stream()
-                .map(c -> c.name().toString()).collect(Collectors.toList());
+                .map(c -> c.name().toString()).toList();
 
         reflectiveClasses.produce(
                 ReflectiveClassBuildItem.builder(knownInterceptorImpls.toArray(new String[knownInterceptorImpls.size()]))

--- a/extensions/aws2-eks/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/eks/deployment/Aws2EksProcessor.java
+++ b/extensions/aws2-eks/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/eks/deployment/Aws2EksProcessor.java
@@ -17,7 +17,6 @@
 package org.apache.camel.quarkus.component.aws2.eks.deployment;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -54,7 +53,7 @@ class Aws2EksProcessor {
         List<String> knownInterceptorImpls = combinedIndexBuildItem.getIndex()
                 .getAllKnownImplementations(EXECUTION_INTERCEPTOR_NAME)
                 .stream()
-                .map(c -> c.name().toString()).collect(Collectors.toList());
+                .map(c -> c.name().toString()).toList();
 
         reflectiveClasses.produce(
                 ReflectiveClassBuildItem.builder(knownInterceptorImpls.toArray(new String[knownInterceptorImpls.size()]))

--- a/extensions/aws2-eventbridge/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/eventbridge/deployment/Aws2EventbridgeProcessor.java
+++ b/extensions/aws2-eventbridge/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/eventbridge/deployment/Aws2EventbridgeProcessor.java
@@ -17,7 +17,6 @@
 package org.apache.camel.quarkus.component.aws2.eventbridge.deployment;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -55,7 +54,7 @@ class Aws2EventbridgeProcessor {
         List<String> knownInterceptorImpls = combinedIndexBuildItem.getIndex()
                 .getAllKnownImplementations(EXECUTION_INTERCEPTOR_NAME)
                 .stream()
-                .map(c -> c.name().toString()).collect(Collectors.toList());
+                .map(c -> c.name().toString()).toList();
 
         reflectiveClasses.produce(
                 ReflectiveClassBuildItem.builder(knownInterceptorImpls.toArray(new String[knownInterceptorImpls.size()]))

--- a/extensions/aws2-iam/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/iam/deployment/Aws2IamProcessor.java
+++ b/extensions/aws2-iam/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/iam/deployment/Aws2IamProcessor.java
@@ -17,7 +17,6 @@
 package org.apache.camel.quarkus.component.aws2.iam.deployment;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -55,7 +54,7 @@ class Aws2IamProcessor {
         List<String> knownInterceptorImpls = combinedIndexBuildItem.getIndex()
                 .getAllKnownImplementations(EXECUTION_INTERCEPTOR_NAME)
                 .stream()
-                .map(c -> c.name().toString()).collect(Collectors.toList());
+                .map(c -> c.name().toString()).toList();
 
         reflectiveClasses.produce(
                 ReflectiveClassBuildItem.builder(knownInterceptorImpls.toArray(new String[knownInterceptorImpls.size()]))

--- a/extensions/aws2-kms/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/kms/deployment/Aws2KmsProcessor.java
+++ b/extensions/aws2-kms/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/kms/deployment/Aws2KmsProcessor.java
@@ -17,7 +17,6 @@
 package org.apache.camel.quarkus.component.aws2.kms.deployment;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -54,7 +53,7 @@ class Aws2KmsProcessor {
         List<String> knownInterceptorImpls = combinedIndexBuildItem.getIndex()
                 .getAllKnownImplementations(EXECUTION_INTERCEPTOR_NAME)
                 .stream()
-                .map(c -> c.name().toString()).collect(Collectors.toList());
+                .map(c -> c.name().toString()).toList();
 
         reflectiveClasses.produce(
                 ReflectiveClassBuildItem.builder(knownInterceptorImpls.toArray(new String[knownInterceptorImpls.size()]))

--- a/extensions/aws2-lambda/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/lambda/deployment/Aws2LambdaProcessor.java
+++ b/extensions/aws2-lambda/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/lambda/deployment/Aws2LambdaProcessor.java
@@ -17,7 +17,6 @@
 package org.apache.camel.quarkus.component.aws2.lambda.deployment;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -55,7 +54,7 @@ class Aws2LambdaProcessor {
         List<String> knownInterceptorImpls = combinedIndexBuildItem.getIndex()
                 .getAllKnownImplementations(EXECUTION_INTERCEPTOR_NAME)
                 .stream()
-                .map(c -> c.name().toString()).collect(Collectors.toList());
+                .map(c -> c.name().toString()).toList();
 
         reflectiveClasses.produce(
                 ReflectiveClassBuildItem.builder(knownInterceptorImpls.toArray(new String[knownInterceptorImpls.size()]))

--- a/extensions/aws2-mq/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/mq/deployment/Aws2MqProcessor.java
+++ b/extensions/aws2-mq/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/mq/deployment/Aws2MqProcessor.java
@@ -17,7 +17,6 @@
 package org.apache.camel.quarkus.component.aws2.mq.deployment;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -54,7 +53,7 @@ class Aws2MqProcessor {
         List<String> knownInterceptorImpls = combinedIndexBuildItem.getIndex()
                 .getAllKnownImplementations(EXECUTION_INTERCEPTOR_NAME)
                 .stream()
-                .map(c -> c.name().toString()).collect(Collectors.toList());
+                .map(c -> c.name().toString()).toList();
 
         reflectiveClasses.produce(
                 ReflectiveClassBuildItem.builder(knownInterceptorImpls.toArray(new String[knownInterceptorImpls.size()]))

--- a/extensions/aws2-msk/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/msk/deployment/Aws2MskProcessor.java
+++ b/extensions/aws2-msk/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/msk/deployment/Aws2MskProcessor.java
@@ -17,7 +17,6 @@
 package org.apache.camel.quarkus.component.aws2.msk.deployment;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -54,7 +53,7 @@ class Aws2MskProcessor {
         List<String> knownInterceptorImpls = combinedIndexBuildItem.getIndex()
                 .getAllKnownImplementations(EXECUTION_INTERCEPTOR_NAME)
                 .stream()
-                .map(c -> c.name().toString()).collect(Collectors.toList());
+                .map(c -> c.name().toString()).toList();
 
         reflectiveClasses.produce(
                 ReflectiveClassBuildItem.builder(knownInterceptorImpls.toArray(new String[knownInterceptorImpls.size()]))

--- a/extensions/aws2-s3/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/s3/deployment/Aws2S3Processor.java
+++ b/extensions/aws2-s3/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/s3/deployment/Aws2S3Processor.java
@@ -17,7 +17,6 @@
 package org.apache.camel.quarkus.component.aws2.s3.deployment;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -56,7 +55,7 @@ class Aws2S3Processor {
         List<String> knownInterceptorImpls = combinedIndexBuildItem.getIndex()
                 .getAllKnownImplementations(EXECUTION_INTERCEPTOR_NAME)
                 .stream()
-                .map(c -> c.name().toString()).collect(Collectors.toList());
+                .map(c -> c.name().toString()).toList();
 
         reflectiveClasses.produce(
                 ReflectiveClassBuildItem.builder(knownInterceptorImpls.toArray(new String[knownInterceptorImpls.size()]))

--- a/extensions/aws2-ses/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/ses/deployment/Aws2SesProcessor.java
+++ b/extensions/aws2-ses/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/ses/deployment/Aws2SesProcessor.java
@@ -17,7 +17,6 @@
 package org.apache.camel.quarkus.component.aws2.ses.deployment;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -54,7 +53,7 @@ class Aws2SesProcessor {
         List<String> knownInterceptorImpls = combinedIndexBuildItem.getIndex()
                 .getAllKnownImplementations(EXECUTION_INTERCEPTOR_NAME)
                 .stream()
-                .map(c -> c.name().toString()).collect(Collectors.toList());
+                .map(c -> c.name().toString()).toList();
 
         reflectiveClasses.produce(
                 ReflectiveClassBuildItem.builder(knownInterceptorImpls.toArray(new String[knownInterceptorImpls.size()]))

--- a/extensions/aws2-sns/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/sns/deployment/Aws2SnsProcessor.java
+++ b/extensions/aws2-sns/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/sns/deployment/Aws2SnsProcessor.java
@@ -17,7 +17,6 @@
 package org.apache.camel.quarkus.component.aws2.sns.deployment;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -56,7 +55,7 @@ class Aws2SnsProcessor {
         List<String> knownInterceptorImpls = combinedIndexBuildItem.getIndex()
                 .getAllKnownImplementations(EXECUTION_INTERCEPTOR_NAME)
                 .stream()
-                .map(c -> c.name().toString()).collect(Collectors.toList());
+                .map(c -> c.name().toString()).toList();
 
         reflectiveClasses.produce(
                 ReflectiveClassBuildItem.builder(knownInterceptorImpls.toArray(new String[knownInterceptorImpls.size()]))

--- a/extensions/aws2-sqs/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/sqs/deployment/Aws2SqsProcessor.java
+++ b/extensions/aws2-sqs/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/sqs/deployment/Aws2SqsProcessor.java
@@ -17,7 +17,6 @@
 package org.apache.camel.quarkus.component.aws2.sqs.deployment;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -55,7 +54,7 @@ class Aws2SqsProcessor {
         List<String> knownInterceptorImpls = combinedIndexBuildItem.getIndex()
                 .getAllKnownImplementations(EXECUTION_INTERCEPTOR_NAME)
                 .stream()
-                .map(c -> c.name().toString()).collect(Collectors.toList());
+                .map(c -> c.name().toString()).toList();
 
         reflectiveClasses.produce(
                 ReflectiveClassBuildItem.builder(knownInterceptorImpls.toArray(new String[knownInterceptorImpls.size()]))

--- a/extensions/aws2-sts/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/sts/deployment/Aws2StsProcessor.java
+++ b/extensions/aws2-sts/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/sts/deployment/Aws2StsProcessor.java
@@ -17,7 +17,6 @@
 package org.apache.camel.quarkus.component.aws2.sts.deployment;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -54,7 +53,7 @@ class Aws2StsProcessor {
         List<String> knownInterceptorImpls = combinedIndexBuildItem.getIndex()
                 .getAllKnownImplementations(EXECUTION_INTERCEPTOR_NAME)
                 .stream()
-                .map(c -> c.name().toString()).collect(Collectors.toList());
+                .map(c -> c.name().toString()).toList();
 
         reflectiveClasses.produce(
                 ReflectiveClassBuildItem.builder(knownInterceptorImpls.toArray(new String[knownInterceptorImpls.size()]))

--- a/extensions/aws2-translate/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/translate/deployment/Aws2TranslateProcessor.java
+++ b/extensions/aws2-translate/deployment/src/main/java/org/apache/camel/quarkus/component/aws2/translate/deployment/Aws2TranslateProcessor.java
@@ -17,7 +17,6 @@
 package org.apache.camel.quarkus.component.aws2.translate.deployment;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -54,7 +53,7 @@ class Aws2TranslateProcessor {
         List<String> knownInterceptorImpls = combinedIndexBuildItem.getIndex()
                 .getAllKnownImplementations(EXECUTION_INTERCEPTOR_NAME)
                 .stream()
-                .map(c -> c.name().toString()).collect(Collectors.toList());
+                .map(c -> c.name().toString()).toList();
 
         reflectiveClasses.produce(
                 ReflectiveClassBuildItem.builder(knownInterceptorImpls.toArray(new String[knownInterceptorImpls.size()]))


### PR DESCRIPTION
This PR modernizes the codebase by adopting cleaner Java Stream API patterns.

**Changes:**
- Replaced `collect(Collectors.toList())` with `.toList()` in `Aws2EksProcessor`, `Aws2AthenaProcessor`, and `Aws2DdbProcessor`.
- Optimized array stream handling in `OpensearchResource` by using `Arrays.stream()` directly.

**Verification:**
- Validated codestyle with `mvn formatter:format impsort:sort`
- Ran `mvn validate`
- Verified local compilation and processed integration tests.