### PR TITLE
Fixes #8860. Add GraalVM substitution for optional zstd-jni in httpclient5

### DIFF
--- a/extensions-support/httpclient5/runtime/src/main/java/org/apache/camel/quarkus/support/httpclient5/graal/ZstdAbsentBooleanSupplier.java
+++ b/extensions-support/httpclient5/runtime/src/main/java/org/apache/camel/quarkus/support/httpclient5/graal/ZstdAbsentBooleanSupplier.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.support.httpclient5.graal;
+
+import java.util.function.BooleanSupplier;
+
+public class ZstdAbsentBooleanSupplier implements BooleanSupplier {
+    @Override
+    public boolean getAsBoolean() {
+        try {
+            Thread.currentThread().getContextClassLoader().loadClass("com.github.luben.zstd.ZstdDecompressCtx");
+            return false;
+        } catch (ClassNotFoundException e) {
+            return true;
+        }
+    }
+}

--- a/extensions-support/httpclient5/runtime/src/main/java/org/apache/camel/quarkus/support/httpclient5/graal/ZstdSubstitutions.java
+++ b/extensions-support/httpclient5/runtime/src/main/java/org/apache/camel/quarkus/support/httpclient5/graal/ZstdSubstitutions.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.support.httpclient5.graal;
+
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+
+/**
+ * Remove references to optional com.github.luben:zstd-jni dependency.
+ */
+final class ZstdSubstitutions {
+}
+
+@TargetClass(className = "org.apache.hc.client5.http.impl.ZstdRuntime", onlyWith = ZstdAbsentBooleanSupplier.class)
+final class SubstituteZstdRuntime {
+    @Substitute
+    public static boolean available() {
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary

- Add GraalVM substitution for `ZstdRuntime.available()` in the `extensions-support/httpclient5` module to return `false` when `com.github.luben:zstd-jni` is absent, preventing native image build failure on unresolved `ZstdDecompressCtx`
- Follows the existing Brotli and Xz substitution pattern in the same module

## Test plan

- [ ] Verify weaviate native integration test passes (the failing scenario that surfaced this)
- [ ] Verify existing httpclient5-dependent extensions still build in native mode

Fixes #8860