### PR TITLE
Add project-level security model documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,6 +217,23 @@ Use `CombinedIndexBuildItem` to discover classes at build time — see `extensio
 
 See also https://quarkus.io/guides/writing-extensions.
 
+## Security Model
+
+Camel Quarkus inherits the security model from Apache Camel. The canonical document is
+[`docs/modules/ROOT/pages/user-guide/security-model.adoc`](docs/modules/ROOT/pages/user-guide/security-model.adoc).
+Use it as the reference when triaging security reports, deciding whether a finding warrants a
+CVE, or reviewing a security-sensitive PR.
+
+### Extension author review checklist (for security-sensitive PRs)
+
+All guidance from https://camel.apache.org/manual/security-model.html applies (header filtering,
+object input filters, secure defaults, auth enforcement). In addition, for Camel Quarkus extensions:
+
+- Does the change add resource registration (`NativeImageResourceBuildItem`) for files that contain
+  secrets or should not be embedded in the native image?
+- Does a new build-time configuration option control a security-relevant default? Prefer
+  `ConfigPhase.RUN_TIME` unless build-time is strictly necessary for native compilation.
+
 ## Common Tasks
 
 ### Update Camel Version

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,53 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+# Security Policy
+
+## Supported Versions
+
+To see which versions of Apache Camel Quarkus are supported please refer to this [page](https://camel.apache.org/camel-quarkus/latest/).
+
+## Reporting a Vulnerability
+
+For information on how to report a new security problem please see [here](https://camel.apache.org/security/).
+
+**Important:** Do **not** file a public GitHub issue or Jira ticket for security vulnerabilities. Only
+report security issues through the private `private-security@camel.apache.org` email address as
+described in the security reporting instructions.
+
+## Security Model
+
+Before submitting a report, please read the project's
+[Security Model](docs/modules/ROOT/pages/user-guide/security-model.adoc). It documents the
+security model for Camel Quarkus, including inherited security considerations from Apache Camel,
+
+The security model defines:
+- Who is trusted (committers, route authors, deployment operators vs. untrusted external message senders)
+- Where the trust boundaries sit (route + configuration vs. data flowing through the route)
+- Which vulnerability classes the Camel Quarkus PMC accepts
+- Which categories are out of scope (route-author or operator responsibility, explicit opt-ins,
+  DoS through unthrottled routes, third-party transitive CVEs not reachable through Camel Quarkus code)
+
+Reports outside the documented scope will be closed with a reference to the security model.
+
+### Quarkus Specific Security Concerns
+
+For suspected vulnerabilities in `io.quarkus` or `io.quarkiverse` dependencies that are not
+reachable through Camel Quarkus extension code, please refer to the
+[Quarkus Security Policy](https://quarkus.io/security/) and report directly to the Quarkus
+project.

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -9,6 +9,7 @@
 ** xref:user-guide/native-mode.adoc[Native mode]
 ** xref:user-guide/command-mode.adoc[Command mode]
 ** xref:user-guide/testing.adoc[Testing]
+** xref:user-guide/security-model.adoc[Security model]
 ** xref:user-guide/examples.adoc[Examples]
 ** xref:user-guide/kubernetes.adoc[Kubernetes]
 * xref:migration-guide/index.adoc[Migration guide]

--- a/docs/modules/ROOT/pages/user-guide/security-model.adoc
+++ b/docs/modules/ROOT/pages/user-guide/security-model.adoc
@@ -1,0 +1,105 @@
+= Security Model
+
+This page documents the Camel Quarkus security model, which inherits the core security model from
+Apache Camel and adds Apache Camel Quarkus specific considerations.
+
+== Inherited Security Model
+
+Apache Camel Quarkus inherits its security model from Apache Camel. The authoritative reference is the
+xref:manual::security-model.adoc[Apache Camel Security Model], which documents:
+
+* Trust assumptions (route authors, deployment operators, and external message senders)
+* Trust boundaries (route + configuration vs. data flowing through routes)
+* In-scope vulnerability classes (unsafe deserialisation, XXE, injection, path traversal, etc.)
+* Out-of-scope categories (route author code execution, explicit opt-ins, DoS, etc.)
+* Deployment hardening guidance
+* Component author review checklist
+
+**Before reporting a security issue to Apache Camel Quarkus**, read the
+xref:manual::security-model.adoc[Apache Camel Security Model] to understand core security
+assumptions and scope.
+
+For suspected vulnerabilities in `io.quarkus` or `io.quarkiverse` dependencies that are **not
+reachable through Camel Quarkus extension code**, refer to the
+https://quarkus.io/security/[Quarkus Security Policy] and report directly to the Quarkus project.
+
+== Camel Quarkus Specific Considerations
+
+In addition to the inherited security model, the following considerations apply specifically to
+Camel Quarkus extensions and native compilation.
+
+=== In-Scope: Build-Time Configuration Baking Insecure Defaults
+
+Build-time configuration (`ConfigPhase.BUILD_TIME`) is baked into the native image and cannot be
+changed at runtime. A security-relevant option that defaults to an insecure value (e.g., disables
+TLS validation, enables unsafe deserialisation) is in scope if it cannot be overridden at runtime
+and should reasonably be runtime-configurable.
+
+Extension authors should prefer `ConfigPhase.RUN_TIME` or `ConfigPhase.BUILD_AND_RUN_TIME_FIXED`
+for security-relevant options unless build-time is necessary for native compilation.
+
+=== Out-of-Scope: Operator Misconfigurations
+
+The following are **not** framework vulnerabilities:
+
+* **Native image build failures** due to missing registrations that cause runtime errors but do not
+  introduce security vulnerabilities. These are bugs, not security issues.
+* **Performance differences** between JVM and native mode, unless the performance degradation
+  enables a DoS attack that would not be possible in JVM mode.
+
+=== Deployment Hardening
+
+In addition to the
+xref:manual::security-model.adoc#_deployment_hardening[Apache Camel deployment hardening guidance],
+operators should:
+
+* **Review build-time configuration** before building production native images. Build-time config
+  (`ConfigPhase.BUILD_TIME`) cannot be changed without a rebuild. Review all `quarkus.camel.*` and
+  extension-specific build-time properties.
+* **Minimize extension surface**. Only include the Camel Quarkus extensions your application
+  actually uses. Each extension increases the native image size, attack surface, and dependency tree.
+* **Use Camel and Quarkus security features**. Leverage xref:manual::security.adoc[Camel security
+  features] (vaults, JSSE Utility, route security) and
+  https://quarkus.io/guides/security[Quarkus security features] (OIDC, JWT, TLS configuration).
+
+=== Extension Author Guidance
+
+When writing or reviewing Camel Quarkus extensions, in addition to the
+xref:manual::security-model.adoc#_guidance_for_component_authors_and_reviewers[Apache Camel
+component author guidance]:
+
+* **Prefer runtime configuration for security options**. Use `ConfigPhase.RUN_TIME` for security-
+  relevant options (TLS settings, auth credentials, validation flags) unless build-time is strictly
+  necessary for native compilation.
+* **Review resource registrations**. When registering resources for native image
+  (`NativeImageResourceBuildItem`, `NativeImageResourceDirectoryBuildItem`), ensure no sensitive
+  files (keys, credentials, `.env`) are included. Prefer specific file registration over directory
+  registration.
+
+== Reporting a Vulnerability
+
+The Apache Camel Quarkus project uses the standard ASF vulnerability reporting process:
+
+* Read https://camel.apache.org/security/[Apache Camel Security] for instructions.
+* Email `private-security@camel.apache.org` with a description, affected versions, and a proof of
+  concept that demonstrates the trust-boundary breach.
+* Do **not** file a public GitHub issue, Jira ticket, open a public pull request, post on a mailing
+  list, social media, or any other public channel. Only contact the
+  https://apache.org/security/[Apache Software Foundation Security team].
+
+Reports that match the in-scope classes (inherited from Apache Camel or Camel Quarkus-specific)
+will be triaged on the private security list, fixed in a coordinated release, and published as a
+CVE advisory. Reports that match the out-of-scope categories will be closed with a reference to
+this document.
+
+== Related Documents
+
+* xref:manual::security-model.adoc[Apache Camel Security Model] - the authoritative security model
+  which Camel Quarkus inherits.
+* xref:manual::security.adoc[Apache Camel Security Features] - catalog of Camel security features
+  (vaults, JSSE, route security).
+* https://quarkus.io/security/[Quarkus Security Policy] - security policy for the Quarkus framework.
+* https://quarkus.io/guides/security[Quarkus Security Guides] - guides on securing Quarkus
+  applications.
+* https://camel.apache.org/security/[Apache Camel Security] - public advisory index and reporting
+  process.


### PR DESCRIPTION
Companion to https://github.com/apache/camel/pull/23181.

Adds security policy documentation for Camel Quarkus, modelled on the Apache Camel security policy. The security model inherits core security assumptions from Apache Camel and documents Camel Quarkus-specific considerations for native compilation and extension development.

Changes:
- SECURITY.md: Root-level security policy file with reporting instructions and explicit warnings against public disclosure via GitHub issues/Jira
- docs/modules/ROOT/pages/user-guide/security-model.adoc: Comprehensive security model documentation that references Apache Camel's authoritative model and adds Quarkus-specific considerations (build-time configuration, resource registration, deployment hardening)
- AGENTS.md: Added Security Model section for AI agents with concise summaries of trust assumptions, scope, and extension author checklist
- docs/modules/ROOT/nav.adoc: Added navigation link to security model page
