### PR TITLE
Fixes #8871 - Support BacklogTracer activityEnabled and activitySize options

### DIFF
--- a/docs/modules/ROOT/pages/reference/extensions/core.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/core.adoc
@@ -481,6 +481,20 @@ Filter for tracing messages.
 | `string`
 | 
 
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-trace-activity-enabled]]`link:#quarkus-camel-trace-activity-enabled[quarkus.camel.trace.activity-enabled]`
+
+Whether activity tracking is enabled. Activity tracking captures a rolling window of completed exchange
+summaries with enriched span decorator attributes (e.g. Kafka topic, HTTP method, SQL query).
+| `boolean`
+| `false`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-trace-activity-size]]`link:#quarkus-camel-trace-activity-size[quarkus.camel.trace.activity-size]`
+
+The maximum number of completed exchange summaries to keep in the activity queue. The valid range is 1 to
+1000.
+| `int`
+| `100`
+
 a|icon:lock[title=Fixed at build time] [[quarkus-camel-type-converter-statistics-enabled]]`link:#quarkus-camel-type-converter-statistics-enabled[quarkus.camel.type-converter.statistics-enabled]`
 
 Whether type converter statistics are enabled. By default, type converter utilization statistics are disabled. Note

--- a/extensions-core/core/deployment/src/test/java/org/apache/camel/quarkus/core/runtime/CamelTraceActivityCamelMainFallbackTest.java
+++ b/extensions-core/core/deployment/src/test/java/org/apache/camel/quarkus/core/runtime/CamelTraceActivityCamelMainFallbackTest.java
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class CamelTraceTest {
+class CamelTraceActivityCamelMainFallbackTest {
     @RegisterExtension
     static final QuarkusUnitTest CONFIG = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
@@ -48,7 +48,8 @@ class CamelTraceTest {
 
         Properties props = new Properties();
         props.setProperty("quarkus.camel.trace.enabled", "true");
-        props.setProperty("quarkus.camel.trace.backlog-size", "100");
+        props.setProperty("camel.trace.activity-enabled", "true");
+        props.setProperty("camel.trace.activity-size", "300");
 
         try {
             props.store(writer, "");
@@ -60,17 +61,11 @@ class CamelTraceTest {
     }
 
     @Test
-    void testTraceConfiguration() {
+    void testTraceActivityConfigurationViaCamelMainFallback() {
         BacklogTracer tracer = camelContext.getCamelContextExtension().getContextPlugin(BacklogTracer.class);
 
-        assertThat(camelContext.isBacklogTracing()).isTrue();
-        assertThat(camelContext.isBacklogTracingStandby()).isFalse();
-        assertThat(camelContext.isBacklogTracingTemplates()).isFalse();
         assertThat(tracer).isNotNull();
-        assertThat(tracer.getBacklogSize()).isEqualTo(100);
-        assertThat(tracer.getTracePattern()).isNull();
-        assertThat(tracer.getTraceFilter()).isNull();
-        assertThat(tracer.isActivityEnabled()).isFalse();
-        assertThat(tracer.getActivitySize()).isEqualTo(100);
+        assertThat(tracer.isActivityEnabled()).isTrue();
+        assertThat(tracer.getActivitySize()).isEqualTo(300);
     }
 }

--- a/extensions-core/core/deployment/src/test/java/org/apache/camel/quarkus/core/runtime/CamelTraceActivityTest.java
+++ b/extensions-core/core/deployment/src/test/java/org/apache/camel/quarkus/core/runtime/CamelTraceActivityTest.java
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class CamelTraceTest {
+class CamelTraceActivityTest {
     @RegisterExtension
     static final QuarkusUnitTest CONFIG = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
@@ -48,7 +48,8 @@ class CamelTraceTest {
 
         Properties props = new Properties();
         props.setProperty("quarkus.camel.trace.enabled", "true");
-        props.setProperty("quarkus.camel.trace.backlog-size", "100");
+        props.setProperty("quarkus.camel.trace.activity-enabled", "true");
+        props.setProperty("quarkus.camel.trace.activity-size", "200");
 
         try {
             props.store(writer, "");
@@ -60,17 +61,11 @@ class CamelTraceTest {
     }
 
     @Test
-    void testTraceConfiguration() {
+    void testTraceActivityConfiguration() {
         BacklogTracer tracer = camelContext.getCamelContextExtension().getContextPlugin(BacklogTracer.class);
 
-        assertThat(camelContext.isBacklogTracing()).isTrue();
-        assertThat(camelContext.isBacklogTracingStandby()).isFalse();
-        assertThat(camelContext.isBacklogTracingTemplates()).isFalse();
         assertThat(tracer).isNotNull();
-        assertThat(tracer.getBacklogSize()).isEqualTo(100);
-        assertThat(tracer.getTracePattern()).isNull();
-        assertThat(tracer.getTraceFilter()).isNull();
-        assertThat(tracer.isActivityEnabled()).isFalse();
-        assertThat(tracer.getActivitySize()).isEqualTo(100);
+        assertThat(tracer.isActivityEnabled()).isTrue();
+        assertThat(tracer.getActivitySize()).isEqualTo(200);
     }
 }

--- a/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/CamelConfig.java
+++ b/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/CamelConfig.java
@@ -550,6 +550,24 @@ public interface CamelConfig {
          * @asciidoclet
          */
         Optional<String> traceFilter();
+
+        /**
+         * Whether activity tracking is enabled. Activity tracking captures a rolling window of completed exchange
+         * summaries with enriched span decorator attributes (e.g. Kafka topic, HTTP method, SQL query).
+         *
+         * @asciidoclet
+         */
+        @WithDefault("false")
+        boolean activityEnabled();
+
+        /**
+         * The maximum number of completed exchange summaries to keep in the activity queue. The valid range is 1 to
+         * 1000.
+         *
+         * @asciidoclet
+         */
+        @WithDefault("100")
+        int activitySize();
     }
 
     /**

--- a/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/CamelContextRecorder.java
+++ b/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/CamelContextRecorder.java
@@ -160,6 +160,18 @@ public class CamelContextRecorder {
             tracer.setTracePattern(trace.tracePattern().orElse(null));
             tracer.setTraceFilter(trace.traceFilter().orElse(null));
 
+            // activityEnabled: prefer quarkus.camel.trace.activity-enabled, fall back to camel.trace.activity-enabled
+            boolean activityEnabled = ConfigProvider.getConfig()
+                    .getOptionalValue("camel.trace.activity-enabled", Boolean.class)
+                    .orElse(trace.activityEnabled());
+            tracer.setActivityEnabled(activityEnabled);
+
+            // activitySize: prefer quarkus.camel.trace.activity-size, fall back to camel.trace.activity-size
+            int activitySize = ConfigProvider.getConfig()
+                    .getOptionalValue("camel.trace.activity-size", Integer.class)
+                    .orElse(trace.activitySize());
+            tracer.setActivitySize(activitySize);
+
             context.getCamelContextExtension().addContextPlugin(BacklogTracer.class, tracer);
         });
     }


### PR DESCRIPTION
## Summary

Adds support for the two new `BacklogTracer` options introduced in Camel 4.22.0:

- `activityEnabled` — enables activity tracking (rolling window of completed exchange summaries with enriched span decorator attributes)
- `activitySize` — bounds the activity queue size (default 100, matching Camel's default)

## Changes

### `CamelConfig.TraceConfig`
Added `activityEnabled()` and `activitySize()` to the deprecated `TraceConfig` interface, exposed as:
- `quarkus.camel.trace.activity-enabled`
- `quarkus.camel.trace.activity-size`

Defaults match those from Camel's `TracerConfigurationProperties` (`false` and `100` respectively).

### `CamelContextRecorder.createBacklogTracerCustomizer`
Wires the new options onto the `BacklogTracer` with a fallback chain:
1. `camel.trace.activity-enabled` / `camel.trace.activity-size` (standard camel-main properties, handled natively by camel-main)
2. `quarkus.camel.trace.activity-enabled` / `quarkus.camel.trace.activity-size` (deprecated `TraceConfig` properties)

### Tests
- `CamelTraceTest` — updated to assert default values (`activityEnabled=false`, `activitySize=100`)
- `CamelTraceActivityTest` — new, verifies configuration via `quarkus.camel.trace.*`
- `CamelTraceActivityCamelMainFallbackTest` — new, verifies configuration via `camel.trace.*` fallback

Fixes #8871