### PR TITLE
Ensure master-infinispan follower node has a unique cluster service id

### DIFF
--- a/integration-tests/master-infinispan/src/test/java/org/apache/camel/quarkus/component/master/it/InfinispanClusterServiceTest.java
+++ b/integration-tests/master-infinispan/src/test/java/org/apache/camel/quarkus/component/master/it/InfinispanClusterServiceTest.java
@@ -66,6 +66,10 @@ class InfinispanClusterServiceTest {
             }
         }
 
+        // Use a distinct cluster service ID so the follower is not mistaken for the
+        // leader recovering from a crash by InfinispanRemoteClusterView's lock logic
+        jvmArgs.add("-Dquarkus.camel.cluster.infinispan.id=follower");
+
         // Start secondary application process
         QuarkusProcessExecutor quarkusProcessExecutor = new QuarkusProcessExecutor(jvmArgs.toArray(String[]::new));
         StartedProcess process = quarkusProcessExecutor.start();


### PR DESCRIPTION
Hopefully cures test flakiness.