### PR TITLE
Verify that gRPC generated stub object toString works in native mode

### DIFF
--- a/integration-tests/grpc/src/main/java/org/apache/camel/quarkus/component/grpc/it/GrpcRoute.java
+++ b/integration-tests/grpc/src/main/java/org/apache/camel/quarkus/component/grpc/it/GrpcRoute.java
@@ -40,6 +40,7 @@ public class GrpcRoute extends RouteBuilder {
     public void configure() throws Exception {
         // Synchronous / asynchronous (dynamic) producers
         from("direct:sendGrpcMessage")
+                .log("Received message: ${body}")
                 .toD("grpc://localhost:${header.port}/" + PING_PONG_SERVICE
                         + "?method=${header.CamelGrpcMethodName}&synchronous=${header.isSync}");
 


### PR DESCRIPTION
Calling `toString` on gRPC generated stub objects was [broken](https://github.com/quarkusio/quarkus/commit/4164181338e2e6f179e93db446d9d37c09e30521#diff-b6cdf8f1de40c2de637b1c31933cb081db824320fe494087efe2ecb009e0bbfb) before Quarkus 3.32.1, due to some missing reflective class configuration. But the issue was hidden for us, as there was nothing testing it.

Hence adding a simple route `.log()` to exercise the relevant code paths.