### PR TITLE
[camel-main] Require JDK 21 minimum

### DIFF
--- a/.github/workflows/check-dependency-convergence.yml
+++ b/.github/workflows/check-dependency-convergence.yml
@@ -40,11 +40,11 @@ jobs:
     permissions:
       issues: write
     steps:
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set Build Info

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -107,12 +107,12 @@ jobs:
           else
             echo "run-checks=false" >> $GITHUB_OUTPUT
           fi
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         if: steps.init.outputs.run-checks == 'true'
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         if: steps.init.outputs.run-checks == 'true'
@@ -164,11 +164,11 @@ jobs:
       - name: Check free space on disk
         run: |
           df -h /
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
       - name: Build Camel
         if: github.ref == 'refs/heads/camel-main' || github.base_ref == 'camel-main'
         run: |
@@ -262,11 +262,11 @@ jobs:
           fetch-depth: 0
       - name: Reclaim Disk Space
         run: .github/reclaim-disk-space.sh
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
       - name: Download Maven Repo
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
         with:
@@ -338,11 +338,11 @@ jobs:
         with:
           ref: ${{ env.CHECKOUT_REF }}
           fetch-depth: 0
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
       - name: Download Maven Repo
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
         with:
@@ -421,7 +421,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ '17', '21' ]
+        java: [ '21', '25' ]
     env:
       MAVEN_OPTS: -Xmx3000m
     steps:
@@ -461,7 +461,7 @@ jobs:
           test-report-xml-base-dir: integration-tests-jvm
 
   integration-tests-alternative-jdk:
-    name: Integration Tests Alternative JDK 21 ${{matrix.name}}
+    name: Integration Tests Alternative JDK 25 ${{matrix.name}}
     runs-on: ubuntu-latest
     needs: initial-mvn-install
     if: github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'JVM')
@@ -478,11 +478,11 @@ jobs:
           fetch-depth: 0
       - name: Reclaim Disk Space
         run: .github/reclaim-disk-space.sh
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
-          java-version: '21'
+          java-version: '25'
       - name: Download Maven Repo
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
         with:
@@ -528,11 +528,11 @@ jobs:
         with:
           ref: ${{ env.CHECKOUT_REF }}
           fetch-depth: 0
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
       - name: Download Maven Repo
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
         with:
@@ -574,11 +574,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
       - name: Download Maven Repo
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
         with:
@@ -604,6 +604,11 @@ jobs:
               EXAMPLES_BRANCH=${GITHUB_REF_NAME}
           elif [[ ${GITHUB_BASE_REF} =~ [0-9]+.[0-9]+.x ]]; then
               EXAMPLES_BRANCH=${GITHUB_BASE_REF}
+          fi
+
+          # TODO: Remove this when example projects are updated for JDK 21 default
+          if [[ ${GITHUB_REF_NAME} == "camel-main" || ${GITHUB_BASE_REF} == "camel-main" ]]; then
+            CQ_MAVEN_ARGS="-Dmaven.compiler.release=21 ${CQ_MAVEN_ARGS}"
           fi
 
           git clone --depth 1 --branch ${EXAMPLES_BRANCH} https://github.com/apache/camel-quarkus-examples.git \

--- a/.github/workflows/generate-sbom-main.yml
+++ b/.github/workflows/generate-sbom-main.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '17' ]
+        java: [ '21' ]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -77,11 +77,11 @@ jobs:
       run: |
         echo "BRANCH_OPTIONS=-Poss-snapshots" >> $GITHUB_ENV
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
       with:
         distribution: 'temurin'
-        java-version: '17'
+        java-version: '21'
     - name: mvn validate
       run: |
         ./mvnw ${CQ_MAVEN_ARGS} ${BRANCH_OPTIONS} -fae \

--- a/.github/workflows/quarkus-master-cron.yaml
+++ b/.github/workflows/quarkus-master-cron.yaml
@@ -43,11 +43,11 @@ jobs:
       - name: Check free space on disk
         run: |
           df -h /
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
       - name: Set Workflow Build ID
         run: |
           [ ! -d ~/build-data ] && mkdir -p ~/build-data
@@ -170,11 +170,11 @@ jobs:
           git config --local user.name "github-actions[bot]"
           git fetch origin main
           git rebase $(cat ~/build-data/main-sha.txt)
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
       - name: Integration Tests
         run: |
           for MODULE in $(yq -M -N e ".${{ matrix.category }}" tooling/scripts/test-categories.yaml | grep -vE '^\s*#' | cut -f2 -d' '); do
@@ -255,11 +255,11 @@ jobs:
           git config --local user.name "github-actions[bot]"
           git fetch origin main
           git rebase $(cat ~/build-data/main-sha.txt)
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
       - name: cd extensions-core && mvn test
         run: |
           cd extensions-core
@@ -413,11 +413,11 @@ jobs:
           git rebase $(cat ~/build-data/main-sha.txt)          
       - name: Reclaim Disk Space
         run: .github/reclaim-disk-space.sh
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
-          java-version: '21'
+          java-version: '25'
       - name: cd integration-tests && mvn clean verify
         shell: bash
         env:
@@ -466,11 +466,11 @@ jobs:
           git config --local user.name "github-actions[bot]"
           git fetch origin main
           git rebase $(cat ~/build-data/main-sha.txt)
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
       - name: cd integration-tests && mvn clean verify
         shell: bash
         run: |
@@ -498,11 +498,11 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.initial-mvn-install.outputs.examples-matrix) }}
     steps:
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
       - name: Download Maven Repo
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
         with:
@@ -583,11 +583,11 @@ jobs:
     needs: native-tests
     runs-on: ubuntu-latest
     steps:
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
       - name: Download Maven Repo
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
         with:

--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,5 +1,5 @@
 # Enable auto-env through the sdkman_auto_env config
 # Add key=value pairs of SDKs to use below
-java=17.0.17-tem
+java=21.0.10-tem
 maven=3.9.11
 mvnd=1.0.2

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 def AGENT_LABEL = env.AGENT_LABEL ?: 'ubuntu'
-def JDK_NAME = env.JDK_NAME ?: 'jdk_17_latest'
+def JDK_NAME = env.JDK_NAME ?: 'jdk_21_latest'
 def MAVEN_PARAMS = '-B -e -ntp'
 
 pipeline {

--- a/Jenkinsfile.sonarcloud
+++ b/Jenkinsfile.sonarcloud
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 def AGENT_LABEL = env.AGENT_LABEL ?: 'ubuntu'
-def JDK_NAME = env.JDK_NAME ?: 'jdk_17_latest'
+def JDK_NAME = env.JDK_NAME ?: 'jdk_21_latest'
 def MAVEN_PARAMS = '-B -e -ntp'
 
 pipeline {

--- a/docs/modules/ROOT/pages/contributor-guide/index.adoc
+++ b/docs/modules/ROOT/pages/contributor-guide/index.adoc
@@ -11,7 +11,7 @@
   documentation.
 * If you are on Linux, `docker` or `podman` is sufficient for the native mode too. Use `-Pnative,docker` instead of `-Pnative`
   if you choose this option.
-* Java 17 or higher (Java 11 is only for Camel Quarkus < 3.0.0).
+* Java 21 or higher
 * Maven {min-maven-version}+ (unless you use the Maven Wrapper, a.k.a. `mvnw` available in the source tree).
 
 [[how-to-build]]

--- a/docs/modules/ROOT/pages/user-guide/first-steps.adoc
+++ b/docs/modules/ROOT/pages/user-guide/first-steps.adoc
@@ -7,7 +7,7 @@ This guide outlines various ways to create a new Camel Quarkus application.
 
 * A `git` client
 * An IDE
-* JDK 17+ with `JAVA_HOME` configured appropriately
+* JDK 21+ with `JAVA_HOME` configured appropriately
 * Apache Maven {min-maven-version}+ ({target-maven-version} is recommended)
 * GraalVM with the `native-image` command installed and the `GRAALVM_HOME` environment variable set. See
   https://quarkus.io/guides/building-native-image-guide[Building a native executable] section of the Quarkus

--- a/extensions-core/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/util/CamelSupport.java
+++ b/extensions-core/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/util/CamelSupport.java
@@ -44,7 +44,7 @@ public final class CamelSupport {
     public static final String CAMEL_SERVICE_BASE_PATH = "META-INF/services/org/apache/camel";
     public static final String CAMEL_ROOT_PACKAGE_DIRECTORY = "org/apache/camel";
     public static final String CLASSPATH_PREFIX = "classpath:";
-    public static final String COMPILATION_JVM_TARGET = "17";
+    public static final String COMPILATION_JVM_TARGET = "21";
 
     private CamelSupport() {
     }

--- a/integration-tests/infinispan/pom.xml
+++ b/integration-tests/infinispan/pom.xml
@@ -119,22 +119,6 @@
                 <skipTests>true</skipTests>
             </properties>
         </profile>
-        <profile>
-            <id>jdk17-build</id>
-            <activation>
-                <jdk>[17,)</jdk>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <argLine>--add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.concurrent=ALL-UNNAMED</argLine>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
     </profiles>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -292,9 +292,9 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <!-- maven-compiler-plugin -->
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
-        <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.release>21</maven.compiler.release>
 
         <!-- maven-enforcer-plugin -->
         <min-maven-version>3.8.2</min-maven-version>


### PR DESCRIPTION
I will create a separate PR for `main` that updates the `camel-master-cron.yaml` scheduled workflow.

I didn't bother touching the `quarkus-lts-ci-build.yaml` workflow. At some point in the future we'll likely have a mix of supported LTS releases where some have a JDK 17 baseline and others have JDK 21. I'll leave it as a future task to handle that.