### PR TITLE
docs: small cleanup of extension docs

### DIFF
--- a/docs/modules/ROOT/pages/reference/extensions/jolokia.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/jolokia.adoc
@@ -211,7 +211,7 @@ This can be done via `@Inject CamelQuarkusJolokiaServer` and then invoking the `
 
 a| [[quarkus-camel-jolokia-server-host]]`link:#quarkus-camel-jolokia-server-host[quarkus.camel.jolokia.server.host]`
 
-The host address to which the Jolokia agent HTTP server should bind to.
+The host address to which the Jolokia agent HTTP server should bind.
 When unspecified, the default is localhost for dev and test mode.
 In prod mode the default is to bind to all interfaces at 0.0.0.0.
 | `string`
@@ -219,7 +219,7 @@ In prod mode the default is to bind to all interfaces at 0.0.0.0.
 
 a| [[quarkus-camel-jolokia-server-port]]`link:#quarkus-camel-jolokia-server-port[quarkus.camel.jolokia.server.port]`
 
-The port on which the Jolokia agent HTTP server should listen on.
+The port on which the Jolokia agent HTTP server should listen.
 | `int`
 | `8778`
 

--- a/docs/modules/ROOT/pages/reference/extensions/management.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/management.adoc
@@ -44,7 +44,7 @@ For information on using Managed Beans in Camel, consult the xref:manual::jmx.ad
 [id="extensions-management-usage-enabling-and-disabling-jmx"]
 === Enabling and Disabling JMX
 
-JMX can be enabled or disabled in Camel-Quarkus by any of the following methods:
+JMX can be enabled or disabled in Camel Quarkus by any of the following methods:
 
 . Adding or removing the `camel-quarkus-management` extension.
 . Setting the `camel.main.jmxEnabled` configuration property to a boolean value.

--- a/docs/modules/ROOT/pages/reference/extensions/quartz.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/quartz.adoc
@@ -121,6 +121,6 @@ public QuartzComponent quartzComponent(Scheduler scheduler) {
 }
 ----
 
-Further customization of the Quartz scheduler can be done via various configuration properties. Refer to to the https://quarkus.io/guides/quartz#quartz-configuration-reference[Quarkus Quartz Configuration] guide for more information.
+Further customization of the Quartz scheduler can be done via various configuration properties. Refer to the https://quarkus.io/guides/quartz#quartz-configuration-reference[Quarkus Quartz Configuration] guide for more information.
 
 endif::[]

--- a/docs/modules/ROOT/pages/reference/extensions/xml-io-dsl.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/xml-io-dsl.adoc
@@ -22,7 +22,7 @@ An XML stack for parsing XML route definitions
 [id="extensions-xml-io-dsl-whats-inside"]
 == What's inside
 
-* xref:{cq-camel-components}:others:java-xml-io-dsl.adoc[XML DSL]
+* xref:{cq-camel-components}:others:xml-io-dsl.adoc[XML DSL]
 
 Please refer to the above link for usage and configuration details.
 

--- a/extensions/jolokia/runtime/src/main/java/org/apache/camel/quarkus/jolokia/config/JolokiaRuntimeConfig.java
+++ b/extensions/jolokia/runtime/src/main/java/org/apache/camel/quarkus/jolokia/config/JolokiaRuntimeConfig.java
@@ -68,14 +68,14 @@ public interface JolokiaRuntimeConfig {
         boolean autoStart();
 
         /**
-         * The host address to which the Jolokia agent HTTP server should bind to.
+         * The host address to which the Jolokia agent HTTP server should bind.
          * When unspecified, the default is localhost for dev and test mode.
          * In prod mode the default is to bind to all interfaces at 0.0.0.0.
          */
         Optional<String> host();
 
         /**
-         * The port on which the Jolokia agent HTTP server should listen on.
+         * The port on which the Jolokia agent HTTP server should listen.
          */
         @WithDefault("8778")
         int port();

--- a/extensions/management/runtime/src/main/doc/usage.adoc
+++ b/extensions/management/runtime/src/main/doc/usage.adoc
@@ -2,7 +2,7 @@ For information on using Managed Beans in Camel, consult the xref:manual::jmx.ad
 
 === Enabling and Disabling JMX
 
-JMX can be enabled or disabled in Camel-Quarkus by any of the following methods:
+JMX can be enabled or disabled in Camel Quarkus by any of the following methods:
 
 . Adding or removing the `camel-quarkus-management` extension.
 . Setting the `camel.main.jmxEnabled` configuration property to a boolean value.

--- a/extensions/quartz/runtime/src/main/doc/usage-advanced.adoc
+++ b/extensions/quartz/runtime/src/main/doc/usage-advanced.adoc
@@ -70,4 +70,4 @@ public QuartzComponent quartzComponent(Scheduler scheduler) {
 }
 ----
 
-Further customization of the Quartz scheduler can be done via various configuration properties. Refer to to the https://quarkus.io/guides/quartz#quartz-configuration-reference[Quarkus Quartz Configuration] guide for more information.
+Further customization of the Quartz scheduler can be done via various configuration properties. Refer to the https://quarkus.io/guides/quartz#quartz-configuration-reference[Quarkus Quartz Configuration] guide for more information.

--- a/integration-tests-support/aws2/src/test/java/org/apache/camel/quarkus/test/support/aws2/Service.java
+++ b/integration-tests-support/aws2/src/test/java/org/apache/camel/quarkus/test/support/aws2/Service.java
@@ -38,7 +38,8 @@ public enum Service {
     CLOUDWATCHLOGS("logs"),
     STS("sts"),
     IAM("iam"),
-    KMS("kms");
+    KMS("kms"),
+    TRANSLATE("translate");
 
     private final String serviceName;
 


### PR DESCRIPTION
Just a small set of documentation improvements to improve readability and consistency across the Jolokia, Quartz, and Management extensions. Mostly fixing minor typos and ensuring we use the 'Camel Quarkus' branding consistently throughout.