### PR TITLE
Register debezium signal action providers

### DIFF
--- a/extensions-support/debezium/deployment/src/main/java/org/apache/camel/quarkus/support/debezium/deployment/DebeziumSupportProcessor.java
+++ b/extensions-support/debezium/deployment/src/main/java/org/apache/camel/quarkus/support/debezium/deployment/DebeziumSupportProcessor.java
@@ -24,6 +24,7 @@ import io.debezium.engine.DebeziumEngine;
 import io.debezium.pipeline.notification.channels.LogNotificationChannel;
 import io.debezium.pipeline.notification.channels.SinkNotificationChannel;
 import io.debezium.pipeline.notification.channels.jmx.JmxNotificationChannel;
+import io.debezium.pipeline.signal.actions.SignalActionProvider;
 import io.debezium.pipeline.signal.actions.StandardActionProvider;
 import io.debezium.pipeline.signal.channels.FileSignalChannel;
 import io.debezium.pipeline.signal.channels.KafkaSignalChannel;
@@ -141,6 +142,11 @@ public class DebeziumSupportProcessor {
     @BuildStep
     ServiceProviderBuildItem registerConverterServiceProviders() {
         return ServiceProviderBuildItem.allProvidersFromClassPath("org.apache.kafka.connect.storage.Converter");
+    }
+
+    @BuildStep
+    ServiceProviderBuildItem registerSignalActionProviders() {
+        return ServiceProviderBuildItem.allProvidersFromClassPath(SignalActionProvider.class.getName());
     }
 
     @BuildStep

--- a/integration-tests/debezium-grouped/pom.xml
+++ b/integration-tests/debezium-grouped/pom.xml
@@ -164,6 +164,7 @@
                                 <group-tests.source.dir>${maven.multiModuleProjectDirectory}/integration-test-groups/debezium</group-tests.source.dir>
                                 <group-tests.dest.module.dir>${project.basedir}</group-tests.dest.module.dir>
                                 <group-tests.concat.rel.paths>src/main/resources/application.properties</group-tests.concat.rel.paths>
+                                <group-tests.files.excludes>${group-tests.files.excludes}</group-tests.files.excludes>
                             </properties>
                         </configuration>
                     </execution>


### PR DESCRIPTION
Follow up to https://github.com/apache/camel-quarkus/pull/8811.

I also added on a tweak to the debezium-grouped module so I can exclude mssql tests from running as the container has issues on macOS + ARM + PodMan.