### PR TITLE
Tidy camel-quarkus-junit configuration classes

### DIFF
--- a/test-framework/camel-quarkus-junit/src/main/java/org/apache/camel/quarkus/test/CamelQuarkusContextConfiguration.java
+++ b/test-framework/camel-quarkus-junit/src/main/java/org/apache/camel/quarkus/test/CamelQuarkusContextConfiguration.java
@@ -18,17 +18,24 @@ package org.apache.camel.quarkus.test;
 
 import org.apache.camel.test.junit6.CamelContextConfiguration;
 
-public final class CustomCamelContextConfiguration extends CamelContextConfiguration {
+/**
+ * Exposes protected methods from {@link CamelContextConfiguration} for use within
+ * the {@code org.apache.camel.quarkus.test} package.
+ */
+final class CamelQuarkusContextConfiguration extends CamelContextConfiguration {
 
-    CustomCamelContextConfiguration withCustomCamelContextSupplier(CamelContextSupplier camelContextSupplier) {
-        return (CustomCamelContextConfiguration) super.withCamelContextSupplier(camelContextSupplier);
+    @Override
+    public CamelQuarkusContextConfiguration withCamelContextSupplier(CamelContextSupplier camelContextSupplier) {
+        return (CamelQuarkusContextConfiguration) super.withCamelContextSupplier(camelContextSupplier);
     }
 
-    CustomCamelContextConfiguration withCustomPostProcessor(PostProcessor postProcessor) {
-        return (CustomCamelContextConfiguration) super.withPostProcessor(postProcessor);
+    @Override
+    protected CamelQuarkusContextConfiguration withPostProcessor(PostProcessor postProcessor) {
+        return (CamelQuarkusContextConfiguration) super.withPostProcessor(postProcessor);
     }
 
-    CustomCamelContextConfiguration withCustomRoutesSupplier(RoutesSupplier routesSupplier) {
-        return (CustomCamelContextConfiguration) super.withRoutesSupplier(routesSupplier);
+    @Override
+    protected CamelQuarkusContextConfiguration withRoutesSupplier(RoutesSupplier routesSupplier) {
+        return (CamelQuarkusContextConfiguration) super.withRoutesSupplier(routesSupplier);
     }
 }

--- a/test-framework/camel-quarkus-junit/src/main/java/org/apache/camel/quarkus/test/CamelQuarkusTestExecutionConfiguration.java
+++ b/test-framework/camel-quarkus-junit/src/main/java/org/apache/camel/quarkus/test/CamelQuarkusTestExecutionConfiguration.java
@@ -18,13 +18,19 @@ package org.apache.camel.quarkus.test;
 
 import org.apache.camel.test.junit6.TestExecutionConfiguration;
 
-public final class CustomTestExecutionConfiguration extends TestExecutionConfiguration {
+/**
+ * Exposes protected methods from {@link TestExecutionConfiguration} for use within
+ * the {@code org.apache.camel.quarkus.test} package.
+ */
+final class CamelQuarkusTestExecutionConfiguration extends TestExecutionConfiguration {
 
-    CustomTestExecutionConfiguration withCustomUseAdviceWith(boolean useAdviceWith) {
-        return (CustomTestExecutionConfiguration) super.withUseAdviceWith(useAdviceWith);
+    @Override
+    public CamelQuarkusTestExecutionConfiguration withUseAdviceWith(boolean useAdviceWith) {
+        return (CamelQuarkusTestExecutionConfiguration) super.withUseAdviceWith(useAdviceWith);
     }
 
-    CustomTestExecutionConfiguration withCustomCreateCamelContextPerClass(boolean createCamelContextPerClass) {
-        return (CustomTestExecutionConfiguration) super.withCreateCamelContextPerClass(createCamelContextPerClass);
+    @Override
+    protected CamelQuarkusTestExecutionConfiguration withCreateCamelContextPerClass(boolean createCamelContextPerClass) {
+        return (CamelQuarkusTestExecutionConfiguration) super.withCreateCamelContextPerClass(createCamelContextPerClass);
     }
 }

--- a/test-framework/camel-quarkus-junit/src/main/java/org/apache/camel/quarkus/test/CamelQuarkusTestSupport.java
+++ b/test-framework/camel-quarkus-junit/src/main/java/org/apache/camel/quarkus/test/CamelQuarkusTestSupport.java
@@ -104,9 +104,6 @@ public class CamelQuarkusTestSupport extends AbstractTestSupport
 
     private static final Logger LOG = LoggerFactory.getLogger(CamelQuarkusTestSupport.class);
 
-    //    @RegisterExtension
-    //    protected CamelTestSupport camelTestSupportExtension = this;
-
     private final StopWatch watch = new StopWatch();
     private String currentTestName;
 
@@ -120,21 +117,21 @@ public class CamelQuarkusTestSupport extends AbstractTestSupport
     private Set<String> existingComponents;
 
     public CamelQuarkusTestSupport() {
-        super(new CustomTestExecutionConfiguration(), new CustomCamelContextConfiguration());
+        super(new CamelQuarkusTestExecutionConfiguration(), new CamelQuarkusContextConfiguration());
 
         this.contextManagerFactory = new ContextNotStoppingManagerFactory();
 
         testConfigurationBuilder()
-                .withCustomUseAdviceWith(isUseAdviceWith())
+                .withUseAdviceWith(isUseAdviceWith())
                 .withJMX(useJmx())
                 .withUseRouteBuilder(isUseRouteBuilder())
                 .withDumpRouteCoverage(isDumpRouteCoverage())
                 .withAutoStartContext(false);
 
         contextConfiguration()
-                .withCustomCamelContextSupplier(this::camelContextSupplier)
-                .withCustomPostProcessor(this::postProcessTest)
-                .withCustomRoutesSupplier(this::createRouteBuilders)
+                .withCamelContextSupplier(this::camelContextSupplier)
+                .withPostProcessor(this::postProcessTest)
+                .withRoutesSupplier(this::createRouteBuilders)
                 .withRegistryBinder(this::bindToRegistry)
                 .withUseOverridePropertiesWithPropertiesComponent(useOverridePropertiesWithPropertiesComponent())
                 .withRouteFilterExcludePattern(getRouteFilterExcludePattern())
@@ -149,12 +146,12 @@ public class CamelQuarkusTestSupport extends AbstractTestSupport
         testConfiguration().withAutoStartContext(false);
     }
 
-    CustomCamelContextConfiguration contextConfiguration() {
-        return (CustomCamelContextConfiguration) camelContextConfiguration;
+    CamelQuarkusContextConfiguration contextConfiguration() {
+        return (CamelQuarkusContextConfiguration) camelContextConfiguration;
     }
 
-    CustomTestExecutionConfiguration testConfigurationBuilder() {
-        return (CustomTestExecutionConfiguration) testConfigurationBuilder;
+    CamelQuarkusTestExecutionConfiguration testConfigurationBuilder() {
+        return (CamelQuarkusTestExecutionConfiguration) testConfigurationBuilder;
     }
 
     //------------------------ quarkus callbacks ---------------
@@ -359,7 +356,7 @@ public class CamelQuarkusTestSupport extends AbstractTestSupport
                 .filter(lc -> lc.equals(TestInstance.Lifecycle.PER_CLASS)).isPresent();
         if (perClassPresent) {
             LOG.trace("Creating a legacy context manager for {}", context.getDisplayName());
-            testConfigurationBuilder().withCustomCreateCamelContextPerClass(perClassPresent);
+            testConfigurationBuilder().withCreateCamelContextPerClass(perClassPresent);
             contextManager = contextManagerFactory.createContextManager(ContextManagerFactory.Type.BEFORE_ALL,
                     testConfigurationBuilder, camelContextConfiguration);
         }


### PR DESCRIPTION
Some small tidying to the test framework before submitting PRs for additional changes to `CamelQuarkusTestExecutionConfiguration`.