### PR TITLE
ci: Cache Atlassian Maven artifacts in additional workflows & fix camel-main handling

### DIFF
--- a/.github/workflows/alternate-jdk-build.yaml
+++ b/.github/workflows/alternate-jdk-build.yaml
@@ -89,7 +89,7 @@ jobs:
           JIRA_VERSION=$(./mvnw help:evaluate -Dexpression=jira-rest-client.version -q -DforceStdout -N)
           echo "version=${JIRA_VERSION}" >> $GITHUB_OUTPUT
       - name: Restore Atlassian Maven Cache
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v4.4.0
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.m2/repository/com/atlassian
@@ -121,7 +121,7 @@ jobs:
           path: ${{ runner.temp }}/maven-repo.tgz
           retention-days: 1
       - name: Save Atlassian Maven Cache
-        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v4.4.0
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         if: always()
         with:
           path: |
@@ -356,16 +356,10 @@ jobs:
         with:
           distribution: ${{ env.JDK_DISTRIBUTION }}
           java-version: ${{ env.JDK_VERSION }}
-      - name: Download Maven Repo
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: Setup Maven Cache
+        uses: ./.github/actions/setup-maven-cache
         with:
-          name: maven-repo
-          path: ..
-      - name: Extract Maven Repo
-        shell: bash
-        run: |
-          tar -xzf ../maven-repo.tgz -C ~
-          rm -f ../maven-repo.tgz
+          atlassian-version: ${{ needs.initial-mvn-install.outputs.atlassian-version }}
       - name: cd integration-tests && mvn clean verify
         shell: bash
         run: |

--- a/.github/workflows/camel-master-cron.yaml
+++ b/.github/workflows/camel-master-cron.yaml
@@ -57,18 +57,6 @@ jobs:
         with:
           ref: camel-main
           fetch-depth: 0
-      - name: Get Atlassian dependency version
-        id: atlassian-version
-        run: |
-          JIRA_VERSION=$(./mvnw help:evaluate -Dexpression=jira-rest-client.version -q -DforceStdout -N)
-          echo "version=${JIRA_VERSION}" >> $GITHUB_OUTPUT
-      - name: Restore Atlassian Maven Cache
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v4.4.0
-        with:
-          path: |
-            ~/.m2/repository/com/atlassian
-            ~/.m2/repository/io/atlassian
-          key: atlassian-maven-${{ steps.atlassian-version.outputs.version }}
       - name: Rebase branch main onto camel-main
         run: |
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -76,13 +64,29 @@ jobs:
           git fetch origin main
           git rebase origin/main
           git rev-parse origin/main > ~/build-data/main-sha.txt
-      - name: Build Camel
+      - name: Clone Camel
         run: |
           cd ../
-          git clone --depth 1 --branch main https://github.com/apache/camel.git \
-            && cd camel \
-            && echo "Current Camel commit:" $(git rev-parse HEAD) \
-            && ./mvnw ${CQ_MAVEN_ARGS} clean install -Dquickly -T1C
+          git clone --depth 1 --branch main https://github.com/apache/camel.git
+          cd camel
+          echo "Current Camel commit:" $(git rev-parse HEAD)
+      - name: Get Atlassian dependency version
+        id: atlassian-version
+        run: |
+          cd ../camel/parent
+          JIRA_VERSION=$(../mvnw help:evaluate -Dexpression=jira-rest-client-api-version -q -DforceStdout -N)
+          echo "version=${JIRA_VERSION}" >> $GITHUB_OUTPUT
+      - name: Restore Atlassian Maven Cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.m2/repository/com/atlassian
+            ~/.m2/repository/io/atlassian
+          key: atlassian-maven-${{ steps.atlassian-version.outputs.version }}
+      - name: Build Camel
+        run: |
+          cd ../camel
+          ./mvnw ${CQ_MAVEN_ARGS} clean install -Dquickly -T1C
       - name: Update extension metadata
         run: |
           ./mvnw -N cq:update-quarkus-metadata ${CQ_MAVEN_ARGS}
@@ -109,7 +113,7 @@ jobs:
           path: ${{ runner.temp }}/maven-repo.tgz
           retention-days: 1
       - name: Save Atlassian Maven Cache
-        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v4.4.0
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         if: always()
         with:
           path: |
@@ -152,30 +156,15 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.initial-mvn-install.outputs.matrix) }}
     steps:
-      - name: Download Maven Repo
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: maven-repo
-          path: ..
-      - name: Extract Maven Repo
-        shell: bash
-        run: |
-          df -h /
-          tar -xzf ../maven-repo.tgz -C ~
-          rm -f ../maven-repo.tgz
-          df -h /
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: camel-main
           fetch-depth: 0
-      - name: Restore Atlassian Maven Cache
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v4.4.0
+      - name: Setup Maven Cache
+        uses: ./.github/actions/setup-maven-cache
         with:
-          path: |
-            ~/.m2/repository/com/atlassian
-            ~/.m2/repository/io/atlassian
-          key: atlassian-maven-${{ needs.initial-mvn-install.outputs.atlassian-version }}
+          atlassian-version: ${{ needs.initial-mvn-install.outputs.atlassian-version }}
       - name: Reclaim Disk Space
         run: .github/reclaim-disk-space.sh
       - name: Rebase branch main onto camel-main
@@ -246,30 +235,15 @@ jobs:
     env:
       MAVEN_OPTS: -Xmx3000m
     steps:
-      - name: Download Maven Repo
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: maven-repo
-          path: ..
-      - name: Extract Maven Repo
-        shell: bash
-        run: |
-          df -h /
-          tar -xzf ../maven-repo.tgz -C ~
-          rm -f ../maven-repo.tgz
-          df -h /
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: camel-main
           fetch-depth: 0
-      - name: Restore Atlassian Maven Cache
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v4.4.0
+      - name: Setup Maven Cache
+        uses: ./.github/actions/setup-maven-cache
         with:
-          path: |
-            ~/.m2/repository/com/atlassian
-            ~/.m2/repository/io/atlassian
-          key: atlassian-maven-${{ needs.initial-mvn-install.outputs.atlassian-version }}
+          atlassian-version: ${{ needs.initial-mvn-install.outputs.atlassian-version }}
       - name: Rebase branch main onto camel-main
         run: |
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -351,30 +325,15 @@ jobs:
     env:
       MAVEN_OPTS: -Xmx3000m
     steps:
-      - name: Download Maven Repo
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: maven-repo
-          path: ..
-      - name: Extract Maven Repo
-        shell: bash
-        run: |
-          df -h /
-          tar -xzf ../maven-repo.tgz -C ~
-          rm -f ../maven-repo.tgz
-          df -h /
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: camel-main
           fetch-depth: 0
-      - name: Restore Atlassian Maven Cache
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v4.4.0
+      - name: Setup Maven Cache
+        uses: ./.github/actions/setup-maven-cache
         with:
-          path: |
-            ~/.m2/repository/com/atlassian
-            ~/.m2/repository/io/atlassian
-          key: atlassian-maven-${{ needs.initial-mvn-install.outputs.atlassian-version }}
+          atlassian-version: ${{ needs.initial-mvn-install.outputs.atlassian-version }}
       - name: Rebase branch main onto camel-main
         run: |
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -413,28 +372,15 @@ jobs:
     env:
       MAVEN_OPTS: -Xmx3000m
     steps:
-      - name: Download Maven Repo
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: maven-repo
-          path: ..
-      - name: Extract Maven Repo
-        shell: bash
-        run: |
-          tar -xzf ../maven-repo.tgz -C ~
-          rm -f ../maven-repo.tgz
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: camel-main
           fetch-depth: 0
-      - name: Restore Atlassian Maven Cache
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v4.4.0
+      - name: Setup Maven Cache
+        uses: ./.github/actions/setup-maven-cache
         with:
-          path: |
-            ~/.m2/repository/com/atlassian
-            ~/.m2/repository/io/atlassian
-          key: atlassian-maven-${{ needs.initial-mvn-install.outputs.atlassian-version }}
+          atlassian-version: ${{ needs.initial-mvn-install.outputs.atlassian-version }}
       - name: Rebase branch main onto camel-main
         run: |
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -473,35 +419,20 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.initial-mvn-install.outputs.examples-matrix) }}
     steps:
-      - name: Set up JDK 17
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-      - name: Download Maven Repo
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: maven-repo
-          path: ..
-      - name: Extract Maven Repo
-        shell: bash
-        run: |
-          df -h /
-          tar -xzf ../maven-repo.tgz -C ~
-          rm -f ../maven-repo.tgz
-          df -h /
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: camel-main
           fetch-depth: 0
-      - name: Restore Atlassian Maven Cache
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v4.4.0
+      - name: Setup Maven Cache
+        uses: ./.github/actions/setup-maven-cache
         with:
-          path: |
-            ~/.m2/repository/com/atlassian
-            ~/.m2/repository/io/atlassian
-          key: atlassian-maven-${{ needs.initial-mvn-install.outputs.atlassian-version }}
+          atlassian-version: ${{ needs.initial-mvn-install.outputs.atlassian-version }}
+      - name: Set up JDK 17
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: 'temurin'
+          java-version: '17'
       - name: Rebase branch main onto camel-main
         run: |
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -570,30 +501,15 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-      - name: Download Maven Repo
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: maven-repo
-          path: ..
-      - name: Extract Maven Repo
-        shell: bash
-        run: |
-          df -h /
-          tar -xzf ../maven-repo.tgz -C ~
-          rm -f ../maven-repo.tgz
-          df -h /
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: camel-main
           fetch-depth: 0
-      - name: Restore Atlassian Maven Cache
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v4.4.0
+      - name: Setup Maven Cache
+        uses: ./.github/actions/setup-maven-cache
         with:
-          path: |
-            ~/.m2/repository/com/atlassian
-            ~/.m2/repository/io/atlassian
-          key: atlassian-maven-${{ needs.initial-mvn-install.outputs.atlassian-version }}
+          atlassian-version: ${{ needs.initial-mvn-install.outputs.atlassian-version }}
       - name: Rebase branch main onto camel-main
         run: |
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/check-dependency-convergence.yml
+++ b/.github/workflows/check-dependency-convergence.yml
@@ -47,6 +47,18 @@ jobs:
           java-version: '17'
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Get Atlassian dependency version
+        id: atlassian-version
+        run: |
+          JIRA_VERSION=$(./mvnw help:evaluate -Dexpression=jira-rest-client.version -q -DforceStdout -N)
+          echo "version=${JIRA_VERSION}" >> $GITHUB_OUTPUT
+      - name: Restore Atlassian Maven Cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.m2/repository/com/atlassian
+            ~/.m2/repository/io/atlassian
+          key: atlassian-maven-${{ steps.atlassian-version.outputs.version }}
       - name: Set Build Info
         run: |
           [ ! -d ~/build-data ] && mkdir -p ~/build-data

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -138,7 +138,7 @@ jobs:
           JIRA_VERSION=$(./mvnw help:evaluate -Dexpression=jira-rest-client.version -q -DforceStdout -N)
           echo "version=${JIRA_VERSION}" >> $GITHUB_OUTPUT
       - name: Restore Atlassian Maven Cache
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v4.4.0
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         if: steps.init.outputs.run-checks == 'true'
         with:
           path: |
@@ -196,14 +196,13 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-      - name: Build Camel
+      - name: Clone Camel
         if: github.ref == 'refs/heads/camel-main' || github.base_ref == 'camel-main'
         run: |
           cd ../
-          git clone --depth 1 --branch main https://github.com/apache/camel.git \
-            && cd camel \
-            && echo "Current Camel commit:" $(git rev-parse HEAD) \
-            && ./mvnw ${CQ_MAVEN_ARGS} clean install -Dquickly -T1C
+          git clone --depth 1 --branch main https://github.com/apache/camel.git
+          cd camel
+          echo "Current Camel commit:" $(git rev-parse HEAD)
       - name: Build Quarkus
         if: github.ref == 'refs/heads/quarkus-main' || github.base_ref == 'quarkus-main'
         run: |
@@ -220,15 +219,25 @@ jobs:
       - name: Get Atlassian dependency version
         id: atlassian-version
         run: |
-          JIRA_VERSION=$(./mvnw help:evaluate -Dexpression=jira-rest-client.version -q -DforceStdout -N)
+          if [[ "${{ github.ref }}" == "refs/heads/camel-main" || "${{ github.base_ref }}" == "camel-main" ]]; then
+            cd ../camel/parent
+            JIRA_VERSION=$(../mvnw help:evaluate -Dexpression=jira-rest-client-api-version -q -DforceStdout -N)
+          else
+            JIRA_VERSION=$(./mvnw help:evaluate -Dexpression=jira-rest-client.version -q -DforceStdout -N)
+          fi
           echo "version=${JIRA_VERSION}" >> $GITHUB_OUTPUT
       - name: Restore Atlassian Maven Cache
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v4.4.0
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.m2/repository/com/atlassian
             ~/.m2/repository/io/atlassian
           key: atlassian-maven-${{ steps.atlassian-version.outputs.version }}
+      - name: Build Camel
+        if: github.ref == 'refs/heads/camel-main' || github.base_ref == 'camel-main'
+        run: |
+          cd ../camel
+          ./mvnw ${CQ_MAVEN_ARGS} clean install -Dquickly -T1C
       - name: Update extension metadata
         run: |
           ./mvnw -N cq:update-quarkus-metadata ${CQ_MAVEN_ARGS}
@@ -255,7 +264,7 @@ jobs:
           path: ${{ runner.temp }}/maven-repo.tgz
           retention-days: 1
       - name: Save Atlassian Maven Cache
-        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v4.4.0
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         if: always()
         with:
           path: |
@@ -487,27 +496,15 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-      - name: Download Maven Repo
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: Setup Maven Cache
+        uses: ./.github/actions/setup-maven-cache
         with:
-          name: maven-repo
-          path: ..
-      - name: Extract Maven Repo
-        shell: bash
-        run: |
-          mkdir "D:\\temp"
-          mkdir "D:\\maven-repo"
-          tar -xzf ../maven-repo.tgz -C "D:\\maven-repo"
-          rm -f ../maven-repo.tgz
+          atlassian-version: ${{ needs.initial-mvn-install.outputs.atlassian-version }}
       - name: cd integration-tests && mvn clean verify
         shell: bash
-        env:
-          TEMP: D:\\temp
-          TMP: D:\\temp
-          MAVEN_REPO_LOCAL: D:\\maven-repo\.m2\repository
         run: |
           cd integration-tests
-          ../mvnw ${CQ_MAVEN_ARGS} ${BRANCH_OPTIONS} -Dmaven.repo.local='${{ env.MAVEN_REPO_LOCAL }}' \
+          ../mvnw ${CQ_MAVEN_ARGS} ${BRANCH_OPTIONS} \
             -Dskip-testcontainers-tests -Dformatter.skip -Dimpsort.skip -Denforcer.skip \
             --fail-at-end \
             clean verify

--- a/.github/workflows/generate-sbom-main.yml
+++ b/.github/workflows/generate-sbom-main.yml
@@ -50,6 +50,18 @@ jobs:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
           cache: 'maven'
+      - name: Get Atlassian dependency version
+        id: atlassian-version
+        run: |
+          JIRA_VERSION=$(./mvnw help:evaluate -Dexpression=jira-rest-client.version -q -DforceStdout -N)
+          echo "version=${JIRA_VERSION}" >> $GITHUB_OUTPUT
+      - name: Restore Atlassian Maven Cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.m2/repository/com/atlassian
+            ~/.m2/repository/io/atlassian
+          key: atlassian-maven-${{ steps.atlassian-version.outputs.version }}
       - name: mvn build and sbom generation
         run: ./mvnw -V --no-transfer-progress -e -Psbom -Dquickly -DskipTests verify ${CQ_MAVEN_ARGS}
       - name: Create Pull Request

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -91,7 +91,7 @@ jobs:
         JIRA_VERSION=$(./mvnw help:evaluate -Dexpression=jira-rest-client.version -q -DforceStdout -N)
         echo "version=${JIRA_VERSION}" >> $GITHUB_OUTPUT
     - name: Restore Atlassian Maven Cache
-      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v4.4.0
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: |
           ~/.m2/repository/com/atlassian
@@ -104,7 +104,7 @@ jobs:
           -Pcheck-format \
           clean validate
     - name: Save Atlassian Maven Cache
-      uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v4.4.0
+      uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       if: always()
       with:
         path: |

--- a/.github/workflows/quarkus-lts-ci-build.yaml
+++ b/.github/workflows/quarkus-lts-ci-build.yaml
@@ -81,7 +81,7 @@ jobs:
           JIRA_VERSION=$(./mvnw help:evaluate -Dexpression=jira-rest-client.version -q -DforceStdout -N)
           echo "version=${JIRA_VERSION}" >> $GITHUB_OUTPUT
       - name: Restore Atlassian Maven Cache
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v4.4.0
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.m2/repository/com/atlassian
@@ -116,7 +116,7 @@ jobs:
           path: ${{ runner.temp }}/maven-repo.tgz
           retention-days: 1
       - name: Save Atlassian Maven Cache
-        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v4.4.0
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         if: always()
         with:
           path: |
@@ -353,16 +353,10 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-      - name: Download Maven Repo
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: Setup Maven Cache
+        uses: ./.github/actions/setup-maven-cache
         with:
-          name: maven-repo
-          path: ..
-      - name: Extract Maven Repo
-        shell: bash
-        run: |
-          tar -xzf ../maven-repo.tgz -C ~
-          rm -f ../maven-repo.tgz
+          atlassian-version: ${{ needs.initial-mvn-install.outputs.atlassian-version }}
       - name: cd integration-tests && mvn clean verify
         shell: bash
         run: |

--- a/.github/workflows/quarkus-master-cron.yaml
+++ b/.github/workflows/quarkus-master-cron.yaml
@@ -63,7 +63,7 @@ jobs:
           JIRA_VERSION=$(./mvnw help:evaluate -Dexpression=jira-rest-client.version -q -DforceStdout -N)
           echo "version=${JIRA_VERSION}" >> $GITHUB_OUTPUT
       - name: Restore Atlassian Maven Cache
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v4.4.0
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.m2/repository/com/atlassian
@@ -110,7 +110,7 @@ jobs:
           path: ${{ runner.temp }}/maven-repo.tgz
           retention-days: 1
       - name: Save Atlassian Maven Cache
-        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v4.4.0
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         if: always()
         with:
           path: |
@@ -153,23 +153,15 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.initial-mvn-install.outputs.matrix) }}
     steps:
-      - name: Download Maven Repo
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: maven-repo
-          path: ..
-      - name: Extract Maven Repo
-        shell: bash
-        run: |
-          df -h /
-          tar -xzf ../maven-repo.tgz -C ~
-          rm -f ../maven-repo.tgz
-          df -h /
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: quarkus-main
           fetch-depth: 0
+      - name: Setup Maven Cache
+        uses: ./.github/actions/setup-maven-cache
+        with:
+          atlassian-version: ${{ needs.initial-mvn-install.outputs.atlassian-version }}
       - name: Reclaim Disk Space
         run: .github/reclaim-disk-space.sh
       - name: Rebase branch main onto quarkus-main
@@ -240,30 +232,15 @@ jobs:
     env:
       MAVEN_OPTS: -Xmx3000m
     steps:
-      - name: Download Maven Repo
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: maven-repo
-          path: ..
-      - name: Extract Maven Repo
-        shell: bash
-        run: |
-          df -h /
-          tar -xzf ../maven-repo.tgz -C ~
-          rm -f ../maven-repo.tgz
-          df -h /
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: quarkus-main
           fetch-depth: 0
-      - name: Restore Atlassian Maven Cache
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v4.4.0
+      - name: Setup Maven Cache
+        uses: ./.github/actions/setup-maven-cache
         with:
-          path: |
-            ~/.m2/repository/com/atlassian
-            ~/.m2/repository/io/atlassian
-          key: atlassian-maven-${{ needs.initial-mvn-install.outputs.atlassian-version }}
+          atlassian-version: ${{ needs.initial-mvn-install.outputs.atlassian-version }}
       - name: Rebase branch main onto quarkus-main
         run: |
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -345,30 +322,15 @@ jobs:
     env:
       MAVEN_OPTS: -Xmx3000m
     steps:
-      - name: Download Maven Repo
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: maven-repo
-          path: ..
-      - name: Extract Maven Repo
-        shell: bash
-        run: |
-          df -h /
-          tar -xzf ../maven-repo.tgz -C ~
-          rm -f ../maven-repo.tgz
-          df -h /
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: quarkus-main
           fetch-depth: 0
-      - name: Restore Atlassian Maven Cache
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v4.4.0
+      - name: Setup Maven Cache
+        uses: ./.github/actions/setup-maven-cache
         with:
-          path: |
-            ~/.m2/repository/com/atlassian
-            ~/.m2/repository/io/atlassian
-          key: atlassian-maven-${{ needs.initial-mvn-install.outputs.atlassian-version }}
+          atlassian-version: ${{ needs.initial-mvn-install.outputs.atlassian-version }}
       - name: Rebase branch main onto quarkus-main
         run: |
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -407,28 +369,15 @@ jobs:
     env:
       MAVEN_OPTS: -Xmx3000m
     steps:
-      - name: Download Maven Repo
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: maven-repo
-          path: ..
-      - name: Extract Maven Repo
-        shell: bash
-        run: |
-          tar -xzf ../maven-repo.tgz -C ~
-          rm -f ../maven-repo.tgz
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: quarkus-main
           fetch-depth: 0
-      - name: Restore Atlassian Maven Cache
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v4.4.0
+      - name: Setup Maven Cache
+        uses: ./.github/actions/setup-maven-cache
         with:
-          path: |
-            ~/.m2/repository/com/atlassian
-            ~/.m2/repository/io/atlassian
-          key: atlassian-maven-${{ needs.initial-mvn-install.outputs.atlassian-version }}
+          atlassian-version: ${{ needs.initial-mvn-install.outputs.atlassian-version }}
       - name: Rebase branch main onto quarkus-main
         run: |
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -467,35 +416,20 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.initial-mvn-install.outputs.examples-matrix) }}
     steps:
-      - name: Set up JDK 17
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-      - name: Download Maven Repo
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: maven-repo
-          path: ..
-      - name: Extract Maven Repo
-        shell: bash
-        run: |
-          df -h /
-          tar -xzf ../maven-repo.tgz -C ~
-          rm -f ../maven-repo.tgz
-          df -h /
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: quarkus-main
           fetch-depth: 0
-      - name: Restore Atlassian Maven Cache
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v4.4.0
+      - name: Setup Maven Cache
+        uses: ./.github/actions/setup-maven-cache
         with:
-          path: |
-            ~/.m2/repository/com/atlassian
-            ~/.m2/repository/io/atlassian
-          key: atlassian-maven-${{ needs.initial-mvn-install.outputs.atlassian-version }}
+          atlassian-version: ${{ needs.initial-mvn-install.outputs.atlassian-version }}
+      - name: Set up JDK 17
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: 'temurin'
+          java-version: '17'
       - name: Rebase branch main onto quarkus-main
         run: |
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -564,30 +498,15 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-      - name: Download Maven Repo
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: maven-repo
-          path: ..
-      - name: Extract Maven Repo
-        shell: bash
-        run: |
-          df -h /
-          tar -xzf ../maven-repo.tgz -C ~
-          rm -f ../maven-repo.tgz
-          df -h /
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: quarkus-main
           fetch-depth: 0
-      - name: Restore Atlassian Maven Cache
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v4.4.0
+      - name: Setup Maven Cache
+        uses: ./.github/actions/setup-maven-cache
         with:
-          path: |
-            ~/.m2/repository/com/atlassian
-            ~/.m2/repository/io/atlassian
-          key: atlassian-maven-${{ needs.initial-mvn-install.outputs.atlassian-version }}
+          atlassian-version: ${{ needs.initial-mvn-install.outputs.atlassian-version }}
       - name: Rebase branch main onto quarkus-main
         run: |
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
* Fix workflows where caching of Atlassian artifacts was missing
* Handle camel-main branch special case where the Atlassian artifact version needs to be gathered from the camel parent/pom.xml
* Remove old inline cache and maven repository restoration steps and use setup-maven-cache consistently across all workflows
* Fixes up version comments for `actions/cache`. Dependabot will increment them automatically on the next update.