### PR TITLE
feat: Ensure extension is created with camel-base metadatas

### DIFF
--- a/extensions-core/core/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-core/core/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -34,3 +34,7 @@ metadata:
   - "quarkus.camel"
   - "quarkus.camel.main"
   status: "deprecated"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-core/reactive-executor/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-core/reactive-executor/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-core/threadpoolfactory-vertx/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-core/threadpoolfactory-vertx/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-core/xml-io-dsl/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-core/xml-io-dsl/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-core/xml-jaxb/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-core/xml-jaxb/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-core/xml-jaxp/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-core/xml-jaxp/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-core/yaml-dsl/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-core/yaml-dsl/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-core/yaml-io/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-core/yaml-io/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/asn1/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/asn1/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/asterisk/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/asterisk/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/aws-xray/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/aws-xray/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "deprecated"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/azure-cosmosdb/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/azure-cosmosdb/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/azure-files/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/azure-files/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/barcode/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/barcode/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/bonita/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/bonita/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/chatscript/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/chatscript/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/chunk/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/chunk/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/cli-connector/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/cli-connector/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -33,3 +33,7 @@ metadata:
   config:
   - "quarkus.camel.cli"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/cli-debug/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/cli-debug/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/cm-sms/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/cm-sms/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/coap/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/coap/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/cometd/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/cometd/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/console/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/console/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -33,3 +33,7 @@ metadata:
   config:
   - "quarkus.camel.console"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/couchbase/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/couchbase/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/dfdl/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/dfdl/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/djl/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/djl/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/dns/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/dns/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/drill/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/drill/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/dsl-modeline/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/dsl-modeline/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/ehcache/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/ehcache/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/fastjson/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/fastjson/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/flink/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/flink/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/google-functions/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/google-functions/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/guava-eventbus/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/guava-eventbus/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "deprecated"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/huaweicloud-smn/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/huaweicloud-smn/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/ibm-secrets-manager/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/ibm-secrets-manager/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/iec60870/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/iec60870/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/ignite/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/ignite/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/irc/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/irc/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/javascript/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/javascript/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/jcr/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/jcr/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/jgroups-raft/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/jgroups-raft/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/jgroups/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/jgroups/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/jooq/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/jooq/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/json-patch/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/json-patch/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "deprecated"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/jsonapi/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/jsonapi/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/ldif/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/ldif/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/lucene/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/lucene/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/mvel/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/mvel/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/opensearch/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/opensearch/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/printer/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/printer/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/pulsar/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/pulsar/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/python/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/python/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/quickfix/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/quickfix/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/redis/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/redis/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/robotframework/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/robotframework/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/schematron/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/schematron/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/smooks/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/smooks/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/smpp/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/smpp/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/snmp/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/snmp/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/spring-redis/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/spring-redis/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/stitch/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/stitch/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/stomp/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/stomp/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "deprecated"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/stub/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/stub/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/thrift/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/thrift/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/web3j/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/web3j/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/wordpress/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/wordpress/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/workday/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/workday/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/xmpp/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/xmpp/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/zookeeper-master/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/zookeeper-master/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions-jvm/zookeeper/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions-jvm/zookeeper/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -31,3 +31,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/activemq/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/activemq/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/activemq6/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/activemq6/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/amqp/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/amqp/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/arangodb/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/arangodb/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/as2/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/as2/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/atom/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/atom/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/attachments/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/attachments/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/avro/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/avro/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/aws-bedrock/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/aws-bedrock/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/aws-secrets-manager/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/aws-secrets-manager/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/aws2-athena/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/aws2-athena/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -32,3 +32,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/aws2-cw/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/aws2-cw/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -32,3 +32,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/aws2-ddb/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/aws2-ddb/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -32,3 +32,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/aws2-ec2/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/aws2-ec2/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -32,3 +32,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/aws2-ecs/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/aws2-ecs/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -32,3 +32,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/aws2-eks/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/aws2-eks/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -32,3 +32,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/aws2-eventbridge/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/aws2-eventbridge/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -32,3 +32,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/aws2-iam/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/aws2-iam/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -32,3 +32,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/aws2-kinesis/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/aws2-kinesis/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -32,3 +32,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/aws2-kms/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/aws2-kms/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -32,3 +32,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/aws2-lambda/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/aws2-lambda/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -32,3 +32,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/aws2-mq/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/aws2-mq/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -32,3 +32,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/aws2-msk/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/aws2-msk/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -32,3 +32,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/aws2-s3/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/aws2-s3/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -32,3 +32,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/aws2-ses/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/aws2-ses/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -32,3 +32,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/aws2-sns/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/aws2-sns/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -32,3 +32,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/aws2-sqs/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/aws2-sqs/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -32,3 +32,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/aws2-sts/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/aws2-sts/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -32,3 +32,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/aws2-translate/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/aws2-translate/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -32,3 +32,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/azure-eventhubs/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/azure-eventhubs/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/azure-key-vault/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/azure-key-vault/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/azure-servicebus/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/azure-servicebus/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/azure-storage-blob/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/azure-storage-blob/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/azure-storage-datalake/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/azure-storage-datalake/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/azure-storage-queue/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/azure-storage-queue/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/base64/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/base64/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/bean-validator/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/bean-validator/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/bean/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/bean/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/beanio/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/beanio/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/bindy/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/bindy/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/box/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/box/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/braintree/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/braintree/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/browse/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/browse/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/caffeine/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/caffeine/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/cassandraql/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/cassandraql/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/cbor/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/cbor/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/cloudevents/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/cloudevents/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/consul/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/consul/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/controlbus/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/controlbus/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/couchdb/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/couchdb/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/cron/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/cron/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/crypto-pgp/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/crypto-pgp/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/crypto/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/crypto/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/csimple/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/csimple/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "preview"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/csv/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/csv/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/cxf-soap/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/cxf-soap/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -32,3 +32,7 @@ metadata:
   config:
   - "quarkus.camel.cxf"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/cyberark-vault/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/cyberark-vault/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/dataformat/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/dataformat/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/dataset/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/dataset/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/datasonnet/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/datasonnet/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/debezium-mongodb/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/debezium-mongodb/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/debezium-mysql/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/debezium-mysql/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/debezium-oracle/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/debezium-oracle/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/debezium-postgres/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/debezium-postgres/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/debezium-sqlserver/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/debezium-sqlserver/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/debug/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/debug/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -32,3 +32,7 @@ metadata:
   config:
   - "quarkus.camel.debug"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/digitalocean/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/digitalocean/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/direct/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/direct/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/disruptor/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/disruptor/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/docling/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/docling/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/dropbox/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/dropbox/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/elasticsearch-rest-client/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/elasticsearch-rest-client/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/elasticsearch/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/elasticsearch/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/exec/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/exec/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/fhir/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/fhir/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -32,3 +32,7 @@ metadata:
   config:
   - "quarkus.camel.fhir"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/file-cluster-service/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/file-cluster-service/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -32,3 +32,7 @@ metadata:
   config:
   - "quarkus.camel.cluster.file"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/file-watch/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/file-watch/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/file/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/file/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/flatpack/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/flatpack/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/fop/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/fop/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/fory/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/fory/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/freemarker/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/freemarker/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/ftp/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/ftp/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/geocoder/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/geocoder/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/git/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/git/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/github/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/github/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "deprecated"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/google-bigquery/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/google-bigquery/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/google-calendar/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/google-calendar/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/google-drive/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/google-drive/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/google-mail/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/google-mail/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/google-pubsub/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/google-pubsub/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/google-secret-manager/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/google-secret-manager/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/google-sheets/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/google-sheets/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/google-storage/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/google-storage/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/graphql/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/graphql/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -32,3 +32,7 @@ metadata:
   config:
   - "quarkus.camel.graphql"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/grok/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/grok/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/groovy/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/groovy/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/grpc/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/grpc/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -32,3 +32,7 @@ metadata:
   config:
   - "quarkus.camel.grpc"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/gson/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/gson/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/hashicorp-vault/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/hashicorp-vault/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/hazelcast/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/hazelcast/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "deprecated"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/headersmap/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/headersmap/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/hl7/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/hl7/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/http/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/http/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/ibm-cos/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/ibm-cos/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/ibm-watson-discovery/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/ibm-watson-discovery/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/ibm-watson-language/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/ibm-watson-language/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/ical/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/ical/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/infinispan-cluster-service/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/infinispan-cluster-service/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -32,3 +32,7 @@ metadata:
   config:
   - "quarkus.camel.cluster.infinispan"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/infinispan/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/infinispan/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/influxdb/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/influxdb/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/iso8583/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/iso8583/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/jackson-avro/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/jackson-avro/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/jackson-protobuf/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/jackson-protobuf/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/jackson/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/jackson/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/jacksonxml/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/jacksonxml/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/jasypt/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/jasypt/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -32,3 +32,7 @@ metadata:
   config:
   - "quarkus.camel.jasypt"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/java-joor-dsl/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/java-joor-dsl/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/jaxb/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/jaxb/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/jcache/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/jcache/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/jdbc/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/jdbc/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/jfr/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/jfr/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -32,3 +32,7 @@ metadata:
   config:
   - "quarkus.camel.jfr"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/jira/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/jira/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/jms/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/jms/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/jolokia/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/jolokia/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -32,3 +32,7 @@ metadata:
   config:
   - "quarkus.camel.jolokia"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/jolt/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/jolt/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/joor/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/joor/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -32,3 +32,7 @@ metadata:
   config:
   - "quarkus.camel.joor"
   status: "deprecated"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/jpa/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/jpa/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/jq/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/jq/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/jsch/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/jsch/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/jslt/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/jslt/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/json-validator/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/json-validator/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/jsonata/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/jsonata/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/jsonb/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/jsonb/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/jsonpath/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/jsonpath/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/jt400/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/jt400/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/jta/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/jta/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/kafka/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/kafka/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -32,3 +32,7 @@ metadata:
   config:
   - "quarkus.camel.kafka"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/kamelet/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/kamelet/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/keycloak/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/keycloak/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "preview"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/knative-consumer/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/knative-consumer/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/knative-producer/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/knative-producer/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/knative/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/knative/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/kubernetes-cluster-service/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/kubernetes-cluster-service/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -32,3 +32,7 @@ metadata:
   config:
   - "quarkus.camel.cluster.kubernetes"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/kubernetes/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/kubernetes/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/kudu/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/kudu/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/langchain4j-agent/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/langchain4j-agent/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "preview"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/langchain4j-chat/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/langchain4j-chat/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "preview"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/langchain4j-embeddings/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/langchain4j-embeddings/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "preview"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/langchain4j-embeddingstore/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/langchain4j-embeddingstore/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "preview"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/langchain4j-tokenizer/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/langchain4j-tokenizer/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "preview"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/langchain4j-tools/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/langchain4j-tools/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "preview"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/langchain4j-web-search/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/langchain4j-web-search/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "preview"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/language/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/language/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/ldap/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/ldap/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -32,3 +32,7 @@ metadata:
   config:
   - "quarkus.camel.ldap"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/leveldb/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/leveldb/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "deprecated"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/log/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/log/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/lra/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/lra/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/lumberjack/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/lumberjack/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/lzf/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/lzf/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/mail-microsoft-oauth/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/mail-microsoft-oauth/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/mail/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/mail/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/management/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/management/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/mapstruct/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/mapstruct/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/master/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/master/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/mdc/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/mdc/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -32,3 +32,7 @@ metadata:
   config:
   - "quarkus.camel.mdc"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/micrometer/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/micrometer/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -32,3 +32,7 @@ metadata:
   config:
   - "quarkus.camel.metrics"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/microprofile-fault-tolerance/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/microprofile-fault-tolerance/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/microprofile-health/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/microprofile-health/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -32,3 +32,7 @@ metadata:
   config:
   - "quarkus.camel.health"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/milo/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/milo/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/milvus/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/milvus/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/mina-sftp/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/mina-sftp/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/minio/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/minio/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/mllp/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/mllp/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/mock/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/mock/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/mongodb-gridfs/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/mongodb-gridfs/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/mongodb/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/mongodb/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/mustache/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/mustache/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/mybatis/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/mybatis/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/nats/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/nats/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/netty-http/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/netty-http/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/netty/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/netty/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/oaipmh/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/oaipmh/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/oauth/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/oauth/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/observability-services/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/observability-services/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/ocsf/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/ocsf/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/ognl/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/ognl/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "deprecated"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/olingo4/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/olingo4/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "deprecated"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/once/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/once/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/openai/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/openai/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/openapi-java/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/openapi-java/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -32,3 +32,7 @@ metadata:
   config:
   - "quarkus.camel.openapi"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/openstack/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/openstack/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/opentelemetry/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/opentelemetry/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -32,3 +32,7 @@ metadata:
   config:
   - "quarkus.camel.opentelemetry"
   status: "deprecated"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/opentelemetry2/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/opentelemetry2/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -32,3 +32,7 @@ metadata:
   config:
   - "quarkus.camel.opentelemetry2"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/optaplanner/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/optaplanner/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/paho-mqtt5/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/paho-mqtt5/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/paho/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/paho/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/pdf/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/pdf/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/pg-replication-slot/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/pg-replication-slot/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/pgevent/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/pgevent/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/pinecone/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/pinecone/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "preview"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/platform-http/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/platform-http/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/pqc/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/pqc/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/protobuf/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/protobuf/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/pubnub/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/pubnub/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/qdrant/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/qdrant/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/quartz/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/quartz/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/qute/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/qute/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/reactive-streams/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/reactive-streams/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/ref/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/ref/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/rest-openapi/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/rest-openapi/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -32,3 +32,7 @@ metadata:
   config:
   - "quarkus.camel.openapi"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/rest/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/rest/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/rocketmq/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/rocketmq/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/rss/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/rss/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/saga/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/saga/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/salesforce/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/salesforce/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/sap-netweaver/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/sap-netweaver/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/saxon/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/saxon/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/scheduler/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/scheduler/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/seda/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/seda/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/servicenow/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/servicenow/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/servlet/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/servlet/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -32,3 +32,7 @@ metadata:
   config:
   - "quarkus.camel.servlet"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/shiro/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/shiro/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/sjms/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/sjms/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/sjms2/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/sjms2/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/slack/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/slack/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/smallrye-reactive-messaging/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/smallrye-reactive-messaging/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/smb/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/smb/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/snakeyaml/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/snakeyaml/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/soap/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/soap/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/solr/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/solr/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/splunk-hec/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/splunk-hec/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/splunk/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/splunk/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "deprecated"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/spring-rabbitmq/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/spring-rabbitmq/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/sql/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/sql/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/ssh/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/ssh/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/stax/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/stax/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/stream/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/stream/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/stringtemplate/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/stringtemplate/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/swift/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/swift/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/syslog/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/syslog/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/tarfile/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/tarfile/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/telegram/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/telegram/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/telemetry-dev/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/telemetry-dev/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -32,3 +32,7 @@ metadata:
   config:
   - "quarkus.camel.telemetryDev"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/tika/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/tika/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/timer/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/timer/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/tls-registry/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/tls-registry/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -32,3 +32,7 @@ metadata:
   config:
   - "quarkus.camel.tls-registry"
   status: "experimental"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/twilio/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/twilio/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/twitter/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/twitter/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/univocity-parsers/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/univocity-parsers/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/validator/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/validator/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/velocity/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/velocity/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/vertx-http/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/vertx-http/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/vertx-websocket/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/vertx-websocket/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/vertx/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/vertx/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/wasm/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/wasm/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "experimental"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/weather/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/weather/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/weaviate/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/weaviate/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/xchange/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/xchange/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/xj/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/xj/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/xmlsecurity/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/xmlsecurity/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/xpath/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/xpath/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/xslt-saxon/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/xslt-saxon/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/xslt/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/xslt/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -32,3 +32,7 @@ metadata:
   config:
   - "quarkus.camel.xslt"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/zendesk/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/zendesk/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/zip-deflater/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/zip-deflater/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/extensions/zipfile/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/zipfile/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -30,3 +30,7 @@ metadata:
   categories:
   - "integration"
   status: "stable"
+  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"

--- a/poms/build-parent/pom.xml
+++ b/poms/build-parent/pom.xml
@@ -136,6 +136,26 @@
                 <artifactId>maven-resources-plugin</artifactId>
                 <executions>
                     <execution>
+                        <id>filter-extension-metadata</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${project.basedir}/src/main/resources</directory>
+                                    <filtering>true</filtering>
+                                    <includes>
+                                        <include>META-INF/quarkus-extension.yaml</include>
+                                    </includes>
+                                </resource>
+                            </resources>
+                            <overwrite>true</overwrite>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>legal-resources</id>
                         <phase>process-resources</phase>
                         <goals>

--- a/tooling/create-extension-templates/quarkus-extension.yaml
+++ b/tooling/create-extension-templates/quarkus-extension.yaml
@@ -47,4 +47,7 @@ metadata:
 [/#if]
 [#if deprecated ]  status: "deprecated"
 [#else]  status: "[=status]"
-[/#if]
+[/#if]  integrates:
+    - name: "Camel"
+      artifact: "org.apache.camel:camel-base"
+      version: "${camel.version}"


### PR DESCRIPTION
Ref #5191 
Ref https://github.com/quarkusio/quarkus/issues/35404

Add the 'integrates' new metadata field filled by default with camel-base artifact reference with a version referencing the property. `version: "${camel.version}"` stays as-is in source (NOT replaced).

Then the version value is added by the maven-resources-plugin. The changes in build:
- Applies to the **implicit `default-resources` execution**
- Says: "Copy everything from `src/main/resources` EXCEPT `META-INF/quarkus-extension.yaml`"
- Other files (like `quarkus-extension.properties`) are still copied normally

The Maven Build Process does the following:

1. Default Resources (default-resources execution)
  Process: src/main/resources/**
  EXCEPT: META-INF/quarkus-extension.yaml (excluded)
  Result: Other files copied to target/classes/

2. Legal Resources (legal-resources execution)
  Copies license files with filtering

3. Filter Extension Metadata (filter-extension-metadata execution)
  Process: ONLY META-INF/quarkus-extension.yaml
  Filtering: true
  Reads: "${camel.version}" from pom properties
  Replaces: "${camel.version}" → "4.19.0"
  Result: Filtered file in target/classes/META-INF/


