### PR TITLE
Fixes #8884. Add CyberArk Vault integration test coverage

### DIFF
--- a/integration-tests/cyberark-vault/src/main/java/org/apache/camel/quarkus/component/cyberark/vault/it/CyberArkRoutes.java
+++ b/integration-tests/cyberark-vault/src/main/java/org/apache/camel/quarkus/component/cyberark/vault/it/CyberArkRoutes.java
@@ -18,6 +18,7 @@ package org.apache.camel.quarkus.component.cyberark.vault.it;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.spi.PropertiesComponent;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 @ApplicationScoped
@@ -40,12 +41,12 @@ public class CyberArkRoutes extends RouteBuilder {
     public void configure() throws Exception {
 
         from("direct:createSecret")
-                .toF("cyberark-vault:secret?operation=createSecret&secretId=BotApp/secretVar&url=%s&account=%s&username=%s&apiKey=%s",
+                .toF("cyberark-vault:secret?operation=createSecret&url=%s&account=%s&username=%s&apiKey=%s",
                         url, account, writeUsername, writeApiKey)
                 .log("Secret created/updated");
 
         from("direct:createSecretUnauthorized")
-                .toF("cyberark-vault:secret?operation=createSecret&secretId=BotApp/secretVar&url=%s&account=%s&username=%s&apiKey=%s",
+                .toF("cyberark-vault:secret?operation=createSecret&url=%s&account=%s&username=%s&apiKey=%s",
                         url, account, readUsername, readApiKey)
                 .log("Secret created/updated");
 
@@ -53,6 +54,23 @@ public class CyberArkRoutes extends RouteBuilder {
                 .toF("cyberark-vault:secret?secretId=BotApp/secretVar&url=%s&account=%s&username=%s&apiKey=%s",
                         url, account, readUsername, readApiKey)
                 .log("Retrieved secret: ${body}");
+
+        from("direct:getSecretByHeader")
+                .toF("cyberark-vault:secret?url=%s&account=%s&username=%s&apiKey=%s",
+                        url, account, readUsername, readApiKey);
+
+        from("direct:getSecretVersion")
+                .toF("cyberark-vault:secret?secretId=BotApp/versionVar&url=%s&account=%s&username=%s&apiKey=%s",
+                        url, account, readUsername, readApiKey);
+
+        // Programmatic equivalent of {{cyberark:BotApp/secretVar}} placeholder — resolved at runtime since the secret doesn't exist at route build time
+        from("direct:propertyPlaceholder")
+                .process(exchange -> {
+                    PropertiesComponent component = exchange.getContext().getPropertiesComponent();
+                    component.resolveProperty("cyberark:BotApp/secretVar").ifPresent(value -> {
+                        exchange.getMessage().setBody(value);
+                    });
+                });
 
     }
 }

--- a/integration-tests/cyberark-vault/src/main/java/org/apache/camel/quarkus/component/cyberark/vault/it/CyberarkVaultResource.java
+++ b/integration-tests/cyberark-vault/src/main/java/org/apache/camel/quarkus/component/cyberark/vault/it/CyberarkVaultResource.java
@@ -16,6 +16,8 @@
  */
 package org.apache.camel.quarkus.component.cyberark.vault.it;
 
+import java.util.Map;
+
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.Consumes;
@@ -27,6 +29,7 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.apache.camel.ProducerTemplate;
+import org.apache.camel.component.cyberark.vault.CyberArkVaultConstants;
 import org.jboss.logging.Logger;
 
 @Path("/cyberark-vault")
@@ -38,12 +41,15 @@ public class CyberarkVaultResource {
     @Inject
     ProducerTemplate producerTemplate;
 
-    @Path("/createSecret/{authorized}")
+    @Path("/createSecret/{authorized}/{policy}/{secret}")
     @POST
     @Consumes(MediaType.TEXT_PLAIN)
-    public Response createSecret(String secret, @PathParam("authorized") boolean authorized) {
+    public Response createSecret(String body, @PathParam("authorized") boolean authorized,
+            @PathParam("policy") String policy, @PathParam("secret") String secret) {
         try {
-            producerTemplate.requestBody("direct:createSecret" + (authorized ? "" : "Unauthorized"), secret, String.class);
+            producerTemplate.requestBodyAndHeader(
+                    "direct:createSecret" + (authorized ? "" : "Unauthorized"), body,
+                    CyberArkVaultConstants.SECRET_ID, policy + "/" + secret, String.class);
         } catch (RuntimeException e) {
             return Response.serverError().entity(e.getCause().getCause().getMessage()).build();
         }
@@ -55,5 +61,30 @@ public class CyberarkVaultResource {
     @Produces(MediaType.TEXT_PLAIN)
     public String getSecret() {
         return producerTemplate.requestBody("direct:getSecret", "", String.class);
+    }
+
+    @Path("/getSecretByHeader/{policy}/{secret}")
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String getSecretByHeader(@PathParam("policy") String policy, @PathParam("secret") String secret) {
+        return producerTemplate.requestBodyAndHeader(
+                "direct:getSecretByHeader", "", CyberArkVaultConstants.SECRET_ID, policy + "/" + secret, String.class);
+    }
+
+    @Path("/getSecretVersion/{version}")
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String getSecretVersion(@PathParam("version") int version) {
+        return producerTemplate.requestBodyAndHeaders(
+                "direct:getSecretVersion", "",
+                Map.of(CyberArkVaultConstants.SECRET_VERSION, version),
+                String.class);
+    }
+
+    @Path("/propertyPlaceholder")
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String propertyPlaceholder() {
+        return producerTemplate.requestBody("direct:propertyPlaceholder", "", String.class);
     }
 }

--- a/integration-tests/cyberark-vault/src/test/java/org/apache/camel/quarkus/component/cyberark/vault/it/CyberarkVaultTest.java
+++ b/integration-tests/cyberark-vault/src/test/java/org/apache/camel/quarkus/component/cyberark/vault/it/CyberarkVaultTest.java
@@ -41,7 +41,7 @@ class CyberarkVaultTest {
         //create secret
         RestAssured.given()
                 .body(secret)
-                .post("/cyberark-vault/createSecret/false")
+                .post("/cyberark-vault/createSecret/false/BotApp/secretVar")
                 .then()
                 .statusCode(500)
                 .body(containsString("403"));
@@ -49,7 +49,7 @@ class CyberarkVaultTest {
         //create secret
         RestAssured.given()
                 .body(secret)
-                .post("/cyberark-vault/createSecret/true")
+                .post("/cyberark-vault/createSecret/true/BotApp/secretVar")
                 .then()
                 .statusCode(200);
 
@@ -59,5 +59,69 @@ class CyberarkVaultTest {
                 .then()
                 .statusCode(200)
                 .body(is(secret));
+    }
+
+    @Test
+    void testPropertyPlaceholder() {
+        String secret = UUID.randomUUID().toString();
+
+        RestAssured.given()
+                .body(secret)
+                .post("/cyberark-vault/createSecret/true/BotApp/secretVar")
+                .then()
+                .statusCode(200);
+
+        RestAssured
+                .get("/cyberark-vault/propertyPlaceholder")
+                .then()
+                .statusCode(200)
+                .body(is(secret));
+    }
+
+    @Test
+    void testGetSecretByHeader() {
+        String secret = UUID.randomUUID().toString();
+
+        RestAssured.given()
+                .body(secret)
+                .post("/cyberark-vault/createSecret/true/BotApp/secretVar")
+                .then()
+                .statusCode(200);
+
+        RestAssured
+                .get("/cyberark-vault/getSecretByHeader/BotApp/secretVar")
+                .then()
+                .statusCode(200)
+                .body(is(secret));
+    }
+
+    @Test
+    void testGetSecretVersion() {
+        String secretV1 = UUID.randomUUID().toString();
+        String secretV2 = UUID.randomUUID().toString();
+
+        RestAssured.given()
+                .body(secretV1)
+                .post("/cyberark-vault/createSecret/true/BotApp/versionVar")
+                .then()
+                .statusCode(200);
+
+        RestAssured.given()
+                .body(secretV2)
+                .post("/cyberark-vault/createSecret/true/BotApp/versionVar")
+                .then()
+                .statusCode(200);
+
+        RestAssured
+                .get("/cyberark-vault/getSecretVersion/1")
+                .then()
+                .statusCode(200)
+                .body(is(secretV1));
+
+        RestAssured
+                .get("/cyberark-vault/getSecretVersion/2")
+                .then()
+                .statusCode(200)
+                .body(is(secretV2));
     }
 }

--- a/integration-tests/cyberark-vault/src/test/java/org/apache/camel/quarkus/component/cyberark/vault/it/CyberarkVaultTestResource.java
+++ b/integration-tests/cyberark-vault/src/test/java/org/apache/camel/quarkus/component/cyberark/vault/it/CyberarkVaultTestResource.java
@@ -122,8 +122,15 @@ public class CyberarkVaultTestResource implements QuarkusTestResourceLifecycleMa
             throw new RuntimeException("Failed to start Conjur test environment", e);
         }
 
+        String conjurUrl = "http://localhost:" + conjurContainer.getMappedPort(80);
+
         result.put("conjur.account", CONJUR_ACCOUNT);
-        result.put("conjur.url", "http://localhost:" + conjurContainer.getMappedPort(80));
+        result.put("conjur.url", conjurUrl);
+
+        result.put("camel.vault.cyberark.url", conjurUrl);
+        result.put("camel.vault.cyberark.account", CONJUR_ACCOUNT);
+        result.put("camel.vault.cyberark.username", result.get("conjur.read.username"));
+        result.put("camel.vault.cyberark.apiKey", result.get("conjur.read.apiKey"));
 
         return result;
     }

--- a/integration-tests/cyberark-vault/src/test/resources/conf/policy/BotApp.yml
+++ b/integration-tests/cyberark-vault/src/test/resources/conf/policy/BotApp.yml
@@ -22,6 +22,7 @@
   - !user Dave
   - !host myDemoApp
   - !variable secretVar
+  - !variable versionVar
   - !permit
     # Give permissions to the human user to update the secret and fetch the secret.
     role: !user Dave
@@ -32,3 +33,11 @@
     role: !host myDemoApp
     privileges: [read, execute]
     resource: !variable secretVar
+  - !permit
+    role: !user Dave
+    privileges: [read, update, execute]
+    resource: !variable versionVar
+  - !permit
+    role: !host myDemoApp
+    privileges: [read, execute]
+    resource: !variable versionVar

--- a/pom.xml
+++ b/pom.xml
@@ -241,7 +241,7 @@
         <couchdb.container.image>mirror.gcr.io/couchdb:3.5.0</couchdb.container.image>
         <cyberark-conjur.container.image>mirror.gcr.io/cyberark/conjur:1.24.0</cyberark-conjur.container.image>
         <cyberark-conjur-cli.container.image>mirror.gcr.io/cyberark/conjur-cli:9</cyberark-conjur-cli.container.image>
-        <cyberark-nginx.container.image>mirror.gcr.io/nginx:1.29.4-alpine3.23-perl</cyberark-nginx.container.image>
+        <cyberark-nginx.container.image>mirror.gcr.io/nginx:1.30.3-alpine3.23-perl</cyberark-nginx.container.image>
         <db2.container.image>icr.io/db2_community/db2:12.1.0.0</db2.container.image>
         <docling.container.image>quay.io/docling-project/docling-serve:v1.9.0</docling.container.image>
         <eclipse-mosquitto.container.image>mirror.gcr.io/eclipse-mosquitto:2.0.18</eclipse-mosquitto.container.image>


### PR DESCRIPTION
## Summary
- Add `testPropertyPlaceholder` exercising `PropertiesComponent.resolveProperty("cyberark:...")` with `camel.vault.cyberark.*` properties
- Add `testGetSecretByHeader` exercising dynamic `CyberArkVaultConstants.SECRET_ID` header
- Add `testGetSecretVersion` with dedicated `versionVar` to verify secret version retrieval via `CyberArkVaultConstants.SECRET_VERSION` header
- Configure `camel.vault.cyberark.*` properties in test resource to enable property placeholder resolution
- Make `createSecret` endpoint accept dynamic `secretId` via header instead of hardcoding it in the route URI
- Add `versionVar` to Conjur policy with appropriate permissions

## Test plan
- [ ] CI passes for `cyberark-vault` integration tests in JVM mode
- [ ] CI passes for `cyberark-vault` integration tests in native mode
- [ ] Existing `testRetrieveSecret` still passes with the dynamic `createSecret` endpoint