### PR TITLE
Add integration tests for aws2-kms #2400

### DIFF
--- a/integration-test-groups/aws2/aws2-kms/pom.xml
+++ b/integration-test-groups/aws2/aws2-kms/pom.xml
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.camel.quarkus</groupId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
+        <version>3.36.0-SNAPSHOT</version>
+        <relativePath>../../../poms/build-parent-it/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>camel-quarkus-integration-test-aws2-kms</artifactId>
+    <name>Camel Quarkus :: Integration Tests :: AWS 2 KMS</name>
+    <description>Integration tests for Camel Quarkus AWS 2 Key Management Service extension</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-aws2-kms</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-jackson</artifactId>
+        </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-integration-tests-support-aws2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-integration-tests-support-aws2</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <id>native</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <properties>
+                <quarkus.native.enabled>true</quarkus.native.enabled>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>virtualDependencies</id>
+            <activation>
+                <property>
+                    <name>!noVirtualDependencies</name>
+                </property>
+            </activation>
+            <dependencies>
+                <!-- The following dependencies guarantee that this module is built after them. You can update them by running `mvn process-resources -Pformat -N` from the source tree root directory -->
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-aws2-kms-deployment</artifactId>
+                    <version>${project.version}</version>
+                    <type>pom</type>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>skip-testcontainers-tests</id>
+            <activation>
+                <property>
+                    <name>skip-testcontainers-tests</name>
+                </property>
+            </activation>
+            <properties>
+                <skipTests>true</skipTests>
+            </properties>
+        </profile>
+    </profiles>
+
+</project>

--- a/integration-test-groups/aws2/aws2-kms/src/main/java/org/apache/camel/quarkus/component/aws2/kms/it/Aws2KmsResource.java
+++ b/integration-test-groups/aws2/aws2-kms/src/main/java/org/apache/camel/quarkus/component/aws2/kms/it/Aws2KmsResource.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.aws2.kms.it;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.component.aws2.kms.KMS2Constants;
+import org.apache.camel.component.aws2.kms.KMS2Operations;
+import org.apache.camel.quarkus.test.support.aws2.BaseAws2Resource;
+import software.amazon.awssdk.services.kms.model.CreateKeyResponse;
+import software.amazon.awssdk.services.kms.model.DescribeKeyResponse;
+import software.amazon.awssdk.services.kms.model.KeyListEntry;
+import software.amazon.awssdk.services.kms.model.ListKeysResponse;
+import software.amazon.awssdk.services.kms.model.ScheduleKeyDeletionResponse;
+
+@Path("/aws2-kms")
+@ApplicationScoped
+public class Aws2KmsResource extends BaseAws2Resource {
+
+    @Inject
+    ProducerTemplate producerTemplate;
+
+    public Aws2KmsResource() {
+        super("kms");
+    }
+
+    @Path("/keys")
+    @POST
+    @Produces(MediaType.TEXT_PLAIN)
+    public String createKey() {
+        CreateKeyResponse response = producerTemplate.requestBodyAndHeaders(
+                componentUri(KMS2Operations.createKey),
+                null,
+                Collections.emptyMap(),
+                CreateKeyResponse.class);
+        return response.keyMetadata().keyId();
+    }
+
+    @Path("/keys")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<String> listKeys() {
+        ListKeysResponse response = producerTemplate.requestBody(
+                componentUri(KMS2Operations.listKeys),
+                null,
+                ListKeysResponse.class);
+        return response.keys().stream().map(KeyListEntry::keyId).collect(Collectors.toList());
+    }
+
+    @Path("/keys/{keyId}")
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String describeKey(@PathParam("keyId") String keyId) {
+        DescribeKeyResponse response = producerTemplate.requestBodyAndHeaders(
+                componentUri(KMS2Operations.describeKey),
+                null,
+                Map.of(KMS2Constants.KEY_ID, keyId),
+                DescribeKeyResponse.class);
+        return response.keyMetadata().keyState().toString();
+    }
+
+    @Path("/keys/{keyId}/disable")
+    @POST
+    public void disableKey(@PathParam("keyId") String keyId) {
+        producerTemplate.requestBodyAndHeaders(
+                componentUri(KMS2Operations.disableKey),
+                null,
+                Map.of(KMS2Constants.KEY_ID, keyId));
+    }
+
+    @Path("/keys/{keyId}/enable")
+    @POST
+    public void enableKey(@PathParam("keyId") String keyId) {
+        producerTemplate.requestBodyAndHeaders(
+                componentUri(KMS2Operations.enableKey),
+                null,
+                Map.of(KMS2Constants.KEY_ID, keyId));
+    }
+
+    @Path("/keys/{keyId}")
+    @DELETE
+    @Consumes(MediaType.TEXT_PLAIN)
+    @Produces(MediaType.TEXT_PLAIN)
+    public String scheduleKeyDeletion(@PathParam("keyId") String keyId, String pendingWindowInDays) {
+        Map<String, Object> headers = pendingWindowInDays == null || pendingWindowInDays.isBlank()
+                ? Map.of(KMS2Constants.KEY_ID, keyId)
+                : Map.of(KMS2Constants.KEY_ID, keyId,
+                        KMS2Constants.PENDING_WINDOW_IN_DAYS, Integer.parseInt(pendingWindowInDays));
+
+        ScheduleKeyDeletionResponse response = producerTemplate.requestBodyAndHeaders(
+                componentUri(KMS2Operations.scheduleKeyDeletion),
+                null,
+                headers,
+                ScheduleKeyDeletionResponse.class);
+        return response.keyId();
+    }
+
+    private String componentUri(KMS2Operations operation) {
+        return "aws2-kms:cq-test?operation=" + operation.name()
+                + "&useDefaultCredentialsProvider=" + isUseDefaultCredentials();
+    }
+}

--- a/integration-test-groups/aws2/aws2-kms/src/main/resources/application.properties
+++ b/integration-test-groups/aws2/aws2-kms/src/main/resources/application.properties
@@ -1,0 +1,21 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+camel.component.aws2-kms.access-key=${AWS_ACCESS_KEY}
+camel.component.aws2-kms.secret-key=${AWS_SECRET_KEY}
+camel.component.aws2-kms.useDefaultCredentialsProvider=${AWS_USE_DEFAULT_CREDENTIALS_PROVIDER}
+camel.component.aws2-kms.region=${AWS_REGION:us-east-1}

--- a/integration-test-groups/aws2/aws2-kms/src/test/java/org/apache/camel/quarkus/component/aws2/kms/it/Aws2KmsIT.java
+++ b/integration-test-groups/aws2/aws2-kms/src/test/java/org/apache/camel/quarkus/component/aws2/kms/it/Aws2KmsIT.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.aws2.kms.it;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+class Aws2KmsIT extends Aws2KmsTest {
+
+}

--- a/integration-test-groups/aws2/aws2-kms/src/test/java/org/apache/camel/quarkus/component/aws2/kms/it/Aws2KmsTest.java
+++ b/integration-test-groups/aws2/aws2-kms/src/test/java/org/apache/camel/quarkus/component/aws2/kms/it/Aws2KmsTest.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.aws2.kms.it;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import org.apache.camel.quarkus.test.support.aws2.Aws2Client;
+import org.apache.camel.quarkus.test.support.aws2.Aws2TestResource;
+import org.apache.camel.quarkus.test.support.aws2.BaseAWs2TestSupport;
+import org.apache.camel.quarkus.test.support.aws2.Service;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.kms.KmsClient;
+import software.amazon.awssdk.services.kms.model.DescribeKeyRequest;
+import software.amazon.awssdk.services.kms.model.KeyState;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.matchesPattern;
+import static org.hamcrest.Matchers.not;
+
+@QuarkusTest
+@QuarkusTestResource(Aws2TestResource.class)
+class Aws2KmsTest extends BaseAWs2TestSupport {
+
+    @Aws2Client(Service.KMS)
+    KmsClient client;
+
+    public Aws2KmsTest() {
+        super("/aws2-kms");
+    }
+
+    @Test
+    public void createListDescribeAndScheduleDeletion() {
+        // createKey
+        final String keyId = given()
+                .post("/aws2-kms/keys")
+                .then()
+                .statusCode(200)
+                .body(matchesPattern("[A-Za-z0-9-]+"))
+                .extract()
+                .asString();
+
+        try {
+            // describeKey via the Camel route — newly created keys start enabled
+            given()
+                    .get("/aws2-kms/keys/" + keyId)
+                    .then()
+                    .statusCode(200)
+                    .body(matchesPattern(KeyState.ENABLED.toString()));
+
+            // listKeys — the new key must be visible
+            given()
+                    .get("/aws2-kms/keys")
+                    .then()
+                    .statusCode(200)
+                    .body("$", hasItem(keyId));
+
+            // cross-check via the AWS SDK that the key exists and is enabled
+            KeyState awsState = client
+                    .describeKey(DescribeKeyRequest.builder().keyId(keyId).build())
+                    .keyMetadata()
+                    .keyState();
+            org.assertj.core.api.Assertions.assertThat(awsState).isEqualTo(KeyState.ENABLED);
+        } finally {
+            // scheduleKeyDeletion as cleanup; AWS minimum window is 7 days
+            given()
+                    .contentType("text/plain")
+                    .body("7")
+                    .delete("/aws2-kms/keys/" + keyId)
+                    .then()
+                    .statusCode(200)
+                    .body(matchesPattern(".*" + keyId + ".*"));
+        }
+    }
+
+    @Test
+    public void disableEnableThenSchedule() {
+        final String keyId = given()
+                .post("/aws2-kms/keys")
+                .then()
+                .statusCode(200)
+                .extract()
+                .asString();
+
+        try {
+            // disableKey
+            given()
+                    .post("/aws2-kms/keys/" + keyId + "/disable")
+                    .then()
+                    .statusCode(204);
+
+            KeyState afterDisable = client
+                    .describeKey(DescribeKeyRequest.builder().keyId(keyId).build())
+                    .keyMetadata()
+                    .keyState();
+            org.assertj.core.api.Assertions.assertThat(afterDisable).isEqualTo(KeyState.DISABLED);
+
+            // enableKey
+            given()
+                    .post("/aws2-kms/keys/" + keyId + "/enable")
+                    .then()
+                    .statusCode(204);
+
+            KeyState afterEnable = client
+                    .describeKey(DescribeKeyRequest.builder().keyId(keyId).build())
+                    .keyMetadata()
+                    .keyState();
+            org.assertj.core.api.Assertions.assertThat(afterEnable).isEqualTo(KeyState.ENABLED);
+
+            // describeKey via Camel should also report ENABLED again
+            given()
+                    .get("/aws2-kms/keys/" + keyId)
+                    .then()
+                    .statusCode(200)
+                    .body(not(matchesPattern(KeyState.DISABLED.toString())));
+        } finally {
+            given()
+                    .contentType("text/plain")
+                    .body("7")
+                    .delete("/aws2-kms/keys/" + keyId)
+                    .then()
+                    .statusCode(200);
+        }
+    }
+
+    @Override
+    public void testMethodForDefaultCredentialsProvider() {
+        RestAssured.given()
+                .post("/aws2-kms/keys")
+                .then()
+                .statusCode(200);
+    }
+}

--- a/integration-test-groups/aws2/aws2-kms/src/test/java/org/apache/camel/quarkus/component/aws2/kms/it/Aws2KmsTest.java
+++ b/integration-test-groups/aws2/aws2-kms/src/test/java/org/apache/camel/quarkus/component/aws2/kms/it/Aws2KmsTest.java
@@ -29,6 +29,7 @@ import software.amazon.awssdk.services.kms.model.DescribeKeyRequest;
 import software.amazon.awssdk.services.kms.model.KeyState;
 
 import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.matchesPattern;
 import static org.hamcrest.Matchers.not;
@@ -75,7 +76,7 @@ class Aws2KmsTest extends BaseAWs2TestSupport {
                     .describeKey(DescribeKeyRequest.builder().keyId(keyId).build())
                     .keyMetadata()
                     .keyState();
-            org.assertj.core.api.Assertions.assertThat(awsState).isEqualTo(KeyState.ENABLED);
+            assertThat(awsState).isEqualTo(KeyState.ENABLED);
         } finally {
             // scheduleKeyDeletion as cleanup; AWS minimum window is 7 days
             given()
@@ -108,7 +109,7 @@ class Aws2KmsTest extends BaseAWs2TestSupport {
                     .describeKey(DescribeKeyRequest.builder().keyId(keyId).build())
                     .keyMetadata()
                     .keyState();
-            org.assertj.core.api.Assertions.assertThat(afterDisable).isEqualTo(KeyState.DISABLED);
+            assertThat(afterDisable).isEqualTo(KeyState.DISABLED);
 
             // enableKey
             given()
@@ -120,7 +121,7 @@ class Aws2KmsTest extends BaseAWs2TestSupport {
                     .describeKey(DescribeKeyRequest.builder().keyId(keyId).build())
                     .keyMetadata()
                     .keyState();
-            org.assertj.core.api.Assertions.assertThat(afterEnable).isEqualTo(KeyState.ENABLED);
+            assertThat(afterEnable).isEqualTo(KeyState.ENABLED);
 
             // describeKey via Camel should also report ENABLED again
             given()

--- a/integration-test-groups/aws2/aws2-kms/src/test/java/org/apache/camel/quarkus/component/aws2/kms/it/Aws2KmsTestEnvCustomizer.java
+++ b/integration-test-groups/aws2/aws2-kms/src/test/java/org/apache/camel/quarkus/component/aws2/kms/it/Aws2KmsTestEnvCustomizer.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.aws2.kms.it;
+
+import org.apache.camel.quarkus.test.support.aws2.Aws2TestEnvContext;
+import org.apache.camel.quarkus.test.support.aws2.Aws2TestEnvCustomizer;
+import org.apache.camel.quarkus.test.support.aws2.Service;
+
+public class Aws2KmsTestEnvCustomizer implements Aws2TestEnvCustomizer {
+
+    @Override
+    public Service[] localstackServices() {
+        return new Service[] { Service.KMS };
+    }
+
+    @Override
+    public void customize(Aws2TestEnvContext envContext) {
+
+    }
+}

--- a/integration-test-groups/aws2/aws2-kms/src/test/resources/META-INF/services/org.apache.camel.quarkus.test.support.aws2.Aws2TestEnvCustomizer
+++ b/integration-test-groups/aws2/aws2-kms/src/test/resources/META-INF/services/org.apache.camel.quarkus.test.support.aws2.Aws2TestEnvCustomizer
@@ -1,0 +1,1 @@
+org.apache.camel.quarkus.component.aws2.kms.it.Aws2KmsTestEnvCustomizer

--- a/integration-test-groups/aws2/pom.xml
+++ b/integration-test-groups/aws2/pom.xml
@@ -41,6 +41,7 @@
         <module>aws2-cw</module>
         <module>aws2-ddb</module>
         <module>aws2-kinesis</module>
+        <module>aws2-kms</module>
         <module>aws2-lambda</module>
         <module>aws2-mq</module>
         <module>aws2-msk</module>


### PR DESCRIPTION
Fixes #2400.

## Summary

Adds the missing integration test module for the `camel-quarkus-aws2-kms` extension. Module follows the same shape as the existing AWS test modules (e.g. `aws2-cw`, `aws2-ddb`).

## What's covered

- **`createKey` + `describeKey` + `listKeys`** — a key is created via the Camel producer, then verified through the same producer (`describeKey`, `listKeys`) and cross-checked with a direct `KmsClient.describeKey` call.
- **`disableKey` + `enableKey`** — state transitions verified both through the Camel route and `KmsClient.describeKey`.
- **`scheduleKeyDeletion`** — used as the cleanup path; minimum `pendingWindowInDays` of 7 is supplied to satisfy the AWS API.
- The inherited `successfulDefaultCredentialsProviderTest` / `failingDefaultCredentialsProviderTest` from `BaseAWs2TestSupport` run automatically.

## Files

- `integration-test-groups/aws2/aws2-kms/pom.xml`
- `integration-test-groups/aws2/aws2-kms/src/main/resources/application.properties`
- `integration-test-groups/aws2/aws2-kms/src/main/java/.../it/Aws2KmsResource.java`
- `integration-test-groups/aws2/aws2-kms/src/test/java/.../it/Aws2KmsTestEnvCustomizer.java`
- `integration-test-groups/aws2/aws2-kms/src/test/java/.../it/Aws2KmsTest.java`
- `integration-test-groups/aws2/aws2-kms/src/test/java/.../it/Aws2KmsIT.java`
- `integration-test-groups/aws2/aws2-kms/src/test/resources/META-INF/services/...Aws2TestEnvCustomizer`
- `integration-test-groups/aws2/pom.xml` (+1 line: `<module>aws2-kms</module>`)

The grouped pom under `integration-tests/aws2-grouped/pom.xml` already declared the `camel-quarkus-aws2-kms` dependency, so no changes were needed there.

## Verification

- `./mvnw test -pl integration-test-groups/aws2/aws2-kms` — **4/4 tests pass**, ~23 s on LocalStack via Testcontainers
- `./mvnw process-resources -Pformat -N` — no formatting changes required
- Full reactor `./mvnw clean install -Dquickly` — green on macOS