### PR TITLE
Increase initial delay for Camel dev mode live reload tasks

### DIFF
--- a/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/devmode/CamelHotReplacementSetup.java
+++ b/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/devmode/CamelHotReplacementSetup.java
@@ -22,23 +22,34 @@ import java.util.concurrent.TimeUnit;
 
 import io.quarkus.dev.spi.HotReplacementContext;
 import io.quarkus.dev.spi.HotReplacementSetup;
+import org.jboss.logging.Logger;
 
 public class CamelHotReplacementSetup implements HotReplacementSetup {
-    private static final long TWO_SECS = TimeUnit.SECONDS.toMillis(2);
+    private static final long INITIAL_DELAY = TimeUnit.SECONDS.toMillis(5);
+    private static final long TASK_DELAY = TimeUnit.SECONDS.toMillis(2);
+    private static final Logger LOG = Logger.getLogger(CamelHotReplacementSetup.class);
+    private Timer timer;
 
     @Override
     public void setupHotDeployment(HotReplacementContext context) {
-        Timer timer = new Timer(true);
+        timer = new Timer("camel-live-reload", true);
         timer.schedule(new TimerTask() {
             @Override
             public void run() {
                 try {
                     context.doScan(false);
                 } catch (Exception e) {
-                    e.printStackTrace();
+                    LOG.warn("Camel live reload task failed", e);
                 }
             }
-        }, TWO_SECS, TWO_SECS);
+        }, INITIAL_DELAY, TASK_DELAY);
     }
 
+    @Override
+    public void close() {
+        if (timer != null) {
+            timer.cancel();
+            timer = null;
+        }
+    }
 }

--- a/test-framework/camel-quarkus-junit-tests/src/test/java/org/apache/camel/quarkus/test/extensions/continousDev/ContinuousDevTest.java
+++ b/test-framework/camel-quarkus-junit-tests/src/test/java/org/apache/camel/quarkus/test/extensions/continousDev/ContinuousDevTest.java
@@ -16,9 +16,6 @@
  */
 package org.apache.camel.quarkus.test.extensions.continousDev;
 
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.function.Function;
 import java.util.function.Supplier;
 
 import io.quarkus.test.ContinuousTestingTestUtils;
@@ -27,15 +24,10 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-@Disabled //https://github.com/apache/camel-quarkus/issues/8318
 public class ContinuousDevTest {
-
-    private static final Path LOG_FILE = Paths.get("target/" + ContinuousDevTest.class.getSimpleName() + ".log");
-
     @RegisterExtension
     static final QuarkusDevModeTest TEST = new QuarkusDevModeTest()
             .setArchiveProducer(new Supplier<>() {
@@ -56,7 +48,7 @@ public class ContinuousDevTest {
             });
 
     @Test
-    public void checkTests() throws InterruptedException {
+    public void checkTests() {
         ContinuousTestingTestUtils utils = new ContinuousTestingTestUtils();
         ContinuousTestingTestUtils.TestStatus ts = utils.waitForNextCompletion();
 
@@ -64,13 +56,7 @@ public class ContinuousDevTest {
         Assertions.assertEquals(1L, ts.getTestsPassed());
         Assertions.assertEquals(0L, ts.getTestsSkipped());
 
-        TEST.modifyResourceFile("application.properties", new Function<String, String>() {
-            @Override
-            public String apply(String s) {
-                return ContinuousTestingTestUtils.appProperties("quarkus.naming.enable-jndi=true",
-                        "camel-quarkus.junit.message=Leonard");
-            }
-        });
+        TEST.modifyResourceFile("application.properties", s -> s.replace("Sheldon", "Leonard"));
         ts = utils.waitForNextCompletion();
 
         Assertions.assertEquals(1L, ts.getTestsFailed());

--- a/test-framework/camel-quarkus-junit-tests/src/test/java/org/apache/camel/quarkus/test/extensions/doubeRouteBuilder/RouteBuilder.java
+++ b/test-framework/camel-quarkus-junit-tests/src/test/java/org/apache/camel/quarkus/test/extensions/doubeRouteBuilder/RouteBuilder.java
@@ -21,6 +21,6 @@ public class RouteBuilder extends org.apache.camel.builder.RouteBuilder {
     public void configure() throws Exception {
         from("direct:start").setBody(constant("Some Value")).log("The body is: ${body}");
 
-        from("timer:timeToAct?period=5000").routeId("TimerRoute").log("Calling direct:start").to("direct:start");
+        from("timer:timeToAct?delay=0&repeatCount=1").routeId("TimerRoute").log("Calling direct:start").to("direct:start");
     }
 }

--- a/test-framework/camel-quarkus-junit-tests/src/test/java/org/apache/camel/quarkus/test/extensions/producedRouteBuilder/ProducedRouteBuilderTest.java
+++ b/test-framework/camel-quarkus-junit-tests/src/test/java/org/apache/camel/quarkus/test/extensions/producedRouteBuilder/ProducedRouteBuilderTest.java
@@ -24,14 +24,12 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Test for https://github.com/apache/camel-quarkus/issues/4362
  */
-@Disabled //https://github.com/apache/camel-quarkus/issues/8318
 public class ProducedRouteBuilderTest {
 
     @RegisterExtension

--- a/test-framework/camel-quarkus-junit-tests/src/test/java/org/apache/camel/quarkus/test/extensions/routeBuilder/RouteBuilderFailureTest.java
+++ b/test-framework/camel-quarkus-junit-tests/src/test/java/org/apache/camel/quarkus/test/extensions/routeBuilder/RouteBuilderFailureTest.java
@@ -25,14 +25,12 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Scenario when useRouteBuilder is FALSE and NO RouteBuilder is produced -> should fail.
  */
-@Disabled //https://github.com/apache/camel-quarkus/issues/8318
 public class RouteBuilderFailureTest {
 
     @RegisterExtension

--- a/test-framework/camel-quarkus-junit-tests/src/test/java/org/apache/camel/quarkus/test/extensions/routeBuilder/RouteBuilderWarningWithProducedBuilderTest.java
+++ b/test-framework/camel-quarkus-junit-tests/src/test/java/org/apache/camel/quarkus/test/extensions/routeBuilder/RouteBuilderWarningWithProducedBuilderTest.java
@@ -24,7 +24,6 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -32,7 +31,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
  * Scenario when useRouteBuilder is TRUE and RouteBuilder is created via HelloRouteBuilder -> should succeed with
  * warning.
  */
-@Disabled //https://github.com/apache/camel-quarkus/issues/8318
 public class RouteBuilderWarningWithProducedBuilderTest {
 
     @RegisterExtension

--- a/test-framework/camel-quarkus-junit-tests/src/test/java/org/apache/camel/quarkus/test/extensions/routeBuilder/RouteBuilderWarningWithoutProducedBuilderTest.java
+++ b/test-framework/camel-quarkus-junit-tests/src/test/java/org/apache/camel/quarkus/test/extensions/routeBuilder/RouteBuilderWarningWithoutProducedBuilderTest.java
@@ -24,7 +24,6 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -32,7 +31,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
  * Scenario when useRouteBuilder is TRUE and RouteBuilder is created via HelloRouteBuilder -> should succeed without
  * warning.
  */
-@Disabled //https://github.com/apache/camel-quarkus/issues/8318
 public class RouteBuilderWarningWithoutProducedBuilderTest {
 
     @RegisterExtension


### PR DESCRIPTION
Fixes #8318

* Increases dev mode live reload timer task to 5 seconds, to avoid triggering scans when the app is not fully started
* Implements `close` in `CamelHotReplacementSetup` to cancel existing timer tasks. Otherwise scans can get triggered during live reloads. Which leads to exceptions being thrown and potential strange behaviour.