### PR TITLE
adding fix and update guide to describe the fixing integration cassandra-source kamelet to log on openshift is in running state but pod is not ready

### DIFF
--- a/docs/modules/ROOT/pages/migration-guide/3.39.0.adoc
+++ b/docs/modules/ROOT/pages/migration-guide/3.39.0.adoc
@@ -36,17 +36,17 @@ quarkus.camel.jolokia.remote-access-allowed=true
 
 This is safe when combined with SSL client authentication (enabled by default in Kubernetes environments), which ensures only clients presenting a valid certificate can connect. Refer to the xref:reference/extensions/jolokia.adoc[Jolokia extension documentation] for full details.
 
-== CassandraQL extension
+== CassandraQL extension changes
 
-=== Cassandra health check may cause pod readiness failures
+=== Cassandra health check disabled by default
 
-The `cassandra-quarkus-client` dependency used by the CassandraQL extension automatically registers a health check that connects to the Cassandra instance configured via `quarkus.cassandra.contact-points`. Since Camel manages its own `CqlSession` independently, this property is typically not set, causing the health check to default to `127.0.0.1:9042` and fail. This results in Kubernetes readiness probes reporting the pod as not ready.
+The `cassandra-quarkus-client` health check is now disabled by default (`quarkus.cassandra.health.enabled=false`). Camel manages its own `CqlSession` independently and does not use the Quarkus-managed Cassandra client, so the health check may fail and cause Kubernetes readiness probes to report the pod as not ready.
 
-If you encounter this issue, disable the Cassandra Quarkus Client health check in your `application.properties`:
+If you use `quarkus.cassandra.*` configuration properties to set up the Cassandra client and leverage that in the Camel CassandraQL component, re-enable the health check in your `application.properties`:
 
 [source,properties]
 ----
-quarkus.cassandra.health.enabled=false
+quarkus.cassandra.health.enabled=true
 ----
 
 Refer to the xref:reference/extensions/cassandraql.adoc[CassandraQL extension documentation] for more details.

--- a/docs/modules/ROOT/pages/reference/extensions/cassandraql.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/cassandraql.adoc
@@ -51,13 +51,13 @@ endif::[]
 [id="extensions-cassandraql-configuration-cassandra-health-check"]
 === Cassandra health check
 
-The `cassandra-quarkus-client` dependency, which is used internally by this extension, automatically registers a health check. However, Camel manages its own `CqlSession` independently and does not use the Quarkus-managed Cassandra client, so the health check may fail and cause Kubernetes readiness probes to report the pod as not ready.
+The `cassandra-quarkus-client` dependency, which is used internally by this extension, automatically registers a health check. However, Camel manages its own `CqlSession` independently and does not use the Quarkus-managed Cassandra client, so the health check may fail and cause Kubernetes readiness probes to report the pod as not ready. For this reason, the Cassandra health check is disabled by default (`quarkus.cassandra.health.enabled=false`).
 
-To work around this, disable the Cassandra health check in your `application.properties`:
+If you use `quarkus.cassandra.*` configuration properties to set up the Cassandra client and leverage that in the Camel CassandraQL component, you should re-enable the health check in your `application.properties`:
 
 [source,properties]
 ----
-quarkus.cassandra.health.enabled=false
+quarkus.cassandra.health.enabled=true
 ----
 
 [id="extensions-cassandraql-configuration-cassandra-aggregation-repository-in-native-mode"]

--- a/extensions/cassandraql/runtime/src/main/doc/configuration.adoc
+++ b/extensions/cassandraql/runtime/src/main/doc/configuration.adoc
@@ -1,12 +1,12 @@
 === Cassandra health check
 
-The `cassandra-quarkus-client` dependency, which is used internally by this extension, automatically registers a health check. However, Camel manages its own `CqlSession` independently and does not use the Quarkus-managed Cassandra client, so the health check may fail and cause Kubernetes readiness probes to report the pod as not ready.
+The `cassandra-quarkus-client` dependency, which is used internally by this extension, automatically registers a health check. However, Camel manages its own `CqlSession` independently and does not use the Quarkus-managed Cassandra client, so the health check may fail and cause Kubernetes readiness probes to report the pod as not ready. For this reason, the Cassandra health check is disabled by default (`quarkus.cassandra.health.enabled=false`).
 
-To work around this, disable the Cassandra health check in your `application.properties`:
+If you use `quarkus.cassandra.*` configuration properties to set up the Cassandra client and leverage that in the Camel CassandraQL component, you should re-enable the health check in your `application.properties`:
 
 [source,properties]
 ----
-quarkus.cassandra.health.enabled=false
+quarkus.cassandra.health.enabled=true
 ----
 
 === Cassandra aggregation repository in native mode

--- a/extensions/cassandraql/runtime/src/main/resources/application.properties
+++ b/extensions/cassandraql/runtime/src/main/resources/application.properties
@@ -1,0 +1,17 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+quarkus.cassandra.health.enabled=false


### PR DESCRIPTION
set quarkus.cassandra.health.enabled to false by default to prevent openshift/k8s readness probes issue caused pod is running but not ready status issue. Update docs to show case the command to use if user would like to set up quarkus cassandra client in camel quarkus.