### PR TITLE
Fix Aws2KinesisTest.failingDefaultCredentialsProviderTest flakiness

### DIFF
--- a/integration-test-groups/aws2/aws2-kinesis/src/main/java/org/apache/camel/quarkus/component/aws2/kinesis/it/Aws2KinesisResource.java
+++ b/integration-test-groups/aws2/aws2-kinesis/src/main/java/org/apache/camel/quarkus/component/aws2/kinesis/it/Aws2KinesisResource.java
@@ -104,11 +104,27 @@ public class Aws2KinesisResource extends BaseAws2Resource {
     @Override
     protected void onDefaultCredentialsProviderChange() throws Exception {
         log.info("onDefaultCredentialsProviderChange start");
-        //reset connection, because irt is cached since https://github.com/apache/camel/pull/10919
+
+        // Suspend consumers so they don't race to recreate the shared KinesisClient
+        // with static credentials before the producer can recreate it with DefaultCredentialsProvider
+        for (org.apache.camel.Route route : camelContext.getRoutes()) {
+            if (route.getEndpoint().getEndpointUri().startsWith("aws2-kinesis://")) {
+                camelContext.getRouteController().suspendRoute(route.getRouteId());
+            }
+        }
+
+        //reset connection, because it is cached since https://github.com/apache/camel/pull/10919
         KinesisConnection kc = camelContext.getRegistry().findSingleByType(Kinesis2Component.class).getConnection();
         kc.close();
         kc.setKinesisAsyncClient(null);
         kc.setKinesisClient(null);
         super.onDefaultCredentialsProviderChange();
+
+        // Resume consumers
+        for (org.apache.camel.Route route : camelContext.getRoutes()) {
+            if (route.getEndpoint().getEndpointUri().startsWith("aws2-kinesis://")) {
+                camelContext.getRouteController().resumeRoute(route.getRouteId());
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Fixes #7733
- The shared `KinesisConnection` recreates its client using whichever endpoint calls `getClient()` first. After a connection reset, consumer poll threads can race the producer and recreate the client with static credentials instead of `DefaultCredentialsProvider`, causing `failingDefaultCredentialsProviderTest` to succeed when it should fail.
- Suspend Kinesis consumer routes before resetting the connection and resume them after, so the producer is always the first to trigger client recreation.

## Test plan
- [x] `Aws2KinesisTest` passes 5/5 runs locally
- [x] `GroupedAws2KinesisTest` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)