### PR TITLE
Revert Scalpel includePaths filtering

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -200,7 +200,6 @@ jobs:
       run-integration-tests-jvm: ${{ steps.process-incremental.outputs.run-integration-tests-jvm }}
       run-test-framework-tests: ${{ steps.process-incremental.outputs.run-test-framework-tests }}
       run-tooling-tests: ${{ steps.process-incremental.outputs.run-tooling-tests }}
-      incremental-build-enabled: ${{ steps.process-incremental.outputs.use-incremental }}
     env:
       MAVEN_OPTS: -Xmx4600m
       SCALPEL_ENABLED: "-Dscalpel.enabled=true"
@@ -543,7 +542,7 @@ jobs:
       || needs.initial-mvn-install.outputs.run-catalog-tests == 'true')
     env:
       MAVEN_OPTS: -Xmx3000m
-      SCALPEL_TRIM_ARGS: "-Dscalpel.enabled=true -Dscalpel.mode=trim -Dscalpel.alsoMake=false -Dscalpel.alsoMakeDependents=true"
+      SCALPEL_TRIM_ARGS: "-Dscalpel.enabled=true -Dscalpel.mode=trim -Dscalpel.alsoMake=true -Dscalpel.alsoMakeDependents=false"
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -560,20 +559,15 @@ jobs:
         with:
           cache-key: ${{ needs.initial-mvn-install.outputs.cache-key }}
           download-maven-repo: 'true'
-      - name: extensions-core mvn test
+      - name: cd extensions-core && mvn test
         if: needs.initial-mvn-install.outputs.run-extensions-core-tests == 'true'
         run: |
-          MVNW="./mvnw"
-          if [ "${{ needs.initial-mvn-install.outputs.incremental-build-enabled }}" != "true" ]; then
-            cd extensions-core
-            MVNW="../mvnw"
-          fi
-          ${MVNW} ${CQ_MAVEN_ARGS} ${BRANCH_OPTIONS} \
+          cd extensions-core
+          ../mvnw ${CQ_MAVEN_ARGS} ${BRANCH_OPTIONS} \
             ${CQ_MAVEN_SKIP_CHECKS} \
             ${SCALPEL_TRIM_ARGS} \
             ${SCALPEL_FULL_BUILD_TRIGGERS} \
             ${SCALPEL_EXCLUDE_PATHS} \
-            -Dscalpel.includePaths=extensions-core/** \
             --fail-at-end \
             test
       - name: Report test failures
@@ -581,20 +575,15 @@ jobs:
         if: ${{ failure() }}
         with:
           test-report-xml-base-dir: extensions-core
-      - name: extensions mvn test
+      - name: cd extensions && mvn test
         if: needs.initial-mvn-install.outputs.run-extensions-tests == 'true'
         run: |
-          MVNW="./mvnw"
-          if [ "${{ needs.initial-mvn-install.outputs.incremental-build-enabled }}" != "true" ]; then
-            cd extensions
-            MVNW="../mvnw"
-          fi
-          ${MVNW} ${CQ_MAVEN_ARGS} ${BRANCH_OPTIONS} \
+          cd extensions
+          ../mvnw ${CQ_MAVEN_ARGS} ${BRANCH_OPTIONS} \
             ${CQ_MAVEN_SKIP_CHECKS} \
             ${SCALPEL_TRIM_ARGS} \
             ${SCALPEL_FULL_BUILD_TRIGGERS} \
             ${SCALPEL_EXCLUDE_PATHS} \
-            -Dscalpel.includePaths=extensions/** \
             --fail-at-end \
             test
       - name: Report test failures
@@ -602,20 +591,15 @@ jobs:
         if: ${{ failure() }}
         with:
           test-report-xml-base-dir: extensions
-      - name: test-framework mvn test
+      - name: cd test-framework && mvn test
         if: needs.initial-mvn-install.outputs.run-test-framework-tests == 'true'
         run: |
-          MVNW="./mvnw"
-          if [ "${{ needs.initial-mvn-install.outputs.incremental-build-enabled }}" != "true" ]; then
-            cd test-framework
-            MVNW="../mvnw"
-          fi
-          ${MVNW} ${CQ_MAVEN_ARGS} ${BRANCH_OPTIONS} \
+          cd test-framework
+          ../mvnw ${CQ_MAVEN_ARGS} ${BRANCH_OPTIONS} \
             ${CQ_MAVEN_SKIP_CHECKS} \
             ${SCALPEL_TRIM_ARGS} \
             ${SCALPEL_FULL_BUILD_TRIGGERS} \
             ${SCALPEL_EXCLUDE_PATHS} \
-            -Dscalpel.includePaths=test-framework/** \
             --fail-at-end \
             test
       - name: Report test failures
@@ -623,20 +607,15 @@ jobs:
         if: ${{ failure() }}
         with:
           test-report-xml-base-dir: test-framework
-      - name: tooling mvn verify
+      - name: cd tooling && mvn verify
         if: needs.initial-mvn-install.outputs.run-tooling-tests == 'true'
         run: |
-          MVNW="./mvnw"
-          if [ "${{ needs.initial-mvn-install.outputs.incremental-build-enabled }}" != "true" ]; then
-            cd tooling
-            MVNW="../mvnw"
-          fi
-          ${MVNW} ${CQ_MAVEN_ARGS} ${BRANCH_OPTIONS} \
+          cd tooling
+          ../mvnw ${CQ_MAVEN_ARGS} ${BRANCH_OPTIONS} \
             ${CQ_MAVEN_SKIP_CHECKS} \
             ${SCALPEL_TRIM_ARGS} \
             ${SCALPEL_FULL_BUILD_TRIGGERS} \
             ${SCALPEL_EXCLUDE_PATHS} \
-            -Dscalpel.includePaths=tooling/** \
             --fail-at-end \
             verify
       - name: Report test failures
@@ -644,20 +623,15 @@ jobs:
         if: ${{ failure() }}
         with:
           test-report-xml-base-dir: tooling
-      - name: catalog mvn test
+      - name: cd catalog && mvn test
         if: needs.initial-mvn-install.outputs.run-catalog-tests == 'true'
         run: |
-          MVNW="./mvnw"
-          if [ "${{ needs.initial-mvn-install.outputs.incremental-build-enabled }}" != "true" ]; then
-            cd catalog
-            MVNW="../mvnw"
-          fi
-          ${MVNW} ${CQ_MAVEN_ARGS} ${BRANCH_OPTIONS} \
+          cd catalog
+          ../mvnw ${CQ_MAVEN_ARGS} ${BRANCH_OPTIONS} \
             ${CQ_MAVEN_SKIP_CHECKS} \
             ${SCALPEL_TRIM_ARGS} \
             ${SCALPEL_FULL_BUILD_TRIGGERS} \
             ${SCALPEL_EXCLUDE_PATHS} \
-            -Dscalpel.includePaths=catalog/** \
             test
       - name: Report test failures
         uses: ./.github/actions/test-summary-report


### PR DESCRIPTION
Partially reverts the Scalpel `includePaths` approach introduced in:

* https://github.com/apache/camel-quarkus/commit/47becad6e6bfce8d2ecd6feaab11990f2a656efd
* https://github.com/apache/camel-quarkus/commit/7f70f22a823ab7dc7090ed3b871502bd4464c890

## Problem

The `includePaths` filtering in Scalpel trim mode causes the full 1569-module reactor to be built when the filter excludes all affected modules. This happens because:

1. Scalpel applies `includePaths` filtering **before** downstream dependency expansion (`alsoMakeDependents`)
2. When directly affected modules live outside the target directory (e.g. `extensions-support/` changes for the `extensions` step with `includePaths=extensions/**`), the seed modules are filtered out
3. With zero modules surviving the filter, Scalpel falls back to not trimming — the full reactor runs

This was observed in:
- [Run 30899516273](https://github.com/apache/camel-quarkus/actions/runs/30899516273) — functional-extension-tests took 2h40m
- [Run 30912366659](https://github.com/apache/camel-quarkus/actions/runs/30912366659) — functional-extension-tests ran 2h17m before manual cancellation

## What this PR does

**Reverts** (workflow changes):
- Removes `includePaths` flags and conditional root execution from all functional test steps
- Restores the simple `cd <dir> && ../mvnw test` pattern with Scalpel trim (no `includePaths`)
- Reverts `SCALPEL_TRIM_ARGS` back to `alsoMake=true,alsoMakeDependents=false`
- Removes unused `incremental-build-enabled` job output

**Keeps** (scope detection improvement from 47becad):
- `detectFunctionalScope()` and `shouldRunExamples()` use `UPSTREAM` category filter instead of `DIRECT`-only, so DOWNSTREAM and TRANSITIVE modules are still considered when determining which functional test steps to run