### PR TITLE
fix integration cassandra-source kamelet pod status is in running state but not ready

### DIFF
--- a/docs/modules/ROOT/pages/migration-guide/3.39.0.adoc
+++ b/docs/modules/ROOT/pages/migration-guide/3.39.0.adoc
@@ -35,3 +35,18 @@ quarkus.camel.jolokia.remote-access-allowed=true
 ----
 
 This is safe when combined with SSL client authentication (enabled by default in Kubernetes environments), which ensures only clients presenting a valid certificate can connect. Refer to the xref:reference/extensions/jolokia.adoc[Jolokia extension documentation] for full details.
+
+== CassandraQL extension
+
+=== Cassandra health check may cause pod readiness failures
+
+The `cassandra-quarkus-client` dependency used by the CassandraQL extension automatically registers a health check that connects to the Cassandra instance configured via `quarkus.cassandra.contact-points`. Since Camel manages its own `CqlSession` independently, this property is typically not set, causing the health check to default to `127.0.0.1:9042` and fail. This results in Kubernetes readiness probes reporting the pod as not ready.
+
+If you encounter this issue, disable the Cassandra Quarkus Client health check in your `application.properties`:
+
+[source,properties]
+----
+quarkus.cassandra.health.enabled=false
+----
+
+Refer to the xref:reference/extensions/cassandraql.adoc[CassandraQL extension documentation] for more details.

--- a/docs/modules/ROOT/pages/reference/extensions/cassandraql.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/cassandraql.adoc
@@ -48,6 +48,18 @@ endif::[]
 [id="extensions-cassandraql-additional-camel-quarkus-configuration"]
 == Additional Camel Quarkus configuration
 
+[id="extensions-cassandraql-configuration-cassandra-health-check"]
+=== Cassandra health check
+
+The `cassandra-quarkus-client` dependency, which is used internally by this extension, automatically registers a health check. However, Camel manages its own `CqlSession` independently and does not use the Quarkus-managed Cassandra client, so the health check may fail and cause Kubernetes readiness probes to report the pod as not ready.
+
+To work around this, disable the Cassandra health check in your `application.properties`:
+
+[source,properties]
+----
+quarkus.cassandra.health.enabled=false
+----
+
 [id="extensions-cassandraql-configuration-cassandra-aggregation-repository-in-native-mode"]
 === Cassandra aggregation repository in native mode
 

--- a/extensions/cassandraql/runtime/src/main/doc/configuration.adoc
+++ b/extensions/cassandraql/runtime/src/main/doc/configuration.adoc
@@ -1,3 +1,14 @@
+=== Cassandra health check
+
+The `cassandra-quarkus-client` dependency, which is used internally by this extension, automatically registers a health check. However, Camel manages its own `CqlSession` independently and does not use the Quarkus-managed Cassandra client, so the health check may fail and cause Kubernetes readiness probes to report the pod as not ready.
+
+To work around this, disable the Cassandra health check in your `application.properties`:
+
+[source,properties]
+----
+quarkus.cassandra.health.enabled=false
+----
+
 === Cassandra aggregation repository in native mode
 
 In order to use Cassandra aggregation repositories like `CassandraAggregationRepository` in native mode, you must xref:extensions/core.adoc#quarkus-camel-native-reflection-serialization-enabled[enable native serialization support].


### PR DESCRIPTION
This fix related to a downstream issue that tested camel quarkus integrated with cassandra-source kamelet in openshift/k8s found pod status is in running status but not ready.

**root cause found**:
cassandra-quarkus-client auto registered a health check that defaults to 127.0.0.1:9042 when quarkus.cassandra.contact-points isn't configured as camel managed it's own cqlsession, the health check could not find the cassandra target and caused openshift/k8s readiness probe failures.

**update**:
provide workaround in guide with quarkus.cassandra.health.enabled set to false to fix this issue.

**Before fix**:
jinyuchen@Jinyus-MacBook-Pro camel-quarkus % kubectl get pods                                          
NAME                                            READY   STATUS    RESTARTS   AGE
cassandra-5f7c94bf8c-g7lzp                      1/1     Running   0          3m15s
cassandra-source-kamelet-test-8448d69bd-cpfnd   **0/1**     Running   0          114s

**After fix**:
jinyuchen@Jinyus-MacBook-Pro camel-quarkus % kubectl get pods
NAME                                            READY   STATUS    RESTARTS   AGE
cassandra-5f7c94bf8c-g7lzp                      1/1     Running   0          25m
cassandra-source-kamelet-test-8cfd57cbc-9cqgh   **1/1**     Running   0          22s