### PR TITLE
Remove xref component links from removed Stomp and AWS X-Ray components

### DIFF
--- a/docs/modules/ROOT/pages/contributor-guide/extension-documentation.adoc
+++ b/docs/modules/ROOT/pages/contributor-guide/extension-documentation.adoc
@@ -65,4 +65,4 @@ To override parts of the xref link, the following `update-extension-doc-page` co
 <3> The overridden component kind in the generated xref link (`component`, `dataformat`, `language`, `other`).
 <4> The overridden component generated xref link prefix. Useful for rare circumstances where the component requires you to link to an unconventional part of the Camel documentation (E.g. link `manual`).
 +
-The component link can be removed entirely by setting `xrefPrefix` to an empty value. This is useful when a component is removed from the Camel core and the Camel Quarkus main branch references the `latest` Camel website docs version.
+The component link can be removed entirely by setting `xrefPrefix` to a value of `remove`. This is useful when a component is removed from the Camel core and the Camel Quarkus main branch references the `latest` Camel website docs version.

--- a/docs/modules/ROOT/pages/reference/extensions/aws-xray.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/aws-xray.adoc
@@ -22,9 +22,9 @@ Distributed tracing using AWS XRay
 [id="extensions-aws-xray-whats-inside"]
 == What's inside
 
-* xref:{cq-camel-components}:others:aws-xray.adoc[AWS XRay]
+* AWS XRay
 
-Please refer to the above link for usage and configuration details.
+
 
 [id="extensions-aws-xray-maven-coordinates"]
 == Maven coordinates

--- a/docs/modules/ROOT/pages/reference/extensions/stomp.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/stomp.adoc
@@ -22,9 +22,9 @@ Send and rececive messages to/from STOMP (Simple Text Oriented Messaging Protoco
 [id="extensions-stomp-whats-inside"]
 == What's inside
 
-* xref:{cq-camel-components}::stomp-component.adoc[Stomp component], URI syntax: `stomp:destination`
+* Stomp
 
-Please refer to the above link for usage and configuration details.
+
 
 [id="extensions-stomp-maven-coordinates"]
 == Maven coordinates

--- a/extensions-jvm/pom.xml
+++ b/extensions-jvm/pom.xml
@@ -142,10 +142,20 @@
                                 <phase>process-classes</phase>
                                 <configuration>
                                     <componentLinkOverrides>
+                                        <!-- TODO: Remove for Camel > 4.20.0 -->
+                                        <aws-xray>
+                                            <name>camel-aws-xray</name>
+                                            <xrefPrefix>remove</xrefPrefix>
+                                        </aws-xray>
                                         <console>
                                             <name>camel-console</name>
                                             <xrefPrefix>xref:manual::</xrefPrefix>
                                         </console>
+                                        <!-- TODO: Remove for Camel > 4.20.0 -->
+                                        <stomp>
+                                            <name>camel-stomp</name>
+                                            <xrefPrefix>remove</xrefPrefix>
+                                        </stomp>
                                     </componentLinkOverrides>
                                 </configuration>
                             </execution>

--- a/tooling/maven-plugin/src/main/java/org/apache/camel/quarkus/maven/UpdateExtensionDocPageMojo.java
+++ b/tooling/maven-plugin/src/main/java/org/apache/camel/quarkus/maven/UpdateExtensionDocPageMojo.java
@@ -241,7 +241,11 @@ public class UpdateExtensionDocPageMojo extends AbstractDocGeneratorMojo {
                         }
 
                         if (override.getXrefPrefix() != null) {
-                            xrefPrefix = override.getXrefPrefix();
+                            if (override.getXrefPrefix().equals("remove")) {
+                                xrefPrefix = "";
+                            } else {
+                                xrefPrefix = override.getXrefPrefix();
+                            }
                         }
 
                         if (override.getKind() != null) {


### PR DESCRIPTION
Preempting website build failures due to recently removed Camel components.