### PR TITLE
Remove superfluous underscores from Keycloak test method names

### DIFF
--- a/integration-tests/keycloak/src/test/java/org/apache/camel/quarkus/component/keycloak/it/KeycloakAuthorizationTest.java
+++ b/integration-tests/keycloak/src/test/java/org/apache/camel/quarkus/component/keycloak/it/KeycloakAuthorizationTest.java
@@ -48,7 +48,7 @@ class KeycloakAuthorizationTest extends KeycloakTestBase {
 
     @Test
     @Order(1)
-    public void testSetup_CreateRealm() {
+    void testSetupCreateRealm() {
         KeycloakRealmLifecycle.createRealmWithSmtp(TEST_REALM_NAME);
 
         // Create a client with authorization enabled
@@ -72,7 +72,7 @@ class KeycloakAuthorizationTest extends KeycloakTestBase {
 
     @Test
     @Order(2)
-    public void testCreateResource() {
+    void testCreateResource() {
         ResourceRepresentation resource = new ResourceRepresentation();
         resource.setName("test-resource");
         resource.setDisplayName("Test Resource");
@@ -97,7 +97,7 @@ class KeycloakAuthorizationTest extends KeycloakTestBase {
 
     @Test
     @Order(3)
-    public void testListResources() {
+    void testListResources() {
         List<ResourceRepresentation> resources = given()
                 .when()
                 .get("/keycloak/resource/{realmName}/{clientId}", TEST_REALM_NAME, TEST_AUTHZ_CLIENT_ID)
@@ -123,7 +123,7 @@ class KeycloakAuthorizationTest extends KeycloakTestBase {
 
     @Test
     @Order(4)
-    public void testGetResource() {
+    void testGetResource() {
         assertThat(TEST_RESOURCE_ID, notNullValue());
 
         ResourceRepresentation resource = given()
@@ -143,7 +143,7 @@ class KeycloakAuthorizationTest extends KeycloakTestBase {
 
     @Test
     @Order(5)
-    public void testUpdateResource() {
+    void testUpdateResource() {
         assertThat(TEST_RESOURCE_ID, notNullValue());
 
         ResourceRepresentation resource = given()
@@ -183,7 +183,7 @@ class KeycloakAuthorizationTest extends KeycloakTestBase {
 
     @Test
     @Order(11)
-    public void testCreateResourcePolicy() {
+    void testCreateResourcePolicy() {
         PolicyRepresentation policy = new PolicyRepresentation();
         policy.setName("test-policy");
         policy.setDescription("Test Policy");
@@ -209,7 +209,7 @@ class KeycloakAuthorizationTest extends KeycloakTestBase {
 
     @Test
     @Order(12)
-    public void testListResourcePolicies() {
+    void testListResourcePolicies() {
         List<PolicyRepresentation> policies = given()
                 .when()
                 .get("/keycloak/resource-policy/{realmName}/{clientId}", TEST_REALM_NAME, TEST_AUTHZ_CLIENT_ID)
@@ -235,7 +235,7 @@ class KeycloakAuthorizationTest extends KeycloakTestBase {
 
     @Test
     @Order(13)
-    public void testGetResourcePolicy() {
+    void testGetResourcePolicy() {
         assertThat(TEST_POLICY_ID, notNullValue());
 
         PolicyRepresentation policy = given()
@@ -254,7 +254,7 @@ class KeycloakAuthorizationTest extends KeycloakTestBase {
 
     @Test
     @Order(14)
-    public void testUpdateResourcePolicy() {
+    void testUpdateResourcePolicy() {
         assertThat(TEST_POLICY_ID, notNullValue());
 
         PolicyRepresentation policy = given()
@@ -294,7 +294,7 @@ class KeycloakAuthorizationTest extends KeycloakTestBase {
 
     @Test
     @Order(21)
-    public void testCreateResourcePermission() {
+    void testCreateResourcePermission() {
         assertThat(TEST_RESOURCE_ID, notNullValue());
         assertThat(TEST_POLICY_ID, notNullValue());
 
@@ -324,7 +324,7 @@ class KeycloakAuthorizationTest extends KeycloakTestBase {
 
     @Test
     @Order(22)
-    public void testListResourcePermissions() {
+    void testListResourcePermissions() {
         List<ResourcePermissionRepresentation> permissions = given()
                 .when()
                 .get("/keycloak/resource-permission/{realmName}/{clientId}",
@@ -351,7 +351,7 @@ class KeycloakAuthorizationTest extends KeycloakTestBase {
 
     @Test
     @Order(23)
-    public void testGetResourcePermission() {
+    void testGetResourcePermission() {
         assertThat(TEST_PERMISSION_ID, notNullValue());
 
         PolicyRepresentation permission = given()
@@ -370,7 +370,7 @@ class KeycloakAuthorizationTest extends KeycloakTestBase {
 
     @Test
     @Order(24)
-    public void testUpdateResourcePermission() {
+    void testUpdateResourcePermission() {
         assertThat(TEST_PERMISSION_ID, notNullValue());
 
         PolicyRepresentation permission = given()
@@ -410,7 +410,7 @@ class KeycloakAuthorizationTest extends KeycloakTestBase {
 
     @Test
     @Order(101)
-    public void testDeleteResourcePermission() {
+    void testDeleteResourcePermission() {
         assertThat(TEST_PERMISSION_ID, notNullValue());
 
         given()
@@ -424,7 +424,7 @@ class KeycloakAuthorizationTest extends KeycloakTestBase {
 
     @Test
     @Order(102)
-    public void testDeleteResourcePolicy() {
+    void testDeleteResourcePolicy() {
         assertThat(TEST_POLICY_ID, notNullValue());
 
         given()
@@ -438,7 +438,7 @@ class KeycloakAuthorizationTest extends KeycloakTestBase {
 
     @Test
     @Order(103)
-    public void testDeleteResource() {
+    void testDeleteResource() {
         assertThat(TEST_RESOURCE_ID, notNullValue());
 
         given()
@@ -452,7 +452,7 @@ class KeycloakAuthorizationTest extends KeycloakTestBase {
 
     @Test
     @Order(104)
-    public void testCleanupAuthorizationClient() {
+    void testCleanupAuthorizationClient() {
         given()
                 .when()
                 .delete("/keycloak/client/{realmName}/{clientId}", TEST_REALM_NAME, TEST_AUTHZ_CLIENT_ID)
@@ -463,7 +463,7 @@ class KeycloakAuthorizationTest extends KeycloakTestBase {
 
     @Test
     @Order(105)
-    public void testCleanup_DeleteRealm() {
+    void testCleanupDeleteRealm() {
         KeycloakRealmLifecycle.deleteRealm(TEST_REALM_NAME);
     }
 }

--- a/integration-tests/keycloak/src/test/java/org/apache/camel/quarkus/component/keycloak/it/KeycloakClientTest.java
+++ b/integration-tests/keycloak/src/test/java/org/apache/camel/quarkus/component/keycloak/it/KeycloakClientTest.java
@@ -47,7 +47,7 @@ class KeycloakClientTest extends KeycloakTestBase {
 
     @Test
     @Order(1)
-    public void testSetup_CreateRealm() {
+    void testSetupCreateRealm() {
         KeycloakRealmLifecycle.createRealmWithSmtp(TEST_REALM_NAME);
 
         // Create a test user for client role assignments
@@ -65,7 +65,7 @@ class KeycloakClientTest extends KeycloakTestBase {
 
     @Test
     @Order(2)
-    public void testCreateClientWithHeaders() {
+    void testCreateClientWithHeaders() {
         given()
                 .when()
                 .post("/keycloak/client/{realmName}/{clientId}", TEST_REALM_NAME, TEST_CLIENT_ID)
@@ -76,7 +76,7 @@ class KeycloakClientTest extends KeycloakTestBase {
 
     @Test
     @Order(2)
-    public void testCreateClientWithPojo() {
+    void testCreateClientWithPojo() {
         String pojoClientId = TEST_CLIENT_ID + "-pojo";
 
         ClientRepresentation client = new ClientRepresentation();
@@ -96,7 +96,7 @@ class KeycloakClientTest extends KeycloakTestBase {
 
     @Test
     @Order(3)
-    public void testListClients() {
+    void testListClients() {
         List<ClientRepresentation> clients = given()
                 .when()
                 .get("/keycloak/client/{realmName}", TEST_REALM_NAME)
@@ -114,7 +114,7 @@ class KeycloakClientTest extends KeycloakTestBase {
 
     @Test
     @Order(4)
-    public void testGetClient() {
+    void testGetClient() {
         ClientRepresentation client = given()
                 .when()
                 .get("/keycloak/client/{realmName}/{clientId}", TEST_REALM_NAME, TEST_CLIENT_ID)
@@ -130,7 +130,7 @@ class KeycloakClientTest extends KeycloakTestBase {
 
     @Test
     @Order(5)
-    public void testUpdateClient() {
+    void testUpdateClient() {
         ClientRepresentation client = given()
                 .when()
                 .get("/keycloak/client/{realmName}/{clientId}", TEST_REALM_NAME, TEST_CLIENT_ID)
@@ -165,7 +165,7 @@ class KeycloakClientTest extends KeycloakTestBase {
 
     @Test
     @Order(10)
-    public void testCreateClientRoleWithHeaders() {
+    void testCreateClientRoleWithHeaders() {
         given()
                 .queryParam("description", "Test client role for integration testing")
                 .when()
@@ -178,7 +178,7 @@ class KeycloakClientTest extends KeycloakTestBase {
 
     @Test
     @Order(11)
-    public void testCreateClientRoleWithPojo() {
+    void testCreateClientRoleWithPojo() {
         String pojoClientRoleName = TEST_CLIENT_ROLE_NAME + "-pojo";
 
         RoleRepresentation role = new RoleRepresentation();
@@ -197,7 +197,7 @@ class KeycloakClientTest extends KeycloakTestBase {
 
     @Test
     @Order(12)
-    public void testListClientRoles() {
+    void testListClientRoles() {
         List<RoleRepresentation> clientRoles = given()
                 .when()
                 .get("/keycloak/client-role/{realmName}/{clientId}", TEST_REALM_NAME, TEST_CLIENT_ID)
@@ -215,7 +215,7 @@ class KeycloakClientTest extends KeycloakTestBase {
 
     @Test
     @Order(13)
-    public void testGetClientRole() {
+    void testGetClientRole() {
         RoleRepresentation clientRole = given()
                 .when()
                 .get("/keycloak/client-role/{realmName}/{clientId}/{roleName}",
@@ -233,7 +233,7 @@ class KeycloakClientTest extends KeycloakTestBase {
 
     @Test
     @Order(14)
-    public void testUpdateClientRole() {
+    void testUpdateClientRole() {
         RoleRepresentation clientRole = given()
                 .when()
                 .get("/keycloak/client-role/{realmName}/{clientId}/{roleName}",
@@ -269,7 +269,7 @@ class KeycloakClientTest extends KeycloakTestBase {
 
     @Test
     @Order(15)
-    public void testAssignClientRoleToUser() {
+    void testAssignClientRoleToUser() {
         given()
                 .when()
                 .post("/keycloak/client-role-user/{realmName}/{clientId}/{username}/{roleName}",
@@ -281,7 +281,7 @@ class KeycloakClientTest extends KeycloakTestBase {
 
     @Test
     @Order(16)
-    public void testRemoveClientRoleFromUser() {
+    void testRemoveClientRoleFromUser() {
         given()
                 .when()
                 .delete("/keycloak/client-role-user/{realmName}/{clientId}/{username}/{roleName}",
@@ -295,7 +295,7 @@ class KeycloakClientTest extends KeycloakTestBase {
 
     @Test
     @Order(20)
-    public void testCreateClientScopeWithPojo() {
+    void testCreateClientScopeWithPojo() {
         ClientScopeRepresentation scope = new ClientScopeRepresentation();
         scope.setName(TEST_CLIENT_SCOPE_NAME);
         scope.setProtocol("openid-connect");
@@ -313,7 +313,7 @@ class KeycloakClientTest extends KeycloakTestBase {
 
     @Test
     @Order(21)
-    public void testListClientScopes() {
+    void testListClientScopes() {
         List<ClientScopeRepresentation> scopes = given()
                 .when()
                 .get("/keycloak/client-scope/{realmName}", TEST_REALM_NAME)
@@ -331,7 +331,7 @@ class KeycloakClientTest extends KeycloakTestBase {
 
     @Test
     @Order(22)
-    public void testGetClientScope() {
+    void testGetClientScope() {
         ClientScopeRepresentation scope = given()
                 .when()
                 .get("/keycloak/client-scope/{realmName}/{scopeName}", TEST_REALM_NAME, TEST_CLIENT_SCOPE_NAME)
@@ -347,7 +347,7 @@ class KeycloakClientTest extends KeycloakTestBase {
 
     @Test
     @Order(23)
-    public void testUpdateClientScope() {
+    void testUpdateClientScope() {
         ClientScopeRepresentation scope = given()
                 .when()
                 .get("/keycloak/client-scope/{realmName}/{scopeName}", TEST_REALM_NAME, TEST_CLIENT_SCOPE_NAME)
@@ -382,7 +382,7 @@ class KeycloakClientTest extends KeycloakTestBase {
 
     @Test
     @Order(30)
-    public void testGetClientSecret() {
+    void testGetClientSecret() {
         // First, make the client confidential to have a secret
         ClientRepresentation client = given()
                 .when()
@@ -418,7 +418,7 @@ class KeycloakClientTest extends KeycloakTestBase {
 
     @Test
     @Order(31)
-    public void testRegenerateClientSecret() {
+    void testRegenerateClientSecret() {
         CredentialRepresentation oldSecretData = given()
                 .when()
                 .get("/keycloak/client-secret/{realmName}/{clientId}", TEST_REALM_NAME, TEST_CLIENT_ID)
@@ -447,7 +447,7 @@ class KeycloakClientTest extends KeycloakTestBase {
 
     @Test
     @Order(100)
-    public void testCleanupClientRoles() {
+    void testCleanupClientRoles() {
         String[] rolesToDelete = { TEST_CLIENT_ROLE_NAME, TEST_CLIENT_ROLE_NAME + "-pojo" };
 
         for (String roleName : rolesToDelete) {
@@ -463,7 +463,7 @@ class KeycloakClientTest extends KeycloakTestBase {
 
     @Test
     @Order(101)
-    public void testCleanupClientScopes() {
+    void testCleanupClientScopes() {
         given()
                 .when()
                 .delete("/keycloak/client-scope/{realmName}/{scopeName}", TEST_REALM_NAME, TEST_CLIENT_SCOPE_NAME)
@@ -474,7 +474,7 @@ class KeycloakClientTest extends KeycloakTestBase {
 
     @Test
     @Order(102)
-    public void testCleanupClients() {
+    void testCleanupClients() {
         String[] clientsToDelete = { TEST_CLIENT_ID, TEST_CLIENT_ID + "-pojo" };
 
         for (String clientId : clientsToDelete) {
@@ -489,7 +489,7 @@ class KeycloakClientTest extends KeycloakTestBase {
 
     @Test
     @Order(103)
-    public void testCleanup_DeleteRealm() {
+    void testCleanupDeleteRealm() {
         KeycloakRealmLifecycle.deleteRealm(TEST_REALM_NAME);
     }
 }

--- a/integration-tests/keycloak/src/test/java/org/apache/camel/quarkus/component/keycloak/it/KeycloakConsumerTest.java
+++ b/integration-tests/keycloak/src/test/java/org/apache/camel/quarkus/component/keycloak/it/KeycloakConsumerTest.java
@@ -71,7 +71,7 @@ class KeycloakConsumerTest {
 
     @Test
     @Order(1)
-    public void testSetup_CreateRealm() {
+    void testSetupCreateRealm() {
         // Create test realm
         given()
                 .when()
@@ -83,7 +83,7 @@ class KeycloakConsumerTest {
 
     @Test
     @Order(2)
-    public void testSetup_EnableAdminEvents() {
+    void testSetupEnableAdminEvents() {
         // Enable admin events and regular events for the realm
         given()
                 .when()
@@ -95,7 +95,7 @@ class KeycloakConsumerTest {
 
     @Test
     @Order(3)
-    public void testSetup_CreateConsumerRoutes() {
+    void testSetupCreateConsumerRoutes() {
         // Create consumer routes for this realm
         given()
                 .when()
@@ -107,7 +107,7 @@ class KeycloakConsumerTest {
 
     @Test
     @Order(4)
-    public void testConsumeAdminEvents_CreateUser() {
+    void testConsumeAdminEventsCreateUser() {
         // Reset mock before test
         given()
                 .when()
@@ -182,7 +182,7 @@ class KeycloakConsumerTest {
 
     @Test
     @Order(5)
-    public void testConsumeAdminEvents_CreateRole() {
+    void testConsumeAdminEventsCreateRole() {
         // Reset mock before test
         given()
                 .when()
@@ -235,7 +235,7 @@ class KeycloakConsumerTest {
 
     @Test
     @Order(6)
-    public void testConsumer_NoNewEvents() {
+    void testConsumerNoNewEvents() {
         // Reset mock
         given()
                 .when()
@@ -287,7 +287,7 @@ class KeycloakConsumerTest {
 
     @Test
     @Order(7)
-    public void testConsumeRegularEvents() {
+    void testConsumeRegularEvents() {
         // Start the regular events consumer
         given()
                 .when()
@@ -322,7 +322,7 @@ class KeycloakConsumerTest {
 
     @Test
     @Order(98)
-    public void testCleanup_DeleteRole() {
+    void testCleanupDeleteRole() {
         // Delete test role
         given()
                 .when()
@@ -334,7 +334,7 @@ class KeycloakConsumerTest {
 
     @Test
     @Order(99)
-    public void testCleanup_DeleteUser() {
+    void testCleanupDeleteUser() {
         // Delete test user
         given()
                 .when()
@@ -346,7 +346,7 @@ class KeycloakConsumerTest {
 
     @Test
     @Order(100)
-    public void testCleanup_DeleteRealm() {
+    void testCleanupDeleteRealm() {
         // Delete the test realm
         given()
                 .when()

--- a/integration-tests/keycloak/src/test/java/org/apache/camel/quarkus/component/keycloak/it/KeycloakErrorHandlingTest.java
+++ b/integration-tests/keycloak/src/test/java/org/apache/camel/quarkus/component/keycloak/it/KeycloakErrorHandlingTest.java
@@ -32,13 +32,13 @@ class KeycloakErrorHandlingTest extends KeycloakTestBase {
 
     @Test
     @Order(1)
-    public void testSetup_CreateRealm() {
+    void testSetupCreateRealm() {
         KeycloakRealmLifecycle.createRealmWithSmtp(TEST_REALM_NAME);
     }
 
     @Test
     @Order(2)
-    public void testErrorHandling_NonExistentRealm() {
+    void testErrorHandlingNonExistentRealm() {
         given()
                 .queryParam("email", "test@test.com")
                 .queryParam("firstName", "Test")
@@ -51,7 +51,7 @@ class KeycloakErrorHandlingTest extends KeycloakTestBase {
 
     @Test
     @Order(3)
-    public void testErrorHandling_NonExistentUser() {
+    void testErrorHandlingNonExistentUser() {
         given()
                 .when()
                 .get("/keycloak/user/{realmName}/{username}", TEST_REALM_NAME, "non-existent-user")
@@ -61,7 +61,7 @@ class KeycloakErrorHandlingTest extends KeycloakTestBase {
 
     @Test
     @Order(4)
-    public void testErrorHandling_NonExistentRole() {
+    void testErrorHandlingNonExistentRole() {
         given()
                 .when()
                 .get("/keycloak/role/{realmName}/{roleName}", TEST_REALM_NAME, "non-existent-role")
@@ -71,7 +71,7 @@ class KeycloakErrorHandlingTest extends KeycloakTestBase {
 
     @Test
     @Order(99)
-    public void testCleanup_DeleteRealm() {
+    void testCleanupDeleteRealm() {
         KeycloakRealmLifecycle.deleteRealm(TEST_REALM_NAME);
     }
 }

--- a/integration-tests/keycloak/src/test/java/org/apache/camel/quarkus/component/keycloak/it/KeycloakEvaluatePermissionTest.java
+++ b/integration-tests/keycloak/src/test/java/org/apache/camel/quarkus/component/keycloak/it/KeycloakEvaluatePermissionTest.java
@@ -60,7 +60,7 @@ public class KeycloakEvaluatePermissionTest extends KeycloakTestBase {
 
     @Test
     @Order(1)
-    public void testSetup() {
+    void testSetup() {
         KeycloakRealmLifecycle.createRealmWithSmtp(config("test.realm"));
 
         // 1. Confidential client with Authorization Services enabled
@@ -164,7 +164,7 @@ public class KeycloakEvaluatePermissionTest extends KeycloakTestBase {
 
     @Test
     @Order(2)
-    public void testPermissionsOnly_responseContainsRequiredFields() {
+    void testPermissionsOnlyResponseContainsRequiredFields() {
         given()
                 .queryParam("clientId", TEST_CLIENT_ID)
                 .queryParam("clientSecret", TEST_CLIENT_SECRET)
@@ -179,7 +179,7 @@ public class KeycloakEvaluatePermissionTest extends KeycloakTestBase {
 
     @Test
     @Order(3)
-    public void testPermissionsOnly_userGrantedAccessToDocumentsRead() {
+    void testPermissionsOnlyUserGrantedAccessToDocumentsRead() {
         given()
                 .queryParam("clientId", TEST_CLIENT_ID)
                 .queryParam("clientSecret", TEST_CLIENT_SECRET)
@@ -195,7 +195,7 @@ public class KeycloakEvaluatePermissionTest extends KeycloakTestBase {
 
     @Test
     @Order(4)
-    public void testRptMode_responseContainsAllExpectedFields() {
+    void testRptModeResponseContainsAllExpectedFields() {
         given()
                 .queryParam("clientId", TEST_CLIENT_ID)
                 .queryParam("clientSecret", TEST_CLIENT_SECRET)
@@ -214,7 +214,7 @@ public class KeycloakEvaluatePermissionTest extends KeycloakTestBase {
 
     @Test
     @Order(5)
-    public void testPermissionsOnly_resourceNamesWithWhitespace() {
+    void testPermissionsOnlyResourceNamesWithWhitespace() {
         given()
                 .queryParam("clientId", TEST_CLIENT_ID)
                 .queryParam("clientSecret", TEST_CLIENT_SECRET)
@@ -228,7 +228,7 @@ public class KeycloakEvaluatePermissionTest extends KeycloakTestBase {
 
     @Test
     @Order(6)
-    public void testPermissionsOnly_scopeOnlyNoResource() {
+    void testPermissionsOnlyScopeOnlyNoResource() {
         given()
                 .queryParam("clientId", TEST_CLIENT_ID)
                 .queryParam("clientSecret", TEST_CLIENT_SECRET)
@@ -242,7 +242,7 @@ public class KeycloakEvaluatePermissionTest extends KeycloakTestBase {
 
     @Test
     @Order(7)
-    public void testPermissionsOnly_withAudienceHeader() {
+    void testPermissionsOnlyWithAudienceHeader() {
         given()
                 .queryParam("clientId", TEST_CLIENT_ID)
                 .queryParam("clientSecret", TEST_CLIENT_SECRET)
@@ -257,7 +257,7 @@ public class KeycloakEvaluatePermissionTest extends KeycloakTestBase {
 
     @Test
     @Order(8)
-    public void testPermissionsOnly_withSubjectToken() {
+    void testPermissionsOnlyWithSubjectToken() {
         given()
                 .queryParam("clientId", TEST_CLIENT_ID)
                 .queryParam("clientSecret", TEST_CLIENT_SECRET)
@@ -271,7 +271,7 @@ public class KeycloakEvaluatePermissionTest extends KeycloakTestBase {
 
     @Test
     @Order(9)
-    public void testEvaluatePermission_usernamePasswordAuth_granted() {
+    void testEvaluatePermissionUsernamePasswordAuthGranted() {
         given()
                 .queryParam("clientId", TEST_CLIENT_ID)
                 .queryParam("clientSecret", TEST_CLIENT_SECRET)
@@ -286,7 +286,7 @@ public class KeycloakEvaluatePermissionTest extends KeycloakTestBase {
 
     @Test
     @Order(10)
-    public void testEvaluatePermission_missingClientSecret_returns500WithValidationMessage() {
+    void testEvaluatePermissionMissingClientSecretReturns500WithValidationMessage() {
         given()
                 .queryParam("clientId", TEST_CLIENT_ID)
                 .queryParam("clientSecret", "")
@@ -299,7 +299,7 @@ public class KeycloakEvaluatePermissionTest extends KeycloakTestBase {
 
     @Test
     @Order(11)
-    public void testEvaluatePermission_invalidToken_returns500WithAuthError() {
+    void testEvaluatePermissionInvalidTokenReturns500WithAuthError() {
         given()
                 .queryParam("clientId", TEST_CLIENT_ID)
                 .queryParam("clientSecret", TEST_CLIENT_SECRET)
@@ -314,7 +314,7 @@ public class KeycloakEvaluatePermissionTest extends KeycloakTestBase {
 
     @Test
     @Order(15)
-    public void testSetupAuthenticationTests() {
+    void testSetupAuthenticationTests() {
         // Create service account client for client credentials grant testing
         ClientRepresentation serviceAccountClient = new ClientRepresentation();
         serviceAccountClient.setClientId(SERVICE_ACCOUNT_CLIENT_ID);
@@ -328,7 +328,7 @@ public class KeycloakEvaluatePermissionTest extends KeycloakTestBase {
 
     @Test
     @Order(20)
-    public void testServiceAccount_FullResponse() {
+    void testServiceAccountFullResponse() {
         // Verify we can obtain a full token response using client credentials grant
         Map<String, Object> tokenResponse = getServiceAccountTokenResponse(
                 SERVICE_ACCOUNT_CLIENT_ID, TEST_CLIENT_SECRET);
@@ -341,7 +341,7 @@ public class KeycloakEvaluatePermissionTest extends KeycloakTestBase {
 
     @Test
     @Order(21)
-    public void testServiceAccount_ConvenienceMethod() {
+    void testServiceAccountConvenienceMethod() {
         // Verify the convenience method that returns just the access token
         String accessToken = getServiceAccountToken(
                 SERVICE_ACCOUNT_CLIENT_ID, TEST_CLIENT_SECRET);
@@ -351,7 +351,7 @@ public class KeycloakEvaluatePermissionTest extends KeycloakTestBase {
 
     @Test
     @Order(30)
-    public void testPasswordGrant_ObtainTokenWithRefreshToken() {
+    void testPasswordGrantObtainTokenWithRefreshToken() {
         // Obtain a token using password grant to get both access and refresh tokens
         Map<String, Object> tokenResponse = getTokenResponse(
                 TEST_USER_NAME,
@@ -371,7 +371,7 @@ public class KeycloakEvaluatePermissionTest extends KeycloakTestBase {
 
     @Test
     @Order(40)
-    public void testRefreshTokenGrant_FullResponse() {
+    void testRefreshTokenGrantFullResponse() {
         // Verify refresh token can be used to obtain a full token response
         Map<String, Object> refreshedTokenResponse = getRefreshedTokenResponse(
                 userRefreshToken,
@@ -386,7 +386,7 @@ public class KeycloakEvaluatePermissionTest extends KeycloakTestBase {
 
     @Test
     @Order(41)
-    public void testRefreshTokenGrant_ConvenienceMethod() {
+    void testRefreshTokenGrantConvenienceMethod() {
         // Verify the convenience method that returns just the new access token
         String newAccessToken = getRefreshedAccessToken(
                 userRefreshToken,
@@ -398,7 +398,7 @@ public class KeycloakEvaluatePermissionTest extends KeycloakTestBase {
 
     @Test
     @Order(43)
-    public void testRefreshTokenGrant_InvalidRefreshToken() {
+    void testRefreshTokenGrantInvalidRefreshToken() {
         RuntimeException exception = assertThrows(RuntimeException.class, () -> {
             getRefreshedTokenResponse("invalid.refresh.token", TEST_CLIENT_ID, TEST_CLIENT_SECRET);
         }, "Should have thrown an exception for invalid refresh token");
@@ -408,7 +408,7 @@ public class KeycloakEvaluatePermissionTest extends KeycloakTestBase {
 
     @Test
     @Order(44)
-    public void testRefreshTokenGrant_MultipleRefreshes() {
+    void testRefreshTokenGrantMultipleRefreshes() {
         // Test that we can refresh multiple times (token rotation)
         // First refresh using the user's refresh token
         Map<String, Object> firstRefresh = getRefreshedTokenResponse(
@@ -434,7 +434,7 @@ public class KeycloakEvaluatePermissionTest extends KeycloakTestBase {
 
     @Test
     @Order(100)
-    public void testCleanup_DeleteRealm() {
+    void testCleanupDeleteRealm() {
         KeycloakRealmLifecycle.deleteRealm(config("test.realm"));
     }
 

--- a/integration-tests/keycloak/src/test/java/org/apache/camel/quarkus/component/keycloak/it/KeycloakGroupTest.java
+++ b/integration-tests/keycloak/src/test/java/org/apache/camel/quarkus/component/keycloak/it/KeycloakGroupTest.java
@@ -37,7 +37,7 @@ class KeycloakGroupTest extends KeycloakTestBase {
 
     @Test
     @Order(1)
-    public void testSetup_CreateRealm() {
+    void testSetupCreateRealm() {
         KeycloakRealmLifecycle.createRealmWithSmtp(TEST_REALM_NAME);
 
         // Create a test user for group-user operations
@@ -53,7 +53,7 @@ class KeycloakGroupTest extends KeycloakTestBase {
 
     @Test
     @Order(2)
-    public void testCreateGroupWithHeaders() {
+    void testCreateGroupWithHeaders() {
         given()
                 .when()
                 .post("/keycloak/group/{realmName}/{groupName}", TEST_REALM_NAME, TEST_GROUP_NAME)
@@ -64,7 +64,7 @@ class KeycloakGroupTest extends KeycloakTestBase {
 
     @Test
     @Order(2)
-    public void testCreateGroupWithPojo() {
+    void testCreateGroupWithPojo() {
         String pojoGroupName = TEST_GROUP_NAME + "-pojo";
 
         GroupRepresentation group = new GroupRepresentation();
@@ -82,7 +82,7 @@ class KeycloakGroupTest extends KeycloakTestBase {
 
     @Test
     @Order(3)
-    public void testListGroups() {
+    void testListGroups() {
         List<GroupRepresentation> groups = given()
                 .when()
                 .get("/keycloak/group/{realmName}", TEST_REALM_NAME)
@@ -100,7 +100,7 @@ class KeycloakGroupTest extends KeycloakTestBase {
 
     @Test
     @Order(4)
-    public void testGetGroup() {
+    void testGetGroup() {
         GroupRepresentation group = given()
                 .when()
                 .get("/keycloak/group/{realmName}/{groupName}", TEST_REALM_NAME, TEST_GROUP_NAME)
@@ -116,7 +116,7 @@ class KeycloakGroupTest extends KeycloakTestBase {
 
     @Test
     @Order(5)
-    public void testUpdateGroup() {
+    void testUpdateGroup() {
         GroupRepresentation group = given()
                 .when()
                 .get("/keycloak/group/{realmName}/{groupName}", TEST_REALM_NAME, TEST_GROUP_NAME)
@@ -139,7 +139,7 @@ class KeycloakGroupTest extends KeycloakTestBase {
 
     @Test
     @Order(6)
-    public void testAddUserToGroup() {
+    void testAddUserToGroup() {
         given()
                 .when()
                 .post("/keycloak/group-user/{realmName}/{username}/{groupName}",
@@ -151,7 +151,7 @@ class KeycloakGroupTest extends KeycloakTestBase {
 
     @Test
     @Order(7)
-    public void testListUserGroups() {
+    void testListUserGroups() {
         List<GroupRepresentation> groups = given()
                 .when()
                 .get("/keycloak/group-user/{realmName}/{username}", TEST_REALM_NAME, TEST_USER_NAME)
@@ -169,7 +169,7 @@ class KeycloakGroupTest extends KeycloakTestBase {
 
     @Test
     @Order(8)
-    public void testRemoveUserFromGroup() {
+    void testRemoveUserFromGroup() {
         given()
                 .when()
                 .delete("/keycloak/group-user/{realmName}/{username}/{groupName}",
@@ -181,7 +181,7 @@ class KeycloakGroupTest extends KeycloakTestBase {
 
     @Test
     @Order(100)
-    public void testCleanupGroups() {
+    void testCleanupGroups() {
         String[] groupsToDelete = { TEST_GROUP_NAME, TEST_GROUP_NAME + "-pojo" };
 
         for (String groupName : groupsToDelete) {
@@ -196,7 +196,7 @@ class KeycloakGroupTest extends KeycloakTestBase {
 
     @Test
     @Order(101)
-    public void testCleanup_DeleteRealm() {
+    void testCleanupDeleteRealm() {
         KeycloakRealmLifecycle.deleteRealm(TEST_REALM_NAME);
     }
 }

--- a/integration-tests/keycloak/src/test/java/org/apache/camel/quarkus/component/keycloak/it/KeycloakIdentityProviderTest.java
+++ b/integration-tests/keycloak/src/test/java/org/apache/camel/quarkus/component/keycloak/it/KeycloakIdentityProviderTest.java
@@ -37,13 +37,13 @@ class KeycloakIdentityProviderTest extends KeycloakTestBase {
 
     @Test
     @Order(1)
-    public void testSetup_CreateRealm() {
+    void testSetupCreateRealm() {
         KeycloakRealmLifecycle.createRealmWithSmtp(TEST_REALM_NAME);
     }
 
     @Test
     @Order(2)
-    public void testCreateIdentityProvider() {
+    void testCreateIdentityProvider() {
         IdentityProviderRepresentation idp = new IdentityProviderRepresentation();
         idp.setAlias(TEST_IDP_ALIAS);
         idp.setProviderId("oidc");
@@ -62,7 +62,7 @@ class KeycloakIdentityProviderTest extends KeycloakTestBase {
 
     @Test
     @Order(3)
-    public void testListIdentityProviders() {
+    void testListIdentityProviders() {
         List<IdentityProviderRepresentation> idps = given()
                 .when()
                 .get("/keycloak/identity-provider/{realmName}", TEST_REALM_NAME)
@@ -84,7 +84,7 @@ class KeycloakIdentityProviderTest extends KeycloakTestBase {
 
     @Test
     @Order(4)
-    public void testGetIdentityProvider() {
+    void testGetIdentityProvider() {
         IdentityProviderRepresentation idp = given()
                 .when()
                 .get("/keycloak/identity-provider/{realmName}/{idpAlias}", TEST_REALM_NAME, TEST_IDP_ALIAS)
@@ -102,7 +102,7 @@ class KeycloakIdentityProviderTest extends KeycloakTestBase {
 
     @Test
     @Order(5)
-    public void testUpdateIdentityProvider() {
+    void testUpdateIdentityProvider() {
         IdentityProviderRepresentation idp = given()
                 .when()
                 .get("/keycloak/identity-provider/{realmName}/{idpAlias}", TEST_REALM_NAME, TEST_IDP_ALIAS)
@@ -135,7 +135,7 @@ class KeycloakIdentityProviderTest extends KeycloakTestBase {
 
     @Test
     @Order(101)
-    public void testCleanupIdentityProvider() {
+    void testCleanupIdentityProvider() {
         given()
                 .when()
                 .delete("/keycloak/identity-provider/{realmName}/{idpAlias}", TEST_REALM_NAME, TEST_IDP_ALIAS)
@@ -146,7 +146,7 @@ class KeycloakIdentityProviderTest extends KeycloakTestBase {
 
     @Test
     @Order(102)
-    public void testCleanup_DeleteRealm() {
+    void testCleanupDeleteRealm() {
         KeycloakRealmLifecycle.deleteRealm(TEST_REALM_NAME);
     }
 }

--- a/integration-tests/keycloak/src/test/java/org/apache/camel/quarkus/component/keycloak/it/KeycloakRealmTest.java
+++ b/integration-tests/keycloak/src/test/java/org/apache/camel/quarkus/component/keycloak/it/KeycloakRealmTest.java
@@ -35,7 +35,7 @@ class KeycloakRealmTest extends KeycloakTestBase {
 
     @Test
     @Order(1)
-    public void loadComponentKeycloak() {
+    void loadComponentKeycloak() {
         RestAssured.get("/keycloak/load/component/keycloak")
                 .then()
                 .statusCode(200);
@@ -43,13 +43,13 @@ class KeycloakRealmTest extends KeycloakTestBase {
 
     @Test
     @Order(2)
-    public void testSetup_CreateRealm() {
+    void testSetupCreateRealm() {
         KeycloakRealmLifecycle.createRealmWithSmtp(TEST_REALM_NAME);
     }
 
     @Test
     @Order(3)
-    public void testCreateRealmWithPojo() {
+    void testCreateRealmWithPojo() {
         String pojoRealmName = TEST_REALM_NAME + "-pojo";
 
         RealmRepresentation realm = new RealmRepresentation();
@@ -76,7 +76,7 @@ class KeycloakRealmTest extends KeycloakTestBase {
 
     @Test
     @Order(4)
-    public void testGetRealm() {
+    void testGetRealm() {
         RealmRepresentation realm = given()
                 .when()
                 .get("/keycloak/realm/{realmName}", TEST_REALM_NAME)
@@ -93,7 +93,7 @@ class KeycloakRealmTest extends KeycloakTestBase {
 
     @Test
     @Order(5)
-    public void testUpdateRealm() {
+    void testUpdateRealm() {
         // First get the realm
         RealmRepresentation realm = given()
                 .when()
@@ -131,7 +131,7 @@ class KeycloakRealmTest extends KeycloakTestBase {
 
     @Test
     @Order(99)
-    public void testCleanup_DeleteRealm() {
+    void testCleanupDeleteRealm() {
         KeycloakRealmLifecycle.deleteRealm(TEST_REALM_NAME);
         KeycloakRealmLifecycle.verifyRealmDeleted(TEST_REALM_NAME);
     }

--- a/integration-tests/keycloak/src/test/java/org/apache/camel/quarkus/component/keycloak/it/KeycloakRoleTest.java
+++ b/integration-tests/keycloak/src/test/java/org/apache/camel/quarkus/component/keycloak/it/KeycloakRoleTest.java
@@ -41,7 +41,7 @@ class KeycloakRoleTest extends KeycloakTestBase {
 
     @Test
     @Order(1)
-    public void testSetup_CreateRealm() {
+    void testSetupCreateRealm() {
         KeycloakRealmLifecycle.createRealmWithSmtp(TEST_REALM_NAME);
 
         // Create a test user for user-role operations
@@ -57,7 +57,7 @@ class KeycloakRoleTest extends KeycloakTestBase {
 
     @Test
     @Order(2)
-    public void testCreateRoleWithHeaders() {
+    void testCreateRoleWithHeaders() {
         given()
                 .queryParam("description", "Test role for integration testing")
                 .when()
@@ -69,7 +69,7 @@ class KeycloakRoleTest extends KeycloakTestBase {
 
     @Test
     @Order(2)
-    public void testCreateRoleWithPojo() {
+    void testCreateRoleWithPojo() {
         String pojoRoleName = TEST_ROLE_NAME + "-pojo";
 
         RoleRepresentation role = new RoleRepresentation();
@@ -88,7 +88,7 @@ class KeycloakRoleTest extends KeycloakTestBase {
 
     @Test
     @Order(3)
-    public void testGetRole() {
+    void testGetRole() {
         RoleRepresentation role = given()
                 .when()
                 .get("/keycloak/role/{realmName}/{roleName}", TEST_REALM_NAME, TEST_ROLE_NAME)
@@ -105,7 +105,7 @@ class KeycloakRoleTest extends KeycloakTestBase {
 
     @Test
     @Order(4)
-    public void testListRoles() {
+    void testListRoles() {
         List<RoleRepresentation> roles = given()
                 .when()
                 .get("/keycloak/role/{realmName}", TEST_REALM_NAME)
@@ -123,7 +123,7 @@ class KeycloakRoleTest extends KeycloakTestBase {
 
     @Test
     @Order(5)
-    public void testUpdateRole() {
+    void testUpdateRole() {
         RoleRepresentation role = given()
                 .when()
                 .get("/keycloak/role/{realmName}/{roleName}", TEST_REALM_NAME, TEST_ROLE_NAME)
@@ -156,7 +156,7 @@ class KeycloakRoleTest extends KeycloakTestBase {
 
     @Test
     @Order(6)
-    public void testAssignRoleToUser() {
+    void testAssignRoleToUser() {
         given()
                 .when()
                 .post("/keycloak/user-role/{realmName}/{username}/{roleName}",
@@ -168,7 +168,7 @@ class KeycloakRoleTest extends KeycloakTestBase {
 
     @Test
     @Order(7)
-    public void testGetUserRoles() {
+    void testGetUserRoles() {
         List<RoleRepresentation> roles = given()
                 .when()
                 .get("/keycloak/user-role/{realmName}/{username}", TEST_REALM_NAME, TEST_USER_NAME)
@@ -190,7 +190,7 @@ class KeycloakRoleTest extends KeycloakTestBase {
 
     @Test
     @Order(8)
-    public void testRemoveRoleFromUser() {
+    void testRemoveRoleFromUser() {
         given()
                 .when()
                 .delete("/keycloak/user-role/{realmName}/{username}/{roleName}",
@@ -202,7 +202,7 @@ class KeycloakRoleTest extends KeycloakTestBase {
 
     @Test
     @Order(9)
-    public void testAssignRolesToUser() {
+    void testAssignRolesToUser() {
         List<String> existingRoleNames = given()
                 .when()
                 .get("/keycloak/role/{realmName}", TEST_REALM_NAME)
@@ -230,7 +230,7 @@ class KeycloakRoleTest extends KeycloakTestBase {
 
     @Test
     @Order(10)
-    public void testAssignRoleToUsers() {
+    void testAssignRoleToUsers() {
         // get an role
         RoleRepresentation role = given()
                 .when()
@@ -283,7 +283,7 @@ class KeycloakRoleTest extends KeycloakTestBase {
 
     @Test
     @Order(100)
-    public void testCleanupRoles() {
+    void testCleanupRoles() {
         String[] rolesToDelete = { TEST_ROLE_NAME, TEST_ROLE_NAME + "-pojo" };
 
         for (String roleName : rolesToDelete) {
@@ -298,7 +298,7 @@ class KeycloakRoleTest extends KeycloakTestBase {
 
     @Test
     @Order(101)
-    public void testCleanup_DeleteRealm() {
+    void testCleanupDeleteRealm() {
         KeycloakRealmLifecycle.deleteRealm(TEST_REALM_NAME);
     }
 }

--- a/integration-tests/keycloak/src/test/java/org/apache/camel/quarkus/component/keycloak/it/KeycloakSecurityPolicyTest.java
+++ b/integration-tests/keycloak/src/test/java/org/apache/camel/quarkus/component/keycloak/it/KeycloakSecurityPolicyTest.java
@@ -45,7 +45,7 @@ public class KeycloakSecurityPolicyTest extends KeycloakSecurityPolicyTestBase {
 
     @Test
     @Order(1)
-    public void testSetup() {
+    void testSetup() {
         createRealm();
         createClient();
 
@@ -71,7 +71,7 @@ public class KeycloakSecurityPolicyTest extends KeycloakSecurityPolicyTestBase {
 
     @Test
     @Order(2)
-    public void testPropertyTokenWorks() {
+    void testPropertyTokenWorks() {
         given()
                 .when()
                 .queryParam("propertyToken", normalUserToken)
@@ -83,7 +83,7 @@ public class KeycloakSecurityPolicyTest extends KeycloakSecurityPolicyTestBase {
 
     @Test
     @Order(3)
-    public void testHeaderTokenWorks() {
+    void testHeaderTokenWorks() {
         given()
                 .when()
                 .queryParam("headerToken", normalUserToken)
@@ -95,7 +95,7 @@ public class KeycloakSecurityPolicyTest extends KeycloakSecurityPolicyTestBase {
 
     @Test
     @Order(4)
-    public void testPropertyPreferredOverHeaderTokenWorks() {
+    void testPropertyPreferredOverHeaderTokenWorks() {
         given()
                 .when()
                 .queryParam("propertyToken", normalUserToken)
@@ -108,7 +108,7 @@ public class KeycloakSecurityPolicyTest extends KeycloakSecurityPolicyTestBase {
 
     @Test
     @Order(5)
-    public void testInvalidHeaderIgnoredWhenPropertyValid() {
+    void testInvalidHeaderIgnoredWhenPropertyValid() {
         given()
                 .when()
                 .queryParam("propertyToken", normalUserToken)
@@ -121,7 +121,7 @@ public class KeycloakSecurityPolicyTest extends KeycloakSecurityPolicyTestBase {
 
     @Test
     @Order(6)
-    public void testHeaderRejectedWhenHeadersDisabled() {
+    void testHeaderRejectedWhenHeadersDisabled() {
         given()
                 .when()
                 .queryParam("headerToken", normalUserToken)
@@ -133,7 +133,7 @@ public class KeycloakSecurityPolicyTest extends KeycloakSecurityPolicyTestBase {
 
     @Test
     @Order(7)
-    public void testPropertyWorksWhenHeadersDisabled() {
+    void testPropertyWorksWhenHeadersDisabled() {
         given()
                 .when()
                 .queryParam("propertyToken", normalUserToken)
@@ -145,7 +145,7 @@ public class KeycloakSecurityPolicyTest extends KeycloakSecurityPolicyTestBase {
 
     @Test
     @Order(8)
-    public void testPropertyTokenUsedNotHeader() {
+    void testPropertyTokenUsedNotHeader() {
         given()
                 .when()
                 .queryParam("propertyToken", normalUserToken)
@@ -158,7 +158,7 @@ public class KeycloakSecurityPolicyTest extends KeycloakSecurityPolicyTestBase {
 
     @Test
     @Order(9)
-    public void testAttackScenario_SessionHijacking() {
+    void testAttackScenarioSessionHijacking() {
         given()
                 .when()
                 .queryParam("propertyToken", normalUserToken)
@@ -171,7 +171,7 @@ public class KeycloakSecurityPolicyTest extends KeycloakSecurityPolicyTestBase {
 
     @Test
     @Order(10)
-    public void testAttackScenario_LegacyUnsafe() {
+    void testAttackScenarioLegacyUnsafe() {
         given()
                 .when()
                 .queryParam("propertyToken", normalUserToken)
@@ -184,7 +184,7 @@ public class KeycloakSecurityPolicyTest extends KeycloakSecurityPolicyTestBase {
 
     @Test
     @Order(11)
-    public void testAuthorizationHeaderFormat() {
+    void testAuthorizationHeaderFormat() {
         given()
                 .when()
                 .queryParam("headerToken", normalUserToken)
@@ -196,7 +196,7 @@ public class KeycloakSecurityPolicyTest extends KeycloakSecurityPolicyTestBase {
 
     @Test
     @Order(12)
-    public void testNoTokenRejected() {
+    void testNoTokenRejected() {
         given()
                 .when()
                 .get("/keycloak/secure-policy/max-security")
@@ -207,7 +207,7 @@ public class KeycloakSecurityPolicyTest extends KeycloakSecurityPolicyTestBase {
 
     @Test
     @Order(13)
-    public void testAdminOnly() {
+    void testAdminOnly() {
         given()
                 .when()
                 .queryParam("propertyToken", adminToken)
@@ -220,7 +220,7 @@ public class KeycloakSecurityPolicyTest extends KeycloakSecurityPolicyTestBase {
 
     @Test
     @Order(14)
-    public void testIntrospectionEnabledWithDefaultCacheConcurrentMap() {
+    void testIntrospectionEnabledWithDefaultCacheConcurrentMap() {
         given()
                 .when()
                 .queryParam("propertyToken", adminToken)
@@ -234,7 +234,7 @@ public class KeycloakSecurityPolicyTest extends KeycloakSecurityPolicyTestBase {
 
     @Test
     @Order(15)
-    public void testIntrospectionEnabledWithNoCache() {
+    void testIntrospectionEnabledWithNoCache() {
         given()
                 .when()
                 .queryParam("propertyToken", adminToken)
@@ -248,7 +248,7 @@ public class KeycloakSecurityPolicyTest extends KeycloakSecurityPolicyTestBase {
 
     @Test
     @Order(16)
-    public void testIntrospector_concurrentMapCache_tokenIsActive() {
+    void testIntrospectorConcurrentMapCacheTokenIsActive() {
         given()
                 .queryParam("accessToken", normalUserToken)
                 .queryParam("clientId", config("test.client.id"))
@@ -263,7 +263,7 @@ public class KeycloakSecurityPolicyTest extends KeycloakSecurityPolicyTestBase {
 
     @Test
     @Order(17)
-    public void testIntrospector_concurrentMapCache_invalidToken_returnsInactive() {
+    void testIntrospectorConcurrentMapCacheInvalidTokenReturnsInactive() {
         given()
                 .queryParam("accessToken", "invalid.token")
                 .queryParam("clientId", config("test.client.id"))
@@ -276,7 +276,7 @@ public class KeycloakSecurityPolicyTest extends KeycloakSecurityPolicyTestBase {
 
     @Test
     @Order(18)
-    public void testIntrospector_caffeineCache_tokenIsActive() {
+    void testIntrospectorCaffeineCacheTokenIsActive() {
         given()
                 .queryParam("accessToken", normalUserToken)
                 .queryParam("clientId", config("test.client.id"))
@@ -291,7 +291,7 @@ public class KeycloakSecurityPolicyTest extends KeycloakSecurityPolicyTestBase {
 
     @Test
     @Order(19)
-    public void testIntrospector_caffeineCache_invalidToken_returnsInactive() {
+    void testIntrospectorCaffeineCacheInvalidTokenReturnsInactive() {
         given()
                 .queryParam("accessToken", "invalid.token")
                 .queryParam("clientId", config("test.client.id"))
@@ -304,7 +304,7 @@ public class KeycloakSecurityPolicyTest extends KeycloakSecurityPolicyTestBase {
 
     @Test
     @Order(20)
-    public void testIntrospector_noCache_tokenIsActive() {
+    void testIntrospectorNoCacheTokenIsActive() {
         given()
                 .queryParam("accessToken", normalUserToken)
                 .queryParam("clientId", config("test.client.id"))
@@ -319,7 +319,7 @@ public class KeycloakSecurityPolicyTest extends KeycloakSecurityPolicyTestBase {
 
     @Test
     @Order(21)
-    public void testIntrospector_noCache_invalidToken_returnsInactive() {
+    void testIntrospectorNoCacheInvalidTokenReturnsInactive() {
         given()
                 .queryParam("accessToken", "invalid.token")
                 .queryParam("clientId", config("test.client.id"))
@@ -332,7 +332,7 @@ public class KeycloakSecurityPolicyTest extends KeycloakSecurityPolicyTestBase {
 
     @Test
     @Order(22)
-    public void testIntrospector_caffeineStats_secondCallHitsCache() {
+    void testIntrospectorCaffeineStatsSecondCallHitsCache() {
         given()
                 .queryParam("accessToken", normalUserToken)
                 .queryParam("clientId", config("test.client.id"))
@@ -348,7 +348,7 @@ public class KeycloakSecurityPolicyTest extends KeycloakSecurityPolicyTestBase {
 
     @Test
     @Order(23)
-    public void testIntrospector_noCache_invalidToken_returns500() {
+    void testIntrospectorNoCacheInvalidTokenReturns500() {
         given()
                 .queryParam("accessToken", "invalid.token")
                 .queryParam("clientId", config("test.client.id"))
@@ -360,7 +360,7 @@ public class KeycloakSecurityPolicyTest extends KeycloakSecurityPolicyTestBase {
 
     @Test
     @Order(100)
-    public void testCleanup_DeleteRealm() {
+    void testCleanupDeleteRealm() {
         KeycloakRealmLifecycle.deleteRealm(config("test.realm"));
     }
 

--- a/integration-tests/keycloak/src/test/java/org/apache/camel/quarkus/component/keycloak/it/KeycloakUserTest.java
+++ b/integration-tests/keycloak/src/test/java/org/apache/camel/quarkus/component/keycloak/it/KeycloakUserTest.java
@@ -47,13 +47,13 @@ class KeycloakUserTest extends KeycloakTestBase {
 
     @Test
     @Order(1)
-    public void testSetup_CreateRealm() {
+    void testSetupCreateRealm() {
         KeycloakRealmLifecycle.createRealmWithSmtp(TEST_REALM_NAME);
     }
 
     @Test
     @Order(2)
-    public void testCreateUserWithHeaders() {
+    void testCreateUserWithHeaders() {
         given()
                 .queryParam("email", TEST_USER_NAME + "@test.com")
                 .queryParam("firstName", "Test")
@@ -67,7 +67,7 @@ class KeycloakUserTest extends KeycloakTestBase {
 
     @Test
     @Order(3)
-    public void testCreateUserWithPojo() {
+    void testCreateUserWithPojo() {
         String pojoUserName = TEST_USER_NAME + "-pojo";
 
         UserRepresentation user = new UserRepresentation();
@@ -89,7 +89,7 @@ class KeycloakUserTest extends KeycloakTestBase {
 
     @Test
     @Order(4)
-    public void testGetUser() {
+    void testGetUser() {
         UserRepresentation user = given()
                 .when()
                 .get("/keycloak/user/{realmName}/{username}", TEST_REALM_NAME, TEST_USER_NAME)
@@ -108,7 +108,7 @@ class KeycloakUserTest extends KeycloakTestBase {
 
     @Test
     @Order(5)
-    public void testListUsers() {
+    void testListUsers() {
         List<UserRepresentation> users = given()
                 .when()
                 .get("/keycloak/user/{realmName}", TEST_REALM_NAME)
@@ -126,7 +126,7 @@ class KeycloakUserTest extends KeycloakTestBase {
 
     @Test
     @Order(6)
-    public void testUpdateUser() {
+    void testUpdateUser() {
         // First get the user
         UserRepresentation user = given()
                 .when()
@@ -164,7 +164,7 @@ class KeycloakUserTest extends KeycloakTestBase {
 
     @Test
     @Order(7)
-    public void testSearchUsers() {
+    void testSearchUsers() {
         // Search for users by username prefix
         List<UserRepresentation> users = given()
                 .queryParam("query", TEST_USER_NAME)
@@ -186,7 +186,7 @@ class KeycloakUserTest extends KeycloakTestBase {
 
     @Test
     @Order(8)
-    public void testListUserSessions() {
+    void testListUserSessions() {
         List<?> sessions = given()
                 .when()
                 .get("/keycloak/user/{realmName}/{username}/sessions", TEST_REALM_NAME, TEST_USER_NAME)
@@ -204,7 +204,7 @@ class KeycloakUserTest extends KeycloakTestBase {
 
     @Test
     @Order(9)
-    public void testResetUserPassword() {
+    void testResetUserPassword() {
         given()
                 .queryParam("password", "newTestPassword123!")
                 .queryParam("temporary", false)
@@ -217,7 +217,7 @@ class KeycloakUserTest extends KeycloakTestBase {
 
     @Test
     @Order(10)
-    public void testSendVerifyEmail() {
+    void testSendVerifyEmail() {
         given()
                 .when()
                 .post("/keycloak/user/{realmName}/{username}/send-verify-email", TEST_REALM_NAME, TEST_USER_NAME)
@@ -228,7 +228,7 @@ class KeycloakUserTest extends KeycloakTestBase {
 
     @Test
     @Order(11)
-    public void testSendPasswordResetEmail() {
+    void testSendPasswordResetEmail() {
         given()
                 .when()
                 .post("/keycloak/user/{realmName}/{username}/send-password-reset-email", TEST_REALM_NAME,
@@ -240,7 +240,7 @@ class KeycloakUserTest extends KeycloakTestBase {
 
     @Test
     @Order(12)
-    public void testLogoutUser() {
+    void testLogoutUser() {
         given()
                 .when()
                 .post("/keycloak/user/{realmName}/{username}/logout", TEST_REALM_NAME, TEST_USER_NAME)
@@ -251,7 +251,7 @@ class KeycloakUserTest extends KeycloakTestBase {
 
     @Test
     @Order(13)
-    public void testSetUserAttribute() {
+    void testSetUserAttribute() {
         given()
                 .queryParam("attributeValue", "test-department")
                 .when()
@@ -264,7 +264,7 @@ class KeycloakUserTest extends KeycloakTestBase {
 
     @Test
     @Order(14)
-    public void testGetUserAttributes() {
+    void testGetUserAttributes() {
         Map<String, List<String>> attributes = given()
                 .when()
                 .get("/keycloak/user-attribute/{realmName}/{username}", TEST_REALM_NAME, TEST_USER_NAME)
@@ -284,7 +284,7 @@ class KeycloakUserTest extends KeycloakTestBase {
 
     @Test
     @Order(15)
-    public void testDeleteUserAttribute() {
+    void testDeleteUserAttribute() {
         Map<String, List<String>> attributesBefore = given()
                 .when()
                 .get("/keycloak/user-attribute/{realmName}/{username}", TEST_REALM_NAME, TEST_USER_NAME)
@@ -320,7 +320,7 @@ class KeycloakUserTest extends KeycloakTestBase {
 
     @Test
     @Order(16)
-    public void testGetUserCredentials() {
+    void testGetUserCredentials() {
         List<CredentialRepresentation> credentials = given()
                 .when()
                 .get("/keycloak/user-credential/{realmName}/{username}", TEST_REALM_NAME, TEST_USER_NAME)
@@ -337,7 +337,7 @@ class KeycloakUserTest extends KeycloakTestBase {
 
     @Test
     @Order(17)
-    public void testDeleteUserCredential() {
+    void testDeleteUserCredential() {
         List<CredentialRepresentation> credentials = given()
                 .when()
                 .get("/keycloak/user-credential/{realmName}/{username}", TEST_REALM_NAME, TEST_USER_NAME)
@@ -363,7 +363,7 @@ class KeycloakUserTest extends KeycloakTestBase {
 
     @Test
     @Order(18)
-    public void testAddRequiredAction() {
+    void testAddRequiredAction() {
         given()
                 .queryParam("action", "UPDATE_PASSWORD")
                 .when()
@@ -375,7 +375,7 @@ class KeycloakUserTest extends KeycloakTestBase {
 
     @Test
     @Order(19)
-    public void testRemoveRequiredAction() {
+    void testRemoveRequiredAction() {
         given()
                 .queryParam("action", "UPDATE_PASSWORD")
                 .when()
@@ -387,7 +387,7 @@ class KeycloakUserTest extends KeycloakTestBase {
 
     @Test
     @Order(20)
-    public void testExecuteActionsEmail() {
+    void testExecuteActionsEmail() {
         given()
                 .queryParam("actions", "VERIFY_EMAIL,UPDATE_PASSWORD")
                 .queryParam("lifespan", 3600)
@@ -400,7 +400,7 @@ class KeycloakUserTest extends KeycloakTestBase {
 
     @Test
     @Order(21)
-    public void testBulkCreateUsers() {
+    void testBulkCreateUsers() {
         String bulkUserNameOne = TEST_USER_NAME + "-bulkOne";
 
         UserRepresentation userOne = new UserRepresentation();
@@ -438,7 +438,7 @@ class KeycloakUserTest extends KeycloakTestBase {
 
     @Test
     @Order(22)
-    public void testBulkUpdateUsers() {
+    void testBulkUpdateUsers() {
         //First get list of users
         List<UserRepresentation> batchCreatedUsers = given()
                 .when()
@@ -493,7 +493,7 @@ class KeycloakUserTest extends KeycloakTestBase {
 
     @Test
     @Order(23)
-    public void testBulkUpdateUsersWithContinueOnError() {
+    void testBulkUpdateUsersWithContinueOnError() {
         //First get list of users
         List<UserRepresentation> batchCreatedUsers = new ArrayList<>(given()
                 .when()
@@ -525,7 +525,7 @@ class KeycloakUserTest extends KeycloakTestBase {
 
     @Test
     @Order(24)
-    public void testBulkDeleteUsers() {
+    void testBulkDeleteUsers() {
         // First get list of users
         List<String> batchCreatedUsers = given()
                 .when()
@@ -555,7 +555,7 @@ class KeycloakUserTest extends KeycloakTestBase {
 
     @Test
     @Order(100)
-    public void testCleanupUsers() {
+    void testCleanupUsers() {
         // Delete test users
         String[] usersToDelete = { TEST_USER_NAME, TEST_USER_NAME + "-pojo" };
 
@@ -571,7 +571,7 @@ class KeycloakUserTest extends KeycloakTestBase {
 
     @Test
     @Order(101)
-    public void testCleanup_DeleteRealm() {
+    void testCleanupDeleteRealm() {
         KeycloakRealmLifecycle.deleteRealm(TEST_REALM_NAME);
     }
 }


### PR DESCRIPTION
Also took the opportunity to remove public method modifier.