### PR TITLE
[3.33] Remove the last rest of quarkus-junit5*

### DIFF
--- a/extensions/infinispan-cluster-service/deployment/pom.xml
+++ b/extensions/infinispan-cluster-service/deployment/pom.xml
@@ -48,7 +48,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5-internal</artifactId>
+            <artifactId>quarkus-junit-internal</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
those were renamed to quarku…s-junit* in Quarkus 3.31.0 https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.31#junit-6-gear-white_check_mark
