### PR TITLE
Fix FHIR native build warning ClassNotFoundException: com.google.protobuf.JavaFeaturesProto

### DIFF
--- a/extensions/fhir/deployment/src/main/java/org/apache/camel/quarkus/component/fhir/deployment/FhirProcessor.java
+++ b/extensions/fhir/deployment/src/main/java/org/apache/camel/quarkus/component/fhir/deployment/FhirProcessor.java
@@ -34,7 +34,6 @@ import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBundleBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
-import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 import io.quarkus.deployment.pkg.steps.NativeOrNativeSourcesBuild;
 import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.Gizmo;
@@ -135,11 +134,6 @@ final class FhirProcessor {
                 methodCreator.returnValue(stringBuilder.callToString());
             }
         }
-    }
-
-    @BuildStep
-    RuntimeInitializedClassBuildItem runtimeInitializedClasses() {
-        return new RuntimeInitializedClassBuildItem("com.google.protobuf.JavaFeaturesProto");
     }
 
     static final class IsFhirServerAbsent implements BooleanSupplier {

--- a/integration-tests/fhir/src/test/java/org/apache/camel/quarkus/component/fhir/it/util/FhirTestHelper.java
+++ b/integration-tests/fhir/src/test/java/org/apache/camel/quarkus/component/fhir/it/util/FhirTestHelper.java
@@ -16,10 +16,7 @@
  */
 package org.apache.camel.quarkus.component.fhir.it.util;
 
-import java.io.IOException;
-import java.util.Properties;
-
-import org.apache.camel.quarkus.component.fhir.it.AbstractFhirRouteBuilder;
+import org.eclipse.microprofile.config.ConfigProvider;
 
 public final class FhirTestHelper {
 
@@ -28,15 +25,7 @@ public final class FhirTestHelper {
     }
 
     public static boolean isFhirVersionEnabled(String version) {
-        try {
-            Properties properties = new Properties();
-            properties.load(AbstractFhirRouteBuilder.class.getResourceAsStream("/application.properties"));
-            String key = "quarkus.camel.fhir.enable-" + version.toLowerCase();
-            String envKey = key.toUpperCase().replace('.', '_');
-            String value = (String) properties.getOrDefault(key, System.getProperty(key, System.getenv(envKey)));
-            return Boolean.valueOf(value);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+        String key = "quarkus.camel.fhir.enable-" + version.toLowerCase();
+        return ConfigProvider.getConfig().getOptionalValue(key, Boolean.class).orElse(false);
     }
 }


### PR DESCRIPTION
Also fixes FHIR JUnit conditions to resolve properties using `ConfigProvider`. Something must have changed since 3.33.x where the old code was working properly.