### PR TITLE
Fix spelling & grammar in extension documentation

### DIFF
--- a/docs/modules/ROOT/pages/reference/extensions/bean-validator.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/bean-validator.adoc
@@ -52,7 +52,7 @@ endif::[]
 
 Implementation of this extension leverages the https://quarkus.io/guides/validation[Quarkus Hibernate Validator extension].
 
-Therefore it is not possible to configure the `ValidatorFactory` by Camel's properties (`constraintValidatorFactory`, `messageInterpolator`, `traversableResolver`, `validationProviderResolver` and `validatorFactory`).
+Therefore, it is not possible to configure the `ValidatorFactory` by Camel's properties (`constraintValidatorFactory`, `messageInterpolator`, `traversableResolver`, `validationProviderResolver` and `validatorFactory`).
 
 You can configure the `ValidatorFactory` by the creation of beans which will be injected into the default `ValidatorFactory` (created by Quarkus).
 See the https://quarkus.io/guides/validation#hibernate-validator-extension-and-cdi[Quarkus CDI documentation] for more information.

--- a/docs/modules/ROOT/pages/reference/extensions/debezium-mysql.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/debezium-mysql.adoc
@@ -47,14 +47,14 @@ endif::[]
 
 [id="extensions-debezium-mysql-usage"]
 == Usage
-We cannot add the MySQL JDBC driver as a compile scope dependency of this extension because it is GPL2 licensed and it
+We cannot add the MySQL JDBC driver as a compile scope dependency of this extension because it is GPL2 licensed, and it
 would be against the policy of the Apache Software Foundation.
 
 Therefore, you have to add the dependency to your project yourself, as long as you are able to comply with its license
 terms.
 
 `quarkus-bom` (transitively included by `camel-quarkus-bom` and `quarkus-camel-bom`) manages a version
-of `com.mysql:mysql-connector-j` compatible with Camel Quarkus. So you do not need specify the version of the
+of `com.mysql:mysql-connector-j` compatible with Camel Quarkus. So you do not need to specify the version of the
 driver when importing any of the aforementioned BOMs. The following should be sufficient for Maven:
 
 [source,xml]

--- a/docs/modules/ROOT/pages/reference/extensions/flatpack.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/flatpack.adoc
@@ -59,7 +59,7 @@ For instance, the route below loads the Flatpack mappings from a classpath resou
 from("direct:start").to("flatpack:delim:mappings/simple.pzmap.xml");
 ----
 
-To include this (an possibly other mappings stored in `.pzmap.xml` files under the `mappings` directory) in the native image, you would have to add something like the following to your `application.properties` file:
+To include this (and possibly other mappings stored in `.pzmap.xml` files under the `mappings` directory) in the native image, you would have to add something like the following to your `application.properties` file:
 
 [source,properties]
 ----

--- a/docs/modules/ROOT/pages/reference/extensions/graphql.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/graphql.adoc
@@ -64,7 +64,7 @@ a|icon:lock[title=Fixed at build time] [[quarkus-camel-graphql-query-files]]`lin
 
 A comma separated list of paths to files containing GraphQL queries for use by GraphQL endpoints. Query files that
 only need to be accessible from the classpath should be specified on this property. Paths can either be schemeless
-(E.g graphql/my-query.graphql) or be prefixed with the classpath: URI scheme (E.g
+(E.g. graphql/my-query.graphql) or be prefixed with the classpath: URI scheme (E.g.
 classpath:graphql/my-query.graphql). Other URI schemes are not supported.
 | List of `string`
 | 

--- a/docs/modules/ROOT/pages/reference/extensions/grpc.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/grpc.adoc
@@ -197,7 +197,7 @@ them. This property sets the scope of the dependencies to scan. Applicable value
 a|icon:lock[title=Fixed at build time] [[quarkus-camel-grpc-codegen-scan-for-imports]]`link:#quarkus-camel-grpc-codegen-scan-for-imports[quarkus.camel.grpc.codegen.scan-for-imports]`
 
 Camel Quarkus gRPC code generation can scan dependencies for .proto files that can be imported by protos in this
-applications. Applicable values:
+application. Applicable values:
 
 - _none_ - default - don't scan dependencies
 - a comma separated list of _groupId:artifactId_ coordinates to scan

--- a/docs/modules/ROOT/pages/reference/extensions/infinispan-cluster-service.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/infinispan-cluster-service.adoc
@@ -61,7 +61,7 @@ In other words, messages will be logged every 100ms on a single JVM at a time.
 [id="extensions-infinispan-cluster-service-configuration-infinispan-configuration"]
 ==== Infinispan Configuration
 
-You can configure the Infinispan client with the various `quarkus.camel.cluster.infinispan` configuration options in `application.properties.
+You can configure the Infinispan client with the various `quarkus.camel.cluster.infinispan` configuration options in `application.properties`.
 
 [source,properties]
 ----

--- a/docs/modules/ROOT/pages/reference/extensions/infinispan.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/infinispan.adoc
@@ -61,7 +61,7 @@ More details about these two configuration methods is described below.
 [id="extensions-infinispan-usage-camel-infinispan-component-and-endpoint-configuration"]
 === Camel Infinispan component and endpoint configuration
 
-When using 'pure' Camel Infinispan component and endpoint configuration (I.e where's there's no `quarkus.infinispan-client` configuration set), you *must* disable generation of the default Quarkus Infinispan `RemoteCacheManager` bean by adding the following configuration to `application.properties`.
+When using 'pure' Camel Infinispan component and endpoint configuration (I.e. where's there's no `quarkus.infinispan-client` configuration set), you *must* disable generation of the default Quarkus Infinispan `RemoteCacheManager` bean by adding the following configuration to `application.properties`.
 
 [source,properties]
 ----

--- a/docs/modules/ROOT/pages/reference/extensions/jaxb.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/jaxb.adoc
@@ -51,7 +51,7 @@ endif::[]
 === Native mode `ObjectFactory` instantiation of non-JAXB annotated classes
 
 When performing JAXB marshal operations with a custom `ObjectFactory` to instantiate POJO classes that do not have JAXB annotations,
-you must register those POJO classes for reflection in order for them to be instantiated in native mode. E.g via the `@RegisterForReflection`
+you must register those POJO classes for reflection in order for them to be instantiated in native mode. E.g. via the `@RegisterForReflection`
 annotation or configuration property `quarkus.camel.native.reflection.include-patterns`.
 
 Refer to the xref:user-guide/native-mode.adoc#reflection[Native mode] user guide for more information.

--- a/docs/modules/ROOT/pages/reference/extensions/jdbc.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/jdbc.adoc
@@ -52,7 +52,7 @@ endif::[]
 === Configuring a DataSource
 
 This extension leverages https://quarkus.io/guides/datasource[Quarkus Agroal] for `DataSource` support. Setting up a `DataSource` can be achieved via configuration properties.
-It is recommended that you explicitly name the datasource so that it can be referenced in the JDBC endpoint URI. E.g like `to("jdbc:camel")`.
+It is recommended that you explicitly name the datasource so that it can be referenced in the JDBC endpoint URI. E.g. like `to("jdbc:camel")`.
 
 [source,properties]
 ----

--- a/docs/modules/ROOT/pages/reference/extensions/jfr.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/jfr.adoc
@@ -83,7 +83,7 @@ In native mode, the native executable can be executed as follows.
 
 a| [[quarkus-camel-jfr-startup-recorder-dir]]`link:#quarkus-camel-jfr-startup-recorder-dir[quarkus.camel.jfr.startup-recorder-dir]`
 
-Directory to store the recording. By default the current directory will be used. Use false to turn off saving the
+Directory to store the recording. By default, the current directory will be used. Use false to turn off saving the
 recording to disk.
 | `string`
 | 

--- a/docs/modules/ROOT/pages/reference/extensions/jolokia.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/jolokia.adoc
@@ -196,7 +196,7 @@ Comma separated list of allowed MBean domains used by `CamelJolokiaRestrictor`.
 
 a|icon:lock[title=Fixed at build time] [[quarkus-camel-jolokia-kubernetes-expose-container-port]]`link:#quarkus-camel-jolokia-kubernetes-expose-container-port[quarkus.camel.jolokia.kubernetes.expose-container-port]`
 
-When {@code true} and the quarkus-kubernetes extension is present, a container port named jolokia will
+When `true` and the quarkus-kubernetes extension is present, a container port named jolokia will
 be added to the generated Kubernetes manifests within the container spec ports definition.
 | `boolean`
 | `true`
@@ -211,7 +211,7 @@ This can be done via `@Inject CamelQuarkusJolokiaServer` and then invoking the `
 
 a| [[quarkus-camel-jolokia-server-host]]`link:#quarkus-camel-jolokia-server-host[quarkus.camel.jolokia.server.host]`
 
-The host address to which the Jolokia agent HTTP server should bind to.
+The host address to which the Jolokia agent HTTP server should bind.
 When unspecified, the default is localhost for dev and test mode.
 In prod mode the default is to bind to all interfaces at 0.0.0.0.
 | `string`
@@ -219,7 +219,7 @@ In prod mode the default is to bind to all interfaces at 0.0.0.0.
 
 a| [[quarkus-camel-jolokia-server-port]]`link:#quarkus-camel-jolokia-server-port[quarkus.camel.jolokia.server.port]`
 
-The port on which the Jolokia agent HTTP server should listen on.
+The port on which the Jolokia agent HTTP server should listen.
 | `int`
 | `8778`
 

--- a/docs/modules/ROOT/pages/reference/extensions/jolt.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/jolt.adoc
@@ -59,7 +59,7 @@ For instance, the route below would load the Jolt spec from a classpath resource
 from("direct:start").to("jolt:defaultr.json");
 ----
 
-To include this (an possibly other specs stored in `.json` files) in the native image, you would have to add something like the following to your `application.properties` file:
+To include this (and possibly other specs stored in `.json` files) in the native image, you would have to add something like the following to your `application.properties` file:
 
 [source,properties]
 ----

--- a/docs/modules/ROOT/pages/reference/extensions/jq.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/jq.adoc
@@ -52,7 +52,7 @@ endif::[]
 If you choose to perform JQ transformations that specify the result class as some custom type in native mode,
 then you must register that type for reflection.
 
-E.g via the `@RegisterForReflection`
+E.g. via the `@RegisterForReflection`
 annotation or configuration property `quarkus.camel.native.reflection.include-patterns`. For example:
 
 [source,java]

--- a/docs/modules/ROOT/pages/reference/extensions/jslt.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/jslt.adoc
@@ -67,7 +67,7 @@ For instance, the route below would load the JSLT schema from a classpath resour
 from("direct:start").to("jslt:transformation.json");
 ----
 
-To include this (an possibly other templates stored in `.json` files) in the native image, you would have to add something like the following to your `application.properties` file:
+To include this (and possibly other templates stored in `.json` files) in the native image, you would have to add something like the following to your `application.properties` file:
 
 [source,properties]
 ----

--- a/docs/modules/ROOT/pages/reference/extensions/json-validator.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/json-validator.adoc
@@ -65,7 +65,7 @@ For instance, the route below would load the schema from a classpath resource na
 from("direct:start").to("json-validator:schema.json");
 ----
 
-To include this (an possibly other schemas stored in `.json` files) in the native image, you would have to add something like the following to your `application.properties` file:
+To include this (and possibly other schemas stored in `.json` files) in the native image, you would have to add something like the following to your `application.properties` file:
 
 [source,properties]
 ----

--- a/docs/modules/ROOT/pages/reference/extensions/jsonata.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/jsonata.adoc
@@ -62,7 +62,7 @@ by using the `quarkus.native.resources.includes` property.
 from("direct:start").to("jsonata:spec/expressions.spec");
 ----
 
-To include this (an possibly other specifications stored in `.spec` files) in the native image, you would have to add something like the following to your `application.properties` file:
+To include this (and possibly other specifications stored in `.spec` files) in the native image, you would have to add something like the following to your `application.properties` file:
 
 [source,properties]
 ----

--- a/docs/modules/ROOT/pages/reference/extensions/management.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/management.adoc
@@ -44,7 +44,7 @@ For information on using Managed Beans in Camel, consult the xref:manual::jmx.ad
 [id="extensions-management-usage-enabling-and-disabling-jmx"]
 === Enabling and Disabling JMX
 
-JMX can be enabled or disabled in Camel-Quarkus by any of the following methods:
+JMX can be enabled or disabled in Camel Quarkus by any of the following methods:
 
 . Adding or removing the `camel-quarkus-management` extension.
 . Setting the `camel.main.jmxEnabled` configuration property to a boolean value.

--- a/docs/modules/ROOT/pages/reference/extensions/mock.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/mock.adoc
@@ -106,6 +106,6 @@ public class MockRoute extends RouteBuilder {
 
 Injection of CDI beans (described in Usage) does not work in native mode.
 
-In the native mode the test and the application under test are running in two different processes and it is not possible
+In the native mode the test and the application under test are running in two different processes, and it is not possible
 to share a mock bean between them (see https://quarkus.io/guides/getting-started-testing#native-executable-testing[Quarkus documentation]).
 

--- a/docs/modules/ROOT/pages/reference/extensions/mustache.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/mustache.adoc
@@ -65,7 +65,7 @@ For instance, the route below would load the Mustache template from a classpath 
 from("direct:start").to("mustache://template/simple.mustache");
 ----
 
-To include this (an possibly other templates stored in `.mustache` files) in the native image, you would have to add something like the following to your `application.properties` file:
+To include this (and possibly other templates stored in `.mustache` files) in the native image, you would have to add something like the following to your `application.properties` file:
 
 [source,properties]
 ----

--- a/docs/modules/ROOT/pages/reference/extensions/opentelemetry.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/opentelemetry.adoc
@@ -127,7 +127,8 @@ There is more information about CDI instrumentation in the https://quarkus.io/gu
 a| [[quarkus-camel-opentelemetry-encoding]]`link:#quarkus-camel-opentelemetry-encoding[quarkus.camel.opentelemetry.encoding]`
 
 Sets whether header names need to be encoded. Can be useful in situations where OpenTelemetry propagators potentially
-set header name values in formats that are not compatible with the target system. E.g for JMS where the specification
+set header name values in formats that are not compatible with the target system. E.g. for JMS where the
+specification
 mandates header names are valid Java identifiers.
 | `boolean`
 | `false`
@@ -137,11 +138,11 @@ a| [[quarkus-camel-opentelemetry-exclude-patterns]]`link:#quarkus-camel-opentele
 Sets whether to disable tracing for endpoint URIs or Processor ids that match the given comma separated patterns. The
 pattern can take the following forms:
 
-1. An exact match on the endpoint URI. E.g platform-http:/some/path
+1. An exact match on the endpoint URI. E.g. platform-http:/some/path
 
-2. A wildcard match. E.g platform-http:++*++
+2. A wildcard match. E.g. platform-http:++*++
 
-3. A regular expression matching the endpoint URI. E.g platform-http:/prefix/.++*++
+3. A regular expression matching the endpoint URI. E.g. platform-http:/prefix/.++*++
 | `string`
 | 
 

--- a/docs/modules/ROOT/pages/reference/extensions/opentelemetry2.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/opentelemetry2.adoc
@@ -128,11 +128,11 @@ a| [[quarkus-camel-opentelemetry2-exclude-patterns]]`link:#quarkus-camel-opentel
 Sets whether to disable tracing for endpoint URIs or Processor ids that match the given comma separated patterns. The
 pattern can take the following forms:
 
-1. An exact match on the endpoint URI. E.g platform-http:/some/path
+1. An exact match on the endpoint URI. E.g. platform-http:/some/path
 
-2. A wildcard match. E.g platform-http:++*++
+2. A wildcard match. E.g. platform-http:++*++
 
-3. A regular expression matching the endpoint URI. E.g platform-http:/prefix/.++*++
+3. A regular expression matching the endpoint URI. E.g. platform-http:/prefix/.++*++
 | `string`
 | 
 

--- a/docs/modules/ROOT/pages/reference/extensions/platform-http.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/platform-http.adoc
@@ -141,7 +141,7 @@ https://quarkus.io/guides/all-config#quarkus-vertx-http_quarkus-vertx-http-eclip
 
 Platform HTTP component can act as a reverse proxy, in that case `Exchange.HTTP_URI`, `Exchange.HTTP_HOST` headers are populated from the absolute URL received on the request line of the HTTP request.
 
-Here's an example of a HTTP proxy that simply redirects the Exchange to the origin server.
+Here's an example of an HTTP proxy that simply redirects the Exchange to the origin server.
 
 [source,java]
 ----
@@ -153,7 +153,7 @@ from("platform-http:proxy")
 [id="extensions-platform-http-usage-error-handling"]
 === Error handling
 
-If you need to customize the reponse returned to the client when exceptions are thrown from your routes, then you can use Camel error handling constucts like `doTry`, `doCatch` and `onException`.
+If you need to customize the response returned to the client when exceptions are thrown from your routes, then you can use Camel error handling constructs like `doTry`, `doCatch` and `onException`.
 
 For example, to configure a global exception handler in response to a specific Exception type being thrown.
 

--- a/docs/modules/ROOT/pages/reference/extensions/quartz.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/quartz.adoc
@@ -104,7 +104,7 @@ for `DataSource` support.
 ----
 +
 Also add a Quartz database creation script for your chosen database kind.
-The Quartz project provides ready made scripts that can be copied from https://github.com/quartz-scheduler/quartz/tree/master/quartz-core/src/main/resources/org/quartz/impl/jdbcjobstore[here]. Add the SQL
+The Quartz project provides ready-made scripts that can be copied from https://github.com/quartz-scheduler/quartz/tree/master/quartz-core/src/main/resources/org/quartz/impl/jdbcjobstore[here]. Add the SQL
 script to `src/main/resources/db/migration/V1.0.0__QuarkusQuartz.sql`. Quarkus Flyway will detect it on startup and will proceed to create the Quartz database tables.
 
 4. Configure the Camel Quartz component to use the Quarkus Quartz scheduler.
@@ -121,6 +121,6 @@ public QuartzComponent quartzComponent(Scheduler scheduler) {
 }
 ----
 
-Further customization of the Quartz scheduler can be done via various configuration properties. Refer to to the https://quarkus.io/guides/quartz#quartz-configuration-reference[Quarkus Quartz Configuration] guide for more information.
+Further customization of the Quartz scheduler can be done via various configuration properties. Refer to the https://quarkus.io/guides/quartz#quartz-configuration-reference[Quarkus Quartz Configuration] guide for more information.
 
 endif::[]

--- a/docs/modules/ROOT/pages/reference/extensions/saxon.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/saxon.adoc
@@ -60,7 +60,7 @@ from("direct:start").transform().xquery("resource:classpath:myxquery.txt", Strin
 from("direct:start").to("xquery:another-xquery.txt");
 ----
 
-To include these (an possibly other queries stored in `.txt` files) in the native image, you would have to add something like the following to your `application.properties` file:
+To include these (and possibly other queries stored in `.txt` files) in the native image, you would have to add something like the following to your `application.properties` file:
 
 [source,properties]
 ----

--- a/docs/modules/ROOT/pages/reference/extensions/servlet.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/servlet.adoc
@@ -87,7 +87,7 @@ quarkus.camel.servlet.servlet-name = My Custom Name
 
 *Servlet class*
 
-You may use a custom Servlet class (E.g one that extends `CamelHttpTransportServlet`) in your Camel routes.
+You may use a custom Servlet class (E.g. one that extends `CamelHttpTransportServlet`) in your Camel routes.
 
 [source,properties]
 ----

--- a/docs/modules/ROOT/pages/reference/extensions/smallrye-reactive-messaging.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/smallrye-reactive-messaging.adoc
@@ -46,9 +46,9 @@ Examples for how to use the Camel connector are outlined within the https://www.
 [NOTE]
 ====
 Where the SmallRye Reactive Messaging documentation makes references to Camel component maven dependencies, you should ensure that the corresponding camel-quarkus extension is used.
-E.g `<artifactId>camel-file</artifactId>` should be `<artifactId>camel-quarkus-file</artifactId>`.
+E.g. `<artifactId>camel-file</artifactId>` should be `<artifactId>camel-quarkus-file</artifactId>`.
 
-When using this extension, there is no need to explictly add `io.smallrye.reactive:smallrye-reactive-messaging-camel` or `io.quarkus:quarkus-quarkus-smallrye-reactive-messaging` to your project.
+When using this extension, there is no need to explicitly add `io.smallrye.reactive:smallrye-reactive-messaging-camel` or `io.quarkus:quarkus-quarkus-smallrye-reactive-messaging` to your project.
 ====
 
 

--- a/docs/modules/ROOT/pages/reference/extensions/telemetry-dev.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/telemetry-dev.adoc
@@ -57,11 +57,11 @@ a| [[quarkus-camel-telemetrydev-exclude-patterns]]`link:#quarkus-camel-telemetry
 Sets whether to disable tracing for endpoint URIs or Processor ids that match the given comma separated patterns. The
 pattern can take the following forms:
 
-1. An exact match on the endpoint URI. E.g platform-http:/some/path
+1. An exact match on the endpoint URI. E.g. platform-http:/some/path
 
-2. A wildcard match. E.g platform-http:++*++
+2. A wildcard match. E.g. platform-http:++*++
 
-3. A regular expression matching the endpoint URI. E.g platform-http:/prefix/.++*++
+3. A regular expression matching the endpoint URI. E.g. platform-http:/prefix/.++*++
 | `string`
 | 
 

--- a/docs/modules/ROOT/pages/reference/extensions/velocity.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/velocity.adoc
@@ -81,7 +81,7 @@ For instance, the route below would load the Velocity template from a classpath 
 from("direct:start").to("velocity://template/simple.vm");
 ----
 
-To include this (an possibly other templates stored in `.vm` files in the `template` directory) in the native image, you would have to add something like the following to your `application.properties` file:
+To include this (and possibly other templates stored in `.vm` files in the `template` directory) in the native image, you would have to add something like the following to your `application.properties` file:
 
 [source,properties]
 ----

--- a/docs/modules/ROOT/pages/reference/extensions/vertx-websocket.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/vertx-websocket.adoc
@@ -52,7 +52,7 @@ endif::[]
 [id="extensions-vertx-websocket-usage-vert-x-websocket-consumers"]
 === Vert.x WebSocket consumers
 
-When you create a Vert.x WebSocket consumer (E.g with `from("vertx-websocket")`), the host and port configuration in the URI are redundant since the WebSocket will always be hosted on 
+When you create a Vert.x WebSocket consumer (E.g. with `from("vertx-websocket")`), the host and port configuration in the URI are redundant since the WebSocket will always be hosted on
 the Quarkus HTTP server.
 
 The configuration of the consumer can be simplified to only include the resource path of the WebSocket. For example.
@@ -65,7 +65,7 @@ from("vertx-websocket:/my-websocket-path")
 
 NOTE: While you do not need to explicitly configure the host/port on the vertx-websocket consumer. If you choose to,
 the host & port must exactly match the value of the Quarkus HTTP server configuration values for `quarkus.http.host` and `quarkus.http.port`.
-Otherwise an exception will be thrown at runtime.
+Otherwise, an exception will be thrown at runtime.
 
 [id="extensions-vertx-websocket-usage-vert-x-websocket-producers"]
 === Vert.x WebSocket producers

--- a/docs/modules/ROOT/pages/reference/extensions/xpath.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/xpath.adoc
@@ -59,7 +59,7 @@ For instance, the route below would load an XPath expression from a classpath re
 from("direct:start").transform().xpath("resource:classpath:myxpath.txt");
 ----
 
-To include this (an possibly other expressions stored in `.txt` files) in the native image, you would have to add something like the following to your `application.properties` file:
+To include this (and possibly other expressions stored in `.txt` files) in the native image, you would have to add something like the following to your `application.properties` file:
 
 [source,properties]
 ----

--- a/extensions/bean-validator/runtime/src/main/doc/usage.adoc
+++ b/extensions/bean-validator/runtime/src/main/doc/usage.adoc
@@ -2,7 +2,7 @@
 
 Implementation of this extension leverages the https://quarkus.io/guides/validation[Quarkus Hibernate Validator extension].
 
-Therefore it is not possible to configure the `ValidatorFactory` by Camel's properties (`constraintValidatorFactory`, `messageInterpolator`, `traversableResolver`, `validationProviderResolver` and `validatorFactory`).
+Therefore, it is not possible to configure the `ValidatorFactory` by Camel's properties (`constraintValidatorFactory`, `messageInterpolator`, `traversableResolver`, `validationProviderResolver` and `validatorFactory`).
 
 You can configure the `ValidatorFactory` by the creation of beans which will be injected into the default `ValidatorFactory` (created by Quarkus).
 See the https://quarkus.io/guides/validation#hibernate-validator-extension-and-cdi[Quarkus CDI documentation] for more information.

--- a/extensions/debezium-mysql/runtime/src/main/doc/usage.adoc
+++ b/extensions/debezium-mysql/runtime/src/main/doc/usage.adoc
@@ -1,11 +1,11 @@
-We cannot add the MySQL JDBC driver as a compile scope dependency of this extension because it is GPL2 licensed and it
+We cannot add the MySQL JDBC driver as a compile scope dependency of this extension because it is GPL2 licensed, and it
 would be against the policy of the Apache Software Foundation.
 
 Therefore, you have to add the dependency to your project yourself, as long as you are able to comply with its license
 terms.
 
 `quarkus-bom` (transitively included by `camel-quarkus-bom` and `quarkus-camel-bom`) manages a version
-of `com.mysql:mysql-connector-j` compatible with Camel Quarkus. So you do not need specify the version of the
+of `com.mysql:mysql-connector-j` compatible with Camel Quarkus. So you do not need to specify the version of the
 driver when importing any of the aforementioned BOMs. The following should be sufficient for Maven:
 
 [source,xml]

--- a/extensions/flatpack/runtime/src/main/doc/configuration.adoc
+++ b/extensions/flatpack/runtime/src/main/doc/configuration.adoc
@@ -9,7 +9,7 @@ For instance, the route below loads the Flatpack mappings from a classpath resou
 from("direct:start").to("flatpack:delim:mappings/simple.pzmap.xml");
 ----
 
-To include this (an possibly other mappings stored in `.pzmap.xml` files under the `mappings` directory) in the native image, you would have to add something like the following to your `application.properties` file:
+To include this (and possibly other mappings stored in `.pzmap.xml` files under the `mappings` directory) in the native image, you would have to add something like the following to your `application.properties` file:
 
 [source,properties]
 ----

--- a/extensions/graphql/runtime/src/main/java/org/apache/camel/quarkus/component/graphql/CamelGraphQLConfig.java
+++ b/extensions/graphql/runtime/src/main/java/org/apache/camel/quarkus/component/graphql/CamelGraphQLConfig.java
@@ -29,7 +29,7 @@ public interface CamelGraphQLConfig {
     /**
      * A comma separated list of paths to files containing GraphQL queries for use by GraphQL endpoints. Query files that
      * only need to be accessible from the classpath should be specified on this property. Paths can either be schemeless
-     * (E.g graphql/my-query.graphql) or be prefixed with the classpath: URI scheme (E.g
+     * (E.g. graphql/my-query.graphql) or be prefixed with the classpath: URI scheme (E.g.
      * classpath:graphql/my-query.graphql). Other URI schemes are not supported.
      *
      * @asciidoclet

--- a/extensions/grpc/runtime/src/main/java/org/apache/camel/quarkus/grpc/runtime/GrpcBuildTimeConfig.java
+++ b/extensions/grpc/runtime/src/main/java/org/apache/camel/quarkus/grpc/runtime/GrpcBuildTimeConfig.java
@@ -78,7 +78,7 @@ public interface GrpcBuildTimeConfig {
 
         /**
          * Camel Quarkus gRPC code generation can scan dependencies for .proto files that can be imported by protos in this
-         * applications. Applicable values:
+         * application. Applicable values:
          *
          * - _none_ - default - don't scan dependencies
          * - a comma separated list of _groupId:artifactId_ coordinates to scan

--- a/extensions/infinispan-cluster-service/runtime/src/main/doc/configuration.adoc
+++ b/extensions/infinispan-cluster-service/runtime/src/main/doc/configuration.adoc
@@ -17,7 +17,7 @@ In other words, messages will be logged every 100ms on a single JVM at a time.
 
 ==== Infinispan Configuration
 
-You can configure the Infinispan client with the various `quarkus.camel.cluster.infinispan` configuration options in `application.properties.
+You can configure the Infinispan client with the various `quarkus.camel.cluster.infinispan` configuration options in `application.properties`.
 
 [source,properties]
 ----

--- a/extensions/infinispan/runtime/src/main/doc/usage.adoc
+++ b/extensions/infinispan/runtime/src/main/doc/usage.adoc
@@ -10,7 +10,7 @@ More details about these two configuration methods is described below.
 
 === Camel Infinispan component and endpoint configuration
 
-When using 'pure' Camel Infinispan component and endpoint configuration (I.e where's there's no `quarkus.infinispan-client` configuration set), you *must* disable generation of the default Quarkus Infinispan `RemoteCacheManager` bean by adding the following configuration to `application.properties`.
+When using 'pure' Camel Infinispan component and endpoint configuration (I.e. where's there's no `quarkus.infinispan-client` configuration set), you *must* disable generation of the default Quarkus Infinispan `RemoteCacheManager` bean by adding the following configuration to `application.properties`.
 
 [source,properties]
 ----

--- a/extensions/jaxb/runtime/src/main/doc/usage.adoc
+++ b/extensions/jaxb/runtime/src/main/doc/usage.adoc
@@ -1,7 +1,7 @@
 === Native mode `ObjectFactory` instantiation of non-JAXB annotated classes
 
 When performing JAXB marshal operations with a custom `ObjectFactory` to instantiate POJO classes that do not have JAXB annotations,
-you must register those POJO classes for reflection in order for them to be instantiated in native mode. E.g via the `@RegisterForReflection`
+you must register those POJO classes for reflection in order for them to be instantiated in native mode. E.g. via the `@RegisterForReflection`
 annotation or configuration property `quarkus.camel.native.reflection.include-patterns`.
 
 Refer to the xref:user-guide/native-mode.adoc#reflection[Native mode] user guide for more information.

--- a/extensions/jdbc/runtime/src/main/doc/configuration.adoc
+++ b/extensions/jdbc/runtime/src/main/doc/configuration.adoc
@@ -1,7 +1,7 @@
 === Configuring a DataSource
 
 This extension leverages https://quarkus.io/guides/datasource[Quarkus Agroal] for `DataSource` support. Setting up a `DataSource` can be achieved via configuration properties.
-It is recommended that you explicitly name the datasource so that it can be referenced in the JDBC endpoint URI. E.g like `to("jdbc:camel")`.
+It is recommended that you explicitly name the datasource so that it can be referenced in the JDBC endpoint URI. E.g. like `to("jdbc:camel")`.
 
 [source,properties]
 ----

--- a/extensions/jfr/runtime/src/main/java/org/apache/camel/quarkus/component/jfr/RuntimeCamelJfrConfig.java
+++ b/extensions/jfr/runtime/src/main/java/org/apache/camel/quarkus/component/jfr/RuntimeCamelJfrConfig.java
@@ -27,7 +27,7 @@ import io.smallrye.config.ConfigMapping;
 public interface RuntimeCamelJfrConfig {
 
     /**
-     * Directory to store the recording. By default the current directory will be used. Use false to turn off saving the
+     * Directory to store the recording. By default, the current directory will be used. Use false to turn off saving the
      * recording to disk.
      *
      * @asciidoclet

--- a/extensions/jolokia/runtime/src/main/java/org/apache/camel/quarkus/jolokia/config/JolokiaBuildTimeConfig.java
+++ b/extensions/jolokia/runtime/src/main/java/org/apache/camel/quarkus/jolokia/config/JolokiaBuildTimeConfig.java
@@ -65,7 +65,7 @@ public interface JolokiaBuildTimeConfig {
 
     interface Kubernetes {
         /**
-         * When {@code true} and the quarkus-kubernetes extension is present, a container port named jolokia will
+         * When `true` and the quarkus-kubernetes extension is present, a container port named jolokia will
          * be added to the generated Kubernetes manifests within the container spec ports definition.
          */
         @WithDefault("true")

--- a/extensions/jolokia/runtime/src/main/java/org/apache/camel/quarkus/jolokia/config/JolokiaRuntimeConfig.java
+++ b/extensions/jolokia/runtime/src/main/java/org/apache/camel/quarkus/jolokia/config/JolokiaRuntimeConfig.java
@@ -68,14 +68,14 @@ public interface JolokiaRuntimeConfig {
         boolean autoStart();
 
         /**
-         * The host address to which the Jolokia agent HTTP server should bind to.
+         * The host address to which the Jolokia agent HTTP server should bind.
          * When unspecified, the default is localhost for dev and test mode.
          * In prod mode the default is to bind to all interfaces at 0.0.0.0.
          */
         Optional<String> host();
 
         /**
-         * The port on which the Jolokia agent HTTP server should listen on.
+         * The port on which the Jolokia agent HTTP server should listen.
          */
         @WithDefault("8778")
         int port();

--- a/extensions/jolt/runtime/src/main/doc/configuration.adoc
+++ b/extensions/jolt/runtime/src/main/doc/configuration.adoc
@@ -9,7 +9,7 @@ For instance, the route below would load the Jolt spec from a classpath resource
 from("direct:start").to("jolt:defaultr.json");
 ----
 
-To include this (an possibly other specs stored in `.json` files) in the native image, you would have to add something like the following to your `application.properties` file:
+To include this (and possibly other specs stored in `.json` files) in the native image, you would have to add something like the following to your `application.properties` file:
 
 [source,properties]
 ----

--- a/extensions/jq/runtime/src/main/doc/usage.adoc
+++ b/extensions/jq/runtime/src/main/doc/usage.adoc
@@ -3,7 +3,7 @@
 If you choose to perform JQ transformations that specify the result class as some custom type in native mode,
 then you must register that type for reflection.
 
-E.g via the `@RegisterForReflection`
+E.g. via the `@RegisterForReflection`
 annotation or configuration property `quarkus.camel.native.reflection.include-patterns`. For example:
 
 [source,java]

--- a/extensions/jslt/runtime/src/main/doc/configuration.adoc
+++ b/extensions/jslt/runtime/src/main/doc/configuration.adoc
@@ -11,7 +11,7 @@ For instance, the route below would load the JSLT schema from a classpath resour
 from("direct:start").to("jslt:transformation.json");
 ----
 
-To include this (an possibly other templates stored in `.json` files) in the native image, you would have to add something like the following to your `application.properties` file:
+To include this (and possibly other templates stored in `.json` files) in the native image, you would have to add something like the following to your `application.properties` file:
 
 [source,properties]
 ----

--- a/extensions/json-validator/runtime/src/main/doc/configuration.adoc
+++ b/extensions/json-validator/runtime/src/main/doc/configuration.adoc
@@ -9,7 +9,7 @@ For instance, the route below would load the schema from a classpath resource na
 from("direct:start").to("json-validator:schema.json");
 ----
 
-To include this (an possibly other schemas stored in `.json` files) in the native image, you would have to add something like the following to your `application.properties` file:
+To include this (and possibly other schemas stored in `.json` files) in the native image, you would have to add something like the following to your `application.properties` file:
 
 [source,properties]
 ----

--- a/extensions/jsonata/runtime/src/main/doc/configuration.adoc
+++ b/extensions/jsonata/runtime/src/main/doc/configuration.adoc
@@ -7,7 +7,7 @@ by using the `quarkus.native.resources.includes` property.
 from("direct:start").to("jsonata:spec/expressions.spec");
 ----
 
-To include this (an possibly other specifications stored in `.spec` files) in the native image, you would have to add something like the following to your `application.properties` file:
+To include this (and possibly other specifications stored in `.spec` files) in the native image, you would have to add something like the following to your `application.properties` file:
 
 [source,properties]
 ----

--- a/extensions/management/runtime/src/main/doc/usage.adoc
+++ b/extensions/management/runtime/src/main/doc/usage.adoc
@@ -2,7 +2,7 @@ For information on using Managed Beans in Camel, consult the xref:manual::jmx.ad
 
 === Enabling and Disabling JMX
 
-JMX can be enabled or disabled in Camel-Quarkus by any of the following methods:
+JMX can be enabled or disabled in Camel Quarkus by any of the following methods:
 
 . Adding or removing the `camel-quarkus-management` extension.
 . Setting the `camel.main.jmxEnabled` configuration property to a boolean value.

--- a/extensions/mock/runtime/src/main/doc/limitations.adoc
+++ b/extensions/mock/runtime/src/main/doc/limitations.adoc
@@ -1,4 +1,4 @@
 Injection of CDI beans (described in Usage) does not work in native mode.
 
-In the native mode the test and the application under test are running in two different processes and it is not possible
+In the native mode the test and the application under test are running in two different processes, and it is not possible
 to share a mock bean between them (see https://quarkus.io/guides/getting-started-testing#native-executable-testing[Quarkus documentation]).

--- a/extensions/mustache/runtime/src/main/doc/configuration.adoc
+++ b/extensions/mustache/runtime/src/main/doc/configuration.adoc
@@ -9,7 +9,7 @@ For instance, the route below would load the Mustache template from a classpath 
 from("direct:start").to("mustache://template/simple.mustache");
 ----
 
-To include this (an possibly other templates stored in `.mustache` files) in the native image, you would have to add something like the following to your `application.properties` file:
+To include this (and possibly other templates stored in `.mustache` files) in the native image, you would have to add something like the following to your `application.properties` file:
 
 [source,properties]
 ----

--- a/extensions/opentelemetry/runtime/src/main/java/org/apache/camel/quarkus/component/opentelemetry/CamelOpenTelemetryConfig.java
+++ b/extensions/opentelemetry/runtime/src/main/java/org/apache/camel/quarkus/component/opentelemetry/CamelOpenTelemetryConfig.java
@@ -29,7 +29,8 @@ public interface CamelOpenTelemetryConfig {
 
     /**
      * Sets whether header names need to be encoded. Can be useful in situations where OpenTelemetry propagators potentially
-     * set header name values in formats that are not compatible with the target system. E.g for JMS where the specification
+     * set header name values in formats that are not compatible with the target system. E.g. for JMS where the
+     * specification
      * mandates header names are valid Java identifiers.
      *
      * @asciidoclet
@@ -41,11 +42,11 @@ public interface CamelOpenTelemetryConfig {
      * Sets whether to disable tracing for endpoint URIs or Processor ids that match the given comma separated patterns. The
      * pattern can take the following forms:
      *
-     * 1. An exact match on the endpoint URI. E.g platform-http:/some/path
+     * 1. An exact match on the endpoint URI. E.g. platform-http:/some/path
      *
-     * 2. A wildcard match. E.g platform-http:++*++
+     * 2. A wildcard match. E.g. platform-http:++*++
      *
-     * 3. A regular expression matching the endpoint URI. E.g platform-http:/prefix/.++*++
+     * 3. A regular expression matching the endpoint URI. E.g. platform-http:/prefix/.++*++
      *
      * @asciidoclet
      */

--- a/extensions/opentelemetry2/runtime/src/main/java/org/apache/camel/quarkus/component/opentelemetry2/CamelOpenTelemetry2Config.java
+++ b/extensions/opentelemetry2/runtime/src/main/java/org/apache/camel/quarkus/component/opentelemetry2/CamelOpenTelemetry2Config.java
@@ -30,11 +30,11 @@ public interface CamelOpenTelemetry2Config {
      * Sets whether to disable tracing for endpoint URIs or Processor ids that match the given comma separated patterns. The
      * pattern can take the following forms:
      *
-     * 1. An exact match on the endpoint URI. E.g platform-http:/some/path
+     * 1. An exact match on the endpoint URI. E.g. platform-http:/some/path
      *
-     * 2. A wildcard match. E.g platform-http:++*++
+     * 2. A wildcard match. E.g. platform-http:++*++
      *
-     * 3. A regular expression matching the endpoint URI. E.g platform-http:/prefix/.++*++
+     * 3. A regular expression matching the endpoint URI. E.g. platform-http:/prefix/.++*++
      *
      * @asciidoclet
      */

--- a/extensions/platform-http/runtime/src/main/doc/usage.adoc
+++ b/extensions/platform-http/runtime/src/main/doc/usage.adoc
@@ -84,7 +84,7 @@ https://quarkus.io/guides/all-config#quarkus-vertx-http_quarkus-vertx-http-eclip
 
 Platform HTTP component can act as a reverse proxy, in that case `Exchange.HTTP_URI`, `Exchange.HTTP_HOST` headers are populated from the absolute URL received on the request line of the HTTP request.
 
-Here's an example of a HTTP proxy that simply redirects the Exchange to the origin server.
+Here's an example of an HTTP proxy that simply redirects the Exchange to the origin server.
 
 [source,java]
 ----
@@ -95,7 +95,7 @@ from("platform-http:proxy")
 
 === Error handling
 
-If you need to customize the reponse returned to the client when exceptions are thrown from your routes, then you can use Camel error handling constucts like `doTry`, `doCatch` and `onException`.
+If you need to customize the response returned to the client when exceptions are thrown from your routes, then you can use Camel error handling constructs like `doTry`, `doCatch` and `onException`.
 
 For example, to configure a global exception handler in response to a specific Exception type being thrown.
 

--- a/extensions/quartz/runtime/src/main/doc/usage-advanced.adoc
+++ b/extensions/quartz/runtime/src/main/doc/usage-advanced.adoc
@@ -53,7 +53,7 @@ for `DataSource` support.
 ----
 +
 Also add a Quartz database creation script for your chosen database kind.
-The Quartz project provides ready made scripts that can be copied from https://github.com/quartz-scheduler/quartz/tree/master/quartz-core/src/main/resources/org/quartz/impl/jdbcjobstore[here]. Add the SQL
+The Quartz project provides ready-made scripts that can be copied from https://github.com/quartz-scheduler/quartz/tree/master/quartz-core/src/main/resources/org/quartz/impl/jdbcjobstore[here]. Add the SQL
 script to `src/main/resources/db/migration/V1.0.0__QuarkusQuartz.sql`. Quarkus Flyway will detect it on startup and will proceed to create the Quartz database tables.
 
 4. Configure the Camel Quartz component to use the Quarkus Quartz scheduler.
@@ -70,4 +70,4 @@ public QuartzComponent quartzComponent(Scheduler scheduler) {
 }
 ----
 
-Further customization of the Quartz scheduler can be done via various configuration properties. Refer to to the https://quarkus.io/guides/quartz#quartz-configuration-reference[Quarkus Quartz Configuration] guide for more information.
+Further customization of the Quartz scheduler can be done via various configuration properties. Refer to the https://quarkus.io/guides/quartz#quartz-configuration-reference[Quarkus Quartz Configuration] guide for more information.

--- a/extensions/saxon/runtime/src/main/doc/configuration.adoc
+++ b/extensions/saxon/runtime/src/main/doc/configuration.adoc
@@ -10,7 +10,7 @@ from("direct:start").transform().xquery("resource:classpath:myxquery.txt", Strin
 from("direct:start").to("xquery:another-xquery.txt");
 ----
 
-To include these (an possibly other queries stored in `.txt` files) in the native image, you would have to add something like the following to your `application.properties` file:
+To include these (and possibly other queries stored in `.txt` files) in the native image, you would have to add something like the following to your `application.properties` file:
 
 [source,properties]
 ----

--- a/extensions/servlet/runtime/src/main/doc/usage.adoc
+++ b/extensions/servlet/runtime/src/main/doc/usage.adoc
@@ -35,7 +35,7 @@ quarkus.camel.servlet.servlet-name = My Custom Name
 
 *Servlet class*
 
-You may use a custom Servlet class (E.g one that extends `CamelHttpTransportServlet`) in your Camel routes.
+You may use a custom Servlet class (E.g. one that extends `CamelHttpTransportServlet`) in your Camel routes.
 
 [source,properties]
 ----

--- a/extensions/smallrye-reactive-messaging/runtime/src/main/doc/usage.adoc
+++ b/extensions/smallrye-reactive-messaging/runtime/src/main/doc/usage.adoc
@@ -4,7 +4,7 @@ Examples for how to use the Camel connector are outlined within the https://www.
 [NOTE]
 ====
 Where the SmallRye Reactive Messaging documentation makes references to Camel component maven dependencies, you should ensure that the corresponding camel-quarkus extension is used.
-E.g `<artifactId>camel-file</artifactId>` should be `<artifactId>camel-quarkus-file</artifactId>`.
+E.g. `<artifactId>camel-file</artifactId>` should be `<artifactId>camel-quarkus-file</artifactId>`.
 
-When using this extension, there is no need to explictly add `io.smallrye.reactive:smallrye-reactive-messaging-camel` or `io.quarkus:quarkus-quarkus-smallrye-reactive-messaging` to your project.
+When using this extension, there is no need to explicitly add `io.smallrye.reactive:smallrye-reactive-messaging-camel` or `io.quarkus:quarkus-quarkus-smallrye-reactive-messaging` to your project.
 ====

--- a/extensions/telemetry-dev/runtime/src/main/java/org/apache/camel/quarkus/component/telemetry/dev/CamelTelemetryDevConfig.java
+++ b/extensions/telemetry-dev/runtime/src/main/java/org/apache/camel/quarkus/component/telemetry/dev/CamelTelemetryDevConfig.java
@@ -31,11 +31,11 @@ public interface CamelTelemetryDevConfig {
      * Sets whether to disable tracing for endpoint URIs or Processor ids that match the given comma separated patterns. The
      * pattern can take the following forms:
      *
-     * 1. An exact match on the endpoint URI. E.g platform-http:/some/path
+     * 1. An exact match on the endpoint URI. E.g. platform-http:/some/path
      *
-     * 2. A wildcard match. E.g platform-http:++*++
+     * 2. A wildcard match. E.g. platform-http:++*++
      *
-     * 3. A regular expression matching the endpoint URI. E.g platform-http:/prefix/.++*++
+     * 3. A regular expression matching the endpoint URI. E.g. platform-http:/prefix/.++*++
      *
      * @asciidoclet
      */

--- a/extensions/velocity/runtime/src/main/doc/configuration.adoc
+++ b/extensions/velocity/runtime/src/main/doc/configuration.adoc
@@ -9,7 +9,7 @@ For instance, the route below would load the Velocity template from a classpath 
 from("direct:start").to("velocity://template/simple.vm");
 ----
 
-To include this (an possibly other templates stored in `.vm` files in the `template` directory) in the native image, you would have to add something like the following to your `application.properties` file:
+To include this (and possibly other templates stored in `.vm` files in the `template` directory) in the native image, you would have to add something like the following to your `application.properties` file:
 
 [source,properties]
 ----

--- a/extensions/vertx-websocket/runtime/src/main/doc/usage.adoc
+++ b/extensions/vertx-websocket/runtime/src/main/doc/usage.adoc
@@ -1,6 +1,6 @@
 === Vert.x WebSocket consumers
 
-When you create a Vert.x WebSocket consumer (E.g with `from("vertx-websocket")`), the host and port configuration in the URI are redundant since the WebSocket will always be hosted on 
+When you create a Vert.x WebSocket consumer (E.g. with `from("vertx-websocket")`), the host and port configuration in the URI are redundant since the WebSocket will always be hosted on
 the Quarkus HTTP server.
 
 The configuration of the consumer can be simplified to only include the resource path of the WebSocket. For example.
@@ -13,7 +13,7 @@ from("vertx-websocket:/my-websocket-path")
 
 NOTE: While you do not need to explicitly configure the host/port on the vertx-websocket consumer. If you choose to,
 the host & port must exactly match the value of the Quarkus HTTP server configuration values for `quarkus.http.host` and `quarkus.http.port`.
-Otherwise an exception will be thrown at runtime.
+Otherwise, an exception will be thrown at runtime.
 
 === Vert.x WebSocket producers
 

--- a/extensions/xpath/runtime/src/main/doc/configuration.adoc
+++ b/extensions/xpath/runtime/src/main/doc/configuration.adoc
@@ -9,7 +9,7 @@ For instance, the route below would load an XPath expression from a classpath re
 from("direct:start").transform().xpath("resource:classpath:myxpath.txt");
 ----
 
-To include this (an possibly other expressions stored in `.txt` files) in the native image, you would have to add something like the following to your `application.properties` file:
+To include this (and possibly other expressions stored in `.txt` files) in the native image, you would have to add something like the following to your `application.properties` file:
 
 [source,properties]
 ----


### PR DESCRIPTION
Part of my usual pre-LTS release tidying chores.

I will follow up a separate PR to tidy the user & release guides. 