### PR TITLE
Avoid running pr-validate workflow for Dependabot PRs

### DIFF
--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -65,7 +65,7 @@ permissions:  # added using https://github.com/step-security/secure-repo
 
 jobs:
   check-format:
-    if: github.repository == 'apache/camel-quarkus'
+    if: github.repository == 'apache/camel-quarkus' && github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
     - name: Setup apache-snapshots profile


### PR DESCRIPTION
Since Dependabot is only modifying pom.xml files or GitHub workflow YAML, the validation checks for licenses, java code formatting etc are not relevant.

Will hopefully help to reduce the build queue a bit in future.