### PR TITLE
Add openapi automated test in camel quarkus

### DIFF
--- a/integration-tests/openapi-java/src/main/java/org/apache/camel/quarkus/component/openapijava/it/OpenApiRoutes.java
+++ b/integration-tests/openapi-java/src/main/java/org/apache/camel/quarkus/component/openapijava/it/OpenApiRoutes.java
@@ -224,6 +224,17 @@ public class OpenApiRoutes extends RouteBuilder {
                 .endParam()
                 .to("seda:echoMethodPath");
 
+        rest("/api")
+                .post("/body/no-consumes")
+                .description("Post endpoint without consumes")
+                .type(Fruit.class)
+                .param()
+                .type(RestParamType.body)
+                .name("body")
+                .description("The request body")
+                .endParam()
+                .to("seda:res");
+
         rest("/form")
                 .post("/oneOf")
                 .tag("OneOf")

--- a/integration-tests/openapi-java/src/test/java/org/apache/camel/quarkus/component/openapijava/it/v3/OpenApiV3Test.java
+++ b/integration-tests/openapi-java/src/test/java/org/apache/camel/quarkus/component/openapijava/it/v3/OpenApiV3Test.java
@@ -293,6 +293,25 @@ public class OpenApiV3Test {
 
     @ParameterizedTest
     @EnumSource(OpenApiContentType.class)
+    public void openApiDefaultProducesConsumes(OpenApiContentType contentType) {
+        RestAssured.given()
+                .header("Accept", contentType.getMimeType())
+                .get("/openapi")
+                .then()
+                .contentType(ContentType.JSON)
+                .statusCode(200)
+                .body(
+                        "paths.'/api/body/no-consumes'", hasKey("post"),
+                        "paths.'/api/body/no-consumes'.post.summary", is("Post endpoint without consumes"),
+                        "paths.'/api/body/no-consumes'.post.requestBody", hasKey("content"),
+                        "paths.'/api/body/no-consumes'.post.requestBody.content", hasKey("application/json"),
+                        "paths.'/api/body/no-consumes'.post.requestBody.content.'application/json'.schema.$ref",
+                        is("#/components/schemas/Fruit"),
+                        "paths.'/api/body/no-consumes'.post.requestBody.required", is(true));
+    }
+
+    @ParameterizedTest
+    @EnumSource(OpenApiContentType.class)
     public void openApiOneOf(OpenApiContentType contentType) {
         RestAssured.given()
                 .header("Accept", contentType.getMimeType())


### PR DESCRIPTION
added automate test in camel quarkus to validate request body generated in openapi schema with no consume attribute provided. (Jira related)