### PR TITLE
Simplify mina-sftp native configuration for Camel 4.20

### DIFF
--- a/extensions/mina-sftp/deployment/pom.xml
+++ b/extensions/mina-sftp/deployment/pom.xml
@@ -46,10 +46,6 @@
             <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-support-bouncycastle-deployment</artifactId>
         </dependency>
-        <dependency>
-            <groupId>io.quarkiverse.jsch</groupId>
-            <artifactId>quarkus-jsch-deployment</artifactId>
-        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/mina-sftp/deployment/src/main/java/org/apache/camel/quarkus/component/mina/sftp/deployment/MinaSftpProcessor.java
+++ b/extensions/mina-sftp/deployment/src/main/java/org/apache/camel/quarkus/component/mina/sftp/deployment/MinaSftpProcessor.java
@@ -24,8 +24,6 @@ import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.RemovedResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 import io.quarkus.maven.dependency.ArtifactKey;
-import org.apache.camel.quarkus.core.deployment.spi.CamelServiceFilter;
-import org.apache.camel.quarkus.core.deployment.spi.CamelServiceFilterBuildItem;
 
 class MinaSftpProcessor {
 
@@ -34,14 +32,6 @@ class MinaSftpProcessor {
     @BuildStep
     FeatureBuildItem feature() {
         return new FeatureBuildItem(FEATURE);
-    }
-
-    @BuildStep
-    void filterFtpComponents(BuildProducer<CamelServiceFilterBuildItem> serviceFilter) {
-        // camel-mina-sftp depends on camel-ftp only for shared base classes (RemoteFileEndpoint, etc.)
-        serviceFilter.produce(new CamelServiceFilterBuildItem(CamelServiceFilter.forComponent("ftp")));
-        serviceFilter.produce(new CamelServiceFilterBuildItem(CamelServiceFilter.forComponent("ftps")));
-        serviceFilter.produce(new CamelServiceFilterBuildItem(CamelServiceFilter.forComponent("sftp")));
     }
 
     @BuildStep
@@ -55,14 +45,7 @@ class MinaSftpProcessor {
 
     @BuildStep
     void runtimeInitializedClasses(BuildProducer<RuntimeInitializedClassBuildItem> runtimeInitializedClass) {
-        // FTP/FTPS/SFTP endpoint classes are still on the classpath (from camel-ftp)
-        runtimeInitializedClass
-                .produce(new RuntimeInitializedClassBuildItem("org.apache.camel.component.file.remote.FtpEndpoint"));
-        runtimeInitializedClass
-                .produce(new RuntimeInitializedClassBuildItem("org.apache.camel.component.file.remote.FtpsEndpoint"));
-        runtimeInitializedClass
-                .produce(new RuntimeInitializedClassBuildItem("org.apache.camel.component.file.remote.SftpEndpoint"));
-
+        // MinaSftpOperations has Pattern static fields that should be initialized at runtime
         runtimeInitializedClass
                 .produce(
                         new RuntimeInitializedClassBuildItem("org.apache.camel.component.file.remote.mina.MinaSftpOperations"));

--- a/extensions/mina-sftp/runtime/pom.xml
+++ b/extensions/mina-sftp/runtime/pom.xml
@@ -52,19 +52,6 @@
             <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-support-bouncycastle</artifactId>
         </dependency>
-        <!-- Use quarkus-jsch for proper GraalVM configuration -->
-        <dependency>
-            <groupId>io.quarkiverse.jsch</groupId>
-            <artifactId>quarkus-jsch</artifactId>
-        </dependency>
-        
-        <!-- commons-net is excluded by camel-mina-sftp from camel-ftp, but needed for native image build
-             to allow GraalVM to analyze FTP/FTPS endpoint classes. Clean after https://issues.apache.org/jira/browse/CAMEL-23164 -->
-        <dependency>
-            <groupId>commons-net</groupId>
-            <artifactId>commons-net</artifactId>
-        </dependency>
-
         <dependency>
             <groupId>org.graalvm.sdk</groupId>
             <artifactId>nativeimage</artifactId>


### PR DESCRIPTION
Closes #8445 Review and update mina-sftp native support for camel 4.20

Removes previously required workarounds for GraalVM native compilation:                                                             
  - Remove quarkus-jsch dependency (no longer needed in Camel 4.20)                                                                   
  - Remove commons-net dependency added for CAMEL-23164 workaround                                                                    
  - Remove FTP/FTPS/SFTP component filtering from deployment processor                                                                
  - Remove runtime initialization of FtpEndpoint, FtpsEndpoint, SftpEndpoint classes                                                  
                                                                                                                                      
  These dependencies and configurations were workarounds for upstream issues                                                          
  that have been resolved in Camel 4.20. The extension now relies on proper                                                           
  native support provided by Camel core.                                                                                              
                                                                                                                                      
  Keeps MinaSftpOperations runtime initialization as it contains Pattern                                                              
  static fields that must be initialized at runtime. 