### PR TITLE
Use getRuntimeDependencies instead of getDependencies to avoid matching deployment-only transitives

### DIFF
--- a/extensions-support/langchain4j/deployment/src/main/java/org/apache/camel/quarkus/component/support/langchain4j/deployment/SupportLangchain4jProcessor.java
+++ b/extensions-support/langchain4j/deployment/src/main/java/org/apache/camel/quarkus/component/support/langchain4j/deployment/SupportLangchain4jProcessor.java
@@ -79,7 +79,7 @@ class SupportLangchain4jProcessor {
     @BuildStep
     void indexDependencies(CurateOutcomeBuildItem curateOutcome, BuildProducer<IndexDependencyBuildItem> indexedDependencies) {
         ApplicationModel applicationModel = curateOutcome.getApplicationModel();
-        for (ResolvedDependency dependency : applicationModel.getDependencies()) {
+        for (ResolvedDependency dependency : applicationModel.getRuntimeDependencies()) {
             if (dependency.getGroupId().equals("dev.langchain4j")) {
                 indexedDependencies.produce(new IndexDependencyBuildItem(dependency.getGroupId(), dependency.getArtifactId()));
             }
@@ -248,7 +248,7 @@ class SupportLangchain4jProcessor {
             BuildProducer<IndexDependencyBuildItem> indexDependency) {
 
         ApplicationModel applicationModel = curateOutcome.getApplicationModel();
-        for (ResolvedDependency dependency : applicationModel.getDependencies()) {
+        for (ResolvedDependency dependency : applicationModel.getRuntimeDependencies()) {
             String groupId = dependency.getGroupId();
             String artifactId = dependency.getArtifactId();
 
@@ -300,7 +300,7 @@ class SupportLangchain4jProcessor {
 
         nativeImageResource.produce(new NativeImageResourceBuildItem("native/lib/tokenizers.properties"));
 
-        for (ResolvedDependency dependency : curateOutcome.getApplicationModel().getDependencies()) {
+        for (ResolvedDependency dependency : curateOutcome.getApplicationModel().getRuntimeDependencies()) {
             String artifactId = dependency.getArtifactId();
 
             // Native image resources for embeddings tokenizer metadata

--- a/extensions-support/spring/deployment/src/main/java/org/apache/camel/quarkus/support/spring/deployment/SpringKotlinProcessor.java
+++ b/extensions-support/spring/deployment/src/main/java/org/apache/camel/quarkus/support/spring/deployment/SpringKotlinProcessor.java
@@ -56,7 +56,7 @@ public class SpringKotlinProcessor {
 
     private boolean isKotlinStdlibAvailable(ApplicationModel applicationModel) {
         return applicationModel
-                .getDependencies()
+                .getRuntimeDependencies()
                 .stream()
                 .anyMatch(dependency -> dependency.getArtifactId().startsWith("kotlin-stdlib"));
     }

--- a/extensions/csimple/deployment/src/main/java/org/apache/camel/quarkus/component/csimple/deployment/CSimpleProcessor.java
+++ b/extensions/csimple/deployment/src/main/java/org/apache/camel/quarkus/component/csimple/deployment/CSimpleProcessor.java
@@ -207,7 +207,7 @@ class CSimpleProcessor {
 
             final RuntimeValue<?> csimpleLanguage = recorder.buildCSimpleLanguage(builder);
             return new CamelBeanBuildItem("csimple", CSimpleLanguage.class.getName(), csimpleLanguage);
-        } else if (curateOutcomeBuildItem.getApplicationModel().getDependencies().stream().noneMatch(
+        } else if (curateOutcomeBuildItem.getApplicationModel().getRuntimeDependencies().stream().noneMatch(
                 x -> x.getGroupId().equals("org.apache.camel") && x.getArtifactId().equals("camel-csimple-joor"))) {
             LOG.warn(
                     "The expression extraction process has been disabled or failed, please add camel-csimple-joor to your classpath to compile the expressions at runtime");

--- a/extensions/groovy/deployment/src/main/java/org/apache/camel/quarkus/component/groovy/deployment/GroovyProcessor.java
+++ b/extensions/groovy/deployment/src/main/java/org/apache/camel/quarkus/component/groovy/deployment/GroovyProcessor.java
@@ -128,7 +128,7 @@ class GroovyProcessor {
         // Disable InvokeDynamic because it triggers code paths to GraalVM deleted MethodHandleNatives.setCallSiteTargetNormal
         configuration.getOptimizationOptions().put(CompilerConfiguration.INVOKEDYNAMIC, Boolean.FALSE);
         configuration.setClasspathList(
-                curateOutcomeBuildItem.getApplicationModel().getDependencies().stream()
+                curateOutcomeBuildItem.getApplicationModel().getRuntimeDependencies().stream()
                         .map(ResolvedDependency::getResolvedPaths)
                         .flatMap(PathCollection::stream)
                         .map(Objects::toString)

--- a/extensions/hl7/deployment/src/main/java/org/apache/camel/quarkus/component/hl7/deployment/Hl7Processor.java
+++ b/extensions/hl7/deployment/src/main/java/org/apache/camel/quarkus/component/hl7/deployment/Hl7Processor.java
@@ -46,7 +46,7 @@ class Hl7Processor {
     void indexDependencies(BuildProducer<IndexDependencyBuildItem> indexedDependency, CurateOutcomeBuildItem curateOutcome) {
         // Index any optional hapi-structures dependencies present on the classpath
         curateOutcome.getApplicationModel()
-                .getDependencies()
+                .getRuntimeDependencies()
                 .stream()
                 .filter(appArtifact -> appArtifact.getGroupId().equals(CA_UHN_HAPI_GROUP_ID)
                         && appArtifact.getArtifactId().startsWith("hapi-structures-"))

--- a/extensions/java-joor-dsl/deployment/src/main/java/org/apache/camel/quarkus/dsl/java/joor/deployment/JavaJoorDslProcessor.java
+++ b/extensions/java-joor-dsl/deployment/src/main/java/org/apache/camel/quarkus/dsl/java/joor/deployment/JavaJoorDslProcessor.java
@@ -93,7 +93,7 @@ public class JavaJoorDslProcessor {
                 unit,
                 List.of(
                         "-classpath",
-                        curateOutcomeBuildItem.getApplicationModel().getDependencies().stream()
+                        curateOutcomeBuildItem.getApplicationModel().getRuntimeDependencies().stream()
                                 .map(ResolvedDependency::getResolvedPaths)
                                 .flatMap(PathCollection::stream)
                                 .map(Objects::toString)

--- a/extensions/joor/deployment/src/main/java/org/apache/camel/quarkus/component/joor/deployment/JoorProcessor.java
+++ b/extensions/joor/deployment/src/main/java/org/apache/camel/quarkus/component/joor/deployment/JoorProcessor.java
@@ -132,7 +132,7 @@ class JoorProcessor {
             unit.addClass(source.getClassName(), source.getSourceCode());
         }
         ApplicationModel model = curateOutcomeBuildItem.getApplicationModel();
-        List<ResolvedDependency> dependencies = new ArrayList<>(model.getDependencies());
+        List<ResolvedDependency> dependencies = new ArrayList<>(model.getRuntimeDependencies());
         dependencies.add(model.getAppArtifact());
         LOG.debug("Compiling unit: {}", unit);
         CompilationUnit.Result compilationResult = MultiCompile.compileUnit(

--- a/extensions/quartz/deployment/src/main/java/org/apache/camel/quarkus/component/quartz/deployment/QuartzProcessor.java
+++ b/extensions/quartz/deployment/src/main/java/org/apache/camel/quarkus/component/quartz/deployment/QuartzProcessor.java
@@ -79,7 +79,7 @@ class QuartzProcessor {
         IndexView index = combinedIndex.getIndex();
 
         ApplicationModel applicationModel = curateOutcome.getApplicationModel();
-        boolean oracleBlobIsPresent = applicationModel.getDependencies().stream()
+        boolean oracleBlobIsPresent = applicationModel.getRuntimeDependencies().stream()
                 .anyMatch(d -> d.getGroupId().equals("com.oracle.database.jdbc"));
 
         final String[] delegatesImpl = index

--- a/extensions/xchange/deployment/src/main/java/org/apache/camel/quarkus/component/xchange/deployment/XchangeProcessor.java
+++ b/extensions/xchange/deployment/src/main/java/org/apache/camel/quarkus/component/xchange/deployment/XchangeProcessor.java
@@ -63,7 +63,7 @@ class XchangeProcessor {
             CurateOutcomeBuildItem curateOutcome) {
 
         ApplicationModel applicationModel = curateOutcome.getApplicationModel();
-        for (ResolvedDependency dependency : applicationModel.getDependencies()) {
+        for (ResolvedDependency dependency : applicationModel.getRuntimeDependencies()) {
             if (dependency.getGroupId().equals("org.knowm.xchange")) {
                 // Index any org.knowm.xchange dependencies present on the classpath as they contain the APIs for interacting with each crypto exchange
                 String artifactId = dependency.getArtifactId();

--- a/integration-tests/amqp/pom.xml
+++ b/integration-tests/amqp/pom.xml
@@ -48,6 +48,12 @@
             <artifactId>quarkus-pooled-jms</artifactId>
         </dependency>
 
+        <!-- Only present to verify https://github.com/apache/camel-quarkus/issues/8783 -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-openapi</artifactId>
+        </dependency>
+
         <!-- test dependencies -->
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
## Summary
- Fixes #8783
- Replaced `ApplicationModel.getDependencies()` with `getRuntimeDependencies()` across 9 deployment processors to avoid incorrectly matching artifacts that are only present as deployment-only transitives (e.g. `kotlin-stdlib` pulled in by `quarkus-smallrye-openapi-deployment` via `kotlinx-metadata-jvm`)
- Added `quarkus-smallrye-openapi` dependency to `integration-tests/amqp` to verify the fix for `SpringKotlinProcessor`

## Test plan
- [ ] CI passes with the `quarkus-smallrye-openapi` dependency added to `integration-tests/amqp`
- [ ] Native build of an extension using Spring support with `quarkus-smallrye-openapi` no longer fails with `NoClassDefFoundError` for `kotlin/reflect/KCallable`

🤖 Generated with [Claude Code](https://claude.com/claude-code)