### PR TITLE
CAMEL-24369: mcp-server: publish argSchema input schemas and MCP tool annotations

### DIFF
--- a/extensions/mcp-server/runtime/src/main/java/org/apache/camel/quarkus/component/mcp/server/QuarkusMcpServerEngine.java
+++ b/extensions/mcp-server/runtime/src/main/java/org/apache/camel/quarkus/component/mcp/server/QuarkusMcpServerEngine.java
@@ -22,7 +22,9 @@ import java.util.Map;
 import io.quarkiverse.mcp.server.TextContent;
 import io.quarkiverse.mcp.server.ToolManager;
 import io.quarkiverse.mcp.server.ToolResponse;
+import io.vertx.core.json.JsonObject;
 import org.apache.camel.CamelContext;
+import org.apache.camel.component.ai.tool.AiToolAnnotations;
 import org.apache.camel.component.ai.tool.AiToolParameterHelper.ParameterDef;
 import org.apache.camel.component.mcp.server.McpServerEngine;
 import org.apache.camel.component.mcp.server.McpServerInfo;
@@ -72,6 +74,13 @@ public class QuarkusMcpServerEngine extends ServiceSupport implements McpServerE
             ParameterDef def = parameter.getValue();
             definition.addArgument(parameter.getKey(), def.getDescription(), def.isRequired(), javaType(def));
         }
+        // publish the bridge's pre-built JSON Schema as-is so nested argSchema structures and
+        // constraints such as enum survive; without this the schema shown to clients would be
+        // regenerated from the flat arguments above (empty for argSchema-based tools)
+        if (tool.inputSchemaJson() != null) {
+            definition.setInputSchema(new JsonObject(tool.inputSchemaJson()));
+        }
+        applyAnnotations(definition, tool.annotations());
         definition.setHandler(arguments -> {
             Map<String, Object> args = arguments.args() != null ? arguments.args() : Map.of();
             McpToolCallResult result = tool.handler().call(args);
@@ -89,6 +98,31 @@ public class QuarkusMcpServerEngine extends ServiceSupport implements McpServerE
             LOG.debug("MCP tool removed: {}", toolName);
         } catch (Exception e) {
             LOG.debug("Failed to remove MCP tool {}: {}", toolName, e.getMessage());
+        }
+    }
+
+    /**
+     * Maps the ai-tool annotation hints to the quarkiverse tool definition: {@code title} to the tool's top-level
+     * title and the boolean hints to {@link ToolManager.ToolAnnotations}. The quarkiverse annotations record uses
+     * primitive booleans, so hints left unset on the ai-tool endpoint are published with the MCP specification's
+     * client-side defaults (readOnly=false, destructive=true, idempotent=false, openWorld=true); when no hint is set
+     * at all, no annotations are published.
+     */
+    private static void applyAnnotations(ToolManager.ToolDefinition definition, AiToolAnnotations annotations) {
+        if (annotations == null) {
+            return;
+        }
+        if (annotations.title() != null) {
+            definition.setTitle(annotations.title());
+        }
+        if (annotations.readOnlyHint() != null || annotations.destructiveHint() != null
+                || annotations.idempotentHint() != null || annotations.openWorldHint() != null) {
+            definition.setAnnotations(new ToolManager.ToolAnnotations(
+                    null,
+                    annotations.readOnlyHint() != null ? annotations.readOnlyHint() : false,
+                    annotations.destructiveHint() != null ? annotations.destructiveHint() : true,
+                    annotations.idempotentHint() != null ? annotations.idempotentHint() : false,
+                    annotations.openWorldHint() != null ? annotations.openWorldHint() : true));
         }
     }
 

--- a/integration-tests/mcp-server/src/main/java/org/apache/camel/quarkus/component/mcp/server/it/McpServerRoutes.java
+++ b/integration-tests/mcp-server/src/main/java/org/apache/camel/quarkus/component/mcp/server/it/McpServerRoutes.java
@@ -16,6 +16,9 @@
  */
 package org.apache.camel.quarkus.component.mcp.server.it;
 
+import java.util.List;
+import java.util.Map;
+
 import jakarta.enterprise.context.ApplicationScoped;
 import org.apache.camel.builder.RouteBuilder;
 
@@ -43,5 +46,19 @@ public class McpServerRoutes extends RouteBuilder {
 
         from("ai-tool:other_tool?tags=untrusted&description=Not a selected tag, must not be exposed")
                 .setBody(constant("other"));
+
+        from("ai-tool:annotated_tool?tags=conformance&description=Tool with annotation hints"
+                + "&title=Annotated tool"
+                + "&readOnlyHint=true"
+                + "&idempotentHint=true")
+                .setBody(constant("annotated"));
+
+        from("ai-tool:create_order?tags=conformance&description=Create an order"
+                + "&argSchema=classpath:schema/create-order.json")
+                .process(e -> {
+                    Map<?, ?> customer = e.getMessage().getHeader("customer", Map.class);
+                    List<?> items = e.getMessage().getHeader("items", List.class);
+                    e.getMessage().setBody("order for customer " + customer.get("id") + " with " + items.size() + " item(s)");
+                });
     }
 }

--- a/integration-tests/mcp-server/src/main/resources/application.properties
+++ b/integration-tests/mcp-server/src/main/resources/application.properties
@@ -16,3 +16,5 @@
 ## ---------------------------------------------------------------------------
 quarkus.camel.mcp-server.tags=conformance
 quarkus.camel.mcp-server.tool-timeout=2000
+# the argSchema resource must be reachable in native mode
+quarkus.native.resources.includes=schema/create-order.json

--- a/integration-tests/mcp-server/src/main/resources/schema/create-order.json
+++ b/integration-tests/mcp-server/src/main/resources/schema/create-order.json
@@ -1,0 +1,27 @@
+{
+  "type": "object",
+  "properties": {
+    "customer": {
+      "type": "object",
+      "description": "The customer placing the order",
+      "properties": {
+        "id": { "type": "string", "description": "Customer id" }
+      },
+      "required": ["id"]
+    },
+    "items": {
+      "type": "array",
+      "description": "The items to order",
+      "items": {
+        "type": "object",
+        "properties": {
+          "sku": { "type": "string" },
+          "qty": { "type": "integer" }
+        },
+        "required": ["sku", "qty"]
+      }
+    }
+  },
+  "required": ["customer", "items"],
+  "additionalProperties": false
+}

--- a/integration-tests/mcp-server/src/test/java/org/apache/camel/quarkus/component/mcp/server/it/McpServerTest.java
+++ b/integration-tests/mcp-server/src/test/java/org/apache/camel/quarkus/component/mcp/server/it/McpServerTest.java
@@ -76,6 +76,46 @@ class McpServerTest {
     }
 
     @Test
+    void testToolAnnotationHintsArePublished() {
+        client().when()
+                .toolsList(page -> {
+                    ToolInfo tool = toolByName(page, "annotated_tool");
+                    assertThat(tool.title()).isEqualTo("Annotated tool");
+                    assertThat(tool.annotations()).isPresent();
+                    assertThat(tool.annotations().orElseThrow().readOnlyHint()).isTrue();
+                    assertThat(tool.annotations().orElseThrow().idempotentHint()).isTrue();
+                })
+                .thenAssertResults();
+    }
+
+    @Test
+    void testArgSchemaIsPublishedAsInputSchema() {
+        client().when()
+                .toolsList(page -> {
+                    ToolInfo tool = toolByName(page, "create_order");
+                    assertThat(tool.inputSchema().getJsonObject("properties").getJsonObject("customer")
+                            .getString("type")).isEqualTo("object");
+                    assertThat(tool.inputSchema().getJsonObject("properties").getJsonObject("items")
+                            .getString("type")).isEqualTo("array");
+                    assertThat(tool.inputSchema().getJsonArray("required")).contains("customer", "items");
+                })
+                .thenAssertResults();
+    }
+
+    @Test
+    void testArgSchemaToolExecutesWithNestedArguments() {
+        client().when()
+                .toolsCall("create_order",
+                        Map.of("customer", Map.of("id", "C-1"),
+                                "items", List.of(Map.of("sku", "BOOK", "qty", 2))),
+                        response -> {
+                            assertThat(response.isError()).isFalse();
+                            assertThat(textOf(response)).isEqualTo("order for customer C-1 with 1 item(s)");
+                        })
+                .thenAssertResults();
+    }
+
+    @Test
     void testQuarkusAnnotatedToolsCoexistWithCamelTools() {
         // both tool sources are served by the same MCP server
         client().when()
@@ -159,6 +199,13 @@ class McpServerTest {
 
     private static List<String> toolNames(ToolsPage page) {
         return page.tools().stream().map(ToolInfo::name).toList();
+    }
+
+    private static ToolInfo toolByName(ToolsPage page, String name) {
+        return page.tools().stream()
+                .filter(t -> name.equals(t.name()))
+                .findFirst()
+                .orElseThrow();
     }
 
     private static String textOf(ToolResponse response) {


### PR DESCRIPTION
JIRA: [CAMEL-24369](https://issues.apache.org/jira/browse/CAMEL-24369) — companion PRs: apache/camel#25404, apache/camel-spring-boot#1881.

Two engine gaps found by running the same ai-tool + mcp-server application on Camel Main, Spring Boot and Quarkus:

1. **argSchema tools advertised an empty inputSchema.** `QuarkusMcpServerEngine` rebuilt the schema from the flat `addArgument` calls, so a tool defined with a nested `argSchema` was exposed as `{"type":"object","properties":{},"required":[]}` — an MCP client/LLM could not know what arguments to send (flat parameters also lost `enum` constraints). The engine now publishes the bridge's pre-built JSON Schema via `ToolDefinition.setInputSchema(new JsonObject(inputSchemaJson))`, which quarkiverse serves verbatim in `tools/list`.

2. **MCP tool annotation hints were dropped.** `title`, `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint` are now mapped via `setTitle`/`setAnnotations`, matching the Vert.x and Spring AI engines. The quarkiverse annotations record uses primitive booleans, so unset hints are published with the MCP specification's client-side defaults; when no hint is set at all, no annotations are published.

Three new conformance scenarios in `integration-tests/mcp-server` (annotations, argSchema in `tools/list`, argSchema execution with nested Map/List arguments); full module suite passes (9 tests), and the argSchema classpath resource is registered for native mode.

---
_Claude Code on behalf of Croway (Federico Mariani)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)