### PR TITLE
Fixes (with workaround) hashicorp-vault test running localy. Relates to #7543

### DIFF
--- a/extensions-support/spring/shade/core/pom.xml
+++ b/extensions-support/spring/shade/core/pom.xml
@@ -82,6 +82,33 @@
                     </execution>
                 </executions>
             </plugin>
+            <!--
+                 Workaround for https://github.com/apache/camel-quarkus/issues/7543.
+                 This module produces an artifact that does not include any compiled classes only license files, which causes tests to fail when the empty target/classes directory is detected.
+                 The workaround explicitly loads and installs the license files from the target/license directory.
+            -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>legal-resources</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.basedir}/target/license/</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <classesDirectory>${project.basedir}/target/license</classesDirectory>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/extensions-support/spring/shade/pom.xml
+++ b/extensions-support/spring/shade/pom.xml
@@ -59,6 +59,12 @@
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-core</artifactId>
                 <version>${spring.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.springframework</groupId>
+                        <artifactId>spring-jcl</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.springframework</groupId>

--- a/tooling/enforcer-rules/camel-quarkus-banned-dependencies-spring.xml
+++ b/tooling/enforcer-rules/camel-quarkus-banned-dependencies-spring.xml
@@ -43,6 +43,7 @@
                 <exclude>org.springframework.hateoas:*</exclude>
                 <exclude>org.springframework.integration:*</exclude>
                 <exclude>org.springframework.javaconfig:*</exclude>
+                <exclude>org.springframework.jcl:*</exclude>
                 <exclude>org.springframework.kafka:*</exclude>
                 <exclude>org.springframework.ldap:*</exclude>
                 <exclude>org.springframework.maven:*</exclude>


### PR DESCRIPTION
Workaround for https://github.com/apache/camel-quarkus/issues/7543

 When hashicorp test runs on the system, which contains this module's /target/classes folder, test  fails.
 Reason is explained in the ticket https://github.com/apache/camel-quarkus/issues/7543

 Artifact created by this module does not contain anything (except license) in the target/classes folder.
 Workaround loads and installs  the licences from the different folder (target/license) and therefore does not trigger the Quarkus classloader.

<!-- Uncomment and fill this section if your PR is not trivial
[ ] An issue should be filed for the change unless this is a trivial change (fixing a typo or similar). One issue should ideally be fixed by not more than one commit and the other way round, each commit should fix just one issue, without pulling in other changes.
[ ] Each commit in the pull request should have a meaningful and properly spelled subject line and body. Copying the title of the associated issue is typically enough. Please include the issue number in the commit message prefixed by #.
[ ] The pull request description should explain what the pull request does, how, and why. If the info is available in the associated issue or some other external document, a link is enough.
[ ] Phrases like Fix #<issueNumber> or Fixes #<issueNumber> will auto-close the named issue upon merging the pull request. Using them is typically a good idea.
[ ] Please run mvn process-resources -Pformat (and amend the changes if necessary) before sending the pull request.
[ ] Contributor guide is your good friend: https://camel.apache.org/camel-quarkus/latest/contributor-guide.html
-->