### PR TITLE
Clean up usage of deprecated APIs - part 2

### DIFF
--- a/extensions/grpc/codegen/src/main/java/org/apache/camel/quarkus/grpc/codegen/CamelQuarkusGrpcCodegenProvider.java
+++ b/extensions/grpc/codegen/src/main/java/org/apache/camel/quarkus/grpc/codegen/CamelQuarkusGrpcCodegenProvider.java
@@ -34,7 +34,6 @@ import io.quarkus.bootstrap.model.ApplicationModel;
 import io.quarkus.bootstrap.prebuild.CodeGenException;
 import io.quarkus.deployment.CodeGenContext;
 import io.quarkus.deployment.CodeGenProvider;
-import io.quarkus.deployment.util.ProcessUtil;
 import io.quarkus.maven.dependency.ResolvedDependency;
 import io.quarkus.paths.PathFilter;
 import io.quarkus.runtime.util.HashUtil;
@@ -156,8 +155,11 @@ public class CamelQuarkusGrpcCodegenProvider implements CodeGenProvider {
                 command.addAll(protoFiles);
 
                 ProcessBuilder processBuilder = new ProcessBuilder(command);
+                if (context.shouldRedirectIO()) {
+                    processBuilder.inheritIO();
+                }
 
-                final Process process = ProcessUtil.launchProcess(processBuilder, context.shouldRedirectIO());
+                final Process process = processBuilder.start();
                 int resultCode = process.waitFor();
                 if (resultCode != 0) {
                     throw new CodeGenException("Failed to generate Java classes from proto files: " + protoFiles +

--- a/extensions/kafka/deployment/src/main/java/org/apache/camel/quarkus/component/kafka/deployment/KafkaProcessor.java
+++ b/extensions/kafka/deployment/src/main/java/org/apache/camel/quarkus/component/kafka/deployment/KafkaProcessor.java
@@ -22,7 +22,7 @@ import java.util.stream.Stream;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Capability;
-import io.quarkus.deployment.IsNormal;
+import io.quarkus.deployment.IsProduction;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
@@ -57,7 +57,7 @@ class KafkaProcessor {
         }
     }
 
-    @BuildStep(onlyIfNot = IsNormal.class, onlyIf = DevServicesConfig.Enabled.class)
+    @BuildStep(onlyIfNot = IsProduction.class, onlyIf = DevServicesConfig.Enabled.class)
     public void configureKafkaComponentForDevServices(
             KafkaBuildTimeConfig kafkaBuildTimeConfig,
             BuildProducer<AdditionalBeanBuildItem> additionalBean) {


### PR DESCRIPTION
* Replaced gRPC codegen usage of deprecated io.quarkus.deployment.util.ProcessUtil with processBuilder.start()
* Fixed lingering references to io.quarkus.deployment.IsNormal with io.quarkus.deployment.IsProduction
