### PR TITLE
Cache Atlassian Maven artifacts

### DIFF
--- a/.github/actions/setup-maven-cache/action.yaml
+++ b/.github/actions/setup-maven-cache/action.yaml
@@ -1,0 +1,46 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: 'Setup Maven Cache'
+description: 'Downloads Maven repository artifact and restores Atlassian dependencies cache'
+inputs:
+  atlassian-version:
+    description: 'Version of Atlassian dependencies for cache key'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Restore Atlassian Maven Cache
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.4.0
+      with:
+        path: |
+          ~/.m2/repository/com/atlassian
+          ~/.m2/repository/io/atlassian
+        key: atlassian-maven-${{ inputs.atlassian-version }}
+    - name: Download Maven Repo
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: maven-repo
+        path: ..
+    - name: Extract Maven Repo
+      shell: bash
+      run: |
+        df -h /
+        tar -xzf ../maven-repo.tgz -C ~
+        rm -f ../maven-repo.tgz
+        df -h /

--- a/.github/workflows/camel-master-cron.yaml
+++ b/.github/workflows/camel-master-cron.yaml
@@ -37,6 +37,7 @@ jobs:
       matrix: ${{ steps.set-native-matrix.outputs.matrix }}
       examples-matrix: ${{ steps.set-examples-matrix.outputs.examples-matrix }}
       alternate-jvm-matrix: ${{ steps.set-alternate-jvm-matrix.outputs.alternate-jvm-matrix }}
+      atlassian-version: ${{ steps.atlassian-version.outputs.version }}
     env:
       MAVEN_OPTS: -Xmx4600m
     steps:
@@ -57,6 +58,18 @@ jobs:
         with:
           ref: camel-main
           fetch-depth: 0
+      - name: Get Atlassian dependency version
+        id: atlassian-version
+        run: |
+          JIRA_VERSION=$(./mvnw help:evaluate -Dexpression=jira-rest-client.version -q -DforceStdout -N)
+          echo "version=${JIRA_VERSION}" >> $GITHUB_OUTPUT
+      - name: Restore Atlassian Maven Cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.4.0
+        with:
+          path: |
+            ~/.m2/repository/com/atlassian
+            ~/.m2/repository/io/atlassian
+          key: atlassian-maven-${{ steps.atlassian-version.outputs.version }}
       - name: Rebase branch main onto camel-main
         run: |
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -96,6 +109,14 @@ jobs:
           name: maven-repo
           path: ${{ runner.temp }}/maven-repo.tgz
           retention-days: 1
+      - name: Save Atlassian Maven Cache
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.4.0
+        if: always()
+        with:
+          path: |
+            ~/.m2/repository/com/atlassian
+            ~/.m2/repository/io/atlassian
+          key: atlassian-maven-${{ steps.atlassian-version.outputs.version }}
       - name: Setup Native Test Matrix
         id: set-native-matrix
         run: |
@@ -161,6 +182,13 @@ jobs:
         with:
           ref: camel-main
           fetch-depth: 0
+      - name: Restore Atlassian Maven Cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.4.0
+        with:
+          path: |
+            ~/.m2/repository/com/atlassian
+            ~/.m2/repository/io/atlassian
+          key: atlassian-maven-${{ needs.initial-mvn-install.outputs.atlassian-version }}
       - name: Reclaim Disk Space
         run: .github/reclaim-disk-space.sh
       - name: Rebase branch main onto camel-main
@@ -248,6 +276,13 @@ jobs:
         with:
           ref: camel-main
           fetch-depth: 0
+      - name: Restore Atlassian Maven Cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.4.0
+        with:
+          path: |
+            ~/.m2/repository/com/atlassian
+            ~/.m2/repository/io/atlassian
+          key: atlassian-maven-${{ needs.initial-mvn-install.outputs.atlassian-version }}
       - name: Rebase branch main onto camel-main
         run: |
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -350,6 +385,13 @@ jobs:
         with:
           ref: camel-main
           fetch-depth: 0
+      - name: Restore Atlassian Maven Cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.4.0
+        with:
+          path: |
+            ~/.m2/repository/com/atlassian
+            ~/.m2/repository/io/atlassian
+          key: atlassian-maven-${{ needs.initial-mvn-install.outputs.atlassian-version }}
       - name: Rebase branch main onto camel-main
         run: |
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -404,6 +446,13 @@ jobs:
         with:
           ref: camel-main
           fetch-depth: 0
+      - name: Restore Atlassian Maven Cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.4.0
+        with:
+          path: |
+            ~/.m2/repository/com/atlassian
+            ~/.m2/repository/io/atlassian
+          key: atlassian-maven-${{ needs.initial-mvn-install.outputs.atlassian-version }}
       - name: Rebase branch main onto camel-main
         run: |
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -459,6 +508,13 @@ jobs:
         with:
           ref: camel-main
           fetch-depth: 0
+      - name: Restore Atlassian Maven Cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.4.0
+        with:
+          path: |
+            ~/.m2/repository/com/atlassian
+            ~/.m2/repository/io/atlassian
+          key: atlassian-maven-${{ needs.initial-mvn-install.outputs.atlassian-version }}
       - name: Rebase branch main onto camel-main
         run: |
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -519,6 +575,13 @@ jobs:
         with:
           ref: camel-main
           fetch-depth: 0
+      - name: Restore Atlassian Maven Cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.4.0
+        with:
+          path: |
+            ~/.m2/repository/com/atlassian
+            ~/.m2/repository/io/atlassian
+          key: atlassian-maven-${{ needs.initial-mvn-install.outputs.atlassian-version }}
       - name: Rebase branch main onto camel-main
         run: |
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -604,6 +667,13 @@ jobs:
         with:
           ref: camel-main
           fetch-depth: 0
+      - name: Restore Atlassian Maven Cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.4.0
+        with:
+          path: |
+            ~/.m2/repository/com/atlassian
+            ~/.m2/repository/io/atlassian
+          key: atlassian-maven-${{ needs.initial-mvn-install.outputs.atlassian-version }}
       - name: Rebase branch main onto camel-main
         run: |
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -123,6 +123,20 @@ jobs:
         with:
           ref: ${{ env.CHECKOUT_REF }}
           fetch-depth: 0
+      - name: Get Atlassian dependency version
+        id: atlassian-version
+        if: steps.init.outputs.run-checks == 'true'
+        run: |
+          JIRA_VERSION=$(./mvnw help:evaluate -Dexpression=jira-rest-client.version -q -DforceStdout -N)
+          echo "version=${JIRA_VERSION}" >> $GITHUB_OUTPUT
+      - name: Restore Atlassian Maven Cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.4.0
+        if: steps.init.outputs.run-checks == 'true'
+        with:
+          path: |
+            ~/.m2/repository/com/atlassian
+            ~/.m2/repository/io/atlassian
+          key: atlassian-maven-${{ steps.atlassian-version.outputs.version }}
       - name: Pre build checks
         id: pre-build-checks
         run: |
@@ -163,6 +177,7 @@ jobs:
       matrix: ${{ steps.set-native-matrix.outputs.matrix }}
       examples-matrix: ${{ steps.set-examples-matrix.outputs.examples-matrix }}
       alternate-jvm-matrix: ${{ steps.set-alternate-jvm-matrix.outputs.alternate-jvm-matrix }}
+      atlassian-version: ${{ steps.atlassian-version.outputs.version }}
     env:
       MAVEN_OPTS: -Xmx4600m
     steps:
@@ -195,6 +210,18 @@ jobs:
         with:
           ref: ${{ env.CHECKOUT_REF }}
           fetch-depth: 0
+      - name: Get Atlassian dependency version
+        id: atlassian-version
+        run: |
+          JIRA_VERSION=$(./mvnw help:evaluate -Dexpression=jira-rest-client.version -q -DforceStdout -N)
+          echo "version=${JIRA_VERSION}" >> $GITHUB_OUTPUT
+      - name: Restore Atlassian Maven Cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.4.0
+        with:
+          path: |
+            ~/.m2/repository/com/atlassian
+            ~/.m2/repository/io/atlassian
+          key: atlassian-maven-${{ steps.atlassian-version.outputs.version }}
       - name: Update extension metadata
         run: |
           ./mvnw -N cq:update-quarkus-metadata ${CQ_MAVEN_ARGS}
@@ -220,6 +247,14 @@ jobs:
           name: maven-repo
           path: ${{ runner.temp }}/maven-repo.tgz
           retention-days: 1
+      - name: Save Atlassian Maven Cache
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.4.0
+        if: always()
+        with:
+          path: |
+            ~/.m2/repository/com/atlassian
+            ~/.m2/repository/io/atlassian
+          key: atlassian-maven-${{ steps.atlassian-version.outputs.version }}
       - name: Setup Native Test Matrix
         id: set-native-matrix
         run: |
@@ -272,18 +307,10 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-      - name: Download Maven Repo
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: Setup Maven Cache
+        uses: ./.github/actions/setup-maven-cache
         with:
-          name: maven-repo
-          path: ..
-      - name: Extract Maven Repo
-        shell: bash
-        run: |
-          df -h /
-          tar -xzf ../maven-repo.tgz -C ~
-          rm -f ../maven-repo.tgz
-          df -h /
+          atlassian-version: ${{ needs.initial-mvn-install.outputs.atlassian-version }}
       - name: Integration Tests
         run: |
           for MODULE in $(yq -M -N e ".${{ matrix.category }}" tooling/scripts/test-categories.yaml | grep -vE '^\s*#' | cut -f2 -d' '); do
@@ -347,18 +374,10 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-      - name: Download Maven Repo
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: Setup Maven Cache
+        uses: ./.github/actions/setup-maven-cache
         with:
-          name: maven-repo
-          path: ..
-      - name: Extract Maven Repo
-        shell: bash
-        run: |
-          df -h /
-          tar -xzf ../maven-repo.tgz -C ~
-          rm -f ../maven-repo.tgz
-          df -h /
+          atlassian-version: ${{ needs.initial-mvn-install.outputs.atlassian-version }}
       - name: cd extensions-core && mvn test
         run: |
           cd extensions-core
@@ -439,18 +458,10 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
-      - name: Download Maven Repo
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: Setup Maven Cache
+        uses: ./.github/actions/setup-maven-cache
         with:
-          name: maven-repo
-          path: ..
-      - name: Extract Maven Repo
-        shell: bash
-        run: |
-          df -h /
-          tar -xzf ../maven-repo.tgz -C ~
-          rm -f ../maven-repo.tgz
-          df -h /
+          atlassian-version: ${{ needs.initial-mvn-install.outputs.atlassian-version }}
       - name: cd integration-tests-jvm && mvn clean test
         run: |
           cd integration-tests-jvm
@@ -487,18 +498,10 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
-      - name: Download Maven Repo
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: Setup Maven Cache
+        uses: ./.github/actions/setup-maven-cache
         with:
-          name: maven-repo
-          path: ..
-      - name: Extract Maven Repo
-        shell: bash
-        run: |
-          df -h /
-          tar -xzf ../maven-repo.tgz -C ~
-          rm -f ../maven-repo.tgz
-          df -h /
+          atlassian-version: ${{ needs.initial-mvn-install.outputs.atlassian-version }}
       - name: cd integration-tests && mvn clean verify
         shell: bash
         env:
@@ -583,18 +586,10 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-      - name: Download Maven Repo
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: Setup Maven Cache
+        uses: ./.github/actions/setup-maven-cache
         with:
-          name: maven-repo
-          path: ..
-      - name: Extract Maven Repo
-        shell: bash
-        run: |
-          df -h /
-          tar -xzf ../maven-repo.tgz -C ~
-          rm -f ../maven-repo.tgz
-          df -h /
+          atlassian-version: ${{ needs.initial-mvn-install.outputs.atlassian-version }}
       - name: set CQ_VERSION
         run: echo "CQ_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout -N)" >> $GITHUB_ENV
       - name: clone and verify examples

--- a/.github/workflows/ci-semeru-jdk.yaml
+++ b/.github/workflows/ci-semeru-jdk.yaml
@@ -46,6 +46,7 @@ jobs:
       matrix: ${{ steps.set-native-matrix.outputs.matrix }}
       examples-matrix: ${{ steps.set-examples-matrix.outputs.examples-matrix }}
       alternate-jvm-matrix: ${{ steps.set-alternate-jvm-matrix.outputs.alternate-jvm-matrix }}
+      atlassian-version: ${{ steps.atlassian-version.outputs.version }}
     env:
       MAVEN_OPTS: -Xmx4600m
     steps:
@@ -62,6 +63,18 @@ jobs:
         with:
           ref: ${{ env.CHECKOUT_REF }}
           fetch-depth: 0
+      - name: Get Atlassian dependency version
+        id: atlassian-version
+        run: |
+          JIRA_VERSION=$(./mvnw help:evaluate -Dexpression=jira-rest-client.version -q -DforceStdout -N)
+          echo "version=${JIRA_VERSION}" >> $GITHUB_OUTPUT
+      - name: Restore Atlassian Maven Cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.4.0
+        with:
+          path: |
+            ~/.m2/repository/com/atlassian
+            ~/.m2/repository/io/atlassian
+          key: atlassian-maven-${{ steps.atlassian-version.outputs.version }}
       - name: Update extension metadata
         run: |
           ./mvnw -N cq:update-quarkus-metadata ${CQ_MAVEN_ARGS}
@@ -87,6 +100,14 @@ jobs:
           name: maven-repo
           path: ${{ runner.temp }}/maven-repo.tgz
           retention-days: 1
+      - name: Save Atlassian Maven Cache
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.4.0
+        if: always()
+        with:
+          path: |
+            ~/.m2/repository/com/atlassian
+            ~/.m2/repository/io/atlassian
+          key: atlassian-maven-${{ steps.atlassian-version.outputs.version }}
       - name: Setup Native Test Matrix
         id: set-native-matrix
         run: |
@@ -138,18 +159,10 @@ jobs:
         with:
           distribution: 'semeru'
           java-version: '21'
-      - name: Download Maven Repo
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: Setup Maven Cache
+        uses: ./.github/actions/setup-maven-cache
         with:
-          name: maven-repo
-          path: ..
-      - name: Extract Maven Repo
-        shell: bash
-        run: |
-          df -h /
-          tar -xzf ../maven-repo.tgz -C ~
-          rm -f ../maven-repo.tgz
-          df -h /
+          atlassian-version: ${{ needs.initial-mvn-install.outputs.atlassian-version }}
       - name: Integration Tests
         run: |
           for MODULE in $(yq -M -N e ".${{ matrix.category }}" tooling/scripts/test-categories.yaml | grep -vE '^\s*#' | cut -f2 -d' '); do
@@ -213,18 +226,10 @@ jobs:
         with:
           distribution: 'semeru'
           java-version: '21'
-      - name: Download Maven Repo
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: Setup Maven Cache
+        uses: ./.github/actions/setup-maven-cache
         with:
-          name: maven-repo
-          path: ..
-      - name: Extract Maven Repo
-        shell: bash
-        run: |
-          df -h /
-          tar -xzf ../maven-repo.tgz -C ~
-          rm -f ../maven-repo.tgz
-          df -h /
+          atlassian-version: ${{ needs.initial-mvn-install.outputs.atlassian-version }}
       - name: cd extensions-core && mvn test
         run: |
           cd extensions-core
@@ -305,18 +310,10 @@ jobs:
         with:
           distribution: 'semeru'
           java-version: ${{ matrix.java }}
-      - name: Download Maven Repo
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: Setup Maven Cache
+        uses: ./.github/actions/setup-maven-cache
         with:
-          name: maven-repo
-          path: ..
-      - name: Extract Maven Repo
-        shell: bash
-        run: |
-          df -h /
-          tar -xzf ../maven-repo.tgz -C ~
-          rm -f ../maven-repo.tgz
-          df -h /
+          atlassian-version: ${{ needs.initial-mvn-install.outputs.atlassian-version }}
       - name: cd integration-tests-jvm && mvn clean test
         run: |
           cd integration-tests-jvm
@@ -389,18 +386,10 @@ jobs:
         with:
           distribution: 'semeru'
           java-version: '21'
-      - name: Download Maven Repo
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: Setup Maven Cache
+        uses: ./.github/actions/setup-maven-cache
         with:
-          name: maven-repo
-          path: ..
-      - name: Extract Maven Repo
-        shell: bash
-        run: |
-          df -h /
-          tar -xzf ../maven-repo.tgz -C ~
-          rm -f ../maven-repo.tgz
-          df -h /
+          atlassian-version: ${{ needs.initial-mvn-install.outputs.atlassian-version }}
       - name: set CQ_VERSION
         run: echo "CQ_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout -N)" >> $GITHUB_ENV
       - name: clone and verify examples

--- a/.github/workflows/jdk25-build.yaml
+++ b/.github/workflows/jdk25-build.yaml
@@ -49,6 +49,7 @@ jobs:
       matrix: ${{ steps.set-native-matrix.outputs.matrix }}
       examples-matrix: ${{ steps.set-examples-matrix.outputs.examples-matrix }}
       alternate-jvm-matrix: ${{ steps.set-alternate-jvm-matrix.outputs.alternate-jvm-matrix }}
+      atlassian-version: ${{ steps.atlassian-version.outputs.version }}
     env:
       MAVEN_OPTS: -Xmx4600m
     steps:
@@ -65,6 +66,18 @@ jobs:
         with:
           ref: ${{ env.CHECKOUT_REF }}
           fetch-depth: 0
+      - name: Get Atlassian dependency version
+        id: atlassian-version
+        run: |
+          JIRA_VERSION=$(./mvnw help:evaluate -Dexpression=jira-rest-client.version -q -DforceStdout -N)
+          echo "version=${JIRA_VERSION}" >> $GITHUB_OUTPUT
+      - name: Restore Atlassian Maven Cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.4.0
+        with:
+          path: |
+            ~/.m2/repository/com/atlassian
+            ~/.m2/repository/io/atlassian
+          key: atlassian-maven-${{ steps.atlassian-version.outputs.version }}
       - name: Update extension metadata
         run: |
           ./mvnw -N cq:update-quarkus-metadata ${CQ_MAVEN_ARGS}
@@ -90,6 +103,14 @@ jobs:
           name: maven-repo
           path: ${{ runner.temp }}/maven-repo.tgz
           retention-days: 1
+      - name: Save Atlassian Maven Cache
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.4.0
+        if: always()
+        with:
+          path: |
+            ~/.m2/repository/com/atlassian
+            ~/.m2/repository/io/atlassian
+          key: atlassian-maven-${{ steps.atlassian-version.outputs.version }}
       - name: Setup Native Test Matrix
         id: set-native-matrix
         run: |
@@ -142,18 +163,10 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '25'
-      - name: Download Maven Repo
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: Setup Maven Cache
+        uses: ./.github/actions/setup-maven-cache
         with:
-          name: maven-repo
-          path: ..
-      - name: Extract Maven Repo
-        shell: bash
-        run: |
-          df -h /
-          tar -xzf ../maven-repo.tgz -C ~
-          rm -f ../maven-repo.tgz
-          df -h /
+          atlassian-version: ${{ needs.initial-mvn-install.outputs.atlassian-version }}
       - name: Integration Tests
         run: |
           for MODULE in $(yq -M -N e ".${{ matrix.category }}" tooling/scripts/test-categories.yaml | grep -vE '^\s*#' | cut -f2 -d' '); do
@@ -217,18 +230,10 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '25'
-      - name: Download Maven Repo
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: Setup Maven Cache
+        uses: ./.github/actions/setup-maven-cache
         with:
-          name: maven-repo
-          path: ..
-      - name: Extract Maven Repo
-        shell: bash
-        run: |
-          df -h /
-          tar -xzf ../maven-repo.tgz -C ~
-          rm -f ../maven-repo.tgz
-          df -h /
+          atlassian-version: ${{ needs.initial-mvn-install.outputs.atlassian-version }}
       - name: cd extensions-core && mvn test
         run: |
           cd extensions-core
@@ -309,18 +314,10 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
-      - name: Download Maven Repo
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: Setup Maven Cache
+        uses: ./.github/actions/setup-maven-cache
         with:
-          name: maven-repo
-          path: ..
-      - name: Extract Maven Repo
-        shell: bash
-        run: |
-          df -h /
-          tar -xzf ../maven-repo.tgz -C ~
-          rm -f ../maven-repo.tgz
-          df -h /
+          atlassian-version: ${{ needs.initial-mvn-install.outputs.atlassian-version }}
       - name: cd integration-tests-jvm && mvn clean test
         run: |
           cd integration-tests-jvm
@@ -393,18 +390,10 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '25'
-      - name: Download Maven Repo
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: Setup Maven Cache
+        uses: ./.github/actions/setup-maven-cache
         with:
-          name: maven-repo
-          path: ..
-      - name: Extract Maven Repo
-        shell: bash
-        run: |
-          df -h /
-          tar -xzf ../maven-repo.tgz -C ~
-          rm -f ../maven-repo.tgz
-          df -h /
+          atlassian-version: ${{ needs.initial-mvn-install.outputs.atlassian-version }}
       - name: set CQ_VERSION
         run: echo "CQ_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout -N)" >> $GITHUB_ENV
       - name: clone and verify examples

--- a/.github/workflows/quarkus-lts-ci-build.yaml
+++ b/.github/workflows/quarkus-lts-ci-build.yaml
@@ -52,6 +52,7 @@ jobs:
       matrix: ${{ steps.set-native-matrix.outputs.matrix }}
       examples-matrix: ${{ steps.set-examples-matrix.outputs.examples-matrix }}
       alternate-jvm-matrix: ${{ steps.set-alternate-jvm-matrix.outputs.alternate-jvm-matrix }}
+      atlassian-version: ${{ steps.atlassian-version.outputs.version }}
     env:
       MAVEN_OPTS: -Xmx4600m
     steps:
@@ -75,6 +76,18 @@ jobs:
         with:
           ref: ${{ github.event.inputs.branch }}.x
           fetch-depth: 0
+      - name: Get Atlassian dependency version
+        id: atlassian-version
+        run: |
+          JIRA_VERSION=$(./mvnw help:evaluate -Dexpression=jira-rest-client.version -q -DforceStdout -N)
+          echo "version=${JIRA_VERSION}" >> $GITHUB_OUTPUT
+      - name: Restore Atlassian Maven Cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.4.0
+        with:
+          path: |
+            ~/.m2/repository/com/atlassian
+            ~/.m2/repository/io/atlassian
+          key: atlassian-maven-${{ steps.atlassian-version.outputs.version }}
       - name: Set Quarkus SNAPSHOT Version
         run: |
           sed -i 's/<quarkus.version>.*<\/quarkus.version>/<quarkus.version>${{github.event.inputs.branch}}.999-SNAPSHOT<\/quarkus.version>/' pom.xml
@@ -103,6 +116,14 @@ jobs:
           name: maven-repo
           path: ${{ runner.temp }}/maven-repo.tgz
           retention-days: 1
+      - name: Save Atlassian Maven Cache
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.4.0
+        if: always()
+        with:
+          path: |
+            ~/.m2/repository/com/atlassian
+            ~/.m2/repository/io/atlassian
+          key: atlassian-maven-${{ steps.atlassian-version.outputs.version }}
       - name: Setup Native Test Matrix
         id: set-native-matrix
         run: |
@@ -151,18 +172,10 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-      - name: Download Maven Repo
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: Setup Maven Cache
+        uses: ./.github/actions/setup-maven-cache
         with:
-          name: maven-repo
-          path: ..
-      - name: Extract Maven Repo
-        shell: bash
-        run: |
-          df -h /
-          tar -xzf ../maven-repo.tgz -C ~
-          rm -f ../maven-repo.tgz
-          df -h /
+          atlassian-version: ${{ needs.initial-mvn-install.outputs.atlassian-version }}
       - name: Integration Tests
         run: |
           for MODULE in $(yq -M -N e ".${{ matrix.category }}" tooling/scripts/test-categories.yaml | grep -vE '^\s*#' | cut -f2 -d' '); do
@@ -229,18 +242,10 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-      - name: Download Maven Repo
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: Setup Maven Cache
+        uses: ./.github/actions/setup-maven-cache
         with:
-          name: maven-repo
-          path: ..
-      - name: Extract Maven Repo
-        shell: bash
-        run: |
-          df -h /
-          tar -xzf ../maven-repo.tgz -C ~
-          rm -f ../maven-repo.tgz
-          df -h /
+          atlassian-version: ${{ needs.initial-mvn-install.outputs.atlassian-version }}
       - name: cd extensions-core && mvn test
         run: |
           cd extensions-core
@@ -324,18 +329,10 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
-      - name: Download Maven Repo
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: Setup Maven Cache
+        uses: ./.github/actions/setup-maven-cache
         with:
-          name: maven-repo
-          path: ..
-      - name: Extract Maven Repo
-        shell: bash
-        run: |
-          df -h /
-          tar -xzf ../maven-repo.tgz -C ~
-          rm -f ../maven-repo.tgz
-          df -h /
+          atlassian-version: ${{ needs.initial-mvn-install.outputs.atlassian-version }}
       - name: cd integration-tests-jvm && mvn clean test
         run: |
           cd integration-tests-jvm
@@ -374,18 +371,10 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
-      - name: Download Maven Repo
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: Setup Maven Cache
+        uses: ./.github/actions/setup-maven-cache
         with:
-          name: maven-repo
-          path: ..
-      - name: Extract Maven Repo
-        shell: bash
-        run: |
-          df -h /
-          tar -xzf ../maven-repo.tgz -C ~
-          rm -f ../maven-repo.tgz
-          df -h /
+          atlassian-version: ${{ needs.initial-mvn-install.outputs.atlassian-version }}
       - name: cd integration-tests && mvn clean verify
         shell: bash
         env:
@@ -464,18 +453,10 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-      - name: Download Maven Repo
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: Setup Maven Cache
+        uses: ./.github/actions/setup-maven-cache
         with:
-          name: maven-repo
-          path: ..
-      - name: Extract Maven Repo
-        shell: bash
-        run: |
-          df -h /
-          tar -xzf ../maven-repo.tgz -C ~
-          rm -f ../maven-repo.tgz
-          df -h /
+          atlassian-version: ${{ needs.initial-mvn-install.outputs.atlassian-version }}
       - name: set CQ_VERSION
         run: echo "CQ_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout -N)" >> $GITHUB_ENV
       - name: clone and verify examples

--- a/.github/workflows/quarkus-master-cron.yaml
+++ b/.github/workflows/quarkus-master-cron.yaml
@@ -37,6 +37,7 @@ jobs:
       matrix: ${{ steps.set-native-matrix.outputs.matrix }}
       examples-matrix: ${{ steps.set-examples-matrix.outputs.examples-matrix }}
       alternate-jvm-matrix: ${{ steps.set-alternate-jvm-matrix.outputs.alternate-jvm-matrix }}
+      atlassian-version: ${{ steps.atlassian-version.outputs.version }}
     env:
       MAVEN_OPTS: -Xmx4600m
     steps:
@@ -57,6 +58,18 @@ jobs:
         with:
           ref: quarkus-main
           fetch-depth: 0
+      - name: Get Atlassian dependency version
+        id: atlassian-version
+        run: |
+          JIRA_VERSION=$(./mvnw help:evaluate -Dexpression=jira-rest-client.version -q -DforceStdout -N)
+          echo "version=${JIRA_VERSION}" >> $GITHUB_OUTPUT
+      - name: Restore Atlassian Maven Cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.4.0
+        with:
+          path: |
+            ~/.m2/repository/com/atlassian
+            ~/.m2/repository/io/atlassian
+          key: atlassian-maven-${{ steps.atlassian-version.outputs.version }}
       - name: Rebase branch main onto quarkus-main
         run: |
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -97,6 +110,14 @@ jobs:
           name: maven-repo
           path: ${{ runner.temp }}/maven-repo.tgz
           retention-days: 1
+      - name: Save Atlassian Maven Cache
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.4.0
+        if: always()
+        with:
+          path: |
+            ~/.m2/repository/com/atlassian
+            ~/.m2/repository/io/atlassian
+          key: atlassian-maven-${{ steps.atlassian-version.outputs.version }}
       - name: Setup Native Test Matrix
         id: set-native-matrix
         run: |
@@ -249,6 +270,13 @@ jobs:
         with:
           ref: quarkus-main
           fetch-depth: 0
+      - name: Restore Atlassian Maven Cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.4.0
+        with:
+          path: |
+            ~/.m2/repository/com/atlassian
+            ~/.m2/repository/io/atlassian
+          key: atlassian-maven-${{ needs.initial-mvn-install.outputs.atlassian-version }}
       - name: Rebase branch main onto quarkus-main
         run: |
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -351,6 +379,13 @@ jobs:
         with:
           ref: quarkus-main
           fetch-depth: 0
+      - name: Restore Atlassian Maven Cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.4.0
+        with:
+          path: |
+            ~/.m2/repository/com/atlassian
+            ~/.m2/repository/io/atlassian
+          key: atlassian-maven-${{ needs.initial-mvn-install.outputs.atlassian-version }}
       - name: Rebase branch main onto quarkus-main
         run: |
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -405,6 +440,13 @@ jobs:
         with:
           ref: quarkus-main
           fetch-depth: 0
+      - name: Restore Atlassian Maven Cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.4.0
+        with:
+          path: |
+            ~/.m2/repository/com/atlassian
+            ~/.m2/repository/io/atlassian
+          key: atlassian-maven-${{ needs.initial-mvn-install.outputs.atlassian-version }}
       - name: Rebase branch main onto quarkus-main
         run: |
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -460,6 +502,13 @@ jobs:
         with:
           ref: quarkus-main
           fetch-depth: 0
+      - name: Restore Atlassian Maven Cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.4.0
+        with:
+          path: |
+            ~/.m2/repository/com/atlassian
+            ~/.m2/repository/io/atlassian
+          key: atlassian-maven-${{ needs.initial-mvn-install.outputs.atlassian-version }}
       - name: Rebase branch main onto quarkus-main
         run: |
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -520,6 +569,13 @@ jobs:
         with:
           ref: quarkus-main
           fetch-depth: 0
+      - name: Restore Atlassian Maven Cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.4.0
+        with:
+          path: |
+            ~/.m2/repository/com/atlassian
+            ~/.m2/repository/io/atlassian
+          key: atlassian-maven-${{ needs.initial-mvn-install.outputs.atlassian-version }}
       - name: Rebase branch main onto quarkus-main
         run: |
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -605,6 +661,13 @@ jobs:
         with:
           ref: quarkus-main
           fetch-depth: 0
+      - name: Restore Atlassian Maven Cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.4.0
+        with:
+          path: |
+            ~/.m2/repository/com/atlassian
+            ~/.m2/repository/io/atlassian
+          key: atlassian-maven-${{ needs.initial-mvn-install.outputs.atlassian-version }}
       - name: Rebase branch main onto quarkus-main
         run: |
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
Try to work around sporadic Atlassian maven repo 403s.

Obvs it needs to populate the cache initially, which might fail with the 403. But once it's done, workflows should run ok.