### PR TITLE
ci: Use zstd compression when taring Maven repo

### DIFF
--- a/.github/actions/setup-maven-cache/action.yaml
+++ b/.github/actions/setup-maven-cache/action.yaml
@@ -41,6 +41,6 @@ runs:
       shell: bash
       run: |
         df -h /
-        tar -xzf ../maven-repo.tgz -C ~
-        rm -f ../maven-repo.tgz
+        tar -I 'zstd -d' -xf ../maven-repo.tar.zst -C ~
+        rm -f ../maven-repo.tar.zst
         df -h /

--- a/.github/workflows/alternate-jdk-build.yaml
+++ b/.github/workflows/alternate-jdk-build.yaml
@@ -111,14 +111,14 @@ jobs:
       - name: Tar Maven Repo
         shell: bash
         run: |
-          tar -czf ${{ runner.temp }}/maven-repo.tgz -C ~ .m2/repository
-          ls -lh ${{ runner.temp }}/maven-repo.tgz
+          tar -I 'zstd -T0' -cf ${{ runner.temp }}/maven-repo.tar.zst -C ~ .m2/repository
+          ls -lh ${{ runner.temp }}/maven-repo.tar.zst
           df -h /
       - name: Persist Maven Repo
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: maven-repo
-          path: ${{ runner.temp }}/maven-repo.tgz
+          path: ${{ runner.temp }}/maven-repo.tar.zst
           retention-days: 1
       - name: Save Atlassian Maven Cache
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/workflows/camel-master-cron.yaml
+++ b/.github/workflows/camel-master-cron.yaml
@@ -103,14 +103,14 @@ jobs:
       - name: Tar Maven Repo
         shell: bash
         run: |
-          tar -czf ${{ runner.temp }}/maven-repo.tgz -C ~ build-data .m2/repository
-          ls -lh ${{ runner.temp }}/maven-repo.tgz
+          tar -I 'zstd -T0' -cf ${{ runner.temp }}/maven-repo.tar.zst -C ~ build-data .m2/repository
+          ls -lh ${{ runner.temp }}/maven-repo.tar.zst
           df -h /
       - name: Persist Maven Repo
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: maven-repo
-          path: ${{ runner.temp }}/maven-repo.tgz
+          path: ${{ runner.temp }}/maven-repo.tar.zst
           retention-days: 1
       - name: Save Atlassian Maven Cache
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -254,14 +254,14 @@ jobs:
       - name: Tar Maven Repo
         shell: bash
         run: |
-          tar -czf ${{ runner.temp }}/maven-repo.tgz -C ~ .m2/repository
-          ls -lh ${{ runner.temp }}/maven-repo.tgz
+          tar -I 'zstd -T0' -cf ${{ runner.temp }}/maven-repo.tar.zst -C ~ .m2/repository
+          ls -lh ${{ runner.temp }}/maven-repo.tar.zst
           df -h /
       - name: Persist Maven Repo
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: maven-repo
-          path: ${{ runner.temp }}/maven-repo.tgz
+          path: ${{ runner.temp }}/maven-repo.tar.zst
           retention-days: 1
       - name: Save Atlassian Maven Cache
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/workflows/quarkus-lts-ci-build.yaml
+++ b/.github/workflows/quarkus-lts-ci-build.yaml
@@ -106,14 +106,14 @@ jobs:
       - name: Tar Maven Repo
         shell: bash
         run: |
-          tar -czf ${{ runner.temp }}/maven-repo.tgz -C ~ .m2/repository
-          ls -lh ${{ runner.temp }}/maven-repo.tgz
+          tar -I 'zstd -T0' -cf ${{ runner.temp }}/maven-repo.tar.zst -C ~ .m2/repository
+          ls -lh ${{ runner.temp }}/maven-repo.tar.zst
           df -h /
       - name: Persist Maven Repo
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: maven-repo
-          path: ${{ runner.temp }}/maven-repo.tgz
+          path: ${{ runner.temp }}/maven-repo.tar.zst
           retention-days: 1
       - name: Save Atlassian Maven Cache
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/workflows/quarkus-master-cron.yaml
+++ b/.github/workflows/quarkus-master-cron.yaml
@@ -100,14 +100,14 @@ jobs:
       - name: Tar Maven Repo
         shell: bash
         run: |
-          tar -czf ${{ runner.temp }}/maven-repo.tgz -C ~ build-data .m2/repository
-          ls -lh ${{ runner.temp }}/maven-repo.tgz
+          tar -I 'zstd -T0' -cf ${{ runner.temp }}/maven-repo.tar.zst -C ~ build-data .m2/repository
+          ls -lh ${{ runner.temp }}/maven-repo.tar.zst
           df -h /
       - name: Persist Maven Repo
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: maven-repo
-          path: ${{ runner.temp }}/maven-repo.tgz
+          path: ${{ runner.temp }}/maven-repo.tar.zst
           retention-days: 1
       - name: Save Atlassian Maven Cache
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5


### PR DESCRIPTION
I noticed that the GitHub cache action uses zstd when it tars up the cache content. So I figured we could do something similar for the m2 build artifact.

Speeds up .m2 archive compression / decompression and reduces its size.