### PR TITLE
Fix clustering integration test flakiness on Windows and slow CI

### DIFF
--- a/integration-tests-support/process-executor-support/src/main/java/org/apache/camel/quarkus/test/support/process/QuarkusProcessExecutor.java
+++ b/integration-tests-support/process-executor-support/src/main/java/org/apache/camel/quarkus/test/support/process/QuarkusProcessExecutor.java
@@ -90,7 +90,8 @@ public class QuarkusProcessExecutor {
                 this.process.onExit().get(timeout, unit);
                 LOGGER.infof("Process %d completed with exit code %d", this.process.pid(), this.process.exitValue());
             } catch (TimeoutException e) {
-                LOGGER.warnf(e, "Timed out waiting to destroy process %d", this.process.pid());
+                LOGGER.warnf("Timed out waiting to destroy process %d, forcing termination", this.process.pid());
+                this.process.destroyForcibly();
             } catch (ExecutionException | InterruptedException e) {
                 LOGGER.warnf(e, "Error occurred destroying process %d", this.process.pid());
             } finally {

--- a/integration-tests/master-file/src/test/java/org/apache/camel/quarkus/component/master/it/MasterFileTest.java
+++ b/integration-tests/master-file/src/test/java/org/apache/camel/quarkus/component/master/it/MasterFileTest.java
@@ -40,14 +40,14 @@ import static org.hamcrest.Matchers.emptyString;
 class MasterFileTest {
 
     @AfterEach
-    public void deleteClusterFiles() throws IOException {
-        FileUtils.deleteDirectory(Paths.get("target/cluster/").toFile());
+    public void deleteClusterFiles() {
+        FileUtils.deleteQuietly(Paths.get("target/cluster/").toFile());
     }
 
     @Test
     public void testFailover() throws IOException {
         // Verify that this process is the cluster leader
-        Awaitility.await().atMost(10, TimeUnit.SECONDS).with().until(() -> {
+        Awaitility.await().atMost(60, TimeUnit.SECONDS).with().until(() -> {
             return readLeaderFile("leader").equals("leader");
         });
 
@@ -70,7 +70,7 @@ class MasterFileTest {
 
             // Verify that the secondary application has been elected as the
             // cluster leader
-            Awaitility.await().atMost(10, TimeUnit.SECONDS).until(() -> {
+            Awaitility.await().atMost(60, TimeUnit.SECONDS).until(() -> {
                 return readLeaderFile("follower").equals("leader");
             });
         } finally {
@@ -81,7 +81,7 @@ class MasterFileTest {
     }
 
     private void awaitStartup(QuarkusProcessExecutor quarkusProcessExecutor) {
-        Awaitility.await().atMost(10, TimeUnit.SECONDS).pollDelay(1, TimeUnit.SECONDS).until(() -> {
+        Awaitility.await().atMost(60, TimeUnit.SECONDS).pollDelay(1, TimeUnit.SECONDS).until(() -> {
             return isApplicationHealthy(quarkusProcessExecutor.getHttpPort());
         });
     }

--- a/integration-tests/master-infinispan/src/test/java/org/apache/camel/quarkus/component/master/it/InfinispanClusterServiceTest.java
+++ b/integration-tests/master-infinispan/src/test/java/org/apache/camel/quarkus/component/master/it/InfinispanClusterServiceTest.java
@@ -43,14 +43,14 @@ import static org.hamcrest.Matchers.emptyString;
 @QuarkusTestResource(InfinispanClusterServiceTestResource.class)
 class InfinispanClusterServiceTest {
     @AfterEach
-    public void deleteClusterFiles() throws IOException {
-        FileUtils.deleteDirectory(Paths.get("target/cluster/").toFile());
+    public void deleteClusterFiles() {
+        FileUtils.deleteQuietly(Paths.get("target/cluster/").toFile());
     }
 
     @Test
     void testFailover() throws IOException {
         // Verify that this process is the cluster leader
-        Awaitility.await().atMost(10, TimeUnit.SECONDS).with().until(() -> {
+        Awaitility.await().atMost(60, TimeUnit.SECONDS).with().until(() -> {
             return readLeaderFile("leader").equals("leader");
         });
 
@@ -82,7 +82,7 @@ class InfinispanClusterServiceTest {
 
             // Verify that the secondary application has been elected as the
             // cluster leader
-            Awaitility.await().atMost(10, TimeUnit.SECONDS).until(() -> {
+            Awaitility.await().atMost(60, TimeUnit.SECONDS).until(() -> {
                 return readLeaderFile("follower").equals("leader");
             });
         } finally {
@@ -93,7 +93,7 @@ class InfinispanClusterServiceTest {
     }
 
     private void awaitStartup(QuarkusProcessExecutor quarkusProcessExecutor) {
-        Awaitility.await().atMost(10, TimeUnit.SECONDS).pollDelay(1, TimeUnit.SECONDS).until(() -> {
+        Awaitility.await().atMost(60, TimeUnit.SECONDS).pollDelay(1, TimeUnit.SECONDS).until(() -> {
             return isApplicationHealthy(quarkusProcessExecutor.getHttpPort());
         });
     }

--- a/integration-tests/master-openshift/src/test/java/org/apache/camel/quarkus/component/master/it/MasterOpenShiftTest.java
+++ b/integration-tests/master-openshift/src/test/java/org/apache/camel/quarkus/component/master/it/MasterOpenShiftTest.java
@@ -55,8 +55,8 @@ class MasterOpenShiftTest {
     private KubernetesServer mockOpenShiftServer;
 
     @BeforeAll
-    public static void deleteClusterFiles() throws IOException {
-        FileUtils.deleteDirectory(Paths.get("target/cluster/").toFile());
+    public static void deleteClusterFiles() {
+        FileUtils.deleteQuietly(Paths.get("target/cluster/").toFile());
     }
 
     @Test
@@ -86,7 +86,7 @@ class MasterOpenShiftTest {
 
             try {
                 // Verify that this process is the cluster leader
-                Awaitility.await().atMost(10, TimeUnit.SECONDS).with().until(() -> {
+                Awaitility.await().atMost(60, TimeUnit.SECONDS).with().until(() -> {
                     return readLeaderFile("leader").equals("leader");
                 });
 
@@ -103,7 +103,7 @@ class MasterOpenShiftTest {
 
                 // Verify that the secondary application has been elected as the
                 // cluster leader
-                Awaitility.await().atMost(10, TimeUnit.SECONDS).until(() -> {
+                Awaitility.await().atMost(60, TimeUnit.SECONDS).until(() -> {
                     return readLeaderFile("follower").equals("leader");
                 });
             } finally {
@@ -119,7 +119,7 @@ class MasterOpenShiftTest {
     }
 
     private void awaitStartup(QuarkusProcessExecutor quarkusProcessExecutor) {
-        Awaitility.await().atMost(40, TimeUnit.SECONDS).pollDelay(1, TimeUnit.SECONDS).until(() -> {
+        Awaitility.await().atMost(60, TimeUnit.SECONDS).pollDelay(1, TimeUnit.SECONDS).until(() -> {
             return isApplicationHealthy(quarkusProcessExecutor.getHttpPort());
         });
     }

--- a/integration-tests/quartz-clustered/src/test/java/org/apache/camel/quarkus/component/quartz/it/QuartzClusteredTest.java
+++ b/integration-tests/quartz-clustered/src/test/java/org/apache/camel/quarkus/component/quartz/it/QuartzClusteredTest.java
@@ -78,7 +78,7 @@ class QuartzClusteredTest {
                     .statusCode(204);
 
             // Verify that the NodeB scheduler is running
-            Awaitility.await().atMost(10, TimeUnit.SECONDS).with().until(() -> {
+            Awaitility.await().atMost(60, TimeUnit.SECONDS).with().until(() -> {
                 return Files.readAllLines(quarkusLog).stream().anyMatch(line -> line.contains("Hello from NodeB"));
             });
 
@@ -101,7 +101,7 @@ class QuartzClusteredTest {
     }
 
     private void awaitStartup(QuarkusProcessExecutor quarkusProcessExecutor) {
-        Awaitility.await().atMost(1, TimeUnit.MINUTES).pollDelay(1, TimeUnit.SECONDS).until(() -> {
+        Awaitility.await().atMost(60, TimeUnit.SECONDS).pollDelay(1, TimeUnit.SECONDS).until(() -> {
             return isApplicationHealthy(quarkusProcessExecutor.getHttpPort());
         });
     }


### PR DESCRIPTION
## Summary

- Align all Awaitility timeouts to 60s across `master-file`, `master-openshift`, `master-infinispan`, and `quartz-clustered` integration tests — the previous values (10s–40s) were too tight for slow CI machines, and `quartz-clustered`'s 10s NodeB verification was near-certain to fail given its cron fires once per minute
- Replace `FileUtils.deleteDirectory` with `FileUtils.deleteQuietly` in cluster file cleanup methods to prevent `FileSystemException` on Windows when `FileLockClusterService` holds OS-level file locks on `target/cluster/ns` and `target/cluster/ns.dat`
- Add `destroyForcibly()` fallback in `QuarkusProcessExecutor.destroy()` when graceful shutdown times out, preventing leaked child processes and held file handles

## Test plan

- [x] master-file JVM tests pass
- [x] master-file native tests pass
- [x] master-openshift JVM tests pass
- [x] master-openshift native tests pass
- [x] master-infinispan JVM tests pass
- [x] master-infinispan native tests pass
- [x] quartz-clustered JVM tests pass
- [x] quartz-clustered native tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)