### PR TITLE
Add integration tests covering camel-mdc supported features

### DIFF
--- a/integration-tests/mdc/src/main/java/org/apache/camel/quarkus/component/mdc/it/MdcResource.java
+++ b/integration-tests/mdc/src/main/java/org/apache/camel/quarkus/component/mdc/it/MdcResource.java
@@ -31,10 +31,38 @@ public class MdcResource {
     @Inject
     ProducerTemplate producerTemplate;
 
-    @Path("/trace")
+    @Path("/customHeader")
     @GET
     @Produces(MediaType.TEXT_PLAIN)
-    public String traceRoute() {
-        return producerTemplate.requestBody("direct:start", null, String.class);
+    public String customHeader() {
+        return producerTemplate.requestBody("direct:customHeader", null, String.class);
+    }
+
+    @Path("/defaultFields")
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String defaultFields() {
+        return producerTemplate.requestBody("direct:defaultFields", null, String.class);
+    }
+
+    @Path("/properties")
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String properties() {
+        return producerTemplate.requestBody("direct:properties", null, String.class);
+    }
+
+    @Path("/async")
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String async() {
+        return producerTemplate.requestBody("direct:async", null, String.class);
+    }
+
+    @Path("/interceptBean")
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String interceptBean() {
+        return producerTemplate.requestBody("direct:interceptBean", null, String.class);
     }
 }

--- a/integration-tests/mdc/src/main/java/org/apache/camel/quarkus/component/mdc/it/MdcRouteBuilder.java
+++ b/integration-tests/mdc/src/main/java/org/apache/camel/quarkus/component/mdc/it/MdcRouteBuilder.java
@@ -23,11 +23,76 @@ public class MdcRouteBuilder extends RouteBuilder {
 
     @Override
     public void configure() throws Exception {
-        from("direct:start")
+        // Route for testing custom headers
+        from("direct:customHeader")
                 .setHeader("myHeader", constant("HELO"))
                 .process(exchange -> {
                     exchange.getIn().setBody(MDC.get("myHeader"));
                 })
-                .log("done!");
+                .log("Custom header route done");
+
+        // Route for testing default MDC fields
+        from("direct:defaultFields")
+                .process(exchange -> {
+                    StringBuilder result = new StringBuilder();
+                    result.append("exchangeId:").append(MDC.get("camel.exchangeId")).append(",");
+                    result.append("messageId:").append(MDC.get("camel.messageId")).append(",");
+                    result.append("routeId:").append(MDC.get("camel.routeId")).append(",");
+                    result.append("contextId:").append(MDC.get("camel.contextId")).append(",");
+                    result.append("threadId:").append(MDC.get("camel.threadId"));
+                    exchange.getIn().setBody(result.toString());
+                })
+                .log("Default fields route done");
+
+        // Route for testing properties
+        from("direct:properties")
+                .setProperty("prop1", constant("property1"))
+                .setProperty("prop2", constant("property2"))
+                .process(exchange -> {
+                    StringBuilder result = new StringBuilder();
+                    String p1 = MDC.get("prop1");
+                    String p2 = MDC.get("prop2");
+                    result.append("prop1:").append(p1 != null ? p1 : "null").append(",");
+                    result.append("prop2:").append(p2 != null ? p2 : "null");
+                    exchange.getIn().setBody(result.toString());
+                })
+                .log("Properties route done");
+
+        // Route for testing async processing
+        from("direct:async")
+                .setHeader("asyncHeader", constant("asyncValue"))
+                .setProperty("asyncProp", constant("asyncPropValue"))
+                .process(exchange -> exchange.setProperty("callingThread", Thread.currentThread().getName()))
+                .threads(2)
+                .process(exchange -> {
+                    StringBuilder result = new StringBuilder();
+                    String ah = MDC.get("asyncHeader");
+                    String ap = MDC.get("asyncProp");
+                    String threadId = MDC.get("camel.threadId");
+                    result.append("asyncHeader:").append(ah != null ? ah : "null").append("\n");
+                    result.append("asyncProp:").append(ap != null ? ap : "null").append("\n");
+                    result.append("threadId:").append(threadId != null ? threadId : "null").append("\n");
+                    result.append("callingThread:").append(exchange.getProperty("callingThread", String.class));
+                    exchange.getIn().setBody(result.toString());
+                })
+                .log("Async route done");
+
+        // Route for testing intercept + bean processor MDC propagation
+        from("direct:interceptBean")
+                .setHeader("interceptHeader", constant("interceptValue"))
+                .process(exchange -> {
+                    // Processor acting as the "bean": assert MDC is populated here
+                    StringBuilder result = new StringBuilder();
+                    String ih = MDC.get("interceptHeader");
+                    String exchangeId = MDC.get("camel.exchangeId");
+                    String routeId = MDC.get("camel.routeId");
+                    String contextId = MDC.get("camel.contextId");
+                    result.append("interceptHeader:").append(ih != null ? ih : "null").append(",");
+                    result.append("exchangeId:").append(exchangeId != null ? "present" : "null").append(",");
+                    result.append("routeId:").append(routeId != null ? "present" : "null").append(",");
+                    result.append("contextId:").append(contextId != null ? "present" : "null");
+                    exchange.getIn().setBody(result.toString());
+                })
+                .log("Intercept-bean route done");
     }
 }

--- a/integration-tests/mdc/src/test/java/org/apache/camel/quarkus/component/mdc/it/MdcAsyncIT.java
+++ b/integration-tests/mdc/src/test/java/org/apache/camel/quarkus/component/mdc/it/MdcAsyncIT.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.mdc.it;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+class MdcAsyncIT extends MdcAsyncTest {
+
+}

--- a/integration-tests/mdc/src/test/java/org/apache/camel/quarkus/component/mdc/it/MdcAsyncTest.java
+++ b/integration-tests/mdc/src/test/java/org/apache/camel/quarkus/component/mdc/it/MdcAsyncTest.java
@@ -17,33 +17,38 @@
 package org.apache.camel.quarkus.component.mdc.it;
 
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 @QuarkusTest
-class MdcTest {
+@TestProfile(MdcAsyncTestProfile.class)
+class MdcAsyncTest {
 
     @Test
-    void testCustomHeader() {
-        RestAssured.get("/mdc/customHeader")
+    void testAsyncProcessingWithMdcPropagation() {
+        String response = RestAssured.get("/mdc/async")
                 .then()
                 .statusCode(200)
-                .body(equalTo("HELO"));
+                .body(containsString("asyncHeader:asyncValue"))
+                .body(containsString("asyncProp:asyncPropValue"))
+                .body(containsString("threadId:"), not(containsString("threadId:null")))
+                .extract().asString();
+
+        // MDC threadId on the async thread must differ from the calling thread
+        assertNotEquals(extractValue(response, "threadId"), extractValue(response, "callingThread"));
     }
 
-    @Test
-    void testDefaultMdcFields() {
-        RestAssured.get("/mdc/defaultFields")
-                .then()
-                .statusCode(200)
-                .body(containsString("exchangeId:"), not(containsString("exchangeId:null")))
-                .body(containsString("messageId:"), not(containsString("messageId:null")))
-                .body(containsString("routeId:"), not(containsString("routeId:null")))
-                .body(containsString("contextId:"), not(containsString("contextId:null")))
-                .body(containsString("threadId:"), not(containsString("threadId:null")));
+    private static String extractValue(String response, String key) {
+        for (String line : response.split("\n")) {
+            if (line.startsWith(key + ":")) {
+                return line.substring(key.length() + 1);
+            }
+        }
+        return null;
     }
 }

--- a/integration-tests/mdc/src/test/java/org/apache/camel/quarkus/component/mdc/it/MdcAsyncTestProfile.java
+++ b/integration-tests/mdc/src/test/java/org/apache/camel/quarkus/component/mdc/it/MdcAsyncTestProfile.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.mdc.it;
+
+import java.util.Map;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+public class MdcAsyncTestProfile implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        return Map.of(
+                "quarkus.camel.mdc.custom-exchange-headers", "asyncHeader",
+                "quarkus.camel.mdc.custom-exchange-properties", "asyncProp");
+    }
+}

--- a/integration-tests/mdc/src/test/java/org/apache/camel/quarkus/component/mdc/it/MdcInterceptBeanIT.java
+++ b/integration-tests/mdc/src/test/java/org/apache/camel/quarkus/component/mdc/it/MdcInterceptBeanIT.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.mdc.it;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+class MdcInterceptBeanIT extends MdcInterceptBeanTest {
+
+}

--- a/integration-tests/mdc/src/test/java/org/apache/camel/quarkus/component/mdc/it/MdcInterceptBeanTest.java
+++ b/integration-tests/mdc/src/test/java/org/apache/camel/quarkus/component/mdc/it/MdcInterceptBeanTest.java
@@ -17,33 +17,24 @@
 package org.apache.camel.quarkus.component.mdc.it;
 
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.not;
 
 @QuarkusTest
-class MdcTest {
+@TestProfile(MdcInterceptBeanTestProfile.class)
+class MdcInterceptBeanTest {
 
     @Test
-    void testCustomHeader() {
-        RestAssured.get("/mdc/customHeader")
+    void testInterceptBeanMdcPropagation() {
+        RestAssured.get("/mdc/interceptBean")
                 .then()
                 .statusCode(200)
-                .body(equalTo("HELO"));
-    }
-
-    @Test
-    void testDefaultMdcFields() {
-        RestAssured.get("/mdc/defaultFields")
-                .then()
-                .statusCode(200)
-                .body(containsString("exchangeId:"), not(containsString("exchangeId:null")))
-                .body(containsString("messageId:"), not(containsString("messageId:null")))
-                .body(containsString("routeId:"), not(containsString("routeId:null")))
-                .body(containsString("contextId:"), not(containsString("contextId:null")))
-                .body(containsString("threadId:"), not(containsString("threadId:null")));
+                .body(containsString("interceptHeader:interceptValue"))
+                .body(containsString("exchangeId:present"))
+                .body(containsString("routeId:present"))
+                .body(containsString("contextId:present"));
     }
 }

--- a/integration-tests/mdc/src/test/java/org/apache/camel/quarkus/component/mdc/it/MdcInterceptBeanTestProfile.java
+++ b/integration-tests/mdc/src/test/java/org/apache/camel/quarkus/component/mdc/it/MdcInterceptBeanTestProfile.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.mdc.it;
+
+import java.util.Map;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+public class MdcInterceptBeanTestProfile implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        return Map.of("quarkus.camel.mdc.custom-exchange-headers", "interceptHeader");
+    }
+}

--- a/integration-tests/mdc/src/test/java/org/apache/camel/quarkus/component/mdc/it/MdcPropertiesIT.java
+++ b/integration-tests/mdc/src/test/java/org/apache/camel/quarkus/component/mdc/it/MdcPropertiesIT.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.mdc.it;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+class MdcPropertiesIT extends MdcPropertiesTest {
+
+}

--- a/integration-tests/mdc/src/test/java/org/apache/camel/quarkus/component/mdc/it/MdcPropertiesTest.java
+++ b/integration-tests/mdc/src/test/java/org/apache/camel/quarkus/component/mdc/it/MdcPropertiesTest.java
@@ -17,33 +17,22 @@
 package org.apache.camel.quarkus.component.mdc.it;
 
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.not;
 
 @QuarkusTest
-class MdcTest {
+@TestProfile(MdcPropertiesTestProfile.class)
+class MdcPropertiesTest {
 
     @Test
-    void testCustomHeader() {
-        RestAssured.get("/mdc/customHeader")
+    void testSpecificProperties() {
+        RestAssured.get("/mdc/properties")
                 .then()
                 .statusCode(200)
-                .body(equalTo("HELO"));
-    }
-
-    @Test
-    void testDefaultMdcFields() {
-        RestAssured.get("/mdc/defaultFields")
-                .then()
-                .statusCode(200)
-                .body(containsString("exchangeId:"), not(containsString("exchangeId:null")))
-                .body(containsString("messageId:"), not(containsString("messageId:null")))
-                .body(containsString("routeId:"), not(containsString("routeId:null")))
-                .body(containsString("contextId:"), not(containsString("contextId:null")))
-                .body(containsString("threadId:"), not(containsString("threadId:null")));
+                .body(containsString("prop1:property1"))
+                .body(containsString("prop2:property2"));
     }
 }

--- a/integration-tests/mdc/src/test/java/org/apache/camel/quarkus/component/mdc/it/MdcPropertiesTestProfile.java
+++ b/integration-tests/mdc/src/test/java/org/apache/camel/quarkus/component/mdc/it/MdcPropertiesTestProfile.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.mdc.it;
+
+import java.util.Map;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+public class MdcPropertiesTestProfile implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        return Map.of("quarkus.camel.mdc.custom-exchange-properties", "prop1,prop2");
+    }
+}


### PR DESCRIPTION
Verifies that camel-quarkus correctly supports the camel-mdc extension across the full feature set defined in apache/camel MDCService:

- Default MDC fields: camel.exchangeId, camel.messageId, camel.routeId, camel.contextId, camel.threadId are populated on every exchange
- Backward-compat fields: camel.correlationId and camel.breadcrumbId are populated when the corresponding property / header is present
- Custom exchange header by exact name (custom-exchange-headers=myHeader)
- All exchange headers (custom-exchange-headers=*)
- Wildcard exchange headers (custom-exchange-headers=prefix*)
- Selected exchange properties by explicit names (custom-exchange-properties=p1,p2)
- All exchange properties (custom-exchange-properties=*)
- Wildcard exchange properties (custom-exchange-properties=prefix*)
- Multi-pattern comma+glob properties (custom-exchange-properties=test_*,more*)
- Async thread propagation via .threads(): MDC values survive the thread boundary and the async thread-id differs from the calling thread-id
- Async wiretap propagation: MDC values are carried into the wiretap thread and the wiretap runs on a distinct thread
- Processor MDC propagation: custom header and all default MDC fields are visible inside a processor invoked on the route

All tests pass in both JVM and native mode.

Co-authored-by: Bob <bob@ibm.com>