### PR TITLE
Ensure forward compatibility for Debezium components with Kafka 4.2.0

### DIFF
--- a/extensions-support/debezium/deployment/pom.xml
+++ b/extensions-support/debezium/deployment/pom.xml
@@ -40,6 +40,10 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-core-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-support-debezium</artifactId>
         </dependency>
     </dependencies>

--- a/extensions-support/debezium/deployment/src/main/java/org/apache/camel/quarkus/support/debezium/deployment/DebeziumSupportProcessor.java
+++ b/extensions-support/debezium/deployment/src/main/java/org/apache/camel/quarkus/support/debezium/deployment/DebeziumSupportProcessor.java
@@ -41,6 +41,7 @@ import io.debezium.snapshot.mode.RecoverySnapshotter;
 import io.debezium.snapshot.mode.WhenNeededSnapshotter;
 import io.debezium.snapshot.spi.SnapshotLock;
 import io.debezium.storage.file.history.FileSchemaHistory;
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
@@ -48,6 +49,7 @@ import io.quarkus.deployment.builditem.IndexDependencyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
+import org.apache.camel.quarkus.support.debezium.DebeziumComponentObserver;
 import org.apache.kafka.common.security.authenticator.SaslClientAuthenticator;
 import org.apache.kafka.connect.json.JsonConverter;
 import org.apache.kafka.connect.source.SourceTask;
@@ -65,6 +67,11 @@ public class DebeziumSupportProcessor {
     @BuildStep
     RuntimeInitializedClassBuildItem runtimeInitializedClasses() {
         return new RuntimeInitializedClassBuildItem(SaslClientAuthenticator.class.getName());
+    }
+
+    @BuildStep
+    public void configureKafkaComponentForDevServices(BuildProducer<AdditionalBeanBuildItem> additionalBean) {
+        additionalBean.produce(AdditionalBeanBuildItem.unremovableOf(DebeziumComponentObserver.class));
     }
 
     @BuildStep

--- a/extensions-support/debezium/runtime/pom.xml
+++ b/extensions-support/debezium/runtime/pom.xml
@@ -48,6 +48,10 @@
             <artifactId>javassist</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-debezium-common</artifactId>
         </dependency>

--- a/extensions-support/debezium/runtime/src/main/java/org/apache/camel/quarkus/support/debezium/DebeziumComponentObserver.java
+++ b/extensions-support/debezium/runtime/src/main/java/org/apache/camel/quarkus/support/debezium/DebeziumComponentObserver.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.support.debezium;
+
+import java.util.Map;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import org.apache.camel.component.debezium.DebeziumComponent;
+import org.apache.camel.quarkus.core.events.ComponentAddEvent;
+
+@ApplicationScoped
+public class DebeziumComponentObserver {
+
+    void initDebeziumBootstrapServers(@Observes ComponentAddEvent event) {
+        if (event.getComponent() instanceof DebeziumComponent<?> debeziumComponent) {
+            Map<String, Object> additionalProperties = debeziumComponent.getConfiguration().getAdditionalProperties();
+            additionalProperties.putIfAbsent("bootstrap.servers", "localhost:9092");
+        }
+    }
+}

--- a/integration-test-groups/debezium/postgresql/src/test/java/org/apache/camel/quarkus/component/debezium/common/it/postgres/DebeziumPostgresTest.java
+++ b/integration-test-groups/debezium/postgresql/src/test/java/org/apache/camel/quarkus/component/debezium/common/it/postgres/DebeziumPostgresTest.java
@@ -60,7 +60,8 @@ class DebeziumPostgresTest extends AbstractDebeziumTest {
         RestAssured.get(Type.postgres.getComponent() + "/getAdditionalProperties")
                 .then()
                 .statusCode(200)
-                .body("'database.connectionTimeZone'", is("CET"));
+                .body("'database.connectionTimeZone'", is("CET"))
+                .body("'bootstrap.servers'", is(notNullValue()));
     }
 
     @AfterAll


### PR DESCRIPTION
Add a DebeziumComponentObserver CDI bean that sets bootstrap.servers into Debezium component additional properties when the component is added to the CamelContext

Starting with Kafka 4.2.0, WorkerConfig no longer comes with a default value for bootstrap.servers. Debezium embedded, which uses that config (without connecting to a broker), fails to create it's config because it no longer provides a value for that required config property. 

Fixes #8530

[x] An issue should be filed for the change unless this is a trivial change (fixing a typo or similar). One issue should ideally be fixed by not more than one commit and the other way round, each commit should fix just one issue, without pulling in other changes.
[x] Each commit in the pull request should have a meaningful and properly spelled subject line and body. Copying the title of the associated issue is typically enough. Please include the issue number in the commit message prefixed by #.
[ ] The pull request description should explain what the pull request does, how, and why. If the info is available in the associated issue or some other external document, a link is enough.
[x] Phrases like Fix #<issueNumber> or Fixes #<issueNumber> will auto-close the named issue upon merging the pull request. Using them is typically a good idea.
[ ] Please run mvn process-resources -Pformat (and amend the changes if necessary) before sending the pull request.
[ ] Contributor guide is your good friend: https://camel.apache.org/camel-quarkus/latest/contributor-guide.html
