### PR TITLE
Upgrade camel-smb-test-server container image to 2.0.0

### DIFF
--- a/integration-tests/smb/src/main/java/org/apache/camel/quarkus/component/smb/it/SmbRoute.java
+++ b/integration-tests/smb/src/main/java/org/apache/camel/quarkus/component/smb/it/SmbRoute.java
@@ -25,6 +25,7 @@ import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
+import org.apache.camel.Message;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.smb.SmbConstants;
 import org.apache.camel.component.smb.SmbFile;
@@ -56,18 +57,20 @@ public class SmbRoute extends RouteBuilder {
 
     @Override
     public void configure() throws Exception {
-        from("smb:{{smb.host}}:{{smb.port}}/{{smb.share}}?username={{smb.username}}&password={{smb.password}}&path=/&repeatCount=1&searchPattern=*.txt&idempotent=true&idempotentRepository=#myRepo")
+        from("smb:{{smb.host}}:{{smb.port}}/{{smb.share}}/?username={{smb.username}}&password={{smb.password}}&repeatCount=1&searchPattern=*.txt&idempotent=true&idempotentRepository=#myRepo")
                 .to("mock:result");
 
         from("direct:send")
-                .toF("smb:%s:%s/%s?username=%s&password=%s&path=/", host, port, share, username, password);
+                .toF("smb:%s:%s/%s?username=%s&password=%s", host, port, share, username, password);
 
-        from("smb:{{smb.host}}:{{smb.port}}/{{smb.share}}?username={{smb.username}}&password={{smb.password}}&path=/&searchPattern=*.tx1&idempotent=true&idempotentRepository=#myRepo")
+        from("smb:{{smb.host}}:{{smb.port}}/{{smb.share}}/?username={{smb.username}}&password={{smb.password}}&searchPattern=*.tx1&idempotent=true&idempotentRepository=#myRepo")
                 .process(e -> {
+                    Message message = e.getMessage();
+                    SmbFile smbFile = message.getBody(SmbFile.class);
                     receivedContents.add(Map.of(
-                            "path", e.getIn().getBody(SmbFile.class).getAbsoluteFilePath(),
-                            "content", new String((byte[]) e.getIn().getBody(SmbFile.class).getBody(), "UTF-8"),
-                            SmbConstants.FILE_PATH, e.getIn().getHeader(SmbConstants.FILE_PATH, String.class)));
+                            "path", smbFile.getAbsoluteFilePath(),
+                            "content", getContext().getTypeConverter().convertTo(String.class, smbFile.getBody()),
+                            SmbConstants.FILE_PATH, message.getHeader(SmbConstants.FILE_PATH, String.class)));
                 });
     }
 

--- a/integration-tests/smb/src/test/java/org/apache/camel/quarkus/component/smb/it/SmbTest.java
+++ b/integration-tests/smb/src/test/java/org/apache/camel/quarkus/component/smb/it/SmbTest.java
@@ -160,7 +160,7 @@ public class SmbTest {
             Set<String> set = Set.of(body.split(","));
 
             assertThat(set)
-                    .contains("path=/msg1.tx1")
+                    .contains("path=msg1.tx1")
                     .contains("content=Hello1")
                     .contains(SmbConstants.FILE_PATH + "=/msg1.tx1");
         });

--- a/integration-tests/smb/src/test/java/org/apache/camel/quarkus/component/smb/it/SmbTestResource.java
+++ b/integration-tests/smb/src/test/java/org/apache/camel/quarkus/component/smb/it/SmbTestResource.java
@@ -25,16 +25,18 @@ import org.testcontainers.containers.wait.strategy.Wait;
 
 public class SmbTestResource implements QuarkusTestResourceLifecycleManager {
 
-    private static final int SMB_PORT = 445;
-
-    private GenericContainer<?> container;
-
     private static final String SMB_IMAGE = ConfigProvider.getConfig().getValue("smb.container.image", String.class);
+    private static final String SMB_USER = "camel";
+    private static final String SMB_PASSWORD = "camelTester123";
+    private static final int SMB_PORT = 445;
+    private GenericContainer<?> container;
 
     @Override
     public Map<String, String> start() {
         try {
             container = new GenericContainer<>(SMB_IMAGE)
+                    .withEnv("SMB_USER", SMB_USER)
+                    .withEnv("SMB_PASSWORD", SMB_PASSWORD)
                     .withExposedPorts(SMB_PORT)
                     .waitingFor(Wait.forListeningPort());
             container.start();
@@ -46,8 +48,8 @@ public class SmbTestResource implements QuarkusTestResourceLifecycleManager {
                     "smb.host", smbHost,
                     "smb.port", Integer.toString(smbPort),
                     "smb.share", "data-rw",
-                    "smb.username", "camel",
-                    "smb.password", "camelTester123");
+                    "smb.username", SMB_USER,
+                    "smb.password", SMB_PASSWORD);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/pom.xml
+++ b/pom.xml
@@ -282,7 +282,7 @@
         <rabbitmq.container.image>mirror.gcr.io/rabbitmq:4.2.4-management-alpine</rabbitmq.container.image>
         <redis.container.image>mirror.gcr.io/redis:7.4.0-alpine</redis.container.image>
         <servicebus-emulator.container.image>mcr.microsoft.com/azure-messaging/servicebus-emulator:latest</servicebus-emulator.container.image>
-        <smb.container.image>quay.io/jamesnetherton/camel-smb-test-server:1.0.0</smb.container.image>
+        <smb.container.image>quay.io/jamesnetherton/camel-smb-test-server:2.0.0</smb.container.image>
         <solr.container.image>mirror.gcr.io/solr:9.9.0-slim</solr.container.image>
         <splunk.container.image>mirror.gcr.io/splunk/splunk:9.4.7</splunk.container.image>
         <sql-server.container.image>mcr.microsoft.com/mssql/server:2022-latest</sql-server.container.image>


### PR DESCRIPTION
Also switches to the supported way of configuring the `path` option. 