### PR TITLE
Check for parent SocketException instead of ConnectException to make …

### DIFF
--- a/integration-tests/jolokia/src/test/java/org/apache/camel/quarkus/component/jolokia/it/JolokiaDisableAutoStartTest.java
+++ b/integration-tests/jolokia/src/test/java/org/apache/camel/quarkus/component/jolokia/it/JolokiaDisableAutoStartTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.camel.quarkus.component.jolokia.it;
 
-import java.net.ConnectException;
+import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.time.Duration;
 import java.util.Map;
@@ -75,7 +75,7 @@ class JolokiaDisableAutoStartTest {
 
         // Connecting to Jolokia should not be possible
         RestAssured.port = 8778;
-        assertThrows(ConnectException.class, () -> {
+        assertThrows(SocketException.class, () -> {
             RestAssured.get("/jolokia/")
                     .then()
                     .statusCode(204);


### PR DESCRIPTION
…it work on different systems with different network settings

I've hit on
```
org.opentest4j.AssertionFailedError: Unexpected exception type thrown, expected: <java.net.ConnectException> but was: <java.net.SocketException>
	at org.apache.camel.quarkus.component.jolokia.it.JolokiaDisableAutoStartTest.autoStartupDisabled(JolokiaDisableAutoStartTest.java:78)
```