### PR TITLE
Restore ci-build.yaml push event branch restrictions and repository namespace check

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -20,7 +20,10 @@ name: Camel Quarkus CI
 on:
   push:
     branches:
-      - '**'
+      - main
+      - camel-main
+      - quarkus-main
+      - "[0-9]+.[0-9]+.x"
     paths-ignore:
       - '**.adoc'
       - '**.md'
@@ -106,6 +109,7 @@ env:
 
 jobs:
   pre-build-checks:
+    if: github.repository == 'apache/camel-quarkus'
     runs-on: ubuntu-latest
     outputs:
       continue-build: ${{ steps.pre-build-checks.outputs.continue-build }}


### PR DESCRIPTION
My bad - accidentally removed in #8765. Leftover from testing that should not have been part of the PR. 