### PR TITLE
Replace external Maven Central URL with local test endpoint in HTTP tests

### DIFF
--- a/integration-test-groups/http/http/src/main/java/org/apache/camel/quarkus/component/http/http/HttpResource.java
+++ b/integration-test-groups/http/http/src/main/java/org/apache/camel/quarkus/component/http/http/HttpResource.java
@@ -115,7 +115,9 @@ public class HttpResource extends AbstractHttpResource {
                         + "&proxyAuthHost=%s"
                         + "&proxyAuthPort=%d"
                         + "&proxyAuthUsername=%s"
-                        + "&proxyAuthPassword=%s", String.format(PROXIED_URL, "http"), proxyHost, proxyPort, USER_ADMIN,
+                        + "&proxyAuthPassword=%s"
+                        + "&sslContextParameters=#sslContextParameters", String.format(PROXIED_URL, "http"), proxyHost,
+                        proxyPort, USER_ADMIN,
                         USER_ADMIN_PASSWORD)
                 .request(String.class);
     }
@@ -133,7 +135,8 @@ public class HttpResource extends AbstractHttpResource {
                         + "&proxyAuthPort=%d"
                         + "&proxyAuthUsername=%s"
                         + "&proxyAuthPassword=%s"
-                        + "&nonProxyHosts=%s", String.format(PROXIED_URL, "http"),
+                        + "&nonProxyHosts=%s"
+                        + "&sslContextParameters=#sslContextParameters", String.format(PROXIED_URL, "http"),
                         proxyHost, proxyPort, USER_ADMIN,
                         USER_ADMIN_PASSWORD, nonProxyHosts)
                 .request(String.class);

--- a/integration-test-groups/http/http/src/test/java/org/apache/camel/quarkus/component/http/http/it/HttpTest.java
+++ b/integration-test-groups/http/http/src/test/java/org/apache/camel/quarkus/component/http/http/it/HttpTest.java
@@ -132,9 +132,9 @@ public class HttpTest extends AbstractHttpTest {
         String expectedGroupId = "org.apache.camel.quarkus";
 
         return Stream.of(
-                arguments("repo.maven.apache.org", actualPort, host, 200, expectedGroupId, false),
-                arguments("*.apache.org", fakePort, host, 200, expectedGroupId, false),
-                arguments("*localhost*", actualPort, host, 200, expectedGroupId, true));
+                arguments("example.com", actualPort, host, 200, expectedGroupId, true),
+                arguments("localhost", fakePort, host, 200, expectedGroupId, false),
+                arguments("*local*", actualPort, host, 200, expectedGroupId, false));
     }
 
 }

--- a/integration-test-groups/http/netty-http/src/main/java/org/apache/camel/quarkus/component/http/netty/NettyHttpResource.java
+++ b/integration-test-groups/http/netty-http/src/main/java/org/apache/camel/quarkus/component/http/netty/NettyHttpResource.java
@@ -100,7 +100,8 @@ public class NettyHttpResource extends AbstractHttpResource {
         String url = String.format(PROXIED_URL, "netty-http");
         return producerTemplate
                 .withHeader(Exchange.HTTP_QUERY, "component=netty-http")
-                .toF("netty-http:%s?clientInitializerFactory=#proxyCapableClientInitializerFactory", url)
+                .toF("netty-http:%s?clientInitializerFactory=#proxyCapableClientInitializerFactory&ssl=true&sslContextParameters=#sslContextParameters",
+                        url)
                 .request(String.class);
     }
 

--- a/integration-test-groups/http/vertx-http/src/main/java/org/apache/camel/quarkus/component/http/vertx/VertxResource.java
+++ b/integration-test-groups/http/vertx-http/src/main/java/org/apache/camel/quarkus/component/http/vertx/VertxResource.java
@@ -101,7 +101,9 @@ public class VertxResource extends AbstractHttpResource {
                         + "&proxyPort=%d"
                         + "&proxyType=HTTP"
                         + "&proxyUsername=%s"
-                        + "&proxyPassword=%s", String.format(PROXIED_URL, "vertx-http"), proxyHost, proxyPort, USER_ADMIN,
+                        + "&proxyPassword=%s"
+                        + "&sslContextParameters=#sslContextParameters", String.format(PROXIED_URL, "vertx-http"), proxyHost,
+                        proxyPort, USER_ADMIN,
                         USER_ADMIN_PASSWORD)
                 .request(String.class);
     }

--- a/integration-tests-support/http/src/main/java/org/apache/camel/quarkus/component/http/common/AbstractHttpResource.java
+++ b/integration-tests-support/http/src/main/java/org/apache/camel/quarkus/component/http/common/AbstractHttpResource.java
@@ -31,7 +31,7 @@ import org.apache.camel.FluentProducerTemplate;
 
 @ApplicationScoped
 public abstract class AbstractHttpResource {
-    public static final String PROXIED_URL = "https://repo.maven.apache.org/maven2/org/apache/camel/quarkus/camel-quarkus-%s/maven-metadata.xml";
+    public static final String PROXIED_URL = "https://localhost:{{quarkus.http.test-ssl-port}}/service/common/maven-metadata/%s";
     public static final String USER_ADMIN = "admin";
     public static final String USER_ADMIN_PASSWORD = "adm1n";
     public static final String USER_NO_ADMIN = "noadmin";

--- a/integration-tests-support/http/src/main/java/org/apache/camel/quarkus/component/http/common/HttpService.java
+++ b/integration-tests-support/http/src/main/java/org/apache/camel/quarkus/component/http/common/HttpService.java
@@ -21,6 +21,7 @@ import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import org.jboss.resteasy.annotations.GZIP;
@@ -56,5 +57,20 @@ public class HttpService {
     @Produces(MediaType.TEXT_PLAIN)
     public String compress() {
         return "Compressed response";
+    }
+
+    @Path("/maven-metadata/{component}")
+    @GET
+    @Produces(MediaType.APPLICATION_XML)
+    public String mavenMetadata(@PathParam("component") String component) {
+        return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                + "<metadata>\n"
+                + "  <groupId>org.apache.camel.quarkus</groupId>\n"
+                + "  <artifactId>camel-quarkus-" + component + "</artifactId>\n"
+                + "  <versioning>\n"
+                + "    <latest>3.0.0</latest>\n"
+                + "    <release>3.0.0</release>\n"
+                + "  </versioning>\n"
+                + "</metadata>";
     }
 }


### PR DESCRIPTION
added maven-metadata/component local sever endpoint to mock the maven metadata response
added sslContextParameters to handle https connection to localhost for different http cllient resources tests

all jvm tests passed. (Some auth related native tests failed but seems not related to this change)

fixes #8686
