### PR TITLE
fix: ssh component native failure with sshd 2.17.1

### DIFF
--- a/extensions/ssh/deployment/src/main/java/org/apache/camel/quarkus/component/ssh/deployment/SshProcessor.java
+++ b/extensions/ssh/deployment/src/main/java/org/apache/camel/quarkus/component/ssh/deployment/SshProcessor.java
@@ -32,6 +32,7 @@ import io.quarkus.deployment.builditem.IndexDependencyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageProxyDefinitionBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 import net.i2p.crypto.eddsa.EdDSAEngine;
 import org.apache.sshd.common.channel.ChannelListener;
 import org.apache.sshd.common.forward.PortForwardingEventListener;
@@ -92,6 +93,12 @@ class SshProcessor {
     @BuildStep
     IndexDependencyBuildItem registerDependencyForIndex2() {
         return new IndexDependencyBuildItem("org.bouncycastle", "bcprov-jdk18on");
+    }
+
+    @BuildStep
+    void runtimeInitializedClasses(BuildProducer<RuntimeInitializedClassBuildItem> runtimeInitializedClass) {
+        runtimeInitializedClass
+                .produce(new RuntimeInitializedClassBuildItem("org.apache.sshd.common.random.JceRandom$Cache"));
     }
 
 }


### PR DESCRIPTION
This fixes a native integration-test failure that will appear with this: https://github.com/quarkusio/quarkus/pull/52995

@jamesnetherton I am not sure it is the right place or target branch, so don't hesitate to tell me if it needs to be done any other way.