### PR TITLE
Align dev.langchain4j dependencies with Quarkus LangChain4j 1.8.0.CR2

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -34,7 +34,7 @@ asciidoc:
     quarkus-version: 3.32.2 # replace ${quarkus.version}
     graalvm-version: 23.1.2 # replace ${graalvm.version}
     graalvm-docs-version: jdk21 # replace ${graalvm-docs.version}
-    langchain4j-version: 1.11.0 # replace ${langchain4j.version}
+    langchain4j-version: 1.12.2 # replace ${langchain4j.version}
     mapstruct-version: 1.6.3 # replace ${mapstruct.version}
     min-maven-version: 3.8.2 # replace ${min-maven-version}
     target-maven-version: 3.9.12 # replace ${target-maven-version}

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <quarkiverse-jackson-jq.version>2.4.0</quarkiverse-jackson-jq.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/jackson-jq/quarkus-jackson-jq-parent/ -->
         <quarkiverse-jgit.version>3.6.1</quarkiverse-jgit.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/jgit/quarkus-jgit/ -->
         <quarkiverse-jsch.version>3.1.2</quarkiverse-jsch.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/jsch/quarkus-jsch/ -->
-        <quarkiverse-langchain4j.version>1.7.4</quarkiverse-langchain4j.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/langchain4j/quarkus-langchain4j-parent -->
+        <quarkiverse-langchain4j.version>1.8.0.CR2</quarkiverse-langchain4j.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/langchain4j/quarkus-langchain4j-parent -->
         <quarkiverse-micrometer.version>3.4.1</quarkiverse-micrometer.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/micrometer/registry/quarkus-micrometer-registry-jmx/ -->
         <quarkiverse-minio.version>3.8.6</quarkiverse-minio.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/minio/quarkus-minio-parent/ -->
         <quarkiverse-mybatis.version>2.4.2</quarkiverse-mybatis.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/mybatis/quarkus-mybatis-parent/ -->
@@ -142,8 +142,8 @@
         <kotlin.version>2.3.10</kotlin.version><!-- @sync io.quarkus:quarkus-bom:${quarkus.version} dep:org.jetbrains.kotlin:kotlin-stdlib -->
         <kotlinx.version>1.4.0</kotlinx.version><!--Used by com.squareup.wire:wire-compiler referenced from aws2:kinesis -->
         <kryo.version>2.24.0</kryo.version><!-- @sync org.apache.flink:flink-core:${flink-version} dep:com.esotericsoftware.kryo:kryo -->
-        <langchain4j.version>1.11.0</langchain4j.version><!-- @sync io.quarkiverse.langchain4j:quarkus-langchain4j-parent:${quarkiverse-langchain4j.version} prop:langchain4j.version -->
-        <langchain4j-beta.version>1.11.0-beta19</langchain4j-beta.version><!-- @sync dev.langchain4j:langchain4j-bom:${langchain4j.version} prop:langchain4j.beta.version -->
+        <langchain4j.version>1.12.2</langchain4j.version><!-- @sync io.quarkiverse.langchain4j:quarkus-langchain4j-parent:${quarkiverse-langchain4j.version} prop:langchain4j.version -->
+        <langchain4j-beta.version>1.12.2-beta22</langchain4j-beta.version><!-- @sync dev.langchain4j:langchain4j-bom:${langchain4j.version} prop:langchain4j.beta.version -->
         <mapstruct.version>${mapstruct-version}</mapstruct.version>
         <mbassador.version>1.3.0</mbassador.version><!-- @sync com.hierynomus:smbj:${smbj-version} dep:net.engio:mbassador -->
         <minio.version>8.6.0</minio.version><!-- @sync io.quarkiverse.minio:quarkus-minio-parent:${quarkiverse-minio.version} prop:minio.version -->

--- a/poms/bom/src/main/generated/flattened-full-pom.xml
+++ b/poms/bom/src/main/generated/flattened-full-pom.xml
@@ -7521,7 +7521,7 @@
       <dependency>
         <groupId>dev.langchain4j</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>langchain4j-embeddings</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <version>1.11.0-beta19</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+        <version>1.12.2-beta22</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
       </dependency>
       <dependency>
         <groupId>io.dropwizard.metrics</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
@@ -23932,484 +23932,509 @@
         <version>1.5.2</version><!-- org.apache.cassandra:java-driver-bom:4.19.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-core</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-core</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-test</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-test</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-http-client</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-http-client</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-http-client-jdk</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-http-client-jdk</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-http-client-apache</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-http-client-apache</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-kotlin</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-kotlin</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-reactor</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-reactor</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-easy-rag</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-easy-rag</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-guardrails</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-guardrails</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-anthropic</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-anthropic</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-azure-open-ai</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-azure-open-ai</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-bedrock</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-bedrock</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-cohere</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-cohere</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-github-models</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-github-models</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-hugging-face</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-hugging-face</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-jlama</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-jlama</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-jina</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-jina</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-onnx-scoring</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-onnx-scoring</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-local-ai</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-local-ai</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-mistral-ai</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-mistral-ai</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-nomic</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-nomic</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-ollama</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-ollama</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-open-ai</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-open-ai</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-open-ai-official</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-open-ai-official</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-ovh-ai</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-ovh-ai</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-vertex-ai</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-vertex-ai</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-vertex-ai-gemini</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-vertex-ai-gemini</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-vertex-ai-anthropic</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-vertex-ai-anthropic</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-google-ai-gemini</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-google-ai-gemini</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-workers-ai</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-workers-ai</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-voyage-ai</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-voyage-ai</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-watsonx</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-watsonx</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-gpu-llama3</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-gpu-llama3</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-azure-ai-search</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-azure-ai-search</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-azure-cosmos-mongo-vcore</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-azure-cosmos-mongo-vcore</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-cassandra</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-cassandra</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-chroma</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-chroma</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-coherence</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-coherence</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-couchbase</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-couchbase</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-elasticsearch</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-elasticsearch</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-infinispan</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-hibernate</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-mariadb</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-infinispan</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-mcp</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-mariadb</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-mcp-docker</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-mcp</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-milvus</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-mcp-docker</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-mongodb-atlas</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-milvus</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-opensearch</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-mongodb-atlas</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-pgvector</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-opensearch</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-pinecone</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-pgvector</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-qdrant</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-pinecone</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-tablestore</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-qdrant</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-vespa</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-tablestore</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-weaviate</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-vespa</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-azure-cosmos-nosql</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-weaviate</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-oracle</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-azure-cosmos-nosql</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-embeddings-all-minilm-l6-v2</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-oracle</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-embeddings-all-minilm-l6-v2-q</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-embeddings-all-minilm-l6-v2</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-embeddings-bge-small-en</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-embeddings-all-minilm-l6-v2-q</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-embeddings-bge-small-en-q</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-embeddings-bge-small-en</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-embeddings-bge-small-en-v15</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-embeddings-bge-small-en-q</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-embeddings-bge-small-en-v15-q</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-embeddings-bge-small-en-v15</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-embeddings-bge-small-zh-v15</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-embeddings-bge-small-en-v15-q</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-embeddings-bge-small-zh-v15-q</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-embeddings-bge-small-zh-v15</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-embeddings-e5-small-v2</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-embeddings-bge-small-zh-v15-q</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-embeddings-e5-small-v2-q</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-embeddings-e5-small-v2</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-code-execution-engine-graalvm-polyglot</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-embeddings-e5-small-v2-q</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-code-execution-engine-judge0</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-code-execution-engine-graalvm-polyglot</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-code-execution-engine-azure-acads</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-code-execution-engine-judge0</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-document-loader-amazon-s3</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-code-execution-engine-azure-acads</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-document-loader-azure-storage-blob</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-document-loader-amazon-s3</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-document-loader-github</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-document-loader-azure-storage-blob</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-document-loader-selenium</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-document-loader-github</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-document-loader-playwright</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-document-loader-selenium</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-document-loader-tencent-cos</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-document-loader-playwright</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-document-loader-google-cloud-storage</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-document-loader-tencent-cos</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-document-parser-apache-pdfbox</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-document-loader-google-cloud-storage</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-document-parser-apache-poi</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-document-parser-apache-pdfbox</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-document-parser-apache-tika</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-document-parser-apache-poi</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-document-parser-markdown</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-document-parser-apache-tika</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-document-parser-yaml</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-document-parser-markdown</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-document-transformer-jsoup</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-document-parser-yaml</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-embedding-store-filter-parser-sql</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-document-transformer-jsoup</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-web-search-engine-google-custom</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-embedding-store-filter-parser-sql</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-web-search-engine-tavily</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-web-search-engine-google-custom</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-web-search-engine-searchapi</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-web-search-engine-tavily</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-experimental-sql</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-web-search-engine-searchapi</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-agentic</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-experimental-sql</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-agentic-a2a</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-agentic</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-agentic-patterns</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-agentic-a2a</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-spring-boot-starter</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-agentic-mcp</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-anthropic-spring-boot-starter</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-agentic-patterns</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-azure-ai-search-spring-boot-starter</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-skills</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-azure-open-ai-spring-boot-starter</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-micrometer-metrics</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-ollama-spring-boot-starter</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-observation</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-open-ai-spring-boot-starter</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-spring-boot-starter</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-anthropic-spring-boot-starter</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-azure-ai-search-spring-boot-starter</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-azure-open-ai-spring-boot-starter</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-ollama-spring-boot-starter</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+      </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-open-ai-spring-boot-starter</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId><!-- io.debezium:debezium-bom:3.4.0.Final -->

--- a/poms/bom/src/main/generated/flattened-reduced-pom.xml
+++ b/poms/bom/src/main/generated/flattened-reduced-pom.xml
@@ -7485,7 +7485,7 @@
       <dependency>
         <groupId>dev.langchain4j</groupId>
         <artifactId>langchain4j-embeddings</artifactId>
-        <version>1.11.0-beta19</version>
+        <version>1.12.2-beta22</version>
       </dependency>
       <dependency>
         <groupId>io.minio</groupId>
@@ -9332,37 +9332,37 @@
       <dependency>
         <groupId>dev.langchain4j</groupId>
         <artifactId>langchain4j-core</artifactId>
-        <version>1.11.0</version>
+        <version>1.12.2</version>
       </dependency>
       <dependency>
         <groupId>dev.langchain4j</groupId>
         <artifactId>langchain4j</artifactId>
-        <version>1.11.0</version>
+        <version>1.12.2</version>
       </dependency>
       <dependency>
         <groupId>dev.langchain4j</groupId>
         <artifactId>langchain4j-http-client</artifactId>
-        <version>1.11.0</version>
+        <version>1.12.2</version>
       </dependency>
       <dependency>
         <groupId>dev.langchain4j</groupId>
         <artifactId>langchain4j-http-client-jdk</artifactId>
-        <version>1.11.0</version>
+        <version>1.12.2</version>
       </dependency>
       <dependency>
         <groupId>dev.langchain4j</groupId>
         <artifactId>langchain4j-hugging-face</artifactId>
-        <version>1.11.0-beta19</version>
+        <version>1.12.2-beta22</version>
       </dependency>
       <dependency>
         <groupId>dev.langchain4j</groupId>
         <artifactId>langchain4j-open-ai</artifactId>
-        <version>1.11.0</version>
+        <version>1.12.2</version>
       </dependency>
       <dependency>
         <groupId>dev.langchain4j</groupId>
         <artifactId>langchain4j-mcp</artifactId>
-        <version>1.11.0-beta19</version>
+        <version>1.12.2-beta22</version>
       </dependency>
       <dependency>
         <groupId>org.apache.kafka</groupId>

--- a/poms/bom/src/main/generated/flattened-reduced-verbose-pom.xml
+++ b/poms/bom/src/main/generated/flattened-reduced-verbose-pom.xml
@@ -7485,7 +7485,7 @@
       <dependency>
         <groupId>dev.langchain4j</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>langchain4j-embeddings</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <version>1.11.0-beta19</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+        <version>1.12.2-beta22</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
       </dependency>
       <dependency>
         <groupId>io.minio</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
@@ -9330,39 +9330,39 @@
         <version>1.5.2</version><!-- org.apache.cassandra:java-driver-bom:4.19.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-core</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-core</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-http-client</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-http-client</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-http-client-jdk</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-http-client-jdk</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-hugging-face</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-hugging-face</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-open-ai</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-open-ai</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
-        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <artifactId>langchain4j-mcp</artifactId><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
-        <version>1.11.0-beta19</version><!-- dev.langchain4j:langchain4j-bom:1.11.0 -->
+        <groupId>dev.langchain4j</groupId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <artifactId>langchain4j-mcp</artifactId><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
+        <version>1.12.2-beta22</version><!-- dev.langchain4j:langchain4j-bom:1.12.2 -->
       </dependency>
       <dependency>
         <groupId>org.apache.kafka</groupId><!-- io.debezium:debezium-bom:3.4.0.Final -->


### PR DESCRIPTION
Not for merging - just want to see if everything still works with LangChain4j 1.12.x.