### PR TITLE
[3.33.x] Cherry-pick 661abc4

### DIFF
--- a/integration-tests/microprofile-health/src/test/java/org/apache/camel/quarkus/component/microprofile/it/health/MicroProfileHealthSupervisedRouteTest.java
+++ b/integration-tests/microprofile-health/src/test/java/org/apache/camel/quarkus/component/microprofile/it/health/MicroProfileHealthSupervisedRouteTest.java
@@ -35,7 +35,7 @@ class MicroProfileHealthSupervisedRouteTest {
     @Test
     void supervisedRouteTest() throws InterruptedException {
         // Verify the initial health state
-        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+        await().atMost(15, TimeUnit.SECONDS).untilAsserted(() -> {
             RestAssured.when().get("/q/health").then()
                     .contentType(ContentType.JSON)
                     .header("Content-Type", containsString("charset=UTF-8"))
@@ -46,7 +46,7 @@ class MicroProfileHealthSupervisedRouteTest {
         });
 
         // camel.routecontroller.unhealthy-on-exhausted is false so the heath status should be UP
-        await().pollDelay(1, TimeUnit.SECONDS).atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+        await().pollDelay(1, TimeUnit.SECONDS).atMost(15, TimeUnit.SECONDS).untilAsserted(() -> {
             RestAssured.when().get("/q/health").then()
                     .contentType(ContentType.JSON)
                     .header("Content-Type", containsString("charset=UTF-8"))

--- a/integration-tests/microprofile-health/src/test/java/org/apache/camel/quarkus/component/microprofile/it/health/SupervisedRouteTestProfile.java
+++ b/integration-tests/microprofile-health/src/test/java/org/apache/camel/quarkus/component/microprofile/it/health/SupervisedRouteTestProfile.java
@@ -26,7 +26,7 @@ public class SupervisedRouteTestProfile implements QuarkusTestProfile {
         return Map.of(
                 "camel.routecontroller.enabled", "true",
                 "camel.routecontroller.initial-delay", "0",
-                "camel.routecontroller.backoff-delay", "250",
+                "camel.routecontroller.backoff-delay", "1000",
                 "camel.routecontroller.backoff-max-attempts", "10",
                 "camel.routecontroller.unhealthy-on-restarting", "true",
                 "camel.routecontroller.unhealthy-on-exhausted", "false");


### PR DESCRIPTION
Fixes #8590. Fix intermittent MicroProfileHealthSupervisedRouteTest failure on Windows

The test was failing intermittently on Windows due to slow application startup causing a timing issue. The test expects to catch the health status in a "DOWN" state while routes are restarting, but on Windows the application can take 10+ seconds to start. By the time the test begins checking, the route has already exhausted all retry attempts (2.5 seconds with 10 × 250ms delay) and transitioned to "UP".

Changes:
- Increased backoff-delay from 250ms to 1000ms (total retry period now 10 seconds instead of 2.5 seconds)
- Increased await timeouts from 5 seconds to 15 seconds to provide more time to catch both DOWN and UP states on slower systems
