### PR TITLE
Rename CI workflow extensions-jvm-tests job to integration-tests-jvm

### DIFF
--- a/.github/workflows/camel-master-cron.yaml
+++ b/.github/workflows/camel-master-cron.yaml
@@ -323,7 +323,7 @@ jobs:
         run: |
           ./mvnw ${CQ_MAVEN_ARGS} verify -N -Pbuild-notification -Dstatus=${{ job.status }} -DissueId=${{ env.ISSUE_ID }} -Dtoken=${{ secrets.GITHUB_TOKEN }} -DbuildId=$(cat ~/build-data/build-id.txt) -Drepo=${GITHUB_REPOSITORY} -Dbranch=camel-main -Dbranch-commit=$(cat ~/build-data/main-sha.txt)
 
-  extensions-jvm-tests:
+  integration-tests-jvm:
     runs-on: ubuntu-latest
     needs: initial-mvn-install
     strategy:

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -415,7 +415,7 @@ jobs:
         with:
           test-report-xml-base-dir: catalog
 
-  extensions-jvm-tests:
+  integration-tests-jvm:
     runs-on: ubuntu-latest
     needs: initial-mvn-install
     strategy:

--- a/.github/workflows/ci-semeru-jdk.yaml
+++ b/.github/workflows/ci-semeru-jdk.yaml
@@ -281,7 +281,7 @@ jobs:
         with:
           test-report-xml-base-dir: catalog
 
-  extensions-jvm-tests:
+  integration-tests-jvm:
     runs-on: ubuntu-latest
     needs: initial-mvn-install
     strategy:

--- a/.github/workflows/jdk25-build.yaml
+++ b/.github/workflows/jdk25-build.yaml
@@ -285,7 +285,7 @@ jobs:
         with:
           test-report-xml-base-dir: catalog
 
-  extensions-jvm-tests:
+  integration-tests-jvm:
     runs-on: ubuntu-latest
     needs: initial-mvn-install
     strategy:

--- a/.github/workflows/quarkus-lts-ci-build.yaml
+++ b/.github/workflows/quarkus-lts-ci-build.yaml
@@ -295,7 +295,7 @@ jobs:
         with:
           test-report-xml-base-dir: catalog
 
-  extensions-jvm-tests:
+  integration-tests-jvm:
     runs-on: ubuntu-latest
     needs: initial-mvn-install
     strategy:

--- a/.github/workflows/quarkus-master-cron.yaml
+++ b/.github/workflows/quarkus-master-cron.yaml
@@ -324,7 +324,7 @@ jobs:
         run: |
           ./mvnw ${CQ_MAVEN_ARGS} verify -N -Pbuild-notification -Dstatus=${{ job.status }} -DissueId=${{ env.ISSUE_ID }} -Dtoken=${{ secrets.GITHUB_TOKEN }} -DbuildId=$(cat ~/build-data/build-id.txt) -Drepo=${GITHUB_REPOSITORY} -Dbranch=quarkus-main -Dbranch-commit=$(cat ~/build-data/main-sha.txt)
 
-  extensions-jvm-tests:
+  integration-tests-jvm:
     runs-on: ubuntu-latest
     needs: initial-mvn-install
     strategy:


### PR DESCRIPTION
To remove confusion (for me) between running tests from `extensions(-jvm)/*/src/test` Vs `integration-tests-jvm`.