### PR TITLE
Add com.google.cloud:libraries-bom to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,6 +38,7 @@ updates:
       - dependency-name: "io.quarkiverse.*:*"
       # Other third party extensions
       - dependency-name: "com.datastax.oss.quarkus:cassandra-quarkus-bom"
+      - dependency-name: "com.google.cloud:libraries-bom"
       - dependency-name: "com.hazelcast:quarkus-hazelcast-client-bom"
       - dependency-name: "com.squareup.okhttp3:okhttp"
       - dependency-name: "io.debezium:debezium-bom"

--- a/tooling/internal-dependency-management/pom.xml
+++ b/tooling/internal-dependency-management/pom.xml
@@ -35,6 +35,13 @@
     <!-- The following dependencies are defined only to enable Dependabot to auto-update version properties in the root pom.xml. Primarily for things that @sync properties depend on -->
     <dependencies>
         <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>libraries-bom</artifactId>
+            <version>${google-cloud-libraries-bom.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.quarkiverse.amazonservices</groupId>
             <artifactId>quarkus-amazon-services-bom</artifactId>
             <version>${quarkiverse-amazonservices.version}</version>


### PR DESCRIPTION
Note - we can't run ahead of whatever Quarkus Google Cloud services aligns to. So this is mostly to check that our gcloud stuff still works with newer `libraries-bom` releases.