### PR TITLE
Adjust Maven plugin inclusion pattern in Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -58,8 +58,7 @@ updates:
       - dependency-name: "com.microsoft.graph:microsoft-graph"
       - dependency-name: "com.microsoft.graph:microsoft-graph-auth"
       # Maven plugins
-      - dependency-name: "*:*-maven-plugin"
-      - dependency-name: "org.apache.maven.plugins:*"
+      - dependency-name: "*:*-plugin"
     ignore:
       # Maven plugins
       # Quarkus is upgraded manually


### PR DESCRIPTION
Was wondering why we have a stale `gmavenplus-plugin`. It was not covered by Dependabot inclusion patterns.