### PR TITLE
Add opt-in capability to skip cxf-soap-grouped AWT tests on macOS

### DIFF
--- a/integration-tests/cxf-soap-grouped/pom.xml
+++ b/integration-tests/cxf-soap-grouped/pom.xml
@@ -30,6 +30,12 @@
     <name>Camel Quarkus :: Integration Tests :: Cxf Soap Grouped</name>
     <description>Cxf Soap tests from ../integration-test-groups/cxf-soap merged together</description>
 
+    <properties>
+        <!-- Placeholder properties used and overriden by the native & disable-awt-tests profiles  -->
+        <cxf-soap-grouped.files.excludes />
+        <cxf-soap-grouped.files.excludes.if-native />
+    </properties>
+
     <!-- Regenerate the dependencies via `mvn process-resources -Pformat -N` from the source tree root directory -->
     <dependencies>
         <dependency>
@@ -151,6 +157,7 @@
                                 <group-tests.source.dir>${maven.multiModuleProjectDirectory}/integration-test-groups/cxf-soap</group-tests.source.dir>
                                 <group-tests.dest.module.dir>${project.basedir}</group-tests.dest.module.dir>
                                 <group-tests.concat.rel.paths>src/main/resources/application.properties</group-tests.concat.rel.paths>
+                                <group-tests.files.excludes>${cxf-soap-grouped.files.excludes}</group-tests.files.excludes>
                             </properties>
                         </configuration>
                     </execution>
@@ -184,6 +191,7 @@
             </activation>
             <properties>
                 <quarkus.native.enabled>true</quarkus.native.enabled>
+                <cxf-soap-grouped.files.excludes>${cxf-soap-grouped.files.excludes.if-native}</cxf-soap-grouped.files.excludes>
             </properties>
             <build>
                 <plugins>
@@ -616,6 +624,31 @@
             <properties>
                 <skipTests>true</skipTests>
             </properties>
+        </profile>
+        <!-- Opt-in profile to disable CXF AWT testing. Primarilly for macOS where AWT is not available in GraalVM -->
+        <profile>
+            <id>disable-awt-tests</id>
+            <activation>
+                <property>
+                    <name>disable-awt-tests</name>
+                </property>
+                <os>
+                    <family>mac</family>
+                </os>
+            </activation>
+            <properties>
+                <cxf-soap-grouped.files.excludes.if-native>cxf-soap-mtom-awt</cxf-soap-grouped.files.excludes.if-native>
+            </properties>
+            <dependencyManagement>
+                <dependencies>
+                    <dependency>
+                        <groupId>io.quarkus</groupId>
+                        <artifactId>quarkus-awt</artifactId>
+                        <version>${quarkus.version}</version>
+                        <scope>provided</scope>
+                    </dependency>
+                </dependencies>
+            </dependencyManagement>
         </profile>
     </profiles>
 


### PR DESCRIPTION
Primarily for me so that I can test QCXF version bumps or changes to the `cxf-soap` extension in native mode, without having to switch to Linux.