### PR TITLE
ci: use relative links in security-model.adoc

### DIFF
--- a/docs/modules/ROOT/pages/user-guide/security-model.adoc
+++ b/docs/modules/ROOT/pages/user-guide/security-model.adoc
@@ -80,7 +80,7 @@ component author guidance]:
 
 The Apache Camel Quarkus project uses the standard ASF vulnerability reporting process:
 
-* Read https://camel.apache.org/security/[Apache Camel Security] for instructions.
+* Read link:/security/[Apache Camel Security] for instructions.
 * Email `private-security@camel.apache.org` with a description, affected versions, and a proof of
   concept that demonstrates the trust-boundary breach.
 * Do **not** file a public GitHub issue, Jira ticket, open a public pull request, post on a mailing
@@ -101,5 +101,5 @@ this document.
 * https://quarkus.io/security/[Quarkus Security Policy] - security policy for the Quarkus framework.
 * https://quarkus.io/guides/security[Quarkus Security Guides] - guides on securing Quarkus
   applications.
-* https://camel.apache.org/security/[Apache Camel Security] - public advisory index and reporting
+* link:/security/[Apache Camel Security] - public advisory index and reporting
   process.


### PR DESCRIPTION
## CI Fix

**Failed run (camel-website):** https://github.com/apache/camel-website/actions/runs/25926572539

### Error

camel-website's `check:html` step enforces the `camel/relative-links` rule:
in-site links must be relative, not absolute `https://camel.apache.org/...`.
The Camel Quarkus security model page
(`docs/modules/ROOT/pages/user-guide/security-model.adoc`) used 2 absolute
in-site URLs, producing **2 errors** in
`public/camel-quarkus/next/user-guide/security-model.html` and failing the
build for **every** camel-website pull request (unrelated to whichever
camel-website PR triggers the run).

### Fix

Convert the 2 in-site links to root-relative `link:/security/[...]`, matching
apache/camel core `security-model.adoc` (fixed identically in
apache/camel#23224; companion PRs: apache/camel-kamelets#2836,
apache/camel-kafka-connector#1774). The `private-security@camel.apache.org`
email reference is left unchanged.

Documentation-only, single file, same link target rendered relative. No local
Antora CLI in the environment; the camel-website build is the definitive check.

### Deferred Issues
None.

---
_Claude Code on behalf of Andrea Cosentino_