### PR TITLE
Fix Milvus extension build failure with milvus-sdk-java 2.6.18

### DIFF
--- a/extensions/milvus/deployment/src/main/java/org/apache/camel/quarkus/component/milvus/deployment/MilvusProcessor.java
+++ b/extensions/milvus/deployment/src/main/java/org/apache/camel/quarkus/component/milvus/deployment/MilvusProcessor.java
@@ -42,7 +42,7 @@ class MilvusProcessor {
         index.getIndex().getKnownClasses().stream()
                 .filter(ci -> {
                     String name = ci.name().toString();
-                    return name.startsWith("io.milvus");
+                    return name.startsWith("io.milvus") && !name.startsWith("io.milvus.shaded");
                 })
                 .forEach(ci -> {
                     transformers.produce(new BytecodeTransformerBuildItem(
@@ -71,6 +71,15 @@ class MilvusProcessor {
                     if (internalName == null)
                         return null;
 
+                    if (internalName.startsWith("io/milvus/shaded/io/grpc/netty/shaded/io/grpc")) {
+                        return internalName.replace("io/milvus/shaded/io/grpc/netty/shaded/io/grpc", "io/grpc");
+                    }
+                    if (internalName.startsWith("io/milvus/shaded/io/grpc/netty/shaded/io/netty")) {
+                        return internalName.replace("io/milvus/shaded/io/grpc/netty/shaded/io/netty", "io/netty");
+                    }
+                    if (internalName.startsWith("io/milvus/shaded/io/grpc")) {
+                        return internalName.replace("io/milvus/shaded/io/grpc", "io/grpc");
+                    }
                     if (internalName.startsWith("io/grpc/netty/shaded/io/grpc")) {
                         return internalName.replace("io/grpc/netty/shaded/io/grpc", "io/grpc");
                     }


### PR DESCRIPTION
## Summary

- Fix `ClassNotFoundException: org.jboss.marshalling.ByteInput` during Quarkus augmentation when building with Camel 4.21.0-SNAPSHOT
- `milvus-sdk-java` 2.6.18 now bundles shaded gRPC/Netty classes (under `io.milvus.shaded.*`), including netty marshalling codec classes that reference `org.jboss.marshalling.ByteInput`
- The `MilvusProcessor` was transforming all `io.milvus.*` classes including these shaded ones, causing the class loading failure
- Exclude `io.milvus.shaded.*` from bytecode transformation and add remapping rules for the new shading prefix

## Test plan

- [x] Verified locally: no `ClassTransformingBuildStep` / `NoClassDefFoundError` errors with Camel 4.21.0-SNAPSHOT
- [x] No regression with current Camel 4.20.0
- [ ] CI should pass on `camel-main` branch after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_Claude Code on behalf of Guillaume Nodet_