### PR TITLE
Add selected LTS branch into LTS workflow run name

### DIFF
--- a/.github/workflows/quarkus-lts-ci-build.yaml
+++ b/.github/workflows/quarkus-lts-ci-build.yaml
@@ -16,6 +16,7 @@
 #
 
 name: Camel Quarkus LTS CI
+run-name: Camel Quarkus LTS CI - ${{ github.event.inputs.branch }}.x
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Should make life easier when viewing workflow runs from the GitHub Actions UI.