### PR TITLE
Clean up usage of deprecated APIs

### DIFF
--- a/extensions/jolokia/deployment/src/main/java/org/apache/camel/quarkus/jolokia/deployment/JolokiaProcessor.java
+++ b/extensions/jolokia/deployment/src/main/java/org/apache/camel/quarkus/jolokia/deployment/JolokiaProcessor.java
@@ -27,7 +27,7 @@ import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.IsDevelopment;
-import io.quarkus.deployment.IsNormal;
+import io.quarkus.deployment.IsProduction;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.BuildSteps;
@@ -121,7 +121,7 @@ public class JolokiaProcessor {
         syntheticBean.produce(beanConfigurator.done());
     }
 
-    @BuildStep(onlyIfNot = { IsNormal.class, IsDevelopment.class })
+    @BuildStep(onlyIfNot = { IsProduction.class, IsDevelopment.class })
     @Record(ExecutionTime.RUNTIME_INIT)
     void registerJolokiaServerShutdownHook(
             JolokiaServerBuildItem jolokiaServer,
@@ -158,7 +158,7 @@ public class JolokiaProcessor {
         }
     }
 
-    @BuildStep(onlyIf = { IsNormal.class, ExposeContainerPortEnabled.class })
+    @BuildStep(onlyIf = { IsProduction.class, ExposeContainerPortEnabled.class })
     KubernetesPortBuildItem configureJolokiaKubernetesPort() {
         return KubernetesPortBuildItem.fromRuntimeConfiguration("jolokia", "quarkus.camel.jolokia.server.port", 8778, true);
     }

--- a/extensions/openapi-java/deployment/src/main/java/org/apache/camel/quarkus/component/openapi/java/deployment/OpenApiJavaProcessor.java
+++ b/extensions/openapi-java/deployment/src/main/java/org/apache/camel/quarkus/component/openapi/java/deployment/OpenApiJavaProcessor.java
@@ -39,6 +39,7 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.smallrye.openapi.deployment.spi.AddToOpenAPIDefinitionBuildItem;
+import io.quarkus.smallrye.openapi.deployment.spi.OpenAPISPIConstants;
 import io.quarkus.swaggerui.deployment.SwaggerUiUrlBuildItem;
 import io.smallrye.openapi.api.util.MergeUtil;
 import io.smallrye.openapi.runtime.io.IOContext;
@@ -133,7 +134,8 @@ class OpenApiJavaProcessor {
             } catch (Exception e) {
                 LOGGER.warn("Failed to configure routes due to: {}.", e.getMessage(), e);
             }
-            openAPI.produce(new AddToOpenAPIDefinitionBuildItem(new CamelRestOASFilter(ctx)));
+            openAPI.produce(new AddToOpenAPIDefinitionBuildItem(new CamelRestOASFilter(ctx),
+                    OpenAPISPIConstants.DEFAULT_DOCUMENT_NAME));
         }
     }
 

--- a/integration-test-groups/debezium/mssql/src/test/java/org/apache/camel/quarkus/component/debezium/common/it/sqlserv/DebeziumSqlserverTestResource.java
+++ b/integration-test-groups/debezium/mssql/src/test/java/org/apache/camel/quarkus/component/debezium/common/it/sqlserv/DebeziumSqlserverTestResource.java
@@ -29,11 +29,11 @@ import org.apache.camel.quarkus.test.support.debezium.AbstractDebeziumTestResour
 import org.apache.camel.quarkus.test.support.debezium.Type;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.logging.Logger;
-import org.testcontainers.containers.MSSQLServerContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.mssqlserver.MSSQLServerContainer;
 import org.testcontainers.utility.DockerImageName;
 
-public class DebeziumSqlserverTestResource extends AbstractDebeziumTestResource<MSSQLServerContainer<?>> {
+public class DebeziumSqlserverTestResource extends AbstractDebeziumTestResource<MSSQLServerContainer> {
     private static final Logger LOG = Logger.getLogger(DebeziumSqlserverTestResource.class);
     private static final DockerImageName DOCKER_IMAGE_NAME = DockerImageName
             .parse(ConfigProvider.getConfig().getValue("sql-server.container.image", String.class));
@@ -45,8 +45,8 @@ public class DebeziumSqlserverTestResource extends AbstractDebeziumTestResource<
     }
 
     @Override
-    protected MSSQLServerContainer<?> createContainer() {
-        return new MSSQLServerContainer<>(DOCKER_IMAGE_NAME)
+    protected MSSQLServerContainer createContainer() {
+        return new MSSQLServerContainer(DOCKER_IMAGE_NAME)
                 .withEnv(Collections.singletonMap("MSSQL_AGENT_ENABLED", "True"))
                 .withInitScript("initSqlserver.sql")
                 .waitingFor(

--- a/integration-test-groups/debezium/mysql/src/test/java/org/apache/camel/quarkus/component/debezium/common/it/mysql/DebeziumMysqlTestResource.java
+++ b/integration-test-groups/debezium/mysql/src/test/java/org/apache/camel/quarkus/component/debezium/common/it/mysql/DebeziumMysqlTestResource.java
@@ -28,10 +28,11 @@ import org.apache.camel.quarkus.test.support.debezium.Type;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.mysql.MySQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
-public class DebeziumMysqlTestResource extends AbstractDebeziumTestResource<MySQLContainer<?>> {
+public class DebeziumMysqlTestResource extends AbstractDebeziumTestResource<MySQLContainer> {
     private static final Logger log = LoggerFactory.getLogger(DebeziumMysqlTestResource.class);
 
     public static final String DB_NAME = "test";
@@ -52,11 +53,11 @@ public class DebeziumMysqlTestResource extends AbstractDebeziumTestResource<MySQ
         // This generally means that you are trying to use an image that Testcontainers has not been designed to use.
         DockerImageName mySqlImage = DockerImageName.parse(MYSQL_IMAGE).asCompatibleSubstituteFor("mysql");
 
-        return new MySQLContainer<>(mySqlImage)
+        return new MySQLContainer(mySqlImage)
                 .withUsername(DB_USERNAME)
                 .withPassword(DB_PASSWORD)
                 .withDatabaseName(DB_NAME)
-                //                .withLogConsumer(new Slf4jLogConsumer(log))
+                .withLogConsumer(new Slf4jLogConsumer(log))
                 .withInitScript("initMysql.sql");
     }
 

--- a/integration-test-groups/debezium/postgresql/src/test/java/org/apache/camel/quarkus/component/debezium/common/it/postgres/DebeziumPostgresTestResource.java
+++ b/integration-test-groups/debezium/postgresql/src/test/java/org/apache/camel/quarkus/component/debezium/common/it/postgres/DebeziumPostgresTestResource.java
@@ -20,10 +20,10 @@ package org.apache.camel.quarkus.component.debezium.common.it.postgres;
 import org.apache.camel.quarkus.test.support.debezium.AbstractDebeziumTestResource;
 import org.apache.camel.quarkus.test.support.debezium.Type;
 import org.eclipse.microprofile.config.ConfigProvider;
-import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.postgresql.PostgreSQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
-public class DebeziumPostgresTestResource extends AbstractDebeziumTestResource<PostgreSQLContainer<?>> {
+public class DebeziumPostgresTestResource extends AbstractDebeziumTestResource<PostgreSQLContainer> {
 
     public static final String DB_USERNAME = "postgres";
     public static final String DB_PASSWORD = "changeit";
@@ -36,10 +36,10 @@ public class DebeziumPostgresTestResource extends AbstractDebeziumTestResource<P
     }
 
     @Override
-    protected PostgreSQLContainer<?> createContainer() {
+    protected PostgreSQLContainer createContainer() {
         DockerImageName imageName = DockerImageName.parse(POSTGRES_IMAGE)
                 .asCompatibleSubstituteFor("postgres");
-        return new PostgreSQLContainer<>(imageName)
+        return new PostgreSQLContainer(imageName)
                 .withUsername(DB_USERNAME)
                 .withPassword(DB_PASSWORD)
                 .withDatabaseName(DebeziumPostgresResource.DB_NAME)

--- a/integration-tests-support/activemq/src/main/java/org/apache/camel/quarkus/test/support/activemq/ActiveMQTestResource.java
+++ b/integration-tests-support/activemq/src/main/java/org/apache/camel/quarkus/test/support/activemq/ActiveMQTestResource.java
@@ -23,8 +23,8 @@ import java.util.Map;
 import com.github.dockerjava.api.model.Ulimit;
 import io.quarkus.artemis.core.runtime.ArtemisBuildTimeConfig;
 import io.quarkus.artemis.core.runtime.ArtemisBuildTimeConfigs;
+import io.quarkus.artemis.core.runtime.ArtemisConstants;
 import io.quarkus.artemis.core.runtime.ArtemisDevServicesBuildTimeConfig;
-import io.quarkus.artemis.core.runtime.ArtemisUtil;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 import io.smallrye.config.SmallRyeConfigBuilder;
 import org.testcontainers.containers.GenericContainer;
@@ -124,7 +124,7 @@ public class ActiveMQTestResource implements QuarkusTestResourceLifecycleManager
                 .withMapping(ArtemisBuildTimeConfigs.class)
                 .withMapping(ArtemisDevServicesBuildTimeConfig.class)
                 .build()
-                .getConfigMapping(ArtemisBuildTimeConfigs.class).configs().get(ArtemisUtil.DEFAULT_CONFIG_NAME)
+                .getConfigMapping(ArtemisBuildTimeConfigs.class).configs().get(ArtemisConstants.DEFAULT_CONFIG_NAME)
                 .devservices().getImageName();
     }
 }

--- a/integration-tests-support/certificate-generator/src/main/java/org/apache/camel/quarkus/test/support/certificate/TestCertificateGenerationExtension.java
+++ b/integration-tests-support/certificate-generator/src/main/java/org/apache/camel/quarkus/test/support/certificate/TestCertificateGenerationExtension.java
@@ -55,9 +55,6 @@ public class TestCertificateGenerationExtension implements BeforeAllCallback {
 
     @Override
     public void beforeAll(ExtensionContext extensionContext) throws Exception {
-
-        extensionContext.getStore(ExtensionContext.Namespace.GLOBAL)
-                .getOrComputeIfAbsent(TestCertificateGenerationExtension.class, c -> this);
         var maybe = AnnotationUtils.findAnnotation(extensionContext.getRequiredTestClass(), TestCertificates.class);
         if (maybe.isEmpty()) {
             return;

--- a/integration-tests/google-pubsub/src/test/java/org/apache/camel/quarkus/component/google/pubsub/it/GooglePubSubCustomizer.java
+++ b/integration-tests/google-pubsub/src/test/java/org/apache/camel/quarkus/component/google/pubsub/it/GooglePubSubCustomizer.java
@@ -38,18 +38,17 @@ import org.apache.camel.quarkus.test.support.google.GoogleCloudContext;
 import org.apache.camel.quarkus.test.support.google.GoogleCloudTestResource;
 import org.apache.camel.quarkus.test.support.google.GoogleTestEnvCustomizer;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.PubSubEmulatorContainer;
+import org.testcontainers.gcloud.PubSubEmulatorContainer;
 import org.testcontainers.utility.DockerImageName;
 
-public class GooglePubSubCustomizer implements GoogleTestEnvCustomizer {
+public class GooglePubSubCustomizer implements GoogleTestEnvCustomizer<PubSubEmulatorContainer> {
 
     private static final String TEST_PROJECT_ID = "test-project";
 
     private PubSubEmulatorContainer container;
 
     @Override
-    public GenericContainer createContainer() {
+    public PubSubEmulatorContainer createContainer() {
         DockerImageName imageName = DockerImageName.parse(GoogleCloudTestResource.GOOGLE_EMULATOR_IMAGE);
         container = new PubSubEmulatorContainer(imageName);
         return container;

--- a/integration-tests/google-secret-manager/src/test/java/org/apache/camel/quarkus/component/google/secret/manager/it/GooglePubSubCustomizer.java
+++ b/integration-tests/google-secret-manager/src/test/java/org/apache/camel/quarkus/component/google/secret/manager/it/GooglePubSubCustomizer.java
@@ -32,18 +32,17 @@ import org.apache.camel.quarkus.test.support.google.GoogleCloudContext;
 import org.apache.camel.quarkus.test.support.google.GoogleCloudTestResource;
 import org.apache.camel.quarkus.test.support.google.GoogleTestEnvCustomizer;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.PubSubEmulatorContainer;
+import org.testcontainers.gcloud.PubSubEmulatorContainer;
 import org.testcontainers.utility.DockerImageName;
 
-public class GooglePubSubCustomizer implements GoogleTestEnvCustomizer {
+public class GooglePubSubCustomizer implements GoogleTestEnvCustomizer<PubSubEmulatorContainer> {
 
     private static final String TEST_PROJECT_ID = "test-project";
 
     private PubSubEmulatorContainer container;
 
     @Override
-    public GenericContainer createContainer() {
+    public PubSubEmulatorContainer createContainer() {
         DockerImageName imageName = DockerImageName.parse(GoogleCloudTestResource.GOOGLE_EMULATOR_IMAGE);
         container = new PubSubEmulatorContainer(imageName);
         return container;

--- a/integration-tests/opentelemetry/src/test/java/org/apache/camel/quarkus/component/opentelemetry/it/OpenTelemetryTest.java
+++ b/integration-tests/opentelemetry/src/test/java/org/apache/camel/quarkus/component/opentelemetry/it/OpenTelemetryTest.java
@@ -28,10 +28,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import static io.opentelemetry.semconv.incubating.CodeIncubatingAttributes.CODE_FUNCTION_NAME;
+import static io.opentelemetry.semconv.CodeAttributes.CODE_FUNCTION_NAME;
 import static org.apache.camel.quarkus.component.opentelemetry.it.OpenTelemetryTestHelper.getSpans;
 import static org.awaitility.Awaitility.await;
-import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/integration-tests/opentelemetry2/src/test/java/org/apache/camel/quarkus/component/opentelemetry2/it/Opentelemetry2Test.java
+++ b/integration-tests/opentelemetry2/src/test/java/org/apache/camel/quarkus/component/opentelemetry2/it/Opentelemetry2Test.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import static io.opentelemetry.semconv.incubating.CodeIncubatingAttributes.CODE_FUNCTION_NAME;
+import static io.opentelemetry.semconv.CodeAttributes.CODE_FUNCTION_NAME;
 import static org.apache.camel.quarkus.component.opentelemetry2.it.OpenTelemetry2TestHelper.getSpans;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.CoreMatchers.equalTo;

--- a/integration-tests/solr/src/test/java/org/apache/camel/quarkus/component/solr/it/SolrTestResource.java
+++ b/integration-tests/solr/src/test/java/org/apache/camel/quarkus/component/solr/it/SolrTestResource.java
@@ -23,8 +23,8 @@ import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testcontainers.containers.SolrContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.solr.SolrContainer;
 import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
 

--- a/integration-tests/spring-rabbitmq/src/test/java/org/apache/camel/quarkus/component/spring/rabbitmq/it/SpringRabbitmqTestResource.java
+++ b/integration-tests/spring-rabbitmq/src/test/java/org/apache/camel/quarkus/component/spring/rabbitmq/it/SpringRabbitmqTestResource.java
@@ -22,8 +22,8 @@ import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 import org.apache.camel.util.CollectionHelper;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
-import org.testcontainers.containers.RabbitMQContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.rabbitmq.RabbitMQContainer;
 import org.testcontainers.utility.DockerImageName;
 
 public class SpringRabbitmqTestResource implements QuarkusTestResourceLifecycleManager {


### PR DESCRIPTION
Some simple deprecation fixes. I will try to follow up with further PRs for more complex cases.

* Replace io.quarkus.deployment.IsNormal with io.quarkus.deployment.IsProduction
* Replace ArtemisUtil with ArtemisConstants for DEFAULT_CONFIG_NAME constant
* Replace io.opentelemetry.semconv.incubating.CodeIncubatingAttributes.CODE_FUNCTION_NAME with io.opentelemetry.semconv.CodeAttributes.CODE_FUNCTION_NAME
* Avoid deprecated AddToOpenAPIDefinitionBuildItem single arg constructor
* Avoid deprecated tescontainers container classes in org.testcontainers.containers package
