### PR TITLE
Tune Scalpel trim args for functional-extension-tests

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -543,7 +543,7 @@ jobs:
       || needs.initial-mvn-install.outputs.run-catalog-tests == 'true')
     env:
       MAVEN_OPTS: -Xmx3000m
-      SCALPEL_TRIM_ARGS: "-Dscalpel.enabled=true -Dscalpel.mode=trim -Dscalpel.alsoMake=true -Dscalpel.alsoMakeDependents=false"
+      SCALPEL_TRIM_ARGS: "-Dscalpel.enabled=true -Dscalpel.mode=trim -Dscalpel.alsoMake=false -Dscalpel.alsoMakeDependents=true"
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
Something I noticed in #8944. In `functional-extension-tests`, all of the upstream dependencies of `extensions/jolokia` were built and tested. I think we only need to consider the downstream modules (i.e anything depending on the bits that have changed).