### PR TITLE
Use unique names for JPA DataSource config

### DIFF
--- a/integration-tests/jpa/src/main/resources/application.properties
+++ b/integration-tests/jpa/src/main/resources/application.properties
@@ -28,18 +28,18 @@ jpa.model.packages=org.apache.camel.quarkus.component.jpa.it.model,org.apache.ca
 
 # single-resource-no-default profile to test single named DataSource / EntityManagerFactory beans without defaults
 %single-resource-no-default.quarkus.camel.routes-discovery.exclude-patterns=**/*
-%single-resource-no-default.quarkus.datasource.testA.db-kind=${cq.sqlJdbcKind:h2}
-%single-resource-no-default.quarkus.hibernate-orm.testA.packages=${jpa.model.packages}
-%single-resource-no-default.quarkus.hibernate-orm.testA.datasource=testA
-%single-resource-no-default.quarkus.hibernate-orm.testA.schema-management.strategy=drop-and-create
+%single-resource-no-default.quarkus.datasource.singleA.db-kind=${cq.sqlJdbcKind:h2}
+%single-resource-no-default.quarkus.hibernate-orm.singleA.packages=${jpa.model.packages}
+%single-resource-no-default.quarkus.hibernate-orm.singleA.datasource=singleA
+%single-resource-no-default.quarkus.hibernate-orm.singleA.schema-management.strategy=drop-and-create
 
 # multi-resource-no-default profile to test multiple named DataSource / EntityManagerFactory beans without defaults
 %multi-resource-no-default.quarkus.camel.routes-discovery.exclude-patterns=**/*
-%multi-resource-no-default.quarkus.datasource.testA.db-kind=${cq.sqlJdbcKind:h2}
-%multi-resource-no-default.quarkus.hibernate-orm.testA.packages=${jpa.model.packages}
-%multi-resource-no-default.quarkus.hibernate-orm.testA.datasource=testA
-%multi-resource-no-default.quarkus.hibernate-orm.testA.schema-management.strategy=drop-and-create
-%multi-resource-no-default.quarkus.datasource.testB.db-kind=${cq.sqlJdbcKind:h2}
-%multi-resource-no-default.quarkus.hibernate-orm.testB.packages=${jpa.model.packages}
-%multi-resource-no-default.quarkus.hibernate-orm.testB.datasource=testB
-%multi-resource-no-default.quarkus.hibernate-orm.testB.schema-management.strategy=drop-and-create
+%multi-resource-no-default.quarkus.datasource.multiA.db-kind=${cq.sqlJdbcKind:h2}
+%multi-resource-no-default.quarkus.hibernate-orm.multiA.packages=${jpa.model.packages}
+%multi-resource-no-default.quarkus.hibernate-orm.multiA.datasource=multiA
+%multi-resource-no-default.quarkus.hibernate-orm.multiA.schema-management.strategy=drop-and-create
+%multi-resource-no-default.quarkus.datasource.multiB.db-kind=${cq.sqlJdbcKind:h2}
+%multi-resource-no-default.quarkus.hibernate-orm.multiB.packages=${jpa.model.packages}
+%multi-resource-no-default.quarkus.hibernate-orm.multiB.datasource=multiB
+%multi-resource-no-default.quarkus.hibernate-orm.multiB.schema-management.strategy=drop-and-create

--- a/integration-tests/jpa/src/test/java/org/apache/camel/quarkus/component/jpa/it/JpaMultipleNamedResourcesWithNoDefaultAndExplicitEntityManagerFactoryTest.java
+++ b/integration-tests/jpa/src/test/java/org/apache/camel/quarkus/component/jpa/it/JpaMultipleNamedResourcesWithNoDefaultAndExplicitEntityManagerFactoryTest.java
@@ -36,7 +36,7 @@ public class JpaMultipleNamedResourcesWithNoDefaultAndExplicitEntityManagerFacto
                 .then()
                 .statusCode(200)
                 .body(
-                        "name", is("testB"),
+                        "name", is("multiB"),
                         "default", is(false));
     }
 
@@ -47,6 +47,6 @@ public class JpaMultipleNamedResourcesWithNoDefaultAndExplicitEntityManagerFacto
 
     @Override
     public Map<String, String> getConfigOverrides() {
-        return Map.of("camel.component.jpa.entity-managerFactory", "#testB");
+        return Map.of("camel.component.jpa.entity-managerFactory", "#multiB");
     }
 }

--- a/integration-tests/jpa/src/test/java/org/apache/camel/quarkus/component/jpa/it/JpaSingleNamedResourceWithNoDefaultTest.java
+++ b/integration-tests/jpa/src/test/java/org/apache/camel/quarkus/component/jpa/it/JpaSingleNamedResourceWithNoDefaultTest.java
@@ -34,7 +34,7 @@ public class JpaSingleNamedResourceWithNoDefaultTest implements QuarkusTestProfi
                 .then()
                 .statusCode(200)
                 .body(
-                        "name", is("testA"),
+                        "name", is("singleA"),
                         "default", is(false));
     }
 


### PR DESCRIPTION
Required for Quarkus 3.34.x.