### PR TITLE
Add integration tests for AWS 2 IAM extension

### DIFF
--- a/integration-test-groups/aws2/aws2-iam/README.adoc
+++ b/integration-test-groups/aws2/aws2-iam/README.adoc
@@ -1,0 +1,29 @@
+= AWS IAM tests
+
+By default the tests run against a LocalStack container via the `Aws2TestEnvCustomizer` SPI.
+
+== Running against real AWS
+
+Refer to the xref:../README.adoc[AWS 2 integration tests README] for general instructions on how to set up AWS credentials.
+
+The AWS credentials must have the following IAM permissions:
+
+* `iam:CreateUser`
+* `iam:GetUser`
+* `iam:ListUsers`
+* `iam:DeleteUser`
+* `iam:CreateGroup`
+* `iam:ListGroups`
+* `iam:DeleteGroup`
+* `iam:AddUserToGroup`
+* `iam:RemoveUserFromGroup`
+
+=== Running tests directly against real AWS
+
+[source,shell]
+----
+export AWS_ACCESS_KEY=<your-access-key-id>
+export AWS_SECRET_KEY=<your-secret-access-key>
+export AWS_REGION=us-east-1
+export CAMEL_QUARKUS_START_MOCK_BACKEND=false
+----

--- a/integration-test-groups/aws2/aws2-iam/pom.xml
+++ b/integration-test-groups/aws2/aws2-iam/pom.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.camel.quarkus</groupId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
+        <version>3.36.0-SNAPSHOT</version>
+        <relativePath>../../../poms/build-parent-it/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>camel-quarkus-integration-test-aws2-iam</artifactId>
+    <name>Camel Quarkus :: Integration Tests :: AWS 2 IAM</name>
+    <description>Integration tests for Camel Quarkus AWS 2 IAM extension</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-aws2-iam</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-jackson</artifactId>
+        </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-integration-tests-support-aws2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-integration-tests-support-aws2</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <id>native</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <properties>
+                <quarkus.native.enabled>true</quarkus.native.enabled>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>virtualDependencies</id>
+            <activation>
+                <property>
+                    <name>!noVirtualDependencies</name>
+                </property>
+            </activation>
+            <dependencies>
+                <!-- The following dependencies guarantee that this module is built after them. You can update them by running `mvn process-resources -Pformat -N` from the source tree root directory -->
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-aws2-iam-deployment</artifactId>
+                    <version>${project.version}</version>
+                    <type>pom</type>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>skip-testcontainers-tests</id>
+            <activation>
+                <property>
+                    <name>skip-testcontainers-tests</name>
+                </property>
+            </activation>
+            <properties>
+                <skipTests>true</skipTests>
+            </properties>
+        </profile>
+    </profiles>
+
+</project>

--- a/integration-test-groups/aws2/aws2-iam/src/main/java/org/apache/camel/quarkus/component/aws2/iam/it/Aws2IamResource.java
+++ b/integration-test-groups/aws2/aws2-iam/src/main/java/org/apache/camel/quarkus/component/aws2/iam/it/Aws2IamResource.java
@@ -1,0 +1,182 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.aws2.iam.it;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.component.aws2.iam.IAM2Constants;
+import org.apache.camel.component.aws2.iam.IAM2Operations;
+import software.amazon.awssdk.services.iam.model.CreateGroupResponse;
+import software.amazon.awssdk.services.iam.model.CreateUserResponse;
+import software.amazon.awssdk.services.iam.model.GetUserResponse;
+import software.amazon.awssdk.services.iam.model.ListGroupsResponse;
+import software.amazon.awssdk.services.iam.model.ListUsersResponse;
+
+@Path("/aws2-iam")
+@ApplicationScoped
+public class Aws2IamResource {
+
+    @Inject
+    ProducerTemplate producerTemplate;
+
+    @Path("/users")
+    @POST
+    @Produces(MediaType.TEXT_PLAIN)
+    public Response createUser(@jakarta.ws.rs.QueryParam("userName") String userName) {
+        CreateUserResponse response = producerTemplate.requestBodyAndHeader(
+                componentUri(IAM2Operations.createUser),
+                null,
+                IAM2Constants.USERNAME,
+                userName,
+                CreateUserResponse.class);
+
+        return Response.ok(response.user().userName()).build();
+    }
+
+    @Path("/users/{userName}")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getUser(@PathParam("userName") String userName) {
+        GetUserResponse response = producerTemplate.requestBodyAndHeader(
+                componentUri(IAM2Operations.getUser),
+                null,
+                IAM2Constants.USERNAME,
+                userName,
+                GetUserResponse.class);
+
+        Map<String, String> result = Map.of(
+                "userName", response.user().userName(),
+                "userId", response.user().userId(),
+                "arn", response.user().arn());
+        return Response.ok(result).build();
+    }
+
+    @Path("/users")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response listUsers() {
+        ListUsersResponse response = producerTemplate.requestBody(
+                componentUri(IAM2Operations.listUsers),
+                null,
+                ListUsersResponse.class);
+
+        List<String> userNames = response.users().stream()
+                .map(user -> user.userName())
+                .collect(Collectors.toList());
+
+        return Response.ok(userNames).build();
+    }
+
+    @Path("/users/{userName}")
+    @DELETE
+    public Response deleteUser(@PathParam("userName") String userName) {
+        producerTemplate.requestBodyAndHeader(
+                componentUri(IAM2Operations.deleteUser),
+                null,
+                IAM2Constants.USERNAME,
+                userName);
+
+        return Response.noContent().build();
+    }
+
+    @Path("/groups")
+    @POST
+    @Produces(MediaType.TEXT_PLAIN)
+    public Response createGroup(@jakarta.ws.rs.QueryParam("groupName") String groupName) {
+        CreateGroupResponse response = producerTemplate.requestBodyAndHeader(
+                componentUri(IAM2Operations.createGroup),
+                null,
+                IAM2Constants.GROUP_NAME,
+                groupName,
+                CreateGroupResponse.class);
+
+        return Response.ok(response.group().groupName()).build();
+    }
+
+    @Path("/groups")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response listGroups() {
+        ListGroupsResponse response = producerTemplate.requestBody(
+                componentUri(IAM2Operations.listGroups),
+                null,
+                ListGroupsResponse.class);
+
+        List<String> groupNames = response.groups().stream()
+                .map(group -> group.groupName())
+                .collect(Collectors.toList());
+
+        return Response.ok(groupNames).build();
+    }
+
+    @Path("/groups/{groupName}")
+    @DELETE
+    public Response deleteGroup(@PathParam("groupName") String groupName) {
+        producerTemplate.requestBodyAndHeader(
+                componentUri(IAM2Operations.deleteGroup),
+                null,
+                IAM2Constants.GROUP_NAME,
+                groupName);
+
+        return Response.noContent().build();
+    }
+
+    @Path("/groups/{groupName}/users/{userName}")
+    @POST
+    public Response addUserToGroup(@PathParam("groupName") String groupName,
+            @PathParam("userName") String userName) {
+        producerTemplate.requestBodyAndHeaders(
+                componentUri(IAM2Operations.addUserToGroup),
+                null,
+                Map.of(
+                        IAM2Constants.GROUP_NAME, groupName,
+                        IAM2Constants.USERNAME, userName));
+
+        return Response.noContent().build();
+    }
+
+    @Path("/groups/{groupName}/users/{userName}")
+    @DELETE
+    public Response removeUserFromGroup(@PathParam("groupName") String groupName,
+            @PathParam("userName") String userName) {
+        producerTemplate.requestBodyAndHeaders(
+                componentUri(IAM2Operations.removeUserFromGroup),
+                null,
+                Map.of(
+                        IAM2Constants.GROUP_NAME, groupName,
+                        IAM2Constants.USERNAME, userName));
+
+        return Response.noContent().build();
+    }
+
+    private String componentUri(IAM2Operations operation) {
+        return "aws2-iam://test?operation=" + operation;
+    }
+}

--- a/integration-test-groups/aws2/aws2-iam/src/main/resources/application.properties
+++ b/integration-test-groups/aws2/aws2-iam/src/main/resources/application.properties
@@ -1,0 +1,21 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+camel.component.aws2-iam.access-key=${AWS_ACCESS_KEY}
+camel.component.aws2-iam.secret-key=${AWS_SECRET_KEY}
+camel.component.aws2-iam.region=${AWS_REGION:us-east-1}
+camel.component.aws2-iam.override-endpoint=false

--- a/integration-test-groups/aws2/aws2-iam/src/test/java/org/apache/camel/quarkus/component/aws2/iam/it/Aws2IamIT.java
+++ b/integration-test-groups/aws2/aws2-iam/src/test/java/org/apache/camel/quarkus/component/aws2/iam/it/Aws2IamIT.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.aws2.iam.it;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+class Aws2IamIT extends Aws2IamTest {
+}

--- a/integration-test-groups/aws2/aws2-iam/src/test/java/org/apache/camel/quarkus/component/aws2/iam/it/Aws2IamTest.java
+++ b/integration-test-groups/aws2/aws2-iam/src/test/java/org/apache/camel/quarkus/component/aws2/iam/it/Aws2IamTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.aws2.iam.it;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import org.apache.camel.quarkus.test.support.aws2.Aws2TestResource;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
+
+@QuarkusTest
+@QuarkusTestResource(Aws2TestResource.class)
+class Aws2IamTest {
+
+    static final String TEST_USER = "cq-test-user";
+    static final String TEST_GROUP = "cq-test-group";
+
+    @Test
+    public void testIamOperations() {
+        try {
+            // Create user
+            RestAssured.given()
+                    .queryParam("userName", TEST_USER)
+                    .post("/aws2-iam/users")
+                    .then()
+                    .statusCode(200)
+                    .body(is(TEST_USER));
+
+            // Get user
+            RestAssured.given()
+                    .get("/aws2-iam/users/" + TEST_USER)
+                    .then()
+                    .statusCode(200)
+                    .body("userName", is(TEST_USER));
+
+            // List users
+            RestAssured.given()
+                    .get("/aws2-iam/users")
+                    .then()
+                    .statusCode(200)
+                    .body("$", hasItem(TEST_USER));
+
+            // Create group
+            RestAssured.given()
+                    .queryParam("groupName", TEST_GROUP)
+                    .post("/aws2-iam/groups")
+                    .then()
+                    .statusCode(200)
+                    .body(is(TEST_GROUP));
+
+            // List groups
+            RestAssured.given()
+                    .get("/aws2-iam/groups")
+                    .then()
+                    .statusCode(200)
+                    .body("$", hasItem(TEST_GROUP));
+
+            // Add user to group
+            RestAssured.given()
+                    .post("/aws2-iam/groups/" + TEST_GROUP + "/users/" + TEST_USER)
+                    .then()
+                    .statusCode(204);
+
+            // Remove user from group
+            RestAssured.given()
+                    .delete("/aws2-iam/groups/" + TEST_GROUP + "/users/" + TEST_USER)
+                    .then()
+                    .statusCode(204);
+        } finally {
+            // Clean up: delete user and group
+            RestAssured.given()
+                    .delete("/aws2-iam/users/" + TEST_USER)
+                    .then()
+                    .statusCode(204);
+
+            RestAssured.given()
+                    .delete("/aws2-iam/groups/" + TEST_GROUP)
+                    .then()
+                    .statusCode(204);
+        }
+    }
+}

--- a/integration-test-groups/aws2/aws2-iam/src/test/java/org/apache/camel/quarkus/component/aws2/iam/it/Aws2IamTestEnvCustomizer.java
+++ b/integration-test-groups/aws2/aws2-iam/src/test/java/org/apache/camel/quarkus/component/aws2/iam/it/Aws2IamTestEnvCustomizer.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.aws2.iam.it;
+
+import org.apache.camel.quarkus.test.support.aws2.Aws2TestEnvContext;
+import org.apache.camel.quarkus.test.support.aws2.Aws2TestEnvCustomizer;
+import org.apache.camel.quarkus.test.support.aws2.Service;
+
+public class Aws2IamTestEnvCustomizer implements Aws2TestEnvCustomizer {
+
+    @Override
+    public Service[] localstackServices() {
+        return new Service[] { Service.IAM };
+    }
+
+    @Override
+    public void customize(Aws2TestEnvContext envContext) {
+        // No additional customization needed for IAM tests
+    }
+}

--- a/integration-test-groups/aws2/aws2-iam/src/test/resources/META-INF/services/org.apache.camel.quarkus.test.support.aws2.Aws2TestEnvCustomizer
+++ b/integration-test-groups/aws2/aws2-iam/src/test/resources/META-INF/services/org.apache.camel.quarkus.test.support.aws2.Aws2TestEnvCustomizer
@@ -1,0 +1,1 @@
+org.apache.camel.quarkus.component.aws2.iam.it.Aws2IamTestEnvCustomizer

--- a/integration-test-groups/aws2/pom.xml
+++ b/integration-test-groups/aws2/pom.xml
@@ -40,6 +40,7 @@
         <module>aws-secrets-manager</module>
         <module>aws2-cw</module>
         <module>aws2-ddb</module>
+        <module>aws2-iam</module>
         <module>aws2-kinesis</module>
         <module>aws2-lambda</module>
         <module>aws2-mq</module>

--- a/integration-tests/aws2-grouped/pom.xml
+++ b/integration-tests/aws2-grouped/pom.xml
@@ -70,6 +70,10 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-aws2-iam</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-aws2-kinesis</artifactId>
         </dependency>
         <dependency>
@@ -111,6 +115,16 @@
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-integration-tests-support-aws2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>iam</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
@@ -156,17 +170,6 @@
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>htmlunit-driver</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>iam</artifactId>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
@@ -271,6 +274,19 @@
                 <dependency>
                     <groupId>org.apache.camel.quarkus</groupId>
                     <artifactId>camel-quarkus-aws2-ddb-deployment</artifactId>
+                    <version>${project.version}</version>
+                    <type>pom</type>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-aws2-iam-deployment</artifactId>
                     <version>${project.version}</version>
                     <type>pom</type>
                     <scope>test</scope>


### PR DESCRIPTION
Implement integration tests for the aws2-iam extension covering:
- User operations: create, get, list, delete
- Group operations: create, list, delete
- Group membership: add user to group, remove user from group

Tests run against LocalStack by default via Aws2TestEnvCustomizer and support running against real AWS IAM service.

All tests pass in both JVM and native modes.

Generated with Claude Code on behalf of Jinyu Chen

Fixes #2399 