### PR TITLE
Manage org.apache.groovy:groovy-json in camel-quarkus-bom-test

### DIFF
--- a/poms/bom-test/pom.xml
+++ b/poms/bom-test/pom.xml
@@ -292,6 +292,11 @@
                 <version>${ftpserver.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.apache.groovy</groupId>
+                <artifactId>groovy-json</artifactId>
+                <version>${groovy.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.pdfbox</groupId>
                 <artifactId>pdfbox</artifactId>
                 <version>${pdfbox.version}</version>


### PR DESCRIPTION
Required because in Quarkus 3.34.0, REST Assured is upgraded to 6.x, which depends on Groovy 5.x. CQ currently aligns to Groovy 4.x, so we need to ensure the test classpath does not have mixed versions.