### PR TITLE
Change how CamelQuartzRecorder looks up scheduler beans to account for cases with composite scheduler

### DIFF
--- a/extensions/quartz/runtime/src/main/java/org/apache/camel/quarkus/component/quartz/CamelQuartzRecorder.java
+++ b/extensions/quartz/runtime/src/main/java/org/apache/camel/quarkus/component/quartz/CamelQuartzRecorder.java
@@ -27,8 +27,8 @@ import io.quarkus.quartz.runtime.QuartzSchedulerImpl;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 import jakarta.enterprise.inject.AmbiguousResolutionException;
+import jakarta.enterprise.inject.Any;
 import org.apache.camel.CamelContext;
-import org.apache.camel.Component;
 import org.apache.camel.Ordered;
 import org.apache.camel.VetoCamelContextStartException;
 import org.apache.camel.component.quartz.QuartzComponent;
@@ -90,8 +90,8 @@ public class CamelQuartzRecorder {
                         //Scheduler may be null in several cases, which would cause an exception in traditional autowiring
                         //see https://github.com/quarkusio/quarkus/issues/27929 for more details
                         if (handle.getBean().getBeanClass().equals(QuartzSchedulerImpl.class)) {
-                            Scheduler scheduler = Arc.container().select(QuartzScheduler.class).getHandle().get()
-                                    .getScheduler();
+                            Scheduler scheduler = Arc.container().select(QuartzScheduler.class, Any.Literal.INSTANCE)
+                                    .getHandle().get().getScheduler();
                             if (scheduler != null) {
                                 //scheduler is added only if is not null
                                 foundSchedulers.add(scheduler);


### PR DESCRIPTION
Originally reported as Quarkus issue (https://github.com/quarkusio/quarkus/issues/52629) along with a reproducer. 

EDIT: I can see @and-yyy already created https://github.com/apache/camel-quarkus/issues/8306 here as well :+1: 
Fixes #8306

If there are multiple scheduler implementations, Quarkus allows users to opt into using `CompositeScheduler` ([doc link](https://quarkus.io/guides/scheduler-reference#how-to-use-multiple-scheduler-implementations)).
Side effect of this approach is that all other scheduler implementations are given an additional qualifier to prevent ambig. dependency resolutions in user code.
`CamelQuartzRecorder` is using a dynamic lookup to find all implementations but presumes that they all have the `@Default` (implicitly present if no other qualifier is added) which will no longer hold true.
The workaround is to explicitly add `@Any` qualifier which all CDI beans always have.

Since I have verified this works with the original reproducer, I decided to put it into a PR as well.