### PR TITLE
Remove explicit cq-maven-plugin version references in the release guide

### DIFF
--- a/docs/modules/ROOT/pages/contributor-guide/release-guide.adoc
+++ b/docs/modules/ROOT/pages/contributor-guide/release-guide.adoc
@@ -427,7 +427,7 @@ NEW_PLATFORM_VERSION=... # E.g. 2.2.0.Final
 git fetch upstream
 git checkout camel-quarkus-main
 git reset --hard upstream/camel-quarkus-main
-./mvnw org.l2x6.cq:cq-maven-plugin:2.10.0:examples-set-platform -Dcq.quarkus.platform.version=$NEW_PLATFORM_VERSION
+./mvnw org.l2x6.cq:cq-maven-plugin:examples-set-platform -Dcq.quarkus.platform.version=$NEW_PLATFORM_VERSION
 ./refresh-dockerfiles.sh
 git add -A
 git commit -m "Upgrade to Quarkus Platform $NEW_PLATFORM_VERSION"
@@ -470,7 +470,7 @@ git push upstream $BRANCH
 NEXT_CQ_VERSION=... # The version used in the current Camel Quarkus main branch without the -SNAPSHOT suffix; e.g. 2.3.0
 git checkout camel-quarkus-main
 git reset --hard main
-./mvnw org.l2x6.cq:cq-maven-plugin:2.10.0:examples-set-platform -Dcq.camel-quarkus.version=${NEXT_CQ_VERSION}-SNAPSHOT -Dcq.newVersion=${NEXT_CQ_VERSION}-SNAPSHOT
+./mvnw org.l2x6.cq:cq-maven-plugin:examples-set-platform -Dcq.camel-quarkus.version=${NEXT_CQ_VERSION}-SNAPSHOT -Dcq.newVersion=${NEXT_CQ_VERSION}-SNAPSHOT
 ./mvnw versions:update-child-modules -N
 # Update version labels in Kubernetes resources
 ./mvnw process-sources


### PR DESCRIPTION
Since the plugin is now declared in the root pom.xml in camel-quarkus-examples.