### PR TITLE
Add integration test coverage for ErrorRegistry SPI configuration #8702

### DIFF
--- a/integration-tests/main/src/main/java/org/apache/camel/quarkus/main/CoreMainResource.java
+++ b/integration-tests/main/src/main/java/org/apache/camel/quarkus/main/CoreMainResource.java
@@ -51,6 +51,7 @@ import org.apache.camel.reactive.vertx.VertXThreadPoolFactory;
 import org.apache.camel.spi.BeanRepository;
 import org.apache.camel.spi.ContextReloadStrategy;
 import org.apache.camel.spi.DataFormat;
+import org.apache.camel.spi.ErrorRegistry;
 import org.apache.camel.spi.FactoryFinderResolver;
 import org.apache.camel.spi.Language;
 import org.apache.camel.spi.ReactiveExecutor;
@@ -202,6 +203,28 @@ public class CoreMainResource {
         }
 
         return builder.build();
+    }
+
+    @Path("/context/error-registry")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public JsonObject errorRegistry() {
+        ErrorRegistry errorRegistry = main.getCamelContext().getErrorRegistry();
+
+        JsonObjectBuilder builder = Json.createObjectBuilder()
+                .add("present", errorRegistry != null);
+
+        if (errorRegistry == null) {
+            return builder.add("enabled", false).build();
+        }
+
+        return builder
+                .add("enabled", errorRegistry.isEnabled())
+                .add("maximumEntries", errorRegistry.getMaximumEntries())
+                .add("timeToLiveSeconds", errorRegistry.getTimeToLive().toSeconds())
+                .add("stackTraceEnabled", errorRegistry.isStackTraceEnabled())
+                .add("size", errorRegistry.size())
+                .build();
     }
 
     @Path("/converter/my-pair")

--- a/integration-tests/main/src/main/resources/application.properties
+++ b/integration-tests/main/src/main/resources/application.properties
@@ -31,6 +31,9 @@ camel.resilience4j.sliding-window-size = 1234
 # Main
 #
 camel.main.auto-configuration-log-summary = false
+camel.main.error-registry-enabled = true
+camel.main.error-registry-maximum-entries = 37
+camel.main.error-registry-time-to-live-seconds = 19
 
 # To verify DebuggerJmxConnectorService substitutions take effect due to lack of camel-quarkus-management on the classpath
 camel.debug.enabled = true

--- a/integration-tests/main/src/test/java/org/apache/camel/quarkus/main/CoreMainErrorRegistryDisabledIT.java
+++ b/integration-tests/main/src/test/java/org/apache/camel/quarkus/main/CoreMainErrorRegistryDisabledIT.java
@@ -19,5 +19,5 @@ package org.apache.camel.quarkus.main;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest
-public class CoreMainIT extends CoreMainTest {
+class CoreMainErrorRegistryDisabledIT extends CoreMainErrorRegistryDisabledTest {
 }

--- a/integration-tests/main/src/test/java/org/apache/camel/quarkus/main/CoreMainErrorRegistryDisabledTest.java
+++ b/integration-tests/main/src/test/java/org/apache/camel/quarkus/main/CoreMainErrorRegistryDisabledTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.main;
+
+import java.util.Map;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.RestAssured;
+import jakarta.ws.rs.core.MediaType;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.Matchers.is;
+
+@QuarkusTest
+@TestProfile(CoreMainErrorRegistryDisabledTest.CoreMainErrorRegistryDisabledTestProfile.class)
+class CoreMainErrorRegistryDisabledTest {
+    @Test
+    void testErrorRegistryDisabled() {
+        RestAssured.given()
+                .accept(MediaType.APPLICATION_JSON)
+                .get("/test/context/error-registry")
+                .then()
+                .statusCode(200)
+                .body("enabled", is(false));
+    }
+
+    public static final class CoreMainErrorRegistryDisabledTestProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("camel.main.error-registry-enabled", "false");
+        }
+    }
+}

--- a/integration-tests/main/src/test/java/org/apache/camel/quarkus/main/CoreMainIT.java
+++ b/integration-tests/main/src/test/java/org/apache/camel/quarkus/main/CoreMainIT.java
@@ -21,3 +21,7 @@ import io.quarkus.test.junit.QuarkusIntegrationTest;
 @QuarkusIntegrationTest
 public class CoreMainIT extends CoreMainTest {
 }
+
+@QuarkusIntegrationTest
+class CoreMainErrorRegistryDisabledIT extends CoreMainErrorRegistryDisabledTest {
+}

--- a/integration-tests/main/src/test/java/org/apache/camel/quarkus/main/CoreMainTest.java
+++ b/integration-tests/main/src/test/java/org/apache/camel/quarkus/main/CoreMainTest.java
@@ -20,6 +20,8 @@ import java.net.HttpURLConnection;
 import java.util.Map;
 
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.path.json.JsonPath;
@@ -174,6 +176,21 @@ public class CoreMainTest {
     }
 
     @Test
+    public void testErrorRegistry() {
+        RestAssured.given()
+                .accept(MediaType.APPLICATION_JSON)
+                .get("/test/context/error-registry")
+                .then()
+                .statusCode(200)
+                .body(
+                        "present", is(true),
+                        "enabled", is(true),
+                        "maximumEntries", is(37),
+                        "timeToLiveSeconds", is(19),
+                        "size", is(0));
+    }
+
+    @Test
     public void testCustomTypeConverter() {
         RestAssured.given()
                 .contentType(ContentType.TEXT).body("a:b")
@@ -235,4 +252,25 @@ public class CoreMainTest {
                 .body(containsString("public class " + CamelCdiBeanRoute.class.getSimpleName()));
     }
 
+}
+
+@QuarkusTest
+@TestProfile(CoreMainErrorRegistryDisabledTest.CoreMainErrorRegistryDisabledTestProfile.class)
+class CoreMainErrorRegistryDisabledTest {
+    @Test
+    void testErrorRegistryDisabled() {
+        RestAssured.given()
+                .accept(MediaType.APPLICATION_JSON)
+                .get("/test/context/error-registry")
+                .then()
+                .statusCode(200)
+                .body("enabled", is(false));
+    }
+
+    public static final class CoreMainErrorRegistryDisabledTestProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("camel.main.error-registry-enabled", "false");
+        }
+    }
 }

--- a/integration-tests/main/src/test/java/org/apache/camel/quarkus/main/CoreMainTest.java
+++ b/integration-tests/main/src/test/java/org/apache/camel/quarkus/main/CoreMainTest.java
@@ -20,8 +20,6 @@ import java.net.HttpURLConnection;
 import java.util.Map;
 
 import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.QuarkusTestProfile;
-import io.quarkus.test.junit.TestProfile;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.path.json.JsonPath;
@@ -252,25 +250,4 @@ public class CoreMainTest {
                 .body(containsString("public class " + CamelCdiBeanRoute.class.getSimpleName()));
     }
 
-}
-
-@QuarkusTest
-@TestProfile(CoreMainErrorRegistryDisabledTest.CoreMainErrorRegistryDisabledTestProfile.class)
-class CoreMainErrorRegistryDisabledTest {
-    @Test
-    void testErrorRegistryDisabled() {
-        RestAssured.given()
-                .accept(MediaType.APPLICATION_JSON)
-                .get("/test/context/error-registry")
-                .then()
-                .statusCode(200)
-                .body("enabled", is(false));
-    }
-
-    public static final class CoreMainErrorRegistryDisabledTestProfile implements QuarkusTestProfile {
-        @Override
-        public Map<String, String> getConfigOverrides() {
-            return Map.of("camel.main.error-registry-enabled", "false");
-        }
-    }
 }


### PR DESCRIPTION
## Summary

Adds integration test coverage confirming the Camel `ErrorRegistry` SPI (CAMEL-23079) can be enabled and configured on Camel Quarkus through `camel.main.*` properties, in JVM and native mode.

## Why this matters

#8702 asks for Quarkus configuration support for the new `ErrorRegistry` SPI. As jamesnetherton noted in the issue, the configuration is already handled by `camel-main`, so what's needed is "some test coverage to confirm it works on CQ" - that's what this PR adds, following the existing patterns in `integration-tests/main`.

## What it covers

`CoreMainResource` gains a `/test/context/error-registry` endpoint that reports the registry's `enabled`, `maximumEntries`, `timeToLive`, `stackTraceEnabled`, and `size` state from the running `CamelContext`. `application.properties` enables the registry with non-default values (`maximum-entries = 37`, `time-to-live-seconds = 19`) so the test proves the values flow through rather than matching defaults, which also keeps the test immune to the planned TTL-default change mentioned in the issue. `CoreMainTest` asserts the configured values; a second `@QuarkusTest` with a `@TestProfile` overriding `camel.main.error-registry-enabled = false` asserts the disabled path. Both run in native mode via the corresponding `@QuarkusIntegrationTest` subclasses.

## Testing

The new assertions run inside the existing `integration-tests/main` module. API usage was verified against `camel-api` 4.20.0 (`CamelContext.getErrorRegistry()`, `ErrorRegistry` accessors, `ErrorRegistryView.size()`).

Fixes #8702
