### PR TITLE
Add security-policy integration test for CAMEL-23250

### DIFF
--- a/integration-test-groups/foundation/pom.xml
+++ b/integration-test-groups/foundation/pom.xml
@@ -50,6 +50,7 @@
         <module>ref</module>
         <module>route-configurations</module>
         <module>scheduler</module>
+        <module>security-policy</module>
         <module>seda</module>
         <module>stream</module>
         <module>timer</module>

--- a/integration-test-groups/foundation/security-policy/pom.xml
+++ b/integration-test-groups/foundation/security-policy/pom.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.camel.quarkus</groupId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
+        <version>3.35.0-SNAPSHOT</version>
+        <relativePath>../../../poms/build-parent-it/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>camel-quarkus-integration-test-security-policy</artifactId>
+    <name>Camel Quarkus :: Integration Tests :: Security Policy</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-log</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-timer</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy</artifactId>
+        </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <id>native</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <properties>
+                <quarkus.native.enabled>true</quarkus.native.enabled>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>virtualDependencies</id>
+            <activation>
+                <property>
+                    <name>!noVirtualDependencies</name>
+                </property>
+            </activation>
+            <dependencies>
+                <!-- The following dependencies guarantee that this module is built after them. You can update them by running `mvn process-resources -Pformat -N` from the source tree root directory -->
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-log-deployment</artifactId>
+                    <version>${project.version}</version>
+                    <type>pom</type>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-timer-deployment</artifactId>
+                    <version>${project.version}</version>
+                    <type>pom</type>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
+</project>

--- a/integration-test-groups/foundation/security-policy/src/main/java/org/apache/camel/quarkus/security/policy/Routes.java
+++ b/integration-test-groups/foundation/security-policy/src/main/java/org/apache/camel/quarkus/security/policy/Routes.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.security.policy;
+
+import org.apache.camel.builder.RouteBuilder;
+
+public class Routes extends RouteBuilder {
+
+    @Override
+    public void configure() {
+        from("timer:tick?repeatCount=1")
+                .log("Timer tick!");
+    }
+}

--- a/integration-test-groups/foundation/security-policy/src/main/java/org/apache/camel/quarkus/security/policy/SecurityPolicyResource.java
+++ b/integration-test-groups/foundation/security-policy/src/main/java/org/apache/camel/quarkus/security/policy/SecurityPolicyResource.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.security.policy;
+
+import java.util.stream.Collectors;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import org.apache.camel.CamelContext;
+import org.apache.camel.main.SecurityPolicyResult;
+
+@Path("/security-policy")
+@ApplicationScoped
+public class SecurityPolicyResource {
+
+    @Inject
+    CamelContext camelContext;
+
+    @GET
+    @Path("/has-violations")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hasViolations() {
+        SecurityPolicyResult result = camelContext.getCamelContextExtension()
+                .getContextPlugin(SecurityPolicyResult.class);
+        if (result == null) {
+            return "null";
+        }
+        return String.valueOf(result.hasViolations());
+    }
+
+    @GET
+    @Path("/violation-categories")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String violationCategories() {
+        SecurityPolicyResult result = camelContext.getCamelContextExtension()
+                .getContextPlugin(SecurityPolicyResult.class);
+        if (result == null) {
+            return "";
+        }
+        return result.getViolations().stream()
+                .map(v -> v.category())
+                .collect(Collectors.joining(","));
+    }
+
+    @GET
+    @Path("/violation-property-keys")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String violationPropertyKeys() {
+        SecurityPolicyResult result = camelContext.getCamelContextExtension()
+                .getContextPlugin(SecurityPolicyResult.class);
+        if (result == null) {
+            return "";
+        }
+        return result.getViolations().stream()
+                .map(v -> v.propertyKey())
+                .collect(Collectors.joining(","));
+    }
+
+    @GET
+    @Path("/violation-policies")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String violationPolicies() {
+        SecurityPolicyResult result = camelContext.getCamelContextExtension()
+                .getContextPlugin(SecurityPolicyResult.class);
+        if (result == null) {
+            return "";
+        }
+        return result.getViolations().stream()
+                .map(v -> v.policy())
+                .collect(Collectors.joining(","));
+    }
+}

--- a/integration-test-groups/foundation/security-policy/src/main/resources/application.properties
+++ b/integration-test-groups/foundation/security-policy/src/main/resources/application.properties
@@ -1,0 +1,18 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+camel.main.devConsoleEnabled = true

--- a/integration-test-groups/foundation/security-policy/src/test/java/org/apache/camel/quarkus/security/policy/SecurityPolicyAllowIT.java
+++ b/integration-test-groups/foundation/security-policy/src/test/java/org/apache/camel/quarkus/security/policy/SecurityPolicyAllowIT.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.security.policy;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+class SecurityPolicyAllowIT extends SecurityPolicyAllowTest {
+}

--- a/integration-test-groups/foundation/security-policy/src/test/java/org/apache/camel/quarkus/security/policy/SecurityPolicyAllowTest.java
+++ b/integration-test-groups/foundation/security-policy/src/test/java/org/apache/camel/quarkus/security/policy/SecurityPolicyAllowTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.security.policy;
+
+import java.util.Map;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.Matchers.is;
+
+@QuarkusTest
+@TestProfile(SecurityPolicyAllowTest.Profile.class)
+class SecurityPolicyAllowTest {
+
+    @Test
+    void allowPolicySuppressesAllViolations() {
+        RestAssured.when().get("/security-policy/has-violations").then().body(is("false"));
+    }
+
+    public static class Profile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("camel.security.policy", "allow");
+        }
+    }
+}

--- a/integration-test-groups/foundation/security-policy/src/test/java/org/apache/camel/quarkus/security/policy/SecurityPolicyAllowedPropertiesIT.java
+++ b/integration-test-groups/foundation/security-policy/src/test/java/org/apache/camel/quarkus/security/policy/SecurityPolicyAllowedPropertiesIT.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.security.policy;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+class SecurityPolicyAllowedPropertiesIT extends SecurityPolicyAllowedPropertiesTest {
+}

--- a/integration-test-groups/foundation/security-policy/src/test/java/org/apache/camel/quarkus/security/policy/SecurityPolicyAllowedPropertiesTest.java
+++ b/integration-test-groups/foundation/security-policy/src/test/java/org/apache/camel/quarkus/security/policy/SecurityPolicyAllowedPropertiesTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.security.policy;
+
+import java.util.Map;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.Matchers.is;
+
+@QuarkusTest
+@TestProfile(SecurityPolicyAllowedPropertiesTest.Profile.class)
+class SecurityPolicyAllowedPropertiesTest {
+
+    @Test
+    void allowedPropertiesExcludesViolations() {
+        RestAssured.when().get("/security-policy/has-violations").then().body(is("false"));
+    }
+
+    public static class Profile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("camel.security.allowed-properties", "camel.main.devConsoleEnabled");
+        }
+    }
+}

--- a/integration-test-groups/foundation/security-policy/src/test/java/org/apache/camel/quarkus/security/policy/SecurityPolicyCategoryOverrideIT.java
+++ b/integration-test-groups/foundation/security-policy/src/test/java/org/apache/camel/quarkus/security/policy/SecurityPolicyCategoryOverrideIT.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.security.policy;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+class SecurityPolicyCategoryOverrideIT extends SecurityPolicyCategoryOverrideTest {
+}

--- a/integration-test-groups/foundation/security-policy/src/test/java/org/apache/camel/quarkus/security/policy/SecurityPolicyCategoryOverrideTest.java
+++ b/integration-test-groups/foundation/security-policy/src/test/java/org/apache/camel/quarkus/security/policy/SecurityPolicyCategoryOverrideTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.security.policy;
+
+import java.util.Map;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.Matchers.is;
+
+@QuarkusTest
+@TestProfile(SecurityPolicyCategoryOverrideTest.Profile.class)
+class SecurityPolicyCategoryOverrideTest {
+
+    @Test
+    void categoryOverrideSuppressesViolations() {
+        RestAssured.when().get("/security-policy/has-violations").then().body(is("false"));
+    }
+
+    public static class Profile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("camel.security.insecure-dev-policy", "allow");
+        }
+    }
+}

--- a/integration-test-groups/foundation/security-policy/src/test/java/org/apache/camel/quarkus/security/policy/SecurityPolicyWarnIT.java
+++ b/integration-test-groups/foundation/security-policy/src/test/java/org/apache/camel/quarkus/security/policy/SecurityPolicyWarnIT.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.security.policy;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+class SecurityPolicyWarnIT extends SecurityPolicyWarnTest {
+}

--- a/integration-test-groups/foundation/security-policy/src/test/java/org/apache/camel/quarkus/security/policy/SecurityPolicyWarnTest.java
+++ b/integration-test-groups/foundation/security-policy/src/test/java/org/apache/camel/quarkus/security/policy/SecurityPolicyWarnTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.security.policy;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+
+@QuarkusTest
+class SecurityPolicyWarnTest {
+
+    @Test
+    void warnPolicyDetectsViolations() {
+        RestAssured.when().get("/security-policy/has-violations").then().body(is("true"));
+    }
+
+    @Test
+    void warnPolicyReportsInsecureDevCategory() {
+        RestAssured.when().get("/security-policy/violation-categories").then().body(containsString("insecure:dev"));
+    }
+
+    @Test
+    void warnPolicyReportsDevConsoleEnabledProperty() {
+        RestAssured.when().get("/security-policy/violation-property-keys").then().body(containsString("devConsoleEnabled"));
+    }
+
+    @Test
+    void warnPolicyReportsWarnLevel() {
+        RestAssured.when().get("/security-policy/violation-policies").then().body(containsString("warn"));
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `integration-test-groups/foundation/security-policy` module to test Camel's security policy enforcement framework (CAMEL-23250) in Quarkus
- Uses `QuarkusTestProfile` with `SecurityPolicyResult` plugin inspection instead of process executor
- 4 test scenarios: warn detection, category override, allowed-properties exclusion, allow policy

## Test cases

1. **SecurityPolicyWarnTest** — default warn policy detects violations via `SecurityPolicyResult` plugin
2. **SecurityPolicyCategoryOverrideTest** — `insecure-dev-policy=allow` suppresses insecure:dev violations
3. **SecurityPolicyAllowedPropertiesTest** — `allowed-properties` excludes specific properties from enforcement
4. **SecurityPolicyAllowTest** — `policy=allow` suppresses all violations

## Prerequisites

Requires Camel 4.21.0+ which includes the security policy framework and the fix from https://github.com/apache/camel/pull/22779 (enforcement running on empty properties map).

## Test plan

- [x] All 4 tests pass in JVM mode
- [ ] CI verification

_Claude Code on behalf of Guillaume Nodet_

🤖 Generated with [Claude Code](https://claude.com/claude-code)