### PR TITLE
Fixes #9003. Add an ingestion tracker SPI with a JDBC impl for AI document ingestion

### DIFF
--- a/extensions-support/langchain4j/README.adoc
+++ b/extensions-support/langchain4j/README.adoc
@@ -84,9 +84,18 @@ transition except `deleteRow`, which removes the row whole.
 reference implementation: deliberately dialect-free SQL (upserts are update-then-insert inside
 application code rather than vendor `MERGE`/`ON CONFLICT`), using only JDK types, so the same
 code runs unmodified against PostgreSQL and H2. It owns its own schema
-(`cq_ingestion_tracker`, created on first use via `ensureSchema()`) and expects to be handed a
+(`camel_quarkus_ingestion_tracker`, created on first use via `ensureSchema()`; document ids up
+to 1024 characters, the S3 object-key maximum) and expects to be handed a
 `javax.sql.DataSource` — in a Quarkus application that's typically an Agroal-managed datasource,
-with Dev Services providing one automatically in dev/test when none is configured.
+with Dev Services providing one automatically in dev/test when none is configured. Operators who
+run the application's DB user without DDL privileges can pre-provision the table and construct
+the tracker with `createTableIfNotExists = false`, in which case `ensureSchema()` only probes
+that the table exists (the same escape hatch camel-sql's `JdbcMessageIdRepository` offers).
+
+NOTE: the tracker table is a durable inventory of the corpus. Document content never lands in
+it, but `doc_id` values are typically paths, URLs or object keys, and those routinely encode
+sensitive structure (`/customers/12345/contract.pdf`). Document ids also appear in exception
+messages, so they reach logs and stack traces.
 
 `JdbcIngestionTrackerTest` (in this module) pins the behavioural guarantees every implementation
 must satisfy (durability of in-progress intents, shrink-bound tracking across re-intents,

--- a/extensions-support/langchain4j/README.adoc
+++ b/extensions-support/langchain4j/README.adoc
@@ -1,0 +1,107 @@
+= LangChain4j Support
+
+This module provides common support code shared by Camel Quarkus LangChain4j extensions.
+
+== Ingestion tracker
+
+Status: *Experimental*.
+
+`org.apache.camel.quarkus.component.support.langchain4j.tracker.IngestionTracker` is the bookkeeping
+SPI behind keeping a vector store in sync with a changing document source (files, buckets, feeds,
+...). Vector stores cannot be enumerated for "what did I already ingest", and LangChain4j has no
+equivalent of LangChain-Python's `RecordManager`
+(https://github.com/langchain4j/langchain4j/issues/2931[langchain4j#2931]), so without external
+bookkeeping any ingestion pipeline is either append-only (restarts re-embed the whole corpus,
+edited documents join their previous vectors instead of replacing them) or wipe-and-reload
+(loses everything between passes). `IngestionTracker` closes that gap: it tracks one row per document
+— fingerprint, content hash, segment count, a two-phase `in_progress`/`done`/`failed` status,
+and `tombstone`/`pinned` flags — as the single authority on what was ingested. The vector store
+itself stays a disposable projection that is never asked questions; losing the tracker only costs
+re-ingestion, never correctness, because segment ids are deterministic.
+
+The two-phase `writeIntent`/`commit` protocol is what makes the tracker crash-safe: a row left
+`in_progress` by a crash (killed process, OOM, ...) is never mistaken for "already ingested", so
+the next delivery of the same document converges the store instead of skipping it.
+
+=== Document states
+
+Each document is one row that moves through the states below. Transitions are the SPI methods;
+the annotations in parentheses describe when the consumer (the ingestion pipeline) invokes them.
+
+----
+ (no row)
+    │  writeIntent                 durable BEFORE the store is touched; a crash strands
+    ▼                              the row here, and an in_progress row is never trusted
+ in_progress                       as "already ingested" — the next delivery of the
+    │  commit                      document converges the store
+    ▼
+  done ◄──────────────────────┐
+    │                         │
+    ├─ (unchanged) ──► done   │  no transition: the skip that makes restarts free
+    │                         │
+    ├─ refreshFingerprint ────┘  fingerprint renewed after a content-hash match
+    │                            (tier-2), so the cheap tier-1 check works next pass
+    │
+    ├─ writeIntent ──► in_progress    (edited content: replace; the shrink bound
+    │                                  max(committed, intended) rides along in the row)
+    │
+    ├─ markFailed ──► failed          (processing failure — also fired straight from
+    │      │                           in_progress; previously committed segments, if
+    │      │                           any — a stale but valid version — keep serving)
+    │      │
+    │      ├─ (fingerprint unchanged) ──► failed   dead-lettered: skipped on every
+    │      │                                       pass until the content changes
+    │      │
+    │      └─ writeIntent ──► in_progress          (changed content: retry)
+    │
+    ├─ tombstone() ──► done(0) + tombstone    (explicit delete: the consumer removes
+    │      │                                   the vectors and records commit(0) with
+    │      │                                   the flag) — "deleted stays deleted":
+    │      │                                   every future ingest of the document is
+    │      │                                   suppressed, even though the source
+    │      │                                   still has it
+    │      │
+    │      └─ unsuppress() ──► done(0)         suppression lifted: the next pass
+    │                                          re-ingests the document
+    │
+    └─ pin() ──► done + pinned        (an API write corrected a source-owned document)
+           │                           — "the correction wins": source-origin updates
+           │                           are suppressed; API-origin writes still pass
+           │
+           └─ unpin() ──► done         the source owns the document again
+
+ any state ── deleteRow ──► (no row)   reconciliation: the source no longer lists the
+                                       document (guarded by the consumer's pass
+                                       interlock, never fired by the tracker itself)
+----
+
+`tombstone` and `pinned` are columns orthogonal to `status`: drawn above off `done` because
+that is how the consumer composes them, but they can accompany any state (a tombstone can even
+be recorded for a never-ingested document, as a pure suppression record) and they survive every
+transition except `deleteRow`, which removes the row whole.
+
+`org.apache.camel.quarkus.component.support.langchain4j.tracker.jdbc.JdbcIngestionTracker` is the
+reference implementation: deliberately dialect-free SQL (upserts are update-then-insert inside
+application code rather than vendor `MERGE`/`ON CONFLICT`), using only JDK types, so the same
+code runs unmodified against PostgreSQL and H2. It owns its own schema
+(`cq_ingestion_tracker`, created on first use via `ensureSchema()`) and expects to be handed a
+`javax.sql.DataSource` — in a Quarkus application that's typically an Agroal-managed datasource,
+with Dev Services providing one automatically in dev/test when none is configured.
+
+`JdbcIngestionTrackerTest` (in this module) pins the behavioural guarantees every implementation
+must satisfy (durability of in-progress intents, shrink-bound tracking across re-intents,
+tombstone/pin lifecycle, dead-letter semantics on failure, ...) against H2 for a fast unit loop.
+Its test methods are written against the SPI only, so they double as the contract: the day a
+second implementation exists — for example an adapter over a future upstream LangChain4j record
+manager — they are meant to be extracted into an abstract `IngestionTrackerContract` base class
+with one `*Test` subclass per implementation, and a replacement is a drop-in exactly when its
+subclass passes. The guarantees are verified twice:
+`integration-tests/langchain4j-ingestion-tracker` runs the same set over REST against a real
+PostgreSQL instance (Dev Services), because H2 alone does not prove the "works on PostgreSQL"
+half of the contract.
+
+CAUTION: `IngestionTracker` and its `tracker.*` package are experimental and an internal SPI, not a
+public API — no compatibility guarantees between releases, and applications must not implement or
+call it directly; it may change or be removed without a deprecation cycle. It exists so the
+implementation can be replaced wholesale later. It is not yet wired into a user-facing extension;
+it is consumed by the upcoming `langchain4j-ingest` extension's `sync` mode.

--- a/extensions-support/langchain4j/runtime/pom.xml
+++ b/extensions-support/langchain4j/runtime/pom.xml
@@ -65,6 +65,18 @@
             <artifactId>camel-langchain4j-agent</artifactId>
             <optional>true</optional>
         </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions-support/langchain4j/runtime/src/main/java/org/apache/camel/quarkus/component/support/langchain4j/tracker/IngestionTracker.java
+++ b/extensions-support/langchain4j/runtime/src/main/java/org/apache/camel/quarkus/component/support/langchain4j/tracker/IngestionTracker.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.support.langchain4j.tracker;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * The ingestion tracker: one row per document, the authority on what was ingested. The vector store is
+ * a projection that is never asked questions — losing the tracker costs re-ingestion (which
+ * converges thanks to deterministic segment ids), never correctness. Reconciliation is
+ * tracker-versus-source; the store is never enumerated.
+ *
+ * <p>
+ * <strong>Status: Experimental.</strong> Internal SPI — not a public API. No compatibility
+ * guarantees between releases; applications must not implement or call this interface, and it
+ * may change or be removed without a deprecation cycle. It exists so the implementation can be
+ * replaced wholesale: LangChain4j has no equivalent of LangChain-Python's {@code RecordManager} yet
+ * (<a href="https://github.com/langchain4j/langchain4j/issues/2931">langchain4j#2931</a>), and
+ * once one lands upstream, an adapter implementing this interface replaces the
+ * {@code tracker.jdbc} package while every consumer stays untouched. New implementations must
+ * pass the behavioural tests of {@code JdbcIngestionTrackerTest}, whose test methods are written
+ * against this SPI only and are meant to be extracted into a shared contract base class the day
+ * a second implementation exists.
+ *
+ * <p>
+ * Two method groups, by replaceability:
+ * <ul>
+ * <li><em>Tracker subset</em> — {@link #ensureSchema}, {@link #read}, {@link #listDocuments},
+ * {@link #refreshFingerprint}, {@link #deleteRow}: mirrors what an upstream record manager
+ * provides and would delegate to it directly.</li>
+ * <li><em>Camel Quarkus extensions</em> — the two-phase {@link #writeIntent}/{@link #commit}
+ * protocol, {@link #tombstone}/{@link #unsuppress}, {@link #pin}/{@link #unpin},
+ * {@link #markFailed}: product semantics an upstream tracker will not carry; an adapter keeps
+ * these in side storage keyed the same way.</li>
+ * </ul>
+ */
+public interface IngestionTracker {
+
+    String ORIGIN_SOURCE = "source";
+    String ORIGIN_API = "api";
+
+    /** Creates or migrates the backing schema. Called once before first use. */
+    void ensureSchema();
+
+    Optional<TrackerRow> read(String pipeline, String documentId);
+
+    /** All rows of a pipeline — the reconciliation input. */
+    List<TrackerRow> listDocuments(String pipeline);
+
+    /**
+     * Durably records the intent to (re)write a document <em>before</em> the store is touched.
+     * A row left {@code in_progress} by a crash is never skipped by change detection, so the
+     * next delivery of the document converges the store.
+     */
+    void writeIntent(String pipeline, String documentId, String fingerprint, String contentHash,
+            int committedCount, int intendedCount, String origin);
+
+    /** Marks the write complete. Only rows in {@code done} status participate in skip decisions. */
+    void commit(String pipeline, String documentId, String fingerprint, String contentHash, int segmentCount);
+
+    /**
+     * Refreshes the stored fingerprint of an already-{@code done} row whose content turned out
+     * unchanged (tier-2 hash match after a tier-1 fingerprint miss), so the cheaper tier-1 check
+     * skips the document next time.
+     */
+    void refreshFingerprint(String pipeline, String documentId, String fingerprint);
+
+    /**
+     * Marks an explicit delete: the row survives as a suppression record, so the document stays
+     * deleted even while its source file still exists. Lifted with {@link #unsuppress}.
+     */
+    void tombstone(String pipeline, String documentId);
+
+    void unsuppress(String pipeline, String documentId);
+
+    /** Pins a document: source updates are suppressed until {@link #unpin}. */
+    void pin(String pipeline, String documentId);
+
+    void unpin(String pipeline, String documentId);
+
+    /** Removes a row entirely — used by deletion-by-disappearance, where nothing needs remembering. */
+    void deleteRow(String pipeline, String documentId);
+
+    /**
+     * Dead-letters a document after a processing failure: records the fingerprint of the failed
+     * attempt so subsequent passes skip the poison document until its content changes, instead
+     * of failing identically forever at cost. Previous committed segments (a stale version that
+     * correctly keeps serving) stay untouched.
+     */
+    void markFailed(String pipeline, String documentId, String fingerprint);
+
+    /**
+     * @param status {@code done}, {@code in_progress} or {@code failed}
+     * @param origin {@link #ORIGIN_SOURCE} or {@link #ORIGIN_API}
+     */
+    record TrackerRow(String pipeline, String documentId, String fingerprint, String contentHash,
+            int segmentCount, int intendedCount, String status, String origin, boolean tombstone,
+            boolean pinned) {
+
+        public boolean done() {
+            return "done".equals(status);
+        }
+
+        public boolean failed() {
+            return "failed".equals(status);
+        }
+
+        /** The shrink bound: the largest segment index that may exist in the store, ever intended. */
+        public int maxKnownCount() {
+            return Math.max(segmentCount, intendedCount);
+        }
+    }
+}

--- a/extensions-support/langchain4j/runtime/src/main/java/org/apache/camel/quarkus/component/support/langchain4j/tracker/IngestionTracker.java
+++ b/extensions-support/langchain4j/runtime/src/main/java/org/apache/camel/quarkus/component/support/langchain4j/tracker/IngestionTracker.java
@@ -65,32 +65,48 @@ public interface IngestionTracker {
     /**
      * Durably records the intent to (re)write a document <em>before</em> the store is touched.
      * A row left {@code in_progress} by a crash is never skipped by change detection, so the
-     * next delivery of the document converges the store.
+     * next delivery of the document converges the store. The recorded intended count is
+     * <em>monotone until commit</em>: a re-intent never lowers it, because once an intent for N
+     * is durable, up to N segments may exist in the store and only a {@link #commit} proves the
+     * sweep happened.
      */
     void writeIntent(String pipeline, String documentId, String fingerprint, String contentHash,
-            int committedCount, int intendedCount, String origin);
+            int intendedCount, String origin);
 
-    /** Marks the write complete. Only rows in {@code done} status participate in skip decisions. */
+    /**
+     * Marks the write complete. Only rows in {@code done} status participate in skip decisions.
+     * Throws {@link IllegalStateException} when no row exists for the key — a commit without a
+     * preceding intent is a protocol violation, never a no-op.
+     */
     void commit(String pipeline, String documentId, String fingerprint, String contentHash, int segmentCount);
 
     /**
      * Refreshes the stored fingerprint of an already-{@code done} row whose content turned out
      * unchanged (tier-2 hash match after a tier-1 fingerprint miss), so the cheaper tier-1 check
-     * skips the document next time.
+     * skips the document next time. Deliberately a silent no-op for rows in any other status: on
+     * a {@code failed} row the fingerprint is the dead-letter gate — the fingerprint of the
+     * attempt that failed — and refreshing it would silently re-arm retries.
      */
     void refreshFingerprint(String pipeline, String documentId, String fingerprint);
 
     /**
      * Marks an explicit delete: the row survives as a suppression record, so the document stays
-     * deleted even while its source file still exists. Lifted with {@link #unsuppress}.
+     * deleted even while its source file still exists. When no row exists (a document deleted
+     * before its first ingest), a pure suppression row is created, so the suppression holds
+     * regardless. Lifted with {@link #unsuppress}.
      */
     void tombstone(String pipeline, String documentId);
 
+    /** Lifts a {@link #tombstone}. A no-op when no row exists. */
     void unsuppress(String pipeline, String documentId);
 
-    /** Pins a document: source updates are suppressed until {@link #unpin}. */
+    /**
+     * Pins a document: source updates are suppressed until {@link #unpin}. A no-op when no row
+     * exists — pinning a document that was never ingested has nothing to protect.
+     */
     void pin(String pipeline, String documentId);
 
+    /** Lifts a {@link #pin}. A no-op when no row exists. */
     void unpin(String pipeline, String documentId);
 
     /** Removes a row entirely — used by deletion-by-disappearance, where nothing needs remembering. */

--- a/extensions-support/langchain4j/runtime/src/main/java/org/apache/camel/quarkus/component/support/langchain4j/tracker/jdbc/JdbcIngestionTracker.java
+++ b/extensions-support/langchain4j/runtime/src/main/java/org/apache/camel/quarkus/component/support/langchain4j/tracker/jdbc/JdbcIngestionTracker.java
@@ -1,0 +1,288 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.support.langchain4j.tracker.jdbc;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import javax.sql.DataSource;
+
+import org.apache.camel.quarkus.component.support.langchain4j.tracker.IngestionTracker;
+
+/**
+ * JDBC-backed {@link IngestionTracker}. Deliberately dialect-free SQL (works on PostgreSQL and H2):
+ * upserts are update-then-insert rather than vendor MERGE/ON CONFLICT.
+ *
+ * <p>
+ * <strong>Concurrency assumption: at most one writer per {@code (pipeline, documentId)} at a
+ * time.</strong> The update-then-insert is not atomic (each statement auto-commits on its own,
+ * there is no transaction), so two concurrent writers for the same row can both see the
+ * {@code UPDATE} affect zero rows and then both attempt the {@code INSERT}, and one fails on the
+ * {@code (pipeline, doc_id)} primary key. Wrapping the two statements in a transaction would not
+ * remove this race without either {@code SERIALIZABLE} isolation or a dialect-specific upsert,
+ * both at odds with staying dialect-free; callers (the sync pass runner processes one document
+ * at a time per pipeline) are relied upon to hold this invariant instead.
+ *
+ * <p>
+ * <strong>Status: Experimental.</strong> See {@link IngestionTracker}.
+ */
+public class JdbcIngestionTracker implements IngestionTracker {
+
+    static final String TABLE = "cq_ingestion_tracker";
+
+    private final DataSource dataSource;
+
+    public JdbcIngestionTracker(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public void ensureSchema() {
+        String ddl = "CREATE TABLE IF NOT EXISTS " + TABLE + " ("
+                + "pipeline VARCHAR(128) NOT NULL, "
+                + "doc_id VARCHAR(512) NOT NULL, "
+                + "fingerprint VARCHAR(256), "
+                + "content_hash VARCHAR(64), "
+                + "segment_count INT DEFAULT 0 NOT NULL, "
+                + "intended_count INT DEFAULT 0 NOT NULL, "
+                + "status VARCHAR(16) NOT NULL, "
+                + "origin VARCHAR(16) DEFAULT 'source' NOT NULL, "
+                + "tombstone BOOLEAN DEFAULT FALSE NOT NULL, "
+                + "pinned BOOLEAN DEFAULT FALSE NOT NULL, "
+                + "updated_at TIMESTAMP, "
+                + "PRIMARY KEY (pipeline, doc_id))";
+        try (Connection connection = dataSource.getConnection()) {
+            connection.createStatement().execute(ddl);
+        } catch (SQLException e) {
+            throw new IllegalStateException(
+                    "Cannot create the ingestion tracker table '" + TABLE + "'. "
+                            + "mode=sync needs a working datasource — configure quarkus.datasource "
+                            + "(Dev Services provides one in dev mode) or use mode=append.",
+                    e);
+        }
+    }
+
+    private static final String ROW_COLUMNS = "fingerprint, content_hash, segment_count, intended_count, status, "
+            + "origin, tombstone, pinned";
+
+    @Override
+    public Optional<TrackerRow> read(String pipeline, String documentId) {
+        String sql = "SELECT " + ROW_COLUMNS + " FROM " + TABLE + " WHERE pipeline = ? AND doc_id = ?";
+        try (Connection connection = dataSource.getConnection();
+                PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, pipeline);
+            statement.setString(2, documentId);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                if (!resultSet.next()) {
+                    return Optional.empty();
+                }
+                return Optional.of(row(pipeline, documentId, resultSet));
+            }
+        } catch (SQLException e) {
+            throw new IllegalStateException("Tracker read failed for '" + documentId + "'", e);
+        }
+    }
+
+    @Override
+    public List<TrackerRow> listDocuments(String pipeline) {
+        String sql = "SELECT doc_id, " + ROW_COLUMNS + " FROM " + TABLE + " WHERE pipeline = ?";
+        try (Connection connection = dataSource.getConnection();
+                PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, pipeline);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                List<TrackerRow> rows = new ArrayList<>();
+                while (resultSet.next()) {
+                    String documentId = resultSet.getString(1);
+                    rows.add(new TrackerRow(pipeline, documentId,
+                            resultSet.getString(2), resultSet.getString(3),
+                            resultSet.getInt(4), resultSet.getInt(5), resultSet.getString(6),
+                            resultSet.getString(7), resultSet.getBoolean(8), resultSet.getBoolean(9)));
+                }
+                return rows;
+            }
+        } catch (SQLException e) {
+            throw new IllegalStateException("Tracker listing failed for pipeline '" + pipeline + "'", e);
+        }
+    }
+
+    private static TrackerRow row(String pipeline, String documentId, ResultSet resultSet) throws SQLException {
+        return new TrackerRow(pipeline, documentId,
+                resultSet.getString(1), resultSet.getString(2),
+                resultSet.getInt(3), resultSet.getInt(4), resultSet.getString(5),
+                resultSet.getString(6), resultSet.getBoolean(7), resultSet.getBoolean(8));
+    }
+
+    @Override
+    public void writeIntent(String pipeline, String documentId, String fingerprint, String contentHash,
+            int committedCount, int intendedCount, String origin) {
+        try (Connection connection = dataSource.getConnection()) {
+            String update = "UPDATE " + TABLE + " SET fingerprint = ?, content_hash = ?, "
+                    + "intended_count = ?, status = 'in_progress', origin = ?, updated_at = ? "
+                    + "WHERE pipeline = ? AND doc_id = ?";
+            int updated;
+            try (PreparedStatement statement = connection.prepareStatement(update)) {
+                statement.setString(1, fingerprint);
+                statement.setString(2, contentHash);
+                statement.setInt(3, intendedCount);
+                statement.setString(4, origin);
+                statement.setTimestamp(5, Timestamp.from(Instant.now()));
+                statement.setString(6, pipeline);
+                statement.setString(7, documentId);
+                updated = statement.executeUpdate();
+            }
+            if (updated == 0) {
+                String insert = "INSERT INTO " + TABLE
+                        + " (pipeline, doc_id, fingerprint, content_hash, segment_count, intended_count, "
+                        + "status, origin, updated_at) VALUES (?, ?, ?, ?, ?, ?, 'in_progress', ?, ?)";
+                try (PreparedStatement statement = connection.prepareStatement(insert)) {
+                    statement.setString(1, pipeline);
+                    statement.setString(2, documentId);
+                    statement.setString(3, fingerprint);
+                    statement.setString(4, contentHash);
+                    statement.setInt(5, committedCount);
+                    statement.setInt(6, intendedCount);
+                    statement.setString(7, origin);
+                    statement.setTimestamp(8, Timestamp.from(Instant.now()));
+                    statement.executeUpdate();
+                }
+            }
+        } catch (SQLException e) {
+            throw new IllegalStateException("Tracker intent write failed for '" + documentId + "'", e);
+        }
+    }
+
+    @Override
+    public void tombstone(String pipeline, String documentId) {
+        setFlag(pipeline, documentId, "tombstone", true);
+    }
+
+    @Override
+    public void unsuppress(String pipeline, String documentId) {
+        setFlag(pipeline, documentId, "tombstone", false);
+    }
+
+    @Override
+    public void pin(String pipeline, String documentId) {
+        setFlag(pipeline, documentId, "pinned", true);
+    }
+
+    @Override
+    public void unpin(String pipeline, String documentId) {
+        setFlag(pipeline, documentId, "pinned", false);
+    }
+
+    private void setFlag(String pipeline, String documentId, String column, boolean value) {
+        String sql = "UPDATE " + TABLE + " SET " + column + " = ?, updated_at = ? "
+                + "WHERE pipeline = ? AND doc_id = ?";
+        try (Connection connection = dataSource.getConnection();
+                PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setBoolean(1, value);
+            statement.setTimestamp(2, Timestamp.from(Instant.now()));
+            statement.setString(3, pipeline);
+            statement.setString(4, documentId);
+            statement.executeUpdate();
+        } catch (SQLException e) {
+            throw new IllegalStateException("Tracker " + column + " update failed for '" + documentId + "'", e);
+        }
+    }
+
+    @Override
+    public void markFailed(String pipeline, String documentId, String fingerprint) {
+        try (Connection connection = dataSource.getConnection()) {
+            String update = "UPDATE " + TABLE + " SET fingerprint = ?, status = 'failed', updated_at = ? "
+                    + "WHERE pipeline = ? AND doc_id = ?";
+            int updated;
+            try (PreparedStatement statement = connection.prepareStatement(update)) {
+                statement.setString(1, fingerprint);
+                statement.setTimestamp(2, Timestamp.from(Instant.now()));
+                statement.setString(3, pipeline);
+                statement.setString(4, documentId);
+                updated = statement.executeUpdate();
+            }
+            if (updated == 0) {
+                String insert = "INSERT INTO " + TABLE
+                        + " (pipeline, doc_id, fingerprint, status, origin, updated_at) "
+                        + "VALUES (?, ?, ?, 'failed', 'source', ?)";
+                try (PreparedStatement statement = connection.prepareStatement(insert)) {
+                    statement.setString(1, pipeline);
+                    statement.setString(2, documentId);
+                    statement.setString(3, fingerprint);
+                    statement.setTimestamp(4, Timestamp.from(Instant.now()));
+                    statement.executeUpdate();
+                }
+            }
+        } catch (SQLException e) {
+            throw new IllegalStateException("Tracker dead-letter update failed for '" + documentId + "'", e);
+        }
+    }
+
+    @Override
+    public void deleteRow(String pipeline, String documentId) {
+        String sql = "DELETE FROM " + TABLE + " WHERE pipeline = ? AND doc_id = ?";
+        try (Connection connection = dataSource.getConnection();
+                PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, pipeline);
+            statement.setString(2, documentId);
+            statement.executeUpdate();
+        } catch (SQLException e) {
+            throw new IllegalStateException("Tracker row deletion failed for '" + documentId + "'", e);
+        }
+    }
+
+    @Override
+    public void commit(String pipeline, String documentId, String fingerprint, String contentHash,
+            int segmentCount) {
+        String sql = "UPDATE " + TABLE + " SET fingerprint = ?, content_hash = ?, segment_count = ?, "
+                + "intended_count = ?, status = 'done', updated_at = ? WHERE pipeline = ? AND doc_id = ?";
+        try (Connection connection = dataSource.getConnection();
+                PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, fingerprint);
+            statement.setString(2, contentHash);
+            statement.setInt(3, segmentCount);
+            statement.setInt(4, segmentCount);
+            statement.setTimestamp(5, Timestamp.from(Instant.now()));
+            statement.setString(6, pipeline);
+            statement.setString(7, documentId);
+            statement.executeUpdate();
+        } catch (SQLException e) {
+            throw new IllegalStateException("Tracker commit failed for '" + documentId + "'", e);
+        }
+    }
+
+    @Override
+    public void refreshFingerprint(String pipeline, String documentId, String fingerprint) {
+        String sql = "UPDATE " + TABLE + " SET fingerprint = ?, updated_at = ? "
+                + "WHERE pipeline = ? AND doc_id = ? AND status = 'done'";
+        try (Connection connection = dataSource.getConnection();
+                PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, fingerprint);
+            statement.setTimestamp(2, Timestamp.from(Instant.now()));
+            statement.setString(3, pipeline);
+            statement.setString(4, documentId);
+            statement.executeUpdate();
+        } catch (SQLException e) {
+            throw new IllegalStateException("Tracker fingerprint refresh failed for '" + documentId + "'", e);
+        }
+    }
+}

--- a/extensions-support/langchain4j/runtime/src/main/java/org/apache/camel/quarkus/component/support/langchain4j/tracker/jdbc/JdbcIngestionTracker.java
+++ b/extensions-support/langchain4j/runtime/src/main/java/org/apache/camel/quarkus/component/support/langchain4j/tracker/jdbc/JdbcIngestionTracker.java
@@ -49,19 +49,45 @@ import org.apache.camel.quarkus.component.support.langchain4j.tracker.IngestionT
  */
 public class JdbcIngestionTracker implements IngestionTracker {
 
-    static final String TABLE = "cq_ingestion_tracker";
+    /**
+     * Concatenated into every statement: this must never become caller-supplied without strict
+     * identifier validation, or the class turns into an SQL injection vector.
+     */
+    static final String TABLE = "camel_quarkus_ingestion_tracker";
 
     private final DataSource dataSource;
+    private final boolean createTableIfNotExists;
 
     public JdbcIngestionTracker(DataSource dataSource) {
+        this(dataSource, true);
+    }
+
+    /**
+     * @param createTableIfNotExists when {@code false}, {@link #ensureSchema()} only probes that
+     *                               a pre-provisioned table exists, so the runtime DB user needs
+     *                               no DDL privilege (mirrors camel-sql's
+     *                               {@code JdbcMessageIdRepository}). When this surfaces as a
+     *                               configuration option it must be {@code ConfigPhase.RUN_TIME}.
+     */
+    public JdbcIngestionTracker(DataSource dataSource, boolean createTableIfNotExists) {
         this.dataSource = dataSource;
+        this.createTableIfNotExists = createTableIfNotExists;
     }
 
     @Override
     public void ensureSchema() {
+        if (!createTableIfNotExists) {
+            if (!tableExists()) {
+                throw new IllegalStateException(
+                        "The ingestion tracker table '" + TABLE + "' does not exist and table creation is "
+                                + "disabled. Pre-provision the table or enable createTableIfNotExists.");
+            }
+            return;
+        }
         String ddl = "CREATE TABLE IF NOT EXISTS " + TABLE + " ("
                 + "pipeline VARCHAR(128) NOT NULL, "
-                + "doc_id VARCHAR(512) NOT NULL, "
+                // 1024: the S3 object-key maximum; file paths and URLs used as ids fit as well
+                + "doc_id VARCHAR(1024) NOT NULL, "
                 + "fingerprint VARCHAR(256), "
                 + "content_hash VARCHAR(64), "
                 + "segment_count INT DEFAULT 0 NOT NULL, "
@@ -72,14 +98,26 @@ public class JdbcIngestionTracker implements IngestionTracker {
                 + "pinned BOOLEAN DEFAULT FALSE NOT NULL, "
                 + "updated_at TIMESTAMP, "
                 + "PRIMARY KEY (pipeline, doc_id))";
-        try (Connection connection = dataSource.getConnection()) {
-            connection.createStatement().execute(ddl);
+        try (Connection connection = dataSource.getConnection();
+                java.sql.Statement statement = connection.createStatement()) {
+            statement.execute(ddl);
         } catch (SQLException e) {
             throw new IllegalStateException(
                     "Cannot create the ingestion tracker table '" + TABLE + "'. "
                             + "mode=sync needs a working datasource — configure quarkus.datasource "
                             + "(Dev Services provides one in dev mode) or use mode=append.",
                     e);
+        }
+    }
+
+    private boolean tableExists() {
+        try (Connection connection = dataSource.getConnection();
+                PreparedStatement statement = connection.prepareStatement(
+                        "SELECT 1 FROM " + TABLE + " WHERE 1 = 0")) {
+            statement.executeQuery();
+            return true;
+        } catch (SQLException e) {
+            return false;
         }
     }
 
@@ -135,35 +173,39 @@ public class JdbcIngestionTracker implements IngestionTracker {
 
     @Override
     public void writeIntent(String pipeline, String documentId, String fingerprint, String contentHash,
-            int committedCount, int intendedCount, String origin) {
+            int intendedCount, String origin) {
         try (Connection connection = dataSource.getConnection()) {
+            // intended_count is monotone until commit: once an intent for N was durable, up to N
+            // segments may exist in the store, so a smaller re-intent must never lower the bound
+            // — only a commit, which runs after the sweep, may collapse it
             String update = "UPDATE " + TABLE + " SET fingerprint = ?, content_hash = ?, "
-                    + "intended_count = ?, status = 'in_progress', origin = ?, updated_at = ? "
+                    + "intended_count = CASE WHEN intended_count > ? THEN intended_count ELSE ? END, "
+                    + "status = 'in_progress', origin = ?, updated_at = ? "
                     + "WHERE pipeline = ? AND doc_id = ?";
             int updated;
             try (PreparedStatement statement = connection.prepareStatement(update)) {
                 statement.setString(1, fingerprint);
                 statement.setString(2, contentHash);
                 statement.setInt(3, intendedCount);
-                statement.setString(4, origin);
-                statement.setTimestamp(5, Timestamp.from(Instant.now()));
-                statement.setString(6, pipeline);
-                statement.setString(7, documentId);
+                statement.setInt(4, intendedCount);
+                statement.setString(5, origin);
+                statement.setTimestamp(6, Timestamp.from(Instant.now()));
+                statement.setString(7, pipeline);
+                statement.setString(8, documentId);
                 updated = statement.executeUpdate();
             }
             if (updated == 0) {
                 String insert = "INSERT INTO " + TABLE
                         + " (pipeline, doc_id, fingerprint, content_hash, segment_count, intended_count, "
-                        + "status, origin, updated_at) VALUES (?, ?, ?, ?, ?, ?, 'in_progress', ?, ?)";
+                        + "status, origin, updated_at) VALUES (?, ?, ?, ?, 0, ?, 'in_progress', ?, ?)";
                 try (PreparedStatement statement = connection.prepareStatement(insert)) {
                     statement.setString(1, pipeline);
                     statement.setString(2, documentId);
                     statement.setString(3, fingerprint);
                     statement.setString(4, contentHash);
-                    statement.setInt(5, committedCount);
-                    statement.setInt(6, intendedCount);
-                    statement.setString(7, origin);
-                    statement.setTimestamp(8, Timestamp.from(Instant.now()));
+                    statement.setInt(5, intendedCount);
+                    statement.setString(6, origin);
+                    statement.setTimestamp(7, Timestamp.from(Instant.now()));
                     statement.executeUpdate();
                 }
             }
@@ -174,7 +216,21 @@ public class JdbcIngestionTracker implements IngestionTracker {
 
     @Override
     public void tombstone(String pipeline, String documentId) {
-        setFlag(pipeline, documentId, "tombstone", true);
+        if (setFlag(pipeline, documentId, "tombstone", true) == 0) {
+            // deleted before ever ingested: create a pure suppression row so the tombstone holds
+            String insert = "INSERT INTO " + TABLE
+                    + " (pipeline, doc_id, segment_count, intended_count, status, origin, tombstone, "
+                    + "updated_at) VALUES (?, ?, 0, 0, 'done', 'api', TRUE, ?)";
+            try (Connection connection = dataSource.getConnection();
+                    PreparedStatement statement = connection.prepareStatement(insert)) {
+                statement.setString(1, pipeline);
+                statement.setString(2, documentId);
+                statement.setTimestamp(3, Timestamp.from(Instant.now()));
+                statement.executeUpdate();
+            } catch (SQLException e) {
+                throw new IllegalStateException("Tracker tombstone insert failed for '" + documentId + "'", e);
+            }
+        }
     }
 
     @Override
@@ -192,7 +248,7 @@ public class JdbcIngestionTracker implements IngestionTracker {
         setFlag(pipeline, documentId, "pinned", false);
     }
 
-    private void setFlag(String pipeline, String documentId, String column, boolean value) {
+    private int setFlag(String pipeline, String documentId, String column, boolean value) {
         String sql = "UPDATE " + TABLE + " SET " + column + " = ?, updated_at = ? "
                 + "WHERE pipeline = ? AND doc_id = ?";
         try (Connection connection = dataSource.getConnection();
@@ -201,7 +257,7 @@ public class JdbcIngestionTracker implements IngestionTracker {
             statement.setTimestamp(2, Timestamp.from(Instant.now()));
             statement.setString(3, pipeline);
             statement.setString(4, documentId);
-            statement.executeUpdate();
+            return statement.executeUpdate();
         } catch (SQLException e) {
             throw new IllegalStateException("Tracker " + column + " update failed for '" + documentId + "'", e);
         }
@@ -221,6 +277,10 @@ public class JdbcIngestionTracker implements IngestionTracker {
                 updated = statement.executeUpdate();
             }
             if (updated == 0) {
+                // a failed row with no prior intent can only originate from a source pass — a
+                // failure before the intent is written (e.g. the content supplier throwing) is
+                // dead-lettered by the pass runner, while API-path failures propagate
+                // synchronously to the caller and never reach markFailed — hence 'source'
                 String insert = "INSERT INTO " + TABLE
                         + " (pipeline, doc_id, fingerprint, status, origin, updated_at) "
                         + "VALUES (?, ?, ?, 'failed', 'source', ?)";
@@ -264,7 +324,11 @@ public class JdbcIngestionTracker implements IngestionTracker {
             statement.setTimestamp(5, Timestamp.from(Instant.now()));
             statement.setString(6, pipeline);
             statement.setString(7, documentId);
-            statement.executeUpdate();
+            if (statement.executeUpdate() == 0) {
+                throw new IllegalStateException(
+                        "Commit without a preceding intent for '" + documentId + "' in pipeline '"
+                                + pipeline + "' — the two-phase protocol requires writeIntent first");
+            }
         } catch (SQLException e) {
             throw new IllegalStateException("Tracker commit failed for '" + documentId + "'", e);
         }

--- a/extensions-support/langchain4j/runtime/src/test/java/org/apache/camel/quarkus/component/support/langchain4j/tracker/jdbc/JdbcIngestionTrackerTest.java
+++ b/extensions-support/langchain4j/runtime/src/test/java/org/apache/camel/quarkus/component/support/langchain4j/tracker/jdbc/JdbcIngestionTrackerTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -60,7 +61,7 @@ class JdbcIngestionTrackerTest {
 
     @Test
     void intentIsDurableAndNeverSkippable() {
-        tracker.writeIntent("p", "doc", "fp1", "hash1", 0, 5, IngestionTracker.ORIGIN_SOURCE);
+        tracker.writeIntent("p", "doc", "fp1", "hash1", 5, IngestionTracker.ORIGIN_SOURCE);
 
         IngestionTracker.TrackerRow row = tracker.read("p", "doc").orElseThrow();
         assertFalse(row.done(), "an intent row must not count as done");
@@ -69,7 +70,7 @@ class JdbcIngestionTrackerTest {
 
     @Test
     void commitCompletesTheIntent() {
-        tracker.writeIntent("p", "doc", "fp1", "hash1", 0, 5, IngestionTracker.ORIGIN_SOURCE);
+        tracker.writeIntent("p", "doc", "fp1", "hash1", 5, IngestionTracker.ORIGIN_SOURCE);
         tracker.commit("p", "doc", "fp1", "hash1", 3);
 
         IngestionTracker.TrackerRow row = tracker.read("p", "doc").orElseThrow();
@@ -80,21 +81,39 @@ class JdbcIngestionTrackerTest {
     }
 
     @Test
+    void commitWithoutIntentThrows() {
+        IllegalStateException e = assertThrows(IllegalStateException.class,
+                () -> tracker.commit("p", "ghost", "fp", "h", 1));
+        assertTrue(e.getMessage().contains("preceding intent"), e.getMessage());
+    }
+
+    @Test
     void reintentKeepsTheLargestKnownCount() {
-        tracker.writeIntent("p", "doc", "fp1", "hash1", 0, 5, IngestionTracker.ORIGIN_SOURCE);
+        tracker.writeIntent("p", "doc", "fp1", "hash1", 5, IngestionTracker.ORIGIN_SOURCE);
         tracker.commit("p", "doc", "fp1", "hash1", 5);
         // a re-intent does not change what the store really holds — the five old segments are
         // still in it, so the committed count has to stay; only commit, which runs after the
         // stale tail was actually removed, may lower the bound
-        tracker.writeIntent("p", "doc", "fp2", "hash2", 5, 2, IngestionTracker.ORIGIN_SOURCE);
+        tracker.writeIntent("p", "doc", "fp2", "hash2", 2, IngestionTracker.ORIGIN_SOURCE);
 
         assertEquals(5, tracker.read("p", "doc").orElseThrow().maxKnownCount(),
                 "shrink must still see the previously committed tail");
     }
 
     @Test
+    void reintentBeforeCommitKeepsTheLargestIntendedCount() {
+        tracker.writeIntent("p", "doc", "fp1", "hash1", 5, IngestionTracker.ORIGIN_SOURCE);
+        // the consumer may have written up to 5 segments before dying without a commit; a
+        // smaller re-intent must not lower the sweep bound below what may exist in the store
+        tracker.writeIntent("p", "doc", "fp2", "hash2", 2, IngestionTracker.ORIGIN_SOURCE);
+
+        assertEquals(5, tracker.read("p", "doc").orElseThrow().maxKnownCount(),
+                "an uncommitted intent must never lower the sweep bound");
+    }
+
+    @Test
     void refreshFingerprintTouchesNothingElse() {
-        tracker.writeIntent("p", "doc", "fp1", "hash1", 0, 2, IngestionTracker.ORIGIN_SOURCE);
+        tracker.writeIntent("p", "doc", "fp1", "hash1", 2, IngestionTracker.ORIGIN_SOURCE);
         tracker.commit("p", "doc", "fp1", "hash1", 2);
         tracker.refreshFingerprint("p", "doc", "fp2");
 
@@ -106,10 +125,20 @@ class JdbcIngestionTrackerTest {
     }
 
     @Test
+    void refreshFingerprintIgnoresRowsThatAreNotDone() {
+        tracker.writeIntent("p", "doc", "fp1", "h1", 1, IngestionTracker.ORIGIN_SOURCE);
+        tracker.markFailed("p", "doc", "fp-failed");
+        tracker.refreshFingerprint("p", "doc", "fp-new");
+
+        assertEquals("fp-failed", tracker.read("p", "doc").orElseThrow().fingerprint(),
+                "a refresh must not re-arm the dead-letter gate of a failed row");
+    }
+
+    @Test
     void listDocumentsIsIsolatedByPipeline() {
-        tracker.writeIntent("p1", "a", "fp", "h", 0, 1, IngestionTracker.ORIGIN_SOURCE);
+        tracker.writeIntent("p1", "a", "fp", "h", 1, IngestionTracker.ORIGIN_SOURCE);
         tracker.commit("p1", "a", "fp", "h", 1);
-        tracker.writeIntent("p2", "b", "fp", "h", 0, 1, IngestionTracker.ORIGIN_SOURCE);
+        tracker.writeIntent("p2", "b", "fp", "h", 1, IngestionTracker.ORIGIN_SOURCE);
         tracker.commit("p2", "b", "fp", "h", 1);
 
         List<IngestionTracker.TrackerRow> rows = tracker.listDocuments("p1");
@@ -119,7 +148,7 @@ class JdbcIngestionTrackerTest {
 
     @Test
     void deleteRowForgetsTheDocument() {
-        tracker.writeIntent("p", "doc", "fp", "h", 0, 1, IngestionTracker.ORIGIN_SOURCE);
+        tracker.writeIntent("p", "doc", "fp", "h", 1, IngestionTracker.ORIGIN_SOURCE);
         tracker.commit("p", "doc", "fp", "h", 1);
         tracker.deleteRow("p", "doc");
 
@@ -129,7 +158,7 @@ class JdbcIngestionTrackerTest {
 
     @Test
     void tombstoneSurvivesAndLifts() {
-        tracker.writeIntent("p", "doc", "fp", "h", 0, 1, IngestionTracker.ORIGIN_SOURCE);
+        tracker.writeIntent("p", "doc", "fp", "h", 1, IngestionTracker.ORIGIN_SOURCE);
         tracker.commit("p", "doc", "fp", "h", 1);
 
         tracker.tombstone("p", "doc");
@@ -141,8 +170,19 @@ class JdbcIngestionTrackerTest {
     }
 
     @Test
+    void tombstoneOfANeverIngestedDocumentCreatesTheSuppressionRow() {
+        tracker.tombstone("p", "ghost");
+
+        IngestionTracker.TrackerRow row = tracker.read("p", "ghost").orElseThrow();
+        assertTrue(row.tombstone(), "a pure suppression row must be created, or the suppression "
+                + "would not survive for a document deleted before its first ingest");
+        assertTrue(row.done());
+        assertEquals(0, row.segmentCount());
+    }
+
+    @Test
     void pinSurvivesAndLifts() {
-        tracker.writeIntent("p", "doc", "fp", "h", 0, 1, IngestionTracker.ORIGIN_API);
+        tracker.writeIntent("p", "doc", "fp", "h", 1, IngestionTracker.ORIGIN_API);
         tracker.commit("p", "doc", "fp", "h", 1);
 
         tracker.pin("p", "doc");
@@ -154,7 +194,7 @@ class JdbcIngestionTrackerTest {
 
     @Test
     void markFailedRecordsTheAttemptAndKeepsCommittedState() {
-        tracker.writeIntent("p", "doc", "fp1", "h1", 0, 2, IngestionTracker.ORIGIN_SOURCE);
+        tracker.writeIntent("p", "doc", "fp1", "h1", 2, IngestionTracker.ORIGIN_SOURCE);
         tracker.commit("p", "doc", "fp1", "h1", 2);
         // the failed attempt's fingerprint has to be persisted, so the tracker knows it was fp2
         // that failed: passes skip the poison document while it still fingerprints as fp2 and
@@ -165,5 +205,30 @@ class JdbcIngestionTrackerTest {
         assertTrue(row.failed());
         assertEquals("fp2", row.fingerprint(), "the failed attempt's fingerprint gates retries");
         assertEquals(2, row.segmentCount(), "previously committed segments keep serving");
+    }
+
+    @Test
+    void markFailedFromInProgressKeepsTheBound() {
+        tracker.writeIntent("p", "doc", "fp1", "h1", 3, IngestionTracker.ORIGIN_SOURCE);
+        tracker.markFailed("p", "doc", "fp1");
+
+        IngestionTracker.TrackerRow row = tracker.read("p", "doc").orElseThrow();
+        assertTrue(row.failed());
+        assertEquals(0, row.segmentCount(), "nothing was ever committed");
+        assertEquals(3, row.maxKnownCount(),
+                "the failed intent's bound must survive — up to 3 segments may sit in the store");
+    }
+
+    @Test
+    void preProvisionedModeRequiresTheTableToExist() {
+        JdbcDataSource fresh = new JdbcDataSource();
+        fresh.setURL("jdbc:h2:mem:" + UUID.randomUUID() + ";DB_CLOSE_DELAY=-1");
+
+        JdbcIngestionTracker probing = new JdbcIngestionTracker(fresh, false);
+        assertThrows(IllegalStateException.class, probing::ensureSchema,
+                "without DDL rights the tracker must refuse loudly, not fail on first use");
+
+        new JdbcIngestionTracker(fresh).ensureSchema();
+        probing.ensureSchema();
     }
 }

--- a/extensions-support/langchain4j/runtime/src/test/java/org/apache/camel/quarkus/component/support/langchain4j/tracker/jdbc/JdbcIngestionTrackerTest.java
+++ b/extensions-support/langchain4j/runtime/src/test/java/org/apache/camel/quarkus/component/support/langchain4j/tracker/jdbc/JdbcIngestionTrackerTest.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.support.langchain4j.tracker.jdbc;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.apache.camel.quarkus.component.support.langchain4j.tracker.IngestionTracker;
+import org.h2.jdbcx.JdbcDataSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The behavioural contract of the {@link IngestionTracker} SPI, exercised against the JDBC
+ * implementation on H2. The test methods are deliberately written against the SPI only — nothing
+ * below {@link #setUpTracker()} references {@link JdbcIngestionTracker}.
+ *
+ * <p>
+ * The contract lives folded into this class only because a single implementation exists today.
+ * When a second one arrives — e.g. an adapter over a future upstream LangChain4j record manager
+ * (langchain4j#2931) — extract the test methods into an abstract {@code IngestionTrackerContract}
+ * base class with a {@code createTracker()} factory, and keep one {@code *Test} subclass per
+ * implementation: a replacement is a drop-in exactly when its subclass passes.
+ */
+class JdbcIngestionTrackerTest {
+
+    IngestionTracker tracker;
+
+    /** A fresh, empty tracker per test. */
+    @BeforeEach
+    void setUpTracker() {
+        JdbcDataSource dataSource = new JdbcDataSource();
+        dataSource.setURL("jdbc:h2:mem:" + UUID.randomUUID() + ";DB_CLOSE_DELAY=-1");
+        tracker = new JdbcIngestionTracker(dataSource);
+        tracker.ensureSchema();
+    }
+
+    @Test
+    void unknownDocumentReadsEmpty() {
+        assertTrue(tracker.read("p", "missing").isEmpty());
+    }
+
+    @Test
+    void intentIsDurableAndNeverSkippable() {
+        tracker.writeIntent("p", "doc", "fp1", "hash1", 0, 5, IngestionTracker.ORIGIN_SOURCE);
+
+        IngestionTracker.TrackerRow row = tracker.read("p", "doc").orElseThrow();
+        assertFalse(row.done(), "an intent row must not count as done");
+        assertEquals(5, row.maxKnownCount(), "the shrink bound must cover the intended count");
+    }
+
+    @Test
+    void commitCompletesTheIntent() {
+        tracker.writeIntent("p", "doc", "fp1", "hash1", 0, 5, IngestionTracker.ORIGIN_SOURCE);
+        tracker.commit("p", "doc", "fp1", "hash1", 3);
+
+        IngestionTracker.TrackerRow row = tracker.read("p", "doc").orElseThrow();
+        assertTrue(row.done());
+        assertEquals("fp1", row.fingerprint());
+        assertEquals("hash1", row.contentHash());
+        assertEquals(3, row.segmentCount());
+    }
+
+    @Test
+    void reintentKeepsTheLargestKnownCount() {
+        tracker.writeIntent("p", "doc", "fp1", "hash1", 0, 5, IngestionTracker.ORIGIN_SOURCE);
+        tracker.commit("p", "doc", "fp1", "hash1", 5);
+        // a re-intent does not change what the store really holds — the five old segments are
+        // still in it, so the committed count has to stay; only commit, which runs after the
+        // stale tail was actually removed, may lower the bound
+        tracker.writeIntent("p", "doc", "fp2", "hash2", 5, 2, IngestionTracker.ORIGIN_SOURCE);
+
+        assertEquals(5, tracker.read("p", "doc").orElseThrow().maxKnownCount(),
+                "shrink must still see the previously committed tail");
+    }
+
+    @Test
+    void refreshFingerprintTouchesNothingElse() {
+        tracker.writeIntent("p", "doc", "fp1", "hash1", 0, 2, IngestionTracker.ORIGIN_SOURCE);
+        tracker.commit("p", "doc", "fp1", "hash1", 2);
+        tracker.refreshFingerprint("p", "doc", "fp2");
+
+        IngestionTracker.TrackerRow row = tracker.read("p", "doc").orElseThrow();
+        assertEquals("fp2", row.fingerprint());
+        assertEquals("hash1", row.contentHash());
+        assertEquals(2, row.segmentCount());
+        assertTrue(row.done());
+    }
+
+    @Test
+    void listDocumentsIsIsolatedByPipeline() {
+        tracker.writeIntent("p1", "a", "fp", "h", 0, 1, IngestionTracker.ORIGIN_SOURCE);
+        tracker.commit("p1", "a", "fp", "h", 1);
+        tracker.writeIntent("p2", "b", "fp", "h", 0, 1, IngestionTracker.ORIGIN_SOURCE);
+        tracker.commit("p2", "b", "fp", "h", 1);
+
+        List<IngestionTracker.TrackerRow> rows = tracker.listDocuments("p1");
+        assertEquals(1, rows.size());
+        assertEquals("a", rows.get(0).documentId());
+    }
+
+    @Test
+    void deleteRowForgetsTheDocument() {
+        tracker.writeIntent("p", "doc", "fp", "h", 0, 1, IngestionTracker.ORIGIN_SOURCE);
+        tracker.commit("p", "doc", "fp", "h", 1);
+        tracker.deleteRow("p", "doc");
+
+        assertTrue(tracker.read("p", "doc").isEmpty());
+        assertTrue(tracker.listDocuments("p").isEmpty());
+    }
+
+    @Test
+    void tombstoneSurvivesAndLifts() {
+        tracker.writeIntent("p", "doc", "fp", "h", 0, 1, IngestionTracker.ORIGIN_SOURCE);
+        tracker.commit("p", "doc", "fp", "h", 1);
+
+        tracker.tombstone("p", "doc");
+        assertTrue(tracker.read("p", "doc").orElseThrow().tombstone(),
+                "a tombstoned row must survive as a suppression record");
+
+        tracker.unsuppress("p", "doc");
+        assertFalse(tracker.read("p", "doc").orElseThrow().tombstone());
+    }
+
+    @Test
+    void pinSurvivesAndLifts() {
+        tracker.writeIntent("p", "doc", "fp", "h", 0, 1, IngestionTracker.ORIGIN_API);
+        tracker.commit("p", "doc", "fp", "h", 1);
+
+        tracker.pin("p", "doc");
+        assertTrue(tracker.read("p", "doc").orElseThrow().pinned());
+
+        tracker.unpin("p", "doc");
+        assertFalse(tracker.read("p", "doc").orElseThrow().pinned());
+    }
+
+    @Test
+    void markFailedRecordsTheAttemptAndKeepsCommittedState() {
+        tracker.writeIntent("p", "doc", "fp1", "h1", 0, 2, IngestionTracker.ORIGIN_SOURCE);
+        tracker.commit("p", "doc", "fp1", "h1", 2);
+        // the failed attempt's fingerprint has to be persisted, so the tracker knows it was fp2
+        // that failed: passes skip the poison document while it still fingerprints as fp2 and
+        // retry only once the content changes (keeping fp1 would retry — and fail — every pass)
+        tracker.markFailed("p", "doc", "fp2");
+
+        IngestionTracker.TrackerRow row = tracker.read("p", "doc").orElseThrow();
+        assertTrue(row.failed());
+        assertEquals("fp2", row.fingerprint(), "the failed attempt's fingerprint gates retries");
+        assertEquals(2, row.segmentCount(), "previously committed segments keep serving");
+    }
+}

--- a/integration-tests/langchain4j-ingestion-tracker/pom.xml
+++ b/integration-tests/langchain4j-ingestion-tracker/pom.xml
@@ -27,7 +27,7 @@
     </parent>
 
     <artifactId>camel-quarkus-integration-test-langchain4j-ingestion-tracker</artifactId>
-    <name>Camel Quarkus :: Integration Tests :: LangChain4j Sync Tracker</name>
+    <name>Camel Quarkus :: Integration Tests :: LangChain4j Ingestion Tracker</name>
     <description>Integration tests for the JDBC ingestion tracker against a real PostgreSQL database</description>
 
     <dependencies>

--- a/integration-tests/langchain4j-ingestion-tracker/pom.xml
+++ b/integration-tests/langchain4j-ingestion-tracker/pom.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.camel.quarkus</groupId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
+        <version>3.39.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>camel-quarkus-integration-test-langchain4j-ingestion-tracker</artifactId>
+    <name>Camel Quarkus :: Integration Tests :: LangChain4j Sync Tracker</name>
+    <description>Integration tests for the JDBC ingestion tracker against a real PostgreSQL database</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-support-langchain4j</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jdbc-postgresql</artifactId>
+        </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <id>native</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <properties>
+                <quarkus.native.enabled>true</quarkus.native.enabled>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>virtualDependencies</id>
+            <activation>
+                <property>
+                    <name>!noVirtualDependencies</name>
+                </property>
+            </activation>
+            <dependencies>
+                <!-- The following dependencies guarantee that this module is built after them. You can update them by running `mvn process-resources -Pformat -N` from the source tree root directory -->
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-support-langchain4j-deployment</artifactId>
+                    <version>${project.version}</version>
+                    <type>pom</type>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>skip-testcontainers-tests</id>
+            <activation>
+                <property>
+                    <name>skip-testcontainers-tests</name>
+                </property>
+            </activation>
+            <properties>
+                <skipTests>true</skipTests>
+            </properties>
+        </profile>
+    </profiles>
+</project>

--- a/integration-tests/langchain4j-ingestion-tracker/src/main/java/org/apache/camel/quarkus/component/langchain4j/ingestiontracker/it/IngestionTrackerResource.java
+++ b/integration-tests/langchain4j-ingestion-tracker/src/main/java/org/apache/camel/quarkus/component/langchain4j/ingestiontracker/it/IngestionTrackerResource.java
@@ -20,7 +20,9 @@ import java.util.List;
 
 import javax.sql.DataSource;
 
-import jakarta.annotation.PostConstruct;
+import io.quarkus.runtime.StartupEvent;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
@@ -38,6 +40,7 @@ import org.apache.camel.quarkus.component.support.langchain4j.tracker.jdbc.JdbcI
  * directly injected test field because {@code @QuarkusIntegrationTest} runs the application as a
  * separate process and cannot use {@code @Inject}.
  */
+@ApplicationScoped
 @Path("/ingestion-tracker")
 public class IngestionTrackerResource {
 
@@ -46,8 +49,7 @@ public class IngestionTrackerResource {
 
     private IngestionTracker tracker;
 
-    @PostConstruct
-    void init() {
+    void init(@Observes StartupEvent startup) {
         tracker = new JdbcIngestionTracker(dataSource);
         tracker.ensureSchema();
     }
@@ -68,9 +70,8 @@ public class IngestionTrackerResource {
     @Path("/{pipeline}/{docId}/intent")
     public TrackerRow writeIntent(@PathParam("pipeline") String pipeline, @PathParam("docId") String docId,
             @QueryParam("fingerprint") String fingerprint, @QueryParam("contentHash") String contentHash,
-            @QueryParam("committedCount") int committedCount, @QueryParam("intendedCount") int intendedCount,
-            @QueryParam("origin") String origin) {
-        tracker.writeIntent(pipeline, docId, fingerprint, contentHash, committedCount, intendedCount, origin);
+            @QueryParam("intendedCount") int intendedCount, @QueryParam("origin") String origin) {
+        tracker.writeIntent(pipeline, docId, fingerprint, contentHash, intendedCount, origin);
         return read(pipeline, docId);
     }
 

--- a/integration-tests/langchain4j-ingestion-tracker/src/main/java/org/apache/camel/quarkus/component/langchain4j/ingestiontracker/it/IngestionTrackerResource.java
+++ b/integration-tests/langchain4j-ingestion-tracker/src/main/java/org/apache/camel/quarkus/component/langchain4j/ingestiontracker/it/IngestionTrackerResource.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.langchain4j.ingestiontracker.it;
+
+import java.util.List;
+
+import javax.sql.DataSource;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.QueryParam;
+import org.apache.camel.quarkus.component.support.langchain4j.tracker.IngestionTracker;
+import org.apache.camel.quarkus.component.support.langchain4j.tracker.IngestionTracker.TrackerRow;
+import org.apache.camel.quarkus.component.support.langchain4j.tracker.jdbc.JdbcIngestionTracker;
+
+/**
+ * Exercises {@link JdbcIngestionTracker} against a real datasource. A REST resource rather than a
+ * directly injected test field because {@code @QuarkusIntegrationTest} runs the application as a
+ * separate process and cannot use {@code @Inject}.
+ */
+@Path("/ingestion-tracker")
+public class IngestionTrackerResource {
+
+    @Inject
+    DataSource dataSource;
+
+    private IngestionTracker tracker;
+
+    @PostConstruct
+    void init() {
+        tracker = new JdbcIngestionTracker(dataSource);
+        tracker.ensureSchema();
+    }
+
+    @GET
+    @Path("/{pipeline}")
+    public List<TrackerRow> listDocuments(@PathParam("pipeline") String pipeline) {
+        return tracker.listDocuments(pipeline);
+    }
+
+    @GET
+    @Path("/{pipeline}/{docId}")
+    public TrackerRow read(@PathParam("pipeline") String pipeline, @PathParam("docId") String docId) {
+        return tracker.read(pipeline, docId).orElseThrow(NotFoundException::new);
+    }
+
+    @POST
+    @Path("/{pipeline}/{docId}/intent")
+    public TrackerRow writeIntent(@PathParam("pipeline") String pipeline, @PathParam("docId") String docId,
+            @QueryParam("fingerprint") String fingerprint, @QueryParam("contentHash") String contentHash,
+            @QueryParam("committedCount") int committedCount, @QueryParam("intendedCount") int intendedCount,
+            @QueryParam("origin") String origin) {
+        tracker.writeIntent(pipeline, docId, fingerprint, contentHash, committedCount, intendedCount, origin);
+        return read(pipeline, docId);
+    }
+
+    @POST
+    @Path("/{pipeline}/{docId}/commit")
+    public TrackerRow commit(@PathParam("pipeline") String pipeline, @PathParam("docId") String docId,
+            @QueryParam("fingerprint") String fingerprint, @QueryParam("contentHash") String contentHash,
+            @QueryParam("segmentCount") int segmentCount) {
+        tracker.commit(pipeline, docId, fingerprint, contentHash, segmentCount);
+        return read(pipeline, docId);
+    }
+
+    @POST
+    @Path("/{pipeline}/{docId}/refresh-fingerprint")
+    public TrackerRow refreshFingerprint(@PathParam("pipeline") String pipeline, @PathParam("docId") String docId,
+            @QueryParam("fingerprint") String fingerprint) {
+        tracker.refreshFingerprint(pipeline, docId, fingerprint);
+        return read(pipeline, docId);
+    }
+
+    @POST
+    @Path("/{pipeline}/{docId}/fail")
+    public TrackerRow markFailed(@PathParam("pipeline") String pipeline, @PathParam("docId") String docId,
+            @QueryParam("fingerprint") String fingerprint) {
+        tracker.markFailed(pipeline, docId, fingerprint);
+        return read(pipeline, docId);
+    }
+
+    @POST
+    @Path("/{pipeline}/{docId}/tombstone")
+    public TrackerRow tombstone(@PathParam("pipeline") String pipeline, @PathParam("docId") String docId) {
+        tracker.tombstone(pipeline, docId);
+        return read(pipeline, docId);
+    }
+
+    @POST
+    @Path("/{pipeline}/{docId}/unsuppress")
+    public TrackerRow unsuppress(@PathParam("pipeline") String pipeline, @PathParam("docId") String docId) {
+        tracker.unsuppress(pipeline, docId);
+        return read(pipeline, docId);
+    }
+
+    @POST
+    @Path("/{pipeline}/{docId}/pin")
+    public TrackerRow pin(@PathParam("pipeline") String pipeline, @PathParam("docId") String docId) {
+        tracker.pin(pipeline, docId);
+        return read(pipeline, docId);
+    }
+
+    @POST
+    @Path("/{pipeline}/{docId}/unpin")
+    public TrackerRow unpin(@PathParam("pipeline") String pipeline, @PathParam("docId") String docId) {
+        tracker.unpin(pipeline, docId);
+        return read(pipeline, docId);
+    }
+
+    @DELETE
+    @Path("/{pipeline}/{docId}")
+    public void deleteRow(@PathParam("pipeline") String pipeline, @PathParam("docId") String docId) {
+        tracker.deleteRow(pipeline, docId);
+    }
+}

--- a/integration-tests/langchain4j-ingestion-tracker/src/main/resources/application.properties
+++ b/integration-tests/langchain4j-ingestion-tracker/src/main/resources/application.properties
@@ -1,0 +1,19 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+quarkus.datasource.db-kind=postgresql
+quarkus.datasource.devservices.image-name=${postgres.container.image}

--- a/integration-tests/langchain4j-ingestion-tracker/src/test/java/org/apache/camel/quarkus/component/langchain4j/ingestiontracker/it/Langchain4jIngestionTrackerIT.java
+++ b/integration-tests/langchain4j-ingestion-tracker/src/test/java/org/apache/camel/quarkus/component/langchain4j/ingestiontracker/it/Langchain4jIngestionTrackerIT.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.langchain4j.ingestiontracker.it;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+class Langchain4jIngestionTrackerIT extends Langchain4jIngestionTrackerTest {
+}

--- a/integration-tests/langchain4j-ingestion-tracker/src/test/java/org/apache/camel/quarkus/component/langchain4j/ingestiontracker/it/Langchain4jIngestionTrackerTest.java
+++ b/integration-tests/langchain4j-ingestion-tracker/src/test/java/org/apache/camel/quarkus/component/langchain4j/ingestiontracker/it/Langchain4jIngestionTrackerTest.java
@@ -26,22 +26,23 @@ import static org.hamcrest.Matchers.hasSize;
 /**
  * Runs the {@code IngestionTracker} behavioural guarantees (mirrored from {@code JdbcIngestionTrackerTest})
  * against a real PostgreSQL server, provisioned by Quarkus Dev Services, through
- * {@link IngestionTrackerResource}.
+ * {@link IngestionTrackerResource}. Each test uses its own pipeline id — the database is shared
+ * across methods and never reset, so isolation comes from the keys.
  */
 @QuarkusTest
 class Langchain4jIngestionTrackerTest {
 
     @Test
     void unknownDocumentReadsEmpty() {
-        RestAssured.get("/ingestion-tracker/p/missing").then().statusCode(404);
+        RestAssured.get("/ingestion-tracker/p-unknown/missing").then().statusCode(404);
     }
 
     @Test
     void intentIsDurableAndNeverSkippable() {
         RestAssured.given()
                 .queryParam("fingerprint", "fp1").queryParam("contentHash", "hash1")
-                .queryParam("committedCount", 0).queryParam("intendedCount", 5).queryParam("origin", "source")
-                .post("/ingestion-tracker/p/doc/intent")
+                .queryParam("intendedCount", 5).queryParam("origin", "source")
+                .post("/ingestion-tracker/p-intent/doc/intent")
                 .then().statusCode(200)
                 .body("status", equalTo("in_progress"))
                 .body("intendedCount", equalTo(5));
@@ -49,11 +50,11 @@ class Langchain4jIngestionTrackerTest {
 
     @Test
     void commitCompletesTheIntent() {
-        writeIntent("p", "doc", "fp1", "hash1", 0, 5, "source");
+        writeIntent("p-commit", "doc", "fp1", "hash1", 5, "source");
 
         RestAssured.given()
                 .queryParam("fingerprint", "fp1").queryParam("contentHash", "hash1").queryParam("segmentCount", 3)
-                .post("/ingestion-tracker/p/doc/commit")
+                .post("/ingestion-tracker/p-commit/doc/commit")
                 .then().statusCode(200)
                 .body("status", equalTo("done"))
                 .body("fingerprint", equalTo("fp1"))
@@ -62,23 +63,41 @@ class Langchain4jIngestionTrackerTest {
     }
 
     @Test
+    void commitWithoutIntentFails() {
+        RestAssured.given()
+                .queryParam("fingerprint", "fp").queryParam("contentHash", "h").queryParam("segmentCount", 1)
+                .post("/ingestion-tracker/p-commit-ghost/ghost/commit")
+                .then().statusCode(500);
+    }
+
+    @Test
     void reintentKeepsTheLargestKnownCount() {
-        writeIntent("p", "doc", "fp1", "hash1", 0, 5, "source");
-        commit("p", "doc", "fp1", "hash1", 5);
-        writeIntent("p", "doc", "fp2", "hash2", 5, 2, "source");
+        writeIntent("p-reintent", "doc", "fp1", "hash1", 5, "source");
+        commit("p-reintent", "doc", "fp1", "hash1", 5);
+        writeIntent("p-reintent", "doc", "fp2", "hash2", 2, "source");
 
         // shrink must still see the previously committed tail
-        RestAssured.get("/ingestion-tracker/p/doc").then()
+        RestAssured.get("/ingestion-tracker/p-reintent/doc").then()
                 .body("segmentCount", equalTo(5));
     }
 
     @Test
+    void reintentBeforeCommitKeepsTheLargestIntendedCount() {
+        writeIntent("p-reintent-crash", "doc", "fp1", "hash1", 5, "source");
+        // no commit — the crashed attempt may have written up to 5 segments
+        writeIntent("p-reintent-crash", "doc", "fp2", "hash2", 2, "source");
+
+        RestAssured.get("/ingestion-tracker/p-reintent-crash/doc").then()
+                .body("intendedCount", equalTo(5));
+    }
+
+    @Test
     void refreshFingerprintTouchesNothingElse() {
-        writeIntent("p", "doc", "fp1", "hash1", 0, 2, "source");
-        commit("p", "doc", "fp1", "hash1", 2);
+        writeIntent("p-refresh", "doc", "fp1", "hash1", 2, "source");
+        commit("p-refresh", "doc", "fp1", "hash1", 2);
 
         RestAssured.given().queryParam("fingerprint", "fp2")
-                .post("/ingestion-tracker/p/doc/refresh-fingerprint")
+                .post("/ingestion-tracker/p-refresh/doc/refresh-fingerprint")
                 .then().statusCode(200)
                 .body("fingerprint", equalTo("fp2"))
                 .body("contentHash", equalTo("hash1"))
@@ -88,52 +107,61 @@ class Langchain4jIngestionTrackerTest {
 
     @Test
     void listDocumentsIsIsolatedByPipeline() {
-        writeIntent("p1", "a", "fp", "h", 0, 1, "source");
-        commit("p1", "a", "fp", "h", 1);
-        writeIntent("p2", "b", "fp", "h", 0, 1, "source");
-        commit("p2", "b", "fp", "h", 1);
+        writeIntent("p-list-a", "a", "fp", "h", 1, "source");
+        commit("p-list-a", "a", "fp", "h", 1);
+        writeIntent("p-list-b", "b", "fp", "h", 1, "source");
+        commit("p-list-b", "b", "fp", "h", 1);
 
-        RestAssured.get("/ingestion-tracker/p1").then()
+        RestAssured.get("/ingestion-tracker/p-list-a").then()
                 .body("", hasSize(1))
                 .body("[0].documentId", equalTo("a"));
     }
 
     @Test
     void deleteRowForgetsTheDocument() {
-        writeIntent("p", "doc", "fp", "h", 0, 1, "source");
-        commit("p", "doc", "fp", "h", 1);
+        writeIntent("p-delete", "doc", "fp", "h", 1, "source");
+        commit("p-delete", "doc", "fp", "h", 1);
 
-        RestAssured.delete("/ingestion-tracker/p/doc").then().statusCode(204);
+        RestAssured.delete("/ingestion-tracker/p-delete/doc").then().statusCode(204);
 
-        RestAssured.get("/ingestion-tracker/p/doc").then().statusCode(404);
-        RestAssured.get("/ingestion-tracker/p").then().body("", hasSize(0));
+        RestAssured.get("/ingestion-tracker/p-delete/doc").then().statusCode(404);
+        RestAssured.get("/ingestion-tracker/p-delete").then().body("", hasSize(0));
     }
 
     @Test
     void tombstoneSurvivesAndLifts() {
-        writeIntent("p", "doc", "fp", "h", 0, 1, "source");
-        commit("p", "doc", "fp", "h", 1);
+        writeIntent("p-tombstone", "doc", "fp", "h", 1, "source");
+        commit("p-tombstone", "doc", "fp", "h", 1);
 
-        RestAssured.post("/ingestion-tracker/p/doc/tombstone").then().body("tombstone", equalTo(true));
-        RestAssured.post("/ingestion-tracker/p/doc/unsuppress").then().body("tombstone", equalTo(false));
+        RestAssured.post("/ingestion-tracker/p-tombstone/doc/tombstone").then().body("tombstone", equalTo(true));
+        RestAssured.post("/ingestion-tracker/p-tombstone/doc/unsuppress").then().body("tombstone", equalTo(false));
+    }
+
+    @Test
+    void tombstoneOfANeverIngestedDocumentCreatesTheSuppressionRow() {
+        RestAssured.post("/ingestion-tracker/p-tombstone-ghost/ghost/tombstone")
+                .then().statusCode(200)
+                .body("tombstone", equalTo(true))
+                .body("status", equalTo("done"))
+                .body("segmentCount", equalTo(0));
     }
 
     @Test
     void pinSurvivesAndLifts() {
-        writeIntent("p", "doc", "fp", "h", 0, 1, "api");
-        commit("p", "doc", "fp", "h", 1);
+        writeIntent("p-pin", "doc", "fp", "h", 1, "api");
+        commit("p-pin", "doc", "fp", "h", 1);
 
-        RestAssured.post("/ingestion-tracker/p/doc/pin").then().body("pinned", equalTo(true));
-        RestAssured.post("/ingestion-tracker/p/doc/unpin").then().body("pinned", equalTo(false));
+        RestAssured.post("/ingestion-tracker/p-pin/doc/pin").then().body("pinned", equalTo(true));
+        RestAssured.post("/ingestion-tracker/p-pin/doc/unpin").then().body("pinned", equalTo(false));
     }
 
     @Test
     void markFailedRecordsTheAttemptAndKeepsCommittedState() {
-        writeIntent("p", "doc", "fp1", "h1", 0, 2, "source");
-        commit("p", "doc", "fp1", "h1", 2);
+        writeIntent("p-fail", "doc", "fp1", "h1", 2, "source");
+        commit("p-fail", "doc", "fp1", "h1", 2);
 
         RestAssured.given().queryParam("fingerprint", "fp2")
-                .post("/ingestion-tracker/p/doc/fail")
+                .post("/ingestion-tracker/p-fail/doc/fail")
                 .then().statusCode(200)
                 .body("status", equalTo("failed"))
                 // the failed attempt's fingerprint gates retries
@@ -143,10 +171,10 @@ class Langchain4jIngestionTrackerTest {
     }
 
     private static void writeIntent(String pipeline, String docId, String fingerprint, String contentHash,
-            int committedCount, int intendedCount, String origin) {
+            int intendedCount, String origin) {
         RestAssured.given()
                 .queryParam("fingerprint", fingerprint).queryParam("contentHash", contentHash)
-                .queryParam("committedCount", committedCount).queryParam("intendedCount", intendedCount)
+                .queryParam("intendedCount", intendedCount)
                 .queryParam("origin", origin)
                 .post("/ingestion-tracker/" + pipeline + "/" + docId + "/intent")
                 .then().statusCode(200);

--- a/integration-tests/langchain4j-ingestion-tracker/src/test/java/org/apache/camel/quarkus/component/langchain4j/ingestiontracker/it/Langchain4jIngestionTrackerTest.java
+++ b/integration-tests/langchain4j-ingestion-tracker/src/test/java/org/apache/camel/quarkus/component/langchain4j/ingestiontracker/it/Langchain4jIngestionTrackerTest.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.langchain4j.ingestiontracker.it;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+
+/**
+ * Runs the {@code IngestionTracker} behavioural guarantees (mirrored from {@code JdbcIngestionTrackerTest})
+ * against a real PostgreSQL server, provisioned by Quarkus Dev Services, through
+ * {@link IngestionTrackerResource}.
+ */
+@QuarkusTest
+class Langchain4jIngestionTrackerTest {
+
+    @Test
+    void unknownDocumentReadsEmpty() {
+        RestAssured.get("/ingestion-tracker/p/missing").then().statusCode(404);
+    }
+
+    @Test
+    void intentIsDurableAndNeverSkippable() {
+        RestAssured.given()
+                .queryParam("fingerprint", "fp1").queryParam("contentHash", "hash1")
+                .queryParam("committedCount", 0).queryParam("intendedCount", 5).queryParam("origin", "source")
+                .post("/ingestion-tracker/p/doc/intent")
+                .then().statusCode(200)
+                .body("status", equalTo("in_progress"))
+                .body("intendedCount", equalTo(5));
+    }
+
+    @Test
+    void commitCompletesTheIntent() {
+        writeIntent("p", "doc", "fp1", "hash1", 0, 5, "source");
+
+        RestAssured.given()
+                .queryParam("fingerprint", "fp1").queryParam("contentHash", "hash1").queryParam("segmentCount", 3)
+                .post("/ingestion-tracker/p/doc/commit")
+                .then().statusCode(200)
+                .body("status", equalTo("done"))
+                .body("fingerprint", equalTo("fp1"))
+                .body("contentHash", equalTo("hash1"))
+                .body("segmentCount", equalTo(3));
+    }
+
+    @Test
+    void reintentKeepsTheLargestKnownCount() {
+        writeIntent("p", "doc", "fp1", "hash1", 0, 5, "source");
+        commit("p", "doc", "fp1", "hash1", 5);
+        writeIntent("p", "doc", "fp2", "hash2", 5, 2, "source");
+
+        // shrink must still see the previously committed tail
+        RestAssured.get("/ingestion-tracker/p/doc").then()
+                .body("segmentCount", equalTo(5));
+    }
+
+    @Test
+    void refreshFingerprintTouchesNothingElse() {
+        writeIntent("p", "doc", "fp1", "hash1", 0, 2, "source");
+        commit("p", "doc", "fp1", "hash1", 2);
+
+        RestAssured.given().queryParam("fingerprint", "fp2")
+                .post("/ingestion-tracker/p/doc/refresh-fingerprint")
+                .then().statusCode(200)
+                .body("fingerprint", equalTo("fp2"))
+                .body("contentHash", equalTo("hash1"))
+                .body("segmentCount", equalTo(2))
+                .body("status", equalTo("done"));
+    }
+
+    @Test
+    void listDocumentsIsIsolatedByPipeline() {
+        writeIntent("p1", "a", "fp", "h", 0, 1, "source");
+        commit("p1", "a", "fp", "h", 1);
+        writeIntent("p2", "b", "fp", "h", 0, 1, "source");
+        commit("p2", "b", "fp", "h", 1);
+
+        RestAssured.get("/ingestion-tracker/p1").then()
+                .body("", hasSize(1))
+                .body("[0].documentId", equalTo("a"));
+    }
+
+    @Test
+    void deleteRowForgetsTheDocument() {
+        writeIntent("p", "doc", "fp", "h", 0, 1, "source");
+        commit("p", "doc", "fp", "h", 1);
+
+        RestAssured.delete("/ingestion-tracker/p/doc").then().statusCode(204);
+
+        RestAssured.get("/ingestion-tracker/p/doc").then().statusCode(404);
+        RestAssured.get("/ingestion-tracker/p").then().body("", hasSize(0));
+    }
+
+    @Test
+    void tombstoneSurvivesAndLifts() {
+        writeIntent("p", "doc", "fp", "h", 0, 1, "source");
+        commit("p", "doc", "fp", "h", 1);
+
+        RestAssured.post("/ingestion-tracker/p/doc/tombstone").then().body("tombstone", equalTo(true));
+        RestAssured.post("/ingestion-tracker/p/doc/unsuppress").then().body("tombstone", equalTo(false));
+    }
+
+    @Test
+    void pinSurvivesAndLifts() {
+        writeIntent("p", "doc", "fp", "h", 0, 1, "api");
+        commit("p", "doc", "fp", "h", 1);
+
+        RestAssured.post("/ingestion-tracker/p/doc/pin").then().body("pinned", equalTo(true));
+        RestAssured.post("/ingestion-tracker/p/doc/unpin").then().body("pinned", equalTo(false));
+    }
+
+    @Test
+    void markFailedRecordsTheAttemptAndKeepsCommittedState() {
+        writeIntent("p", "doc", "fp1", "h1", 0, 2, "source");
+        commit("p", "doc", "fp1", "h1", 2);
+
+        RestAssured.given().queryParam("fingerprint", "fp2")
+                .post("/ingestion-tracker/p/doc/fail")
+                .then().statusCode(200)
+                .body("status", equalTo("failed"))
+                // the failed attempt's fingerprint gates retries
+                .body("fingerprint", equalTo("fp2"))
+                // previously committed segments keep serving
+                .body("segmentCount", equalTo(2));
+    }
+
+    private static void writeIntent(String pipeline, String docId, String fingerprint, String contentHash,
+            int committedCount, int intendedCount, String origin) {
+        RestAssured.given()
+                .queryParam("fingerprint", fingerprint).queryParam("contentHash", contentHash)
+                .queryParam("committedCount", committedCount).queryParam("intendedCount", intendedCount)
+                .queryParam("origin", origin)
+                .post("/ingestion-tracker/" + pipeline + "/" + docId + "/intent")
+                .then().statusCode(200);
+    }
+
+    private static void commit(String pipeline, String docId, String fingerprint, String contentHash,
+            int segmentCount) {
+        RestAssured.given()
+                .queryParam("fingerprint", fingerprint).queryParam("contentHash", contentHash)
+                .queryParam("segmentCount", segmentCount)
+                .post("/ingestion-tracker/" + pipeline + "/" + docId + "/commit")
+                .then().statusCode(200);
+    }
+}

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -165,6 +165,7 @@
         <module>langchain4j-chat</module>
         <module>langchain4j-embeddings</module>
         <module>langchain4j-embeddingstore</module>
+        <module>langchain4j-ingestion-tracker</module>
         <module>langchain4j-rag-bridge-ql4j</module>
         <module>langchain4j-tokenizer</module>
         <module>langchain4j-tools</module>

--- a/tooling/scripts/test-categories.yaml
+++ b/tooling/scripts/test-categories.yaml
@@ -51,6 +51,7 @@ group-02:
   - langchain4j-agent
   - langchain4j-agent-bean-binding-ql4j
   - langchain4j-agent-ql4j
+  - langchain4j-ingestion-tracker
   - oaipmh
   - ocsf
   - pubnub


### PR DESCRIPTION
fixes https://github.com/apache/camel-quarkus/issues/9003

_This work is not plugged into any existing code: no current extension or code path changes behaviour, the module is purely additive and exists as groundwork for an upcoming declarative ingestion feature (a future `langchain4j-ingest` extension's `sync` mode)._

Adds the bookkeeping layer for keeping a vector store in sync with a changing document source,  tracked by #9003.

  - `IngestionTracker` SPI (`extensions-support/langchain4j`): one row per document —  fingerprint, content hash, committed/intended segment counts, two-phase `in_progress`/`done`/`failed` status, `tombstone`/`pinned` flags. The module README documents the full document-state machine.
  - `JdbcIngestionTracker`: reference implementation with dialect-free SQL (PostgreSQL and H2), JDK types only, owning its `cq_ingestion_tracker` schema.
  - `JdbcIngestionTrackerTest`: the behavioural contract on H2 — its test methods are written against the SPI only and are meant to be extracted into a shared contract base class once a second implementation exists.
  - `integration-tests/langchain4j-ingestion-tracker`: the same guarantees over REST against a real PostgreSQL (Dev Services), with a native twin.

  Status: **experimental, internal SPI** — not consumed by any user-facing extension yet; it is the foundation for a future `langchain4j-ingest` extension's `sync` mode. LangChain4j has no equivalent of LangChain-Python's `RecordManager` (langchain4j/langchain4j#2931), so this fills the gap deliberately as a stopgap: if an upstream record manager lands, the SPI is designed to be replaced wholesale by an adapter over it — no long-term compatibility promise is made.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Uncomment and fill this section if your PR is not trivial
[ ] An issue should be filed for the change unless this is a trivial change (fixing a typo or similar). One issue should ideally be fixed by not more than one commit and the other way round, each commit should fix just one issue, without pulling in other changes.
[ ] Each commit in the pull request should have a meaningful and properly spelled subject line and body. Copying the title of the associated issue is typically enough. Please include the issue number in the commit message prefixed by #.
[ ] The pull request description should explain what the pull request does, how, and why. If the info is available in the associated issue or some other external document, a link is enough.
[ ] Phrases like Fix #<issueNumber> or Fixes #<issueNumber> will auto-close the named issue upon merging the pull request. Using them is typically a good idea.
[ ] Please run mvn process-resources -Pformat (and amend the changes if necessary) before sending the pull request.
[ ] Contributor guide is your good friend: https://camel.apache.org/camel-quarkus/latest/contributor-guide.html
-->