### PR TITLE
Add camel-quarkus-cli-connector as a conditional dev mode dependency

### DIFF
--- a/extensions-core/core/runtime/pom.xml
+++ b/extensions-core/core/runtime/pom.xml
@@ -102,7 +102,7 @@
                         <provides>org.apache.camel</provides>
                     </capabilities>
                     <conditionalDevDependencies>
-                        <artifact>org.apache.camel.quarkus:camel-quarkus-console:${project.version}</artifact>
+                        <artifact>org.apache.camel.quarkus:camel-quarkus-cli-connector:${project.version}</artifact>
                         <artifact>org.apache.camel.quarkus:camel-quarkus-debug:${project.version}</artifact>
                     </conditionalDevDependencies>
                 </configuration>

--- a/extensions-jvm/cli-connector/runtime/src/main/java/org/apache/camel/quarkus/component/cli/connector/QuarkusLocalCliConnector.java
+++ b/extensions-jvm/cli-connector/runtime/src/main/java/org/apache/camel/quarkus/component/cli/connector/QuarkusLocalCliConnector.java
@@ -17,6 +17,7 @@
 package org.apache.camel.quarkus.component.cli.connector;
 
 import io.quarkus.runtime.LaunchMode;
+import io.quarkus.runtime.Quarkus;
 import org.apache.camel.cli.connector.LocalCliConnector;
 import org.apache.camel.spi.CliConnectorFactory;
 
@@ -28,9 +29,13 @@ public class QuarkusLocalCliConnector extends LocalCliConnector {
     @Override
     public void sigterm() {
         if (LaunchMode.current().equals(LaunchMode.DEVELOPMENT)) {
-            // If Camel JBang launched us in dev mode, then stopping the CamelContext is not enough as dev mode will remain running.
-            // Therefore, init app shutdown which will still shut Camel down gracefully
-            System.exit(0);
+            if (System.getProperty("user.dir", "").contains(".camel-jbang")) {
+                // If Camel JBang launched us in dev mode, then stopping the CamelContext is not enough as dev mode will remain running.
+                System.exit(0);
+            } else {
+                // Delegate to standard shutdown lifecycle
+                Quarkus.asyncExit();
+            }
         } else {
             super.sigterm();
         }


### PR DESCRIPTION
Fixes #8623

Note - The `camel-quarkus-console` `<artifact>` removal was due to failures in `CamelQuarkusCoreDevUITest`. It's probably due a bug in Quarkus, I'd need to dig into it more another time. But `console` is a transitive of `cli-connector` so it's a safe change. I verified the dev-ui pages still work fine.