### PR TITLE
Add maven-artifact dependency to debezium support

### DIFF
--- a/extensions-support/debezium/runtime/pom.xml
+++ b/extensions-support/debezium/runtime/pom.xml
@@ -95,6 +95,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- Compensate for blanket exclusion from connect-runtime - needed by AbstractHerder.validateConnectorConfig() -->
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact</artifactId>
+        </dependency>
         <dependency>
             <groupId>io.debezium</groupId>
             <artifactId>debezium-connector-common</artifactId>


### PR DESCRIPTION
Relates to #8239

Users were experiencing NoClassDefFoundError for
org.apache.maven.artifact.versioning.InvalidVersionSpecificationException when using Debezium connectors with plugin version validation.

Root cause:
- connect-runtime:4.2.0 has maven-artifact:3.9.6 as a runtime dependency
- camel-quarkus-support-debezium excludes all transitive dependencies from connect-runtime with a blanket <exclusion>*:*</exclusion>
- When Kafka Connect's AbstractHerder.validateConnectorConfig() validates plugin versions, it needs InvalidVersionSpecificationException from maven-artifact

The fix:
- Add explicit maven-artifact dependency to camel-quarkus-support-debezium
- Version is inherited from io.quarkus:quarkus-bom (3.9.15)
- Dependency flows transitively to users automatically
