### PR TITLE
Deprecate Tracer & TypeConverter configuration options shadows with camel-main options

### DIFF
--- a/docs/modules/ROOT/pages/reference/extensions/core.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/core.adoc
@@ -355,6 +355,64 @@ Build time configuration options for enable/disable camel source location.
 | `boolean`
 | `false`
 
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-dev-ui-update-interval]]`link:#quarkus-camel-dev-ui-update-interval[quarkus.camel.dev-ui.update-interval]`
+
+The interval at which data is updated in Camel Quarkus Dev UI pages.
+| link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[`Duration`] link:#duration-note-anchor-core[icon:question-circle[title=More information about the Duration format]]
+| `5S`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-main-shutdown-timeout]]`link:#quarkus-camel-main-shutdown-timeout[quarkus.camel.main.shutdown.timeout]`
+
+A timeout (with millisecond precision) to wait for `CamelMain++#++stop()` to finish
+| link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[`Duration`] link:#duration-note-anchor-core[icon:question-circle[title=More information about the Duration format]]
+| `PT3S`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-main-arguments-on-unknown]]`link:#quarkus-camel-main-arguments-on-unknown[quarkus.camel.main.arguments.on-unknown]`
+
+The action to take when `CamelMain` encounters an unknown argument. fail - Prints the `CamelMain` usage statement and
+throws a `RuntimeException` ignore - Suppresses any warnings and the application startup proceeds as normal warn -
+Prints the `CamelMain` usage statement but allows the application startup to proceed as normal
+| `fail`, `warn`, `ignore`
+| `warn`
+
+a| [[camel-dataformat-data-format-configs]]`link:#camel-dataformat-data-format-configs[camel.dataformat."data-format-configs"]`
+
+Camel data format configuration.
+
+The format of the configuration is as follows.
+
+[source,properties]
+----
+camel.dataformat.<name>.<property> = value
+----
+
+For example.
+[source,properties]
+----
+camel.dataformat.beanio.stream-name = test-stream
+camel.dataformat.beanio.mapping = test-mapping.xml
+----
+| `Map<String,Map<String,String>>`
+| 
+
+a| [[quarkus-camel-bootstrap-enabled]]`link:#quarkus-camel-bootstrap-enabled[quarkus.camel.bootstrap.enabled]`
+
+When set to true, the {@link CamelRuntime} will be started automatically.
+| `boolean`
+| `true`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-routes-discovery-enabled]]`link:#quarkus-camel-routes-discovery-enabled[quarkus.camel.routes-discovery.enabled]`
+
+Enable automatic discovery of routes during static initialization.
+| `boolean`
+| `true`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-csimple-on-build-time-analysis-failure]]`link:#quarkus-camel-csimple-on-build-time-analysis-failure[quarkus.camel.csimple.on-build-time-analysis-failure]`
+
+What to do if it is not possible to extract CSimple expressions from a route definition at build time.
+| `fail`, `warn`, `ignore`
+| `warn`
+
 a|icon:lock[title=Fixed at build time] [[quarkus-camel-trace-enabled]]`link:#quarkus-camel-trace-enabled[quarkus.camel.trace.enabled]`
 
 Enables tracer in your Camel application.
@@ -449,64 +507,6 @@ Whether type converter statistics are enabled. By default, type converter utiliz
 that enabling statistics incurs a minor performance impact under very heavy load.
 | `boolean`
 | `false`
-
-a|icon:lock[title=Fixed at build time] [[quarkus-camel-dev-ui-update-interval]]`link:#quarkus-camel-dev-ui-update-interval[quarkus.camel.dev-ui.update-interval]`
-
-The interval at which data is updated in Camel Quarkus Dev UI pages.
-| link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[`Duration`] link:#duration-note-anchor-core[icon:question-circle[title=More information about the Duration format]]
-| `5S`
-
-a|icon:lock[title=Fixed at build time] [[quarkus-camel-main-shutdown-timeout]]`link:#quarkus-camel-main-shutdown-timeout[quarkus.camel.main.shutdown.timeout]`
-
-A timeout (with millisecond precision) to wait for `CamelMain++#++stop()` to finish
-| link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[`Duration`] link:#duration-note-anchor-core[icon:question-circle[title=More information about the Duration format]]
-| `PT3S`
-
-a|icon:lock[title=Fixed at build time] [[quarkus-camel-main-arguments-on-unknown]]`link:#quarkus-camel-main-arguments-on-unknown[quarkus.camel.main.arguments.on-unknown]`
-
-The action to take when `CamelMain` encounters an unknown argument. fail - Prints the `CamelMain` usage statement and
-throws a `RuntimeException` ignore - Suppresses any warnings and the application startup proceeds as normal warn -
-Prints the `CamelMain` usage statement but allows the application startup to proceed as normal
-| `fail`, `warn`, `ignore`
-| `warn`
-
-a| [[camel-dataformat-data-format-configs]]`link:#camel-dataformat-data-format-configs[camel.dataformat."data-format-configs"]`
-
-Camel data format configuration.
-
-The format of the configuration is as follows.
-
-[source,properties]
-----
-camel.dataformat.<name>.<property> = value
-----
-
-For example.
-[source,properties]
-----
-camel.dataformat.beanio.stream-name = test-stream
-camel.dataformat.beanio.mapping = test-mapping.xml
-----
-| `Map<String,Map<String,String>>`
-| 
-
-a| [[quarkus-camel-bootstrap-enabled]]`link:#quarkus-camel-bootstrap-enabled[quarkus.camel.bootstrap.enabled]`
-
-When set to true, the {@link CamelRuntime} will be started automatically.
-| `boolean`
-| `true`
-
-a|icon:lock[title=Fixed at build time] [[quarkus-camel-routes-discovery-enabled]]`link:#quarkus-camel-routes-discovery-enabled[quarkus.camel.routes-discovery.enabled]`
-
-Enable automatic discovery of routes during static initialization.
-| `boolean`
-| `true`
-
-a|icon:lock[title=Fixed at build time] [[quarkus-camel-csimple-on-build-time-analysis-failure]]`link:#quarkus-camel-csimple-on-build-time-analysis-failure[quarkus.camel.csimple.on-build-time-analysis-failure]`
-
-What to do if it is not possible to extract CSimple expressions from a route definition at build time.
-| `fail`, `warn`, `ignore`
-| `warn`
 |===
 
 [.configuration-legend]

--- a/extensions-core/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/CamelProcessor.java
+++ b/extensions-core/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/CamelProcessor.java
@@ -77,6 +77,7 @@ import org.apache.camel.quarkus.core.deployment.util.PathFilter;
 import org.apache.camel.quarkus.core.util.FileUtils;
 import org.apache.camel.spi.TypeConverterLoader;
 import org.apache.camel.spi.TypeConverterRegistry;
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
@@ -262,8 +263,12 @@ class CamelProcessor {
 
         IndexView index = combinedIndex.getIndex();
 
+        boolean statisticsEnabled = ConfigProvider.getConfig()
+                .getOptionalValue("camel.main.typeConverterStatisticsEnabled", Boolean.class)
+                .orElseGet(() -> config.typeConverter().statisticsEnabled());
+
         RuntimeValue<TypeConverterRegistry> typeConverterRegistry = recorder
-                .createTypeConverterRegistry(config.typeConverter().statisticsEnabled());
+                .createTypeConverterRegistry(statisticsEnabled);
 
         //
         // This should be simplified by searching for classes implementing TypeConverterLoader but that

--- a/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/CamelConfig.java
+++ b/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/CamelConfig.java
@@ -95,15 +95,22 @@ public interface CamelConfig {
     /**
      * Build time configuration options for the Camel tracing.
      *
+     * @deprecated  use the standard Apache Camel {@code camel.trace.*} configuration properties instead. Deprecated in
+     *              3.39.0,
+     *              will be removed in 4.0.0.
      * @asciidoclet
      */
+    @Deprecated(since = "3.39.0", forRemoval = true)
     TraceConfig trace();
 
     /**
      * Build time configuration options for Camel type converters.
      *
+     * @deprecated  use the standard Apache Camel {@code camel.main.typeConverterStatisticsEnabled} configuration property
+     *              instead. Deprecated in 3.39.0, will be removed in 4.0.0.
      * @asciidoclet
      */
+    @Deprecated(since = "3.39.0", forRemoval = true)
     TypeConverterConfig typeConverter();
 
     /**
@@ -423,6 +430,12 @@ public interface CamelConfig {
         boolean enabled();
     }
 
+    /**
+     * @deprecated use the standard Apache Camel {@code camel.trace.*} configuration properties instead. Deprecated in
+     *             3.39.0,
+     *             will be removed in 4.0.0.
+     */
+    @Deprecated(since = "3.39.0", forRemoval = true)
     interface TraceConfig {
         /**
          * Enables tracer in your Camel application.
@@ -539,6 +552,11 @@ public interface CamelConfig {
         Optional<String> traceFilter();
     }
 
+    /**
+     * @deprecated use the standard Apache Camel {@code camel.main.typeConverterStatisticsEnabled} configuration property
+     *             instead. Deprecated in 3.39.0, will be removed in 4.0.0.
+     */
+    @Deprecated(since = "3.39.0", forRemoval = true)
     interface TypeConverterConfig {
         /**
          * Whether type converter statistics are enabled. By default, type converter utilization statistics are disabled. Note


### PR DESCRIPTION
It's a maintenance burden to shadow config options already provided by camel-main. E.g we'd need to add our own options to support this https://github.com/apache/camel-quarkus/issues/8871. It'd be simpler to just leverage the ones from camel-main.