### PR TITLE
CAMEL-24369: openai: make the MCP client work in native mode

### DIFF
--- a/extensions/openai/deployment/src/main/java/org/apache/camel/quarkus/component/openai/deployment/OpenaiProcessor.java
+++ b/extensions/openai/deployment/src/main/java/org/apache/camel/quarkus/component/openai/deployment/OpenaiProcessor.java
@@ -35,6 +35,7 @@ import io.quarkus.deployment.builditem.RemovedResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourcePatternsBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveHierarchyBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
 import io.quarkus.deployment.pkg.steps.NativeOrNativeSourcesBuild;
 import io.quarkus.jackson.deployment.IgnoreJsonDeserializeClassBuildItem;
 import io.quarkus.maven.dependency.ArtifactKey;
@@ -51,8 +52,44 @@ class OpenaiProcessor {
     }
 
     @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
-    IndexDependencyBuildItem indexDependencies() {
-        return new IndexDependencyBuildItem("com.openai", "openai-java-core");
+    void indexDependencies(BuildProducer<IndexDependencyBuildItem> indexDependency) {
+        indexDependency.produce(new IndexDependencyBuildItem("com.openai", "openai-java-core"));
+        indexDependency.produce(new IndexDependencyBuildItem("io.modelcontextprotocol.sdk", "mcp-core"));
+    }
+
+    @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
+    void registerMcpSdkServiceProviders(BuildProducer<ServiceProviderBuildItem> serviceProvider) {
+        // the MCP client (mcpServer.* endpoint options) resolves its JSON mapper and schema
+        // validator through java.util.ServiceLoader; without these registrations a native
+        // application fails at runtime with "No McpJsonMapperSupplier available"
+        serviceProvider.produce(new ServiceProviderBuildItem(
+                "io.modelcontextprotocol.json.McpJsonMapperSupplier",
+                "io.modelcontextprotocol.json.jackson2.JacksonMcpJsonMapperSupplier"));
+        serviceProvider.produce(new ServiceProviderBuildItem(
+                "io.modelcontextprotocol.json.schema.JsonSchemaValidatorSupplier",
+                "io.modelcontextprotocol.json.schema.jackson2.JacksonJsonSchemaValidatorSupplier"));
+    }
+
+    @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
+    void registerMcpSdkSchemaForReflection(
+            CombinedIndexBuildItem combinedIndex,
+            BuildProducer<ReflectiveClassBuildItem> reflectiveClass) {
+        // the MCP protocol messages (McpSchema records and friends) are (de)serialized by Jackson
+        // reflectively; the MCP Java SDK ships no native-image metadata
+        Set<String> mcpSchemaClassNames = combinedIndex.getIndex()
+                .getKnownClasses()
+                .stream()
+                .map(ClassInfo::name)
+                .map(DotName::toString)
+                .filter(className -> className.startsWith("io.modelcontextprotocol.spec")
+                        || className.startsWith("io.modelcontextprotocol.json"))
+                .collect(Collectors.toSet());
+
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(mcpSchemaClassNames.toArray(new String[0]))
+                .constructors()
+                .fields()
+                .methods()
+                .build());
     }
 
     @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)


### PR DESCRIPTION
JIRA: [CAMEL-24369](https://issues.apache.org/jira/browse/CAMEL-24369) — follow-up to #8967.

A native application using the openai component's MCP tool calling (`mcpServer.*` endpoint options) fails at startup with:

```
java.util.ServiceConfigurationError: No McpJsonMapperSupplier available for creating McpJsonMapper
```

and, once past that, the MCP client `initialize` handshake fails on Jackson deserialization of the MCP protocol messages. Root cause: the MCP Java SDK resolves its JSON mapper and schema validator through `java.util.ServiceLoader` and (de)serializes the `McpSchema` records reflectively, but ships no native-image metadata.

`OpenaiProcessor` now registers the two service providers (`McpJsonMapperSupplier`, `JsonSchemaValidatorSupplier` from `mcp-json-jackson2`) and all indexed `io.modelcontextprotocol.spec` / `io.modelcontextprotocol.json` classes for reflection.

Verified with a native (container-build) application acting as MCP client of its own `camel-quarkus-mcp-server` endpoint against local Ollama: before the fix the app failed at startup; after the fix the full agentic tool-calling loop passes the same 27-scenario conformance script that the JVM mode passes (native startup 0.092s).

---
_Claude Code on behalf of Croway (Federico Mariani)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)