### PR TITLE
Clone Quarkus from the 3.x branch

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -223,7 +223,7 @@ jobs:
       - name: Build Quarkus
         if: github.ref == 'refs/heads/quarkus-main' || github.base_ref == 'quarkus-main'
         run: |
-          git clone --depth 1 --branch main https://github.com/quarkusio/quarkus.git \
+          git clone --depth 1 --branch 3.x https://github.com/quarkusio/quarkus.git \
             && cd quarkus \
             && echo "Current Quarkus commit:" $(git rev-parse HEAD) \
             && sed -i '/<module>integration-tests<\/module>/d' pom.xml \

--- a/.github/workflows/quarkus-master-cron.yaml
+++ b/.github/workflows/quarkus-master-cron.yaml
@@ -74,7 +74,7 @@ jobs:
       - name: Build Quarkus
         run: |
           cd ../
-          git clone --depth 1 --branch main https://github.com/quarkusio/quarkus.git \
+          git clone --depth 1 --branch 3.x https://github.com/quarkusio/quarkus.git \
             && cd quarkus \
             && echo "Current Quarkus commit:" $(git rev-parse HEAD) \
             && sed -i '/<module>integration-tests<\/module>/d' pom.xml \


### PR DESCRIPTION
The Quarkus `main` branch is for Quarkus 4 development. We need to clone 3.x until the project is ready to switch.