### PR TITLE
ref #2212 explicitly defining the eddsa version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <dfdl-scala.version>2.12.20</dfdl-scala.version>
         <drill-jdbc-all.version>${apache-drill-version}</drill-jdbc-all.version>
         <dropwizard-metrics.version>${metrics-version}</dropwizard-metrics.version>
-        <eddsa.version>${eddsa-version}</eddsa.version>
+        <eddsa.version>0.3.0</eddsa.version>
         <eclipse-transformer.version>0.5.0</eclipse-transformer.version>
         <freemarker.version>2.3.34</freemarker.version><!-- @sync io.quarkiverse.freemarker:quarkus-freemarker-parent:${quarkiverse-freemarker.version} prop:freemarker.version -->
         <geny.version>0.6.2</geny.version>


### PR DESCRIPTION
ref #2212 Unblock camel-main build by explicitly defining the eddsa version following its deprecation in Camel.

- This PR unblocks the camel-main build by explicitly defining the eddsa version. 
- This change is necessary because the eddsa dependency has been deprecated and removed from the camel
- It remains a requirement for the ssh and nats components in Camel Quarkus.