### PR TITLE
Add test coverage for Gmail DataType Transformers : update-message-labels and draft

### DIFF
--- a/integration-tests/google/pom.xml
+++ b/integration-tests/google/pom.xml
@@ -48,6 +48,10 @@
             <artifactId>camel-quarkus-google-sheets</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-direct</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy</artifactId>
         </dependency>
@@ -113,6 +117,19 @@
             </activation>
             <dependencies>
                 <!-- The following dependencies guarantee that this module is built after them. You can update them by running `mvn process-resources -Pformat -N` from the source tree root directory -->
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-direct-deployment</artifactId>
+                    <version>${project.version}</version>
+                    <type>pom</type>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
                 <dependency>
                     <groupId>org.apache.camel.quarkus</groupId>
                     <artifactId>camel-quarkus-google-calendar-deployment</artifactId>

--- a/integration-tests/google/src/main/java/org/apache/camel/quarkus/component/google/it/GoogleMailResource.java
+++ b/integration-tests/google/src/main/java/org/apache/camel/quarkus/component/google/it/GoogleMailResource.java
@@ -20,13 +20,17 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import com.google.api.services.gmail.model.Draft;
+import com.google.api.services.gmail.model.Label;
 import com.google.api.services.gmail.model.Message;
+import com.google.api.services.gmail.model.MessagePartHeader;
 import com.google.api.services.gmail.model.Profile;
 import jakarta.inject.Inject;
 import jakarta.mail.MessagingException;
@@ -35,6 +39,7 @@ import jakarta.mail.internet.MimeMessage;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PATCH;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
@@ -43,6 +48,7 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.apache.camel.CamelExecutionException;
 import org.apache.camel.ProducerTemplate;
+import org.apache.camel.component.google.mail.stream.GoogleMailStreamConstants;
 
 import static jakarta.mail.Message.RecipientType.TO;
 
@@ -99,6 +105,63 @@ public class GoogleMailResource {
         }
     }
 
+    @Path("/thread-id")
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public Response getThreadId(@QueryParam("messageId") String messageId) {
+        Map<String, Object> headers = new HashMap<>();
+        headers.put("CamelGoogleMail.userId", USER_ID);
+        headers.put("CamelGoogleMail.id", messageId);
+
+        try {
+            Message response = producerTemplate.requestBodyAndHeaders("google-mail://messages/get", null, headers,
+                    Message.class);
+            if (response != null && response.getThreadId() != null) {
+                return Response.ok(response.getThreadId()).build();
+            } else {
+                return Response.status(Response.Status.NOT_FOUND).build();
+            }
+        } catch (CamelExecutionException e) {
+            Exception exchangeException = e.getExchange().getException();
+            if (exchangeException != null && exchangeException.getCause() instanceof GoogleJsonResponseException) {
+                GoogleJsonResponseException originalException = (GoogleJsonResponseException) exchangeException.getCause();
+                return Response.status(originalException.getStatusCode()).build();
+            }
+            throw e;
+        }
+    }
+
+    @Path("/message-id-header")
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public Response getMessageIdHeader(@QueryParam("messageId") String messageId) {
+        Map<String, Object> headers = new HashMap<>();
+        headers.put("CamelGoogleMail.userId", USER_ID);
+        headers.put("CamelGoogleMail.id", messageId);
+
+        try {
+            Message response = producerTemplate.requestBodyAndHeaders("google-mail://messages/get", null, headers,
+                    Message.class);
+            if (response != null && response.getPayload() != null && response.getPayload().getHeaders() != null) {
+                for (MessagePartHeader header : response.getPayload().getHeaders()) {
+                    if ("Message-ID".equalsIgnoreCase(header.getName())) {
+                        return Response.ok(header.getValue()).build();
+                    }
+                }
+                return Response.status(Response.Status.NOT_FOUND).build();
+            } else {
+                return Response.status(Response.Status.NOT_FOUND).build();
+            }
+        } catch (CamelExecutionException e) {
+            Exception exchangeException = e.getExchange().getException();
+            if (exchangeException != null && exchangeException.getCause() instanceof GoogleJsonResponseException) {
+                GoogleJsonResponseException originalException = (GoogleJsonResponseException) exchangeException.getCause();
+                return Response.status(originalException.getStatusCode()).build();
+            }
+            throw e;
+        }
+    }
+
     @Path("/delete")
     @DELETE
     public Response deleteMail(@QueryParam("messageId") String messageId, String message) {
@@ -106,6 +169,164 @@ public class GoogleMailResource {
         headers.put("CamelGoogleMail.userId", USER_ID);
         headers.put("CamelGoogleMail.id", messageId);
         producerTemplate.requestBodyAndHeaders("google-mail://messages/delete", message, headers);
+        return Response.status(Response.Status.NO_CONTENT).build();
+    }
+
+    @Path("/update-labels")
+    @PATCH
+    public Response updateMessageLabels(@QueryParam("messageId") String messageId,
+            @QueryParam("addLabel") String addLabel,
+            @QueryParam("removeLabel") String removeLabel) {
+        Map<String, Object> headers = new HashMap<>();
+        headers.put("CamelGoogleMail.userId", USER_ID);
+        headers.put("CamelGoogleMail.id", messageId);
+
+        // Use DataTypeTransformer: google-mail:update-message-labels
+        // Set exchange variables for transformer to resolve label names to IDs
+        producerTemplate.request("direct:update-message-labels", exchange -> {
+            exchange.getMessage().setHeaders(headers);
+            if (addLabel != null && !addLabel.isEmpty()) {
+                exchange.setVariable("addLabels", Arrays.asList(addLabel));
+            }
+            if (removeLabel != null && !removeLabel.isEmpty()) {
+                exchange.setVariable("removeLabels", Arrays.asList(removeLabel));
+            }
+        });
+
+        return Response.ok().build();
+    }
+
+    @Path("/draft/create")
+    @POST
+    @Consumes(MediaType.TEXT_PLAIN)
+    @Produces(MediaType.TEXT_PLAIN)
+    public Response createDraft(String message,
+            @QueryParam("threadId") String threadId,
+            @QueryParam("messageId") String messageId) throws Exception {
+        // Use DataTypeTransformer: google-mail:draft
+        // Transformer reads String body and converts to Draft using headers
+        Profile profile = producerTemplate.requestBody("google-mail://users/getProfile?inBody=userId", USER_ID, Profile.class);
+
+        Map<String, Object> headers = new HashMap<>();
+        headers.put("CamelGoogleMail.userId", USER_ID);
+        // Set headers for transformer to read (from google-mail-stream)
+        headers.put(GoogleMailStreamConstants.MAIL_FROM, profile.getEmailAddress());
+        headers.put(GoogleMailStreamConstants.MAIL_TO, profile.getEmailAddress());
+        headers.put(GoogleMailStreamConstants.MAIL_SUBJECT, EMAIL_SUBJECT);
+        if (threadId != null && !threadId.isEmpty()) {
+            headers.put(GoogleMailStreamConstants.MAIL_THREAD_ID, threadId);
+        }
+        if (messageId != null && !messageId.isEmpty()) {
+            headers.put(GoogleMailStreamConstants.MAIL_MESSAGE_ID, messageId);
+        }
+
+        Draft response = producerTemplate.requestBodyAndHeaders("direct:create-draft", message, headers, Draft.class);
+        return Response
+                .created(new URI("https://camel.apache.org/"))
+                .entity(response.getId())
+                .build();
+    }
+
+    @Path("/draft/read")
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public Response readDraft(@QueryParam("draftId") String draftId) {
+        Map<String, Object> headers = new HashMap<>();
+        headers.put("CamelGoogleMail.userId", USER_ID);
+        headers.put("CamelGoogleMail.id", draftId);
+
+        try {
+            Draft response = producerTemplate.requestBodyAndHeaders("google-mail://drafts/get", null, headers, Draft.class);
+            if (response != null && response.getMessage() != null && response.getMessage().getPayload() != null) {
+                String body = new String(response.getMessage().getPayload().getBody().decodeData(),
+                        StandardCharsets.UTF_8);
+                return Response.ok(body).build();
+            } else {
+                return Response.status(Response.Status.NOT_FOUND).build();
+            }
+        } catch (CamelExecutionException e) {
+            Exception exchangeException = e.getExchange().getException();
+            if (exchangeException != null && exchangeException.getCause() instanceof GoogleJsonResponseException) {
+                GoogleJsonResponseException originalException = (GoogleJsonResponseException) exchangeException.getCause();
+                return Response.status(originalException.getStatusCode()).build();
+            }
+            throw e;
+        }
+    }
+
+    @Path("/draft/update")
+    @PATCH
+    @Consumes(MediaType.TEXT_PLAIN)
+    @Produces(MediaType.TEXT_PLAIN)
+    public Response updateDraft(@QueryParam("draftId") String draftId, String message) throws Exception {
+        // Use DataTypeTransformer: google-mail:draft for update
+        Profile profile = producerTemplate.requestBody("google-mail://users/getProfile?inBody=userId", USER_ID, Profile.class);
+
+        Map<String, Object> headers = new HashMap<>();
+        headers.put("CamelGoogleMail.userId", USER_ID);
+        headers.put("CamelGoogleMail.id", draftId);
+        // Set headers for transformer to read (from google-mail-stream)
+        headers.put(GoogleMailStreamConstants.MAIL_FROM, profile.getEmailAddress());
+        headers.put(GoogleMailStreamConstants.MAIL_TO, profile.getEmailAddress());
+        headers.put(GoogleMailStreamConstants.MAIL_SUBJECT, EMAIL_SUBJECT);
+
+        Draft response = producerTemplate.requestBodyAndHeaders("direct:update-draft", message, headers, Draft.class);
+        return Response.ok(response.getId()).build();
+    }
+
+    @Path("/draft/send")
+    @POST
+    @Produces(MediaType.TEXT_PLAIN)
+    public Response sendDraft(@QueryParam("draftId") String draftId) {
+        Draft draft = new Draft();
+        draft.setId(draftId);
+
+        Map<String, Object> headers = new HashMap<>();
+        headers.put("CamelGoogleMail.userId", USER_ID);
+        headers.put("CamelGoogleMail.content", draft);
+
+        Message response = producerTemplate.requestBodyAndHeaders("google-mail://drafts/send", null, headers, Message.class);
+        return Response.ok(response.getId()).build();
+    }
+
+    @Path("/draft/delete")
+    @DELETE
+    public Response deleteDraft(@QueryParam("draftId") String draftId) {
+        Map<String, Object> headers = new HashMap<>();
+        headers.put("CamelGoogleMail.userId", USER_ID);
+        headers.put("CamelGoogleMail.id", draftId);
+        producerTemplate.requestBodyAndHeaders("google-mail://drafts/delete", null, headers);
+        return Response.status(Response.Status.NO_CONTENT).build();
+    }
+
+    @Path("/label/create")
+    @POST
+    @Consumes(MediaType.TEXT_PLAIN)
+    @Produces(MediaType.TEXT_PLAIN)
+    public Response createLabel(String labelName) {
+        Label label = new Label();
+        label.setName(labelName);
+        label.setLabelListVisibility("labelShow");
+        label.setMessageListVisibility("show");
+
+        Map<String, Object> headers = new HashMap<>();
+        headers.put("CamelGoogleMail.userId", USER_ID);
+        headers.put("CamelGoogleMail.content", label);
+
+        Label response = producerTemplate.requestBodyAndHeaders("google-mail://labels/create", null, headers, Label.class);
+        return Response
+                .status(Response.Status.CREATED)
+                .entity(response.getId())
+                .build();
+    }
+
+    @Path("/label/delete")
+    @DELETE
+    public Response deleteLabel(@QueryParam("labelId") String labelId) {
+        Map<String, Object> headers = new HashMap<>();
+        headers.put("CamelGoogleMail.userId", USER_ID);
+        headers.put("CamelGoogleMail.id", labelId);
+        producerTemplate.requestBodyAndHeaders("google-mail://labels/delete", null, headers);
         return Response.status(Response.Status.NO_CONTENT).build();
     }
 

--- a/integration-tests/google/src/main/java/org/apache/camel/quarkus/component/google/it/GoogleMailRoutes.java
+++ b/integration-tests/google/src/main/java/org/apache/camel/quarkus/component/google/it/GoogleMailRoutes.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.google.it;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.spi.DataType;
+
+@ApplicationScoped
+public class GoogleMailRoutes extends RouteBuilder {
+
+    @Override
+    public void configure() throws Exception {
+        // Route using google-mail:update-message-labels transformer
+        from("direct:update-message-labels")
+                .transformDataType(new DataType("google-mail:update-message-labels"))
+                .to("google-mail://messages/modify?inBody=modifyMessageRequest");
+
+        // Route using google-mail:draft transformer
+        from("direct:create-draft")
+                .transformDataType(new DataType("google-mail:draft"))
+                .to("google-mail://drafts/create?inBody=content");
+
+        // Route using google-mail:draft transformer for update
+        from("direct:update-draft")
+                .transformDataType(new DataType("google-mail:draft"))
+                .to("google-mail://drafts/update?inBody=content");
+    }
+}

--- a/integration-tests/google/src/test/java/org/apache/camel/quarkus/component/google/it/GoogleComponentsTest.java
+++ b/integration-tests/google/src/test/java/org/apache/camel/quarkus/component/google/it/GoogleComponentsTest.java
@@ -201,6 +201,243 @@ class GoogleComponentsTest {
     }
 
     @Test
+    public void testGoogleMailUpdateLabels() {
+        String message = "Test message for label update";
+        String customLabelName = "TestLabel_" + UUID.randomUUID().toString().substring(0, 8);
+
+        // Create custom label to test name-to-ID resolution
+        String customLabelId = RestAssured.given()
+                .contentType(ContentType.TEXT)
+                .body(customLabelName)
+                .post("/google-mail/label/create")
+                .then()
+                .statusCode(201)
+                .extract()
+                .body()
+                .asString();
+
+        // Create message
+        String messageId = RestAssured.given()
+                .contentType(ContentType.TEXT)
+                .body(message)
+                .post("/google-mail/create")
+                .then()
+                .statusCode(201)
+                .extract()
+                .body()
+                .asString();
+
+        // Test DataTypeTransformer: Use label NAME (not ID)
+        // Transformer should resolve label name to ID automatically
+        RestAssured.given()
+                .queryParam("messageId", messageId)
+                .queryParam("addLabel", customLabelName)
+                .patch("/google-mail/update-labels")
+                .then()
+                .statusCode(200);
+
+        // Update labels - remove custom label and add INBOX (system label)
+        RestAssured.given()
+                .queryParam("messageId", messageId)
+                .queryParam("removeLabel", customLabelName)
+                .queryParam("addLabel", "INBOX")
+                .patch("/google-mail/update-labels")
+                .then()
+                .statusCode(200);
+
+        // Clean up message
+        Awaitility.await()
+                .pollDelay(2, TimeUnit.SECONDS)
+                .pollInterval(500, TimeUnit.MILLISECONDS)
+                .atMost(15, TimeUnit.SECONDS).until(() -> {
+                    final int code = RestAssured.given()
+                            .queryParam("messageId", messageId)
+                            .delete("/google-mail/delete")
+                            .then()
+                            .extract()
+                            .statusCode();
+                    return code == 204;
+                });
+
+        // Clean up custom label
+        RestAssured.given()
+                .queryParam("labelId", customLabelId)
+                .delete("/google-mail/label/delete")
+                .then()
+                .statusCode(204);
+    }
+
+    @Test
+    public void testGoogleMailDraftOperations() {
+        String draftMessage = "Draft message content";
+        String updatedMessage = "Updated draft message content";
+
+        // Create draft
+        String draftId = RestAssured.given()
+                .contentType(ContentType.TEXT)
+                .body(draftMessage)
+                .post("/google-mail/draft/create")
+                .then()
+                .statusCode(201)
+                .extract()
+                .body()
+                .asString();
+
+        // Read draft
+        RestAssured.given()
+                .queryParam("draftId", draftId)
+                .get("/google-mail/draft/read")
+                .then()
+                .statusCode(200)
+                .body(is(draftMessage));
+
+        // Update draft
+        RestAssured.given()
+                .contentType(ContentType.TEXT)
+                .queryParam("draftId", draftId)
+                .body(updatedMessage)
+                .patch("/google-mail/draft/update")
+                .then()
+                .statusCode(200);
+
+        // Verify update
+        RestAssured.given()
+                .queryParam("draftId", draftId)
+                .get("/google-mail/draft/read")
+                .then()
+                .statusCode(200)
+                .body(is(updatedMessage));
+
+        // Send draft
+        String sentMessageId = RestAssured.given()
+                .queryParam("draftId", draftId)
+                .post("/google-mail/draft/send")
+                .then()
+                .statusCode(200)
+                .extract()
+                .body()
+                .asString();
+
+        // Verify draft no longer exists after sending
+        RestAssured.given()
+                .queryParam("draftId", draftId)
+                .get("/google-mail/draft/read")
+                .then()
+                .statusCode(404);
+
+        // Clean up sent message
+        Awaitility.await()
+                .pollDelay(2, TimeUnit.SECONDS)
+                .pollInterval(500, TimeUnit.MILLISECONDS)
+                .atMost(15, TimeUnit.SECONDS).until(() -> {
+                    final int code = RestAssured.given()
+                            .queryParam("messageId", sentMessageId)
+                            .delete("/google-mail/delete")
+                            .then()
+                            .extract()
+                            .statusCode();
+                    return code == 204;
+                });
+    }
+
+    @Test
+    public void testGoogleMailDraftWithThreadingMetadata() {
+        String originalMessage = "Original message";
+        String replyMessage = "Reply to original message";
+
+        // Create original message to get messageId and threadId
+        String originalMessageId = RestAssured.given()
+                .contentType(ContentType.TEXT)
+                .body(originalMessage)
+                .post("/google-mail/create")
+                .then()
+                .statusCode(201)
+                .extract()
+                .body()
+                .asString();
+
+        // Get the actual threadId from the original message
+        String threadId = RestAssured.given()
+                .queryParam("messageId", originalMessageId)
+                .get("/google-mail/thread-id")
+                .then()
+                .statusCode(200)
+                .extract()
+                .body()
+                .asString();
+
+        // Get the actual Message-ID header from the original message
+        String messageIdHeader = RestAssured.given()
+                .queryParam("messageId", originalMessageId)
+                .get("/google-mail/message-id-header")
+                .then()
+                .statusCode(200)
+                .extract()
+                .body()
+                .asString();
+
+        // Create draft with threading metadata
+        // DataTypeTransformer should use threadId and messageId to set In-Reply-To and References headers
+        String draftId = RestAssured.given()
+                .contentType(ContentType.TEXT)
+                .queryParam("threadId", threadId)
+                .queryParam("messageId", messageIdHeader)
+                .body(replyMessage)
+                .post("/google-mail/draft/create")
+                .then()
+                .statusCode(201)
+                .extract()
+                .body()
+                .asString();
+
+        // Read draft to verify it was created
+        RestAssured.given()
+                .queryParam("draftId", draftId)
+                .get("/google-mail/draft/read")
+                .then()
+                .statusCode(200)
+                .body(is(replyMessage));
+
+        // Send the draft
+        String sentMessageId = RestAssured.given()
+                .queryParam("draftId", draftId)
+                .post("/google-mail/draft/send")
+                .then()
+                .statusCode(200)
+                .extract()
+                .body()
+                .asString();
+
+        // Clean up original message
+        Awaitility.await()
+                .pollDelay(2, TimeUnit.SECONDS)
+                .pollInterval(500, TimeUnit.MILLISECONDS)
+                .atMost(15, TimeUnit.SECONDS).until(() -> {
+                    final int code = RestAssured.given()
+                            .queryParam("messageId", originalMessageId)
+                            .delete("/google-mail/delete")
+                            .then()
+                            .extract()
+                            .statusCode();
+                    return code == 204;
+                });
+
+        // Clean up sent message
+        Awaitility.await()
+                .pollDelay(2, TimeUnit.SECONDS)
+                .pollInterval(500, TimeUnit.MILLISECONDS)
+                .atMost(15, TimeUnit.SECONDS).until(() -> {
+                    final int code = RestAssured.given()
+                            .queryParam("messageId", sentMessageId)
+                            .delete("/google-mail/delete")
+                            .then()
+                            .extract()
+                            .statusCode();
+                    return code == 204;
+                });
+    }
+
+    @Test
     public void testGoogleSheetsComponent() {
         String title = "Camel Quarkus Google Sheet";
 


### PR DESCRIPTION
Add test coverage for Gmail DataType Transformers : update-message-labels and draft

   - google-mail:update-message-labels transformer: Tests automatic label name-to-ID resolution when updating message labels via exchange variables

   - google-mail:draft transformer: Tests draft creation and update using GoogleMailStreamConstants headers (MAIL_FROM, MAIL_TO, MAIL_SUBJECT, etc.)

   - Threading metadata support: Tests draft replies with proper threadId and Message-ID headers for email threading

   All added tests pass with real google cloud environment in both JVM and native modes.

   Generated with Claude Code on behalf of Jinyu Chen

   fixes #8531