### PR TITLE
Remove unnecessary extension description overrides

### DIFF
--- a/docs/modules/ROOT/pages/contributor-guide/extension-documentation.adoc
+++ b/docs/modules/ROOT/pages/contributor-guide/extension-documentation.adoc
@@ -30,6 +30,20 @@ The `update-extension-doc-page` mojo merges the https://raw.githubusercontent.co
 * `configuration`: Camel Quarkus specific configuration options (optional); the content of `src/main/doc/configuration.adoc` in the runtime module of the given extension.
 * `limitations`: Camel Quarkus specific limitations (optional); the content of `src/main/doc/limitations.adoc` in the runtime module of the given extension.
 
+== Extension description sync
+
+The `cq:update-quarkus-metadata` goal automatically syncs each extension's runtime `pom.xml` `<description>` with the Camel catalog.
+Extensions that need a custom description (e.g. multi-model extensions or extensions where the catalog description is not suitable) can opt out by setting:
+
+[source,xml]
+----
+<properties>
+    <cq.descriptionSync>false</cq.descriptionSync>
+</properties>
+----
+
+The property defaults to `true`.
+
 == Overriding generated component links
 
 Sometimes the generated component link xref within each extension doc page needs to be overridden.

--- a/extensions-jvm/ignite/runtime/pom.xml
+++ b/extensions-jvm/ignite/runtime/pom.xml
@@ -32,6 +32,7 @@
 
     <properties>
         <camel.quarkus.jvmSince>1.1.0</camel.quarkus.jvmSince>
+        <cq.descriptionSync>false</cq.descriptionSync>
     </properties>
 
     <dependencies>

--- a/extensions-jvm/mvel/runtime/pom.xml
+++ b/extensions-jvm/mvel/runtime/pom.xml
@@ -32,6 +32,7 @@
 
     <properties>
         <camel.quarkus.jvmSince>1.1.0</camel.quarkus.jvmSince>
+        <cq.descriptionSync>false</cq.descriptionSync>
     </properties>
 
     <dependencies>

--- a/extensions-jvm/smooks/runtime/pom.xml
+++ b/extensions-jvm/smooks/runtime/pom.xml
@@ -32,6 +32,7 @@
 
     <properties>
         <camel.quarkus.jvmSince>3.18.0</camel.quarkus.jvmSince>
+        <cq.descriptionSync>false</cq.descriptionSync>
     </properties>
 
     <dependencies>

--- a/extensions-jvm/thrift/runtime/pom.xml
+++ b/extensions-jvm/thrift/runtime/pom.xml
@@ -32,6 +32,7 @@
 
     <properties>
         <camel.quarkus.jvmSince>1.1.0</camel.quarkus.jvmSince>
+        <cq.descriptionSync>false</cq.descriptionSync>
     </properties>
 
     <dependencies>

--- a/extensions/aws-bedrock/runtime/pom.xml
+++ b/extensions/aws-bedrock/runtime/pom.xml
@@ -33,6 +33,7 @@
     <properties>
         <camel.quarkus.jvmSince>3.10.0</camel.quarkus.jvmSince>
         <camel.quarkus.nativeSince>3.10.0</camel.quarkus.nativeSince>
+        <cq.descriptionSync>false</cq.descriptionSync>
     </properties>
 
     <dependencies>

--- a/extensions/bean/runtime/pom.xml
+++ b/extensions/bean/runtime/pom.xml
@@ -33,6 +33,7 @@
     <properties>
         <camel.quarkus.jvmSince>0.1.0</camel.quarkus.jvmSince>
         <camel.quarkus.nativeSince>0.1.0</camel.quarkus.nativeSince>
+        <cq.descriptionSync>false</cq.descriptionSync>
     </properties>
 
     <dependencies>

--- a/extensions/crypto/runtime/pom.xml
+++ b/extensions/crypto/runtime/pom.xml
@@ -33,6 +33,7 @@
     <properties>
         <camel.quarkus.jvmSince>1.1.0</camel.quarkus.jvmSince>
         <camel.quarkus.nativeSince>1.2.0</camel.quarkus.nativeSince>
+        <cq.descriptionSync>false</cq.descriptionSync>
     </properties>
 
     <dependencies>

--- a/extensions/flatpack/runtime/pom.xml
+++ b/extensions/flatpack/runtime/pom.xml
@@ -33,6 +33,7 @@
     <properties>
         <camel.quarkus.jvmSince>1.1.0</camel.quarkus.jvmSince>
         <camel.quarkus.nativeSince>1.1.0</camel.quarkus.nativeSince>
+        <cq.descriptionSync>false</cq.descriptionSync>
     </properties>
 
     <dependencies>

--- a/extensions/ftp/runtime/pom.xml
+++ b/extensions/ftp/runtime/pom.xml
@@ -33,6 +33,7 @@
     <properties>
         <camel.quarkus.jvmSince>1.0.0</camel.quarkus.jvmSince>
         <camel.quarkus.nativeSince>1.0.0</camel.quarkus.nativeSince>
+        <cq.descriptionSync>false</cq.descriptionSync>
     </properties>
 
     <dependencies>

--- a/extensions/hazelcast/runtime/pom.xml
+++ b/extensions/hazelcast/runtime/pom.xml
@@ -33,6 +33,7 @@
     <properties>
         <camel.quarkus.jvmSince>1.1.0</camel.quarkus.jvmSince>
         <camel.quarkus.nativeSince>1.6.0</camel.quarkus.nativeSince>
+        <cq.descriptionSync>false</cq.descriptionSync>
     </properties>
 
     <dependencies>

--- a/extensions/kubernetes/runtime/pom.xml
+++ b/extensions/kubernetes/runtime/pom.xml
@@ -33,6 +33,7 @@
     <properties>
         <camel.quarkus.jvmSince>1.0.0</camel.quarkus.jvmSince>
         <camel.quarkus.nativeSince>1.0.0</camel.quarkus.nativeSince>
+        <cq.descriptionSync>false</cq.descriptionSync>
     </properties>
 
     <dependencies>

--- a/extensions/milo/runtime/pom.xml
+++ b/extensions/milo/runtime/pom.xml
@@ -33,6 +33,7 @@
     <properties>
         <camel.quarkus.jvmSince>3.31.0</camel.quarkus.jvmSince>
         <camel.quarkus.nativeSince>3.31.0</camel.quarkus.nativeSince>
+        <cq.descriptionSync>false</cq.descriptionSync>
     </properties>
 
     <dependencies>

--- a/extensions/openstack/runtime/pom.xml
+++ b/extensions/openstack/runtime/pom.xml
@@ -33,6 +33,7 @@
     <properties>
         <camel.quarkus.jvmSince>1.0.0</camel.quarkus.jvmSince>
         <camel.quarkus.nativeSince>2.0.0</camel.quarkus.nativeSince>
+        <cq.descriptionSync>false</cq.descriptionSync>
     </properties>
 
     <dependencies>

--- a/extensions/pqc/runtime/pom.xml
+++ b/extensions/pqc/runtime/pom.xml
@@ -33,6 +33,7 @@
     <properties>
         <camel.quarkus.jvmSince>3.24.0</camel.quarkus.jvmSince>
         <camel.quarkus.nativeSince>3.35.0</camel.quarkus.nativeSince>
+        <cq.descriptionSync>false</cq.descriptionSync>
     </properties>
 
     <dependencies>

--- a/extensions/rss/runtime/pom.xml
+++ b/extensions/rss/runtime/pom.xml
@@ -33,6 +33,7 @@
     <properties>
         <camel.quarkus.jvmSince>1.1.0</camel.quarkus.jvmSince>
         <camel.quarkus.nativeSince>1.2.0</camel.quarkus.nativeSince>
+        <cq.descriptionSync>false</cq.descriptionSync>
     </properties>
 
     <dependencies>

--- a/extensions/stax/runtime/pom.xml
+++ b/extensions/stax/runtime/pom.xml
@@ -33,6 +33,7 @@
     <properties>
         <camel.quarkus.jvmSince>1.1.0</camel.quarkus.jvmSince>
         <camel.quarkus.nativeSince>1.7.0</camel.quarkus.nativeSince>
+        <cq.descriptionSync>false</cq.descriptionSync>
     </properties>
 
     <dependencies>

--- a/extensions/twitter/runtime/pom.xml
+++ b/extensions/twitter/runtime/pom.xml
@@ -33,6 +33,7 @@
     <properties>
         <camel.quarkus.jvmSince>0.2.0</camel.quarkus.jvmSince>
         <camel.quarkus.nativeSince>0.1.0</camel.quarkus.nativeSince>
+        <cq.descriptionSync>false</cq.descriptionSync>
     </properties>
 
     <dependencies>

--- a/extensions/wasm/runtime/pom.xml
+++ b/extensions/wasm/runtime/pom.xml
@@ -34,6 +34,7 @@
         <camel.quarkus.jvmSince>3.10.0</camel.quarkus.jvmSince>
         <camel.quarkus.nativeSince>3.10.0</camel.quarkus.nativeSince>
         <quarkus.metadata.status>experimental</quarkus.metadata.status>
+        <cq.descriptionSync>false</cq.descriptionSync>
     </properties>
 
     <dependencies>

--- a/extensions/xmlsecurity/runtime/pom.xml
+++ b/extensions/xmlsecurity/runtime/pom.xml
@@ -33,6 +33,7 @@
     <properties>
         <camel.quarkus.jvmSince>1.1.0</camel.quarkus.jvmSince>
         <camel.quarkus.nativeSince>1.7.0</camel.quarkus.nativeSince>
+        <cq.descriptionSync>false</cq.descriptionSync>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Fixes https://github.com/apache/camel-quarkus/issues/7343

 - Remove redundant `<description>` overrides from 129 extension `pom.xml` files so descriptions are inherited directly from the Camel catalog
  - Add "using AWS SDK version 2.x" suffix to 17 AWS extension descriptions (12 new + 5 updated to match catalog wording)
  - For 9 multi-component extensions (crypto, flatpack, mvel, rss, smooks, stax, thrift, wasm, pqc), set the description to the catalog component entry only, preventing redundant  concatenation of component + dataformat/language descriptions
  - Fix several stale or custom descriptions to match the current Camel 4.20.0 catalog (e.g. azure-storage-datalake, once, openai, vertx-http, vertx-websocket)


<!-- Uncomment and fill this section if your PR is not trivial
[ ] An issue should be filed for the change unless this is a trivial change (fixing a typo or similar). One issue should ideally be fixed by not more than one commit and the other way round, each commit should fix just one issue, without pulling in other changes.
[ ] Each commit in the pull request should have a meaningful and properly spelled subject line and body. Copying the title of the associated issue is typically enough. Please include the issue number in the commit message prefixed by #.
[ ] The pull request description should explain what the pull request does, how, and why. If the info is available in the associated issue or some other external document, a link is enough.
[ ] Phrases like Fix #<issueNumber> or Fixes #<issueNumber> will auto-close the named issue upon merging the pull request. Using them is typically a good idea.
[ ] Please run mvn process-resources -Pformat (and amend the changes if necessary) before sending the pull request.
[ ] Contributor guide is your good friend: https://camel.apache.org/camel-quarkus/latest/contributor-guide.html
-->