### PR TITLE
Pin kafka-clients to 4.1.1 for Debezium compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
         <json-schema-validator.version>${networknt-json-schema-validator-version}</json-schema-validator.version>
         <json-smart.version>${json-smart-version}</json-smart.version>
         <jxmpp.version>1.1.0</jxmpp.version><!-- @sync org.apache.camel:camel-xmpp:${camel.version} dep:org.jxmpp:jxmpp-jid -->
-        <kafka.version>4.2.0</kafka.version><!-- @sync io.quarkus:quarkus-bom:${quarkus.version} dep:org.apache.kafka:kafka-clients -->
+        <kafka.version>4.1.1</kafka.version><!-- Pinned to 4.1.1 for Debezium compatibility. Debezium 3.5.x is built against Kafka Connect 4.1.1. kafka-clients 4.2.0 changed bootstrap.servers validation, causing "Missing required configuration 'bootstrap.servers'" errors in camel-quarkus-debezium-* extensions. See https://github.com/apache/camel-quarkus/issues/8530 -->
         <keycloak.version>26.5.7</keycloak.version><!-- @sync io.quarkus:quarkus-build-parent:${quarkus.version} prop:keycloak.server.version -->
         <kudu.version>${kudu-version}</kudu.version>
         <kotlin.version>2.3.10</kotlin.version><!-- @sync io.quarkus:quarkus-bom:${quarkus.version} dep:org.jetbrains.kotlin:kotlin-stdlib -->


### PR DESCRIPTION
## Summary

Pin `kafka-clients` to `4.1.1` to fix `camel-quarkus-debezium-\*` extensions failing with `Missing required configuration 'bootstrap.servers'` after Quarkus 3.35.0 upgraded kafka-clients to 4.2.0.

Debezium 3.5.x is built against Kafka Connect 4.1.1. kafka-clients 4.2.0 changed `bootstrap.servers` validation, breaking the Debezium extension.

## Fix

`pom.xml`: change `<kafka.version>4.2.0</kafka.version>` to `<kafka.version>4.1.1</kafka.version>`

Once Debezium releases a version compatible with kafka-clients 4.2.x (open PR in progress), this pin can be reverted.

## Testing

Run: `mvn test -pl integration-test-groups/debezium/mongodb,...` (all Debezium integration test groups)

## Related

- Fixes https://github.com/apache/camel-quarkus/issues/8530