### PR TITLE
[3.33.x] ci: Use zstd compression when taring Maven repo

### DIFF
--- a/.github/actions/setup-maven-cache/action.yaml
+++ b/.github/actions/setup-maven-cache/action.yaml
@@ -93,8 +93,8 @@ runs:
       shell: bash
       run: |
         df -h /
-        tar -xzf ../maven-repo.tgz -C ~
-        rm -f ../maven-repo.tgz
+        tar -I 'zstd -d' -xf ../maven-repo.tar.zst -C ~
+        rm -f ../maven-repo.tar.zst
         df -h /
     - name: Save Maven Cache
       if: ${{ inputs.action == 'save' }}

--- a/.github/workflows/camel-master-cron.yaml
+++ b/.github/workflows/camel-master-cron.yaml
@@ -90,14 +90,14 @@ jobs:
       - name: Tar Maven Repo
         shell: bash
         run: |
-          tar -czf ${{ runner.temp }}/maven-repo.tgz -C ~ build-data .m2/repository
-          ls -lh ${{ runner.temp }}/maven-repo.tgz
+          tar -I 'zstd -T0' -cf ${{ runner.temp }}/maven-repo.tar.zst -C ~ build-data .m2/repository
+          ls -lh ${{ runner.temp }}/maven-repo.tar.zst
           df -h /
       - name: Persist Maven Repo
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: maven-repo
-          path: ${{ runner.temp }}/maven-repo.tgz
+          path: ${{ runner.temp }}/maven-repo.tar.zst
           retention-days: 1
       - name: Save Maven Cache
         uses: ./.github/actions/setup-maven-cache

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -216,14 +216,14 @@ jobs:
       - name: Tar Maven Repo
         shell: bash
         run: |
-          tar -czf ${{ runner.temp }}/maven-repo.tgz -C ~ .m2/repository
-          ls -lh ${{ runner.temp }}/maven-repo.tgz
+          tar -I 'zstd -T0' -cf ${{ runner.temp }}/maven-repo.tar.zst -C ~ .m2/repository
+          ls -lh ${{ runner.temp }}/maven-repo.tar.zst
           df -h /
       - name: Persist Maven Repo
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: maven-repo
-          path: ${{ runner.temp }}/maven-repo.tgz
+          path: ${{ runner.temp }}/maven-repo.tar.zst
           retention-days: 1
       - name: Save Maven Cache
         uses: ./.github/actions/setup-maven-cache

--- a/.github/workflows/ci-semeru-jdk.yaml
+++ b/.github/workflows/ci-semeru-jdk.yaml
@@ -77,14 +77,14 @@ jobs:
       - name: Tar Maven Repo
         shell: bash
         run: |
-          tar -czf ${{ runner.temp }}/maven-repo.tgz -C ~ .m2/repository
-          ls -lh ${{ runner.temp }}/maven-repo.tgz
+          tar -I 'zstd -T0' -cf ${{ runner.temp }}/maven-repo.tar.zst -C ~ .m2/repository
+          ls -lh ${{ runner.temp }}/maven-repo.tar.zst
           df -h /
       - name: Persist Maven Repo
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: maven-repo
-          path: ${{ runner.temp }}/maven-repo.tgz
+          path: ${{ runner.temp }}/maven-repo.tar.zst
           retention-days: 1
       - name: Save Maven Cache
         uses: ./.github/actions/setup-maven-cache

--- a/.github/workflows/quarkus-lts-ci-build.yaml
+++ b/.github/workflows/quarkus-lts-ci-build.yaml
@@ -93,14 +93,14 @@ jobs:
       - name: Tar Maven Repo
         shell: bash
         run: |
-          tar -czf ${{ runner.temp }}/maven-repo.tgz -C ~ .m2/repository
-          ls -lh ${{ runner.temp }}/maven-repo.tgz
+          tar -I 'zstd -T0' -cf ${{ runner.temp }}/maven-repo.tar.zst -C ~ .m2/repository
+          ls -lh ${{ runner.temp }}/maven-repo.tar.zst
           df -h /
       - name: Persist Maven Repo
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: maven-repo
-          path: ${{ runner.temp }}/maven-repo.tgz
+          path: ${{ runner.temp }}/maven-repo.tar.zst
           retention-days: 1
       - name: Save Maven Cache
         uses: ./.github/actions/setup-maven-cache

--- a/.github/workflows/quarkus-master-cron.yaml
+++ b/.github/workflows/quarkus-master-cron.yaml
@@ -91,14 +91,14 @@ jobs:
       - name: Tar Maven Repo
         shell: bash
         run: |
-          tar -czf ${{ runner.temp }}/maven-repo.tgz -C ~ build-data .m2/repository
-          ls -lh ${{ runner.temp }}/maven-repo.tgz
+          tar -I 'zstd -T0' -cf ${{ runner.temp }}/maven-repo.tar.zst -C ~ build-data .m2/repository
+          ls -lh ${{ runner.temp }}/maven-repo.tar.zst
           df -h /
       - name: Persist Maven Repo
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: maven-repo
-          path: ${{ runner.temp }}/maven-repo.tgz
+          path: ${{ runner.temp }}/maven-repo.tar.zst
           retention-days: 1
       - name: Save Maven Cache
         uses: ./.github/actions/setup-maven-cache


### PR DESCRIPTION
Backport I missed from #8791.