### PR TITLE
Add the vector-store sync engine atop the ingestion tracker

### DIFF
--- a/extensions-support/langchain4j/README.adoc
+++ b/extensions-support/langchain4j/README.adoc
@@ -84,9 +84,18 @@ transition except `deleteRow`, which removes the row whole.
 reference implementation: deliberately dialect-free SQL (upserts are update-then-insert inside
 application code rather than vendor `MERGE`/`ON CONFLICT`), using only JDK types, so the same
 code runs unmodified against PostgreSQL and H2. It owns its own schema
-(`cq_ingestion_tracker`, created on first use via `ensureSchema()`) and expects to be handed a
+(`camel_quarkus_ingestion_tracker`, created on first use via `ensureSchema()`; document ids up
+to 1024 characters, the S3 object-key maximum) and expects to be handed a
 `javax.sql.DataSource` — in a Quarkus application that's typically an Agroal-managed datasource,
-with Dev Services providing one automatically in dev/test when none is configured.
+with Dev Services providing one automatically in dev/test when none is configured. Operators who
+run the application's DB user without DDL privileges can pre-provision the table and construct
+the tracker with `createTableIfNotExists = false`, in which case `ensureSchema()` only probes
+that the table exists (the same escape hatch camel-sql's `JdbcMessageIdRepository` offers).
+
+NOTE: the tracker table is a durable inventory of the corpus. Document content never lands in
+it, but `doc_id` values are typically paths, URLs or object keys, and those routinely encode
+sensitive structure (`/customers/12345/contract.pdf`). Document ids also appear in exception
+messages, so they reach logs and stack traces.
 
 `JdbcIngestionTrackerTest` (in this module) pins the behavioural guarantees every implementation
 must satisfy (durability of in-progress intents, shrink-bound tracking across re-intents,

--- a/extensions-support/langchain4j/README.adoc
+++ b/extensions-support/langchain4j/README.adoc
@@ -1,0 +1,107 @@
+= LangChain4j Support
+
+This module provides common support code shared by Camel Quarkus LangChain4j extensions.
+
+== Ingestion tracker
+
+Status: *Experimental*.
+
+`org.apache.camel.quarkus.component.support.langchain4j.tracker.IngestionTracker` is the bookkeeping
+SPI behind keeping a vector store in sync with a changing document source (files, buckets, feeds,
+...). Vector stores cannot be enumerated for "what did I already ingest", and LangChain4j has no
+equivalent of LangChain-Python's `RecordManager`
+(https://github.com/langchain4j/langchain4j/issues/2931[langchain4j#2931]), so without external
+bookkeeping any ingestion pipeline is either append-only (restarts re-embed the whole corpus,
+edited documents join their previous vectors instead of replacing them) or wipe-and-reload
+(loses everything between passes). `IngestionTracker` closes that gap: it tracks one row per document
+— fingerprint, content hash, segment count, a two-phase `in_progress`/`done`/`failed` status,
+and `tombstone`/`pinned` flags — as the single authority on what was ingested. The vector store
+itself stays a disposable projection that is never asked questions; losing the tracker only costs
+re-ingestion, never correctness, because segment ids are deterministic.
+
+The two-phase `writeIntent`/`commit` protocol is what makes the tracker crash-safe: a row left
+`in_progress` by a crash (killed process, OOM, ...) is never mistaken for "already ingested", so
+the next delivery of the same document converges the store instead of skipping it.
+
+=== Document states
+
+Each document is one row that moves through the states below. Transitions are the SPI methods;
+the annotations in parentheses describe when the consumer (the ingestion pipeline) invokes them.
+
+----
+ (no row)
+    │  writeIntent                 durable BEFORE the store is touched; a crash strands
+    ▼                              the row here, and an in_progress row is never trusted
+ in_progress                       as "already ingested" — the next delivery of the
+    │  commit                      document converges the store
+    ▼
+  done ◄──────────────────────┐
+    │                         │
+    ├─ (unchanged) ──► done   │  no transition: the skip that makes restarts free
+    │                         │
+    ├─ refreshFingerprint ────┘  fingerprint renewed after a content-hash match
+    │                            (tier-2), so the cheap tier-1 check works next pass
+    │
+    ├─ writeIntent ──► in_progress    (edited content: replace; the shrink bound
+    │                                  max(committed, intended) rides along in the row)
+    │
+    ├─ markFailed ──► failed          (processing failure — also fired straight from
+    │      │                           in_progress; previously committed segments, if
+    │      │                           any — a stale but valid version — keep serving)
+    │      │
+    │      ├─ (fingerprint unchanged) ──► failed   dead-lettered: skipped on every
+    │      │                                       pass until the content changes
+    │      │
+    │      └─ writeIntent ──► in_progress          (changed content: retry)
+    │
+    ├─ tombstone() ──► done(0) + tombstone    (explicit delete: the consumer removes
+    │      │                                   the vectors and records commit(0) with
+    │      │                                   the flag) — "deleted stays deleted":
+    │      │                                   every future ingest of the document is
+    │      │                                   suppressed, even though the source
+    │      │                                   still has it
+    │      │
+    │      └─ unsuppress() ──► done(0)         suppression lifted: the next pass
+    │                                          re-ingests the document
+    │
+    └─ pin() ──► done + pinned        (an API write corrected a source-owned document)
+           │                           — "the correction wins": source-origin updates
+           │                           are suppressed; API-origin writes still pass
+           │
+           └─ unpin() ──► done         the source owns the document again
+
+ any state ── deleteRow ──► (no row)   reconciliation: the source no longer lists the
+                                       document (guarded by the consumer's pass
+                                       interlock, never fired by the tracker itself)
+----
+
+`tombstone` and `pinned` are columns orthogonal to `status`: drawn above off `done` because
+that is how the consumer composes them, but they can accompany any state (a tombstone can even
+be recorded for a never-ingested document, as a pure suppression record) and they survive every
+transition except `deleteRow`, which removes the row whole.
+
+`org.apache.camel.quarkus.component.support.langchain4j.tracker.jdbc.JdbcIngestionTracker` is the
+reference implementation: deliberately dialect-free SQL (upserts are update-then-insert inside
+application code rather than vendor `MERGE`/`ON CONFLICT`), using only JDK types, so the same
+code runs unmodified against PostgreSQL and H2. It owns its own schema
+(`cq_ingestion_tracker`, created on first use via `ensureSchema()`) and expects to be handed a
+`javax.sql.DataSource` — in a Quarkus application that's typically an Agroal-managed datasource,
+with Dev Services providing one automatically in dev/test when none is configured.
+
+`JdbcIngestionTrackerTest` (in this module) pins the behavioural guarantees every implementation
+must satisfy (durability of in-progress intents, shrink-bound tracking across re-intents,
+tombstone/pin lifecycle, dead-letter semantics on failure, ...) against H2 for a fast unit loop.
+Its test methods are written against the SPI only, so they double as the contract: the day a
+second implementation exists — for example an adapter over a future upstream LangChain4j record
+manager — they are meant to be extracted into an abstract `IngestionTrackerContract` base class
+with one `*Test` subclass per implementation, and a replacement is a drop-in exactly when its
+subclass passes. The guarantees are verified twice:
+`integration-tests/langchain4j-ingestion-tracker` runs the same set over REST against a real
+PostgreSQL instance (Dev Services), because H2 alone does not prove the "works on PostgreSQL"
+half of the contract.
+
+CAUTION: `IngestionTracker` and its `tracker.*` package are experimental and an internal SPI, not a
+public API — no compatibility guarantees between releases, and applications must not implement or
+call it directly; it may change or be removed without a deprecation cycle. It exists so the
+implementation can be replaced wholesale later. It is not yet wired into a user-facing extension;
+it is consumed by the upcoming `langchain4j-ingest` extension's `sync` mode.

--- a/extensions-support/langchain4j/README.adoc
+++ b/extensions-support/langchain4j/README.adoc
@@ -45,18 +45,21 @@ the annotations in parentheses describe when the consumer (the ingestion pipelin
     ├─ writeIntent ──► in_progress    (edited content: replace; the shrink bound
     │                                  max(committed, intended) rides along in the row)
     │
-    ├─ markFailed ──► failed          (processing failure — also fired straight from
-    │      │                           in_progress; previously committed segments, if
-    │      │                           any — a stale but valid version — keep serving)
+    ├─ markFailed ──► failed          (content-attributable failure only — infrastructure
+    │      │                           failures after the intent instead leave the row
+    │      │                           in_progress and are retried; previously committed
+    │      │                           segments, if any — stale but valid — keep serving)
     │      │
     │      ├─ (fingerprint unchanged) ──► failed   dead-lettered: skipped on every
     │      │                                       pass until the content changes
     │      │
     │      └─ writeIntent ──► in_progress          (changed content: retry)
     │
-    ├─ tombstone() ──► done(0) + tombstone    (explicit delete: the consumer removes
-    │      │                                   the vectors and records commit(0) with
-    │      │                                   the flag) — "deleted stays deleted":
+    ├─ tombstone() ──► done(0) + tombstone    (explicit delete: the flag is written first,
+    │      │                                   then vectors removed, then commit(0) — a
+    │      │                                   crash fails toward "suppressed", never
+    │      │                                   toward a reverting delete) — "deleted stays
+    │      │                                   deleted":
     │      │                                   every future ingest of the document is
     │      │                                   suppressed, even though the source
     │      │                                   still has it
@@ -114,3 +117,101 @@ public API — no compatibility guarantees between releases, and applications mu
 call it directly; it may change or be removed without a deprecation cycle. It exists so the
 implementation can be replaced wholesale later. It is not yet wired into a user-facing extension;
 it is consumed by the upcoming `langchain4j-ingest` extension's `sync` mode.
+
+== Sync engine
+
+Status: *Experimental* — the same caveats as the tracker above: internal, not yet consumed by any
+user-facing extension, groundwork for the upcoming `langchain4j-ingest` extension.
+
+`org.apache.camel.quarkus.component.support.langchain4j.ingest` is the engine that drives the
+document states above — deliberately free of Camel imports, so that together with the tracker it
+forms the unit that could one day be replaced by (or proposed to) an upstream LangChain4j
+record-manager mechanism:
+
+* `IngestService` — the write path for one document: tier-1 fingerprint / tier-2 content-hash
+  change detection, deterministic segment ids, the `writeIntent` → store write → shrink-remove →
+  `commit` protocol, and a per-store write strategy (`upsert` for stores whose same-id write
+  overwrites; `remove-then-add` for stores that keep or mix old content on same-id writes).
+  Embedding calls are batched and optionally rate-limited.
+* `SyncPassRunner` — one bounded synchronisation pass over a complete source listing, ending in
+  reconciliation (tracker-versus-source, the store is never enumerated) behind the safety
+  interlock: a pass with any failure deletes nothing, a bulk-delete floor refuses to remove more
+  than a configured fraction of the corpus without explicit consent, and only `origin=source`
+  rows are ever deletion candidates.
+* `IngestIds` — deterministic RFC 4122 name-based (v5) segment ids: the same
+  `(pipeline, documentId, segmentIndex)` always yields the same id, which is what turns
+  re-ingestion into overwrite instead of duplication and makes crashes converge.
+* `IngestResult` — the per-document outcome (`ingested`, `replaced`, `skipped-unchanged`,
+  `suppressed-*`, `dead-lettered`, `deleted`, `empty`).
+
+=== How `IngestService` decides
+
+One delivery of one document walks the gates below, in code order. The shape to notice is the
+cost ladder: each gate exits earlier and cheaper than the next — gates 1–4 cost a single tracker
+read (tier 1 does not even fetch the document, which is why an unchanged corpus restarts for
+free), gates 5–6 add a fetch and a hash, and only step 7 pays for splitting, embedding and store
+writes. The suppression gates sit above everything deliberately: a tombstone or pin wins before
+any content is looked at.
+
+----
+ingest(docId, fingerprint, textSupplier, origin, tenant)
+│
+├─ docId null/blank ─────────────────────────► throw IllegalArgumentException
+│
+├─ tracker == null?  (APPEND MODE)
+│    ├─ text blank ──────────────────────────► EMPTY        [fetched; nothing else]
+│    └─ split → metadata → embed → store.addAll(derived ids)
+│                                             ► INGESTED    [no tracker at all]
+│
+└─ SYNC MODE — read the tracker row, then:
+   │
+   ├─ 1. row.tombstone? ─────────────────────► SUPPRESSED_TOMBSTONE  [nothing touched:
+   │        "deleted stays deleted"                                    no fetch, no store]
+   │
+   ├─ 2. row.pinned && origin == SOURCE? ────► SUPPRESSED_PINNED     [nothing touched:
+   │        "the correction wins"; API writes pass through             no fetch, no store]
+   │
+   ├─ 3. row.failed && fingerprint == row's? ► DEAD_LETTERED         [nothing touched:
+   │        same content already failed — retry only when it changes; fingerprint-less
+   │        sources gate on the content hash instead, right after step 6]
+   │
+   │    (note: origin == API over a source-owned row ⇒ remember pinAfterWrite)
+   │
+   ├─ 4. TIER 1  row.done && fingerprint == row's?
+   │            ─────────────────────────────► SKIPPED_UNCHANGED     [not even FETCHED —
+   │        the skip that makes restarts free]                         zero cost]
+   │
+   ├─ 5. fetch text via supplier … blank? ───► EMPTY                 [fetched; keep the
+   │        (glitch-proofing: never empty a KB on a blank read)        previous version]
+   │
+   ├─ 6. TIER 2  row.done && contentHash == row's?
+   │        ├─ refreshFingerprint (so tier 1 works next pass)
+   │        └────────────────────────────────► SKIPPED_UNCHANGED     [fetched + hashed;
+   │        (fingerprint moved, bytes didn't — touch/re-upload case)   store untouched]
+   │
+   └─ 7. THE WRITE PROTOCOL  (content genuinely new or changed)
+        split → metadata → derive ids 0…newCount-1
+        maxKnown = max(row.committed, row.intended)   (0 if no row)
+        │
+        ├─ a. tracker.writeIntent(newCount)            durable BEFORE the store
+        ├─ b. REMOVE_THEN_ADD && maxKnown > 0?
+        │        store.removeAll(ids 0…maxKnown-1)     clear the old generation first
+        │        (chroma/milvus: same-id write would keep or mix old content)
+        ├─ c. per batch: throttle → embedAll → store.addAll(ids…)
+        ├─ d. UPSERT && maxKnown > newCount?
+        │        store.removeAll(ids newCount…maxKnown-1)   the shrink tail
+        ├─ e. tracker.commit(newCount)
+        └─ f. pinAfterWrite? tracker.pin
+                 │
+                 ├─ row existed (maxKnown > 0) ──────► REPLACED
+                 └─ first time ─────────────────────► INGESTED
+
+ failure typing: anything thrown in b–e is infrastructure — the row stays in_progress, the
+ next delivery retries and converges, and it is NEVER dead-lettered (a transient provider
+ outage must not freeze or drop a document). Only failures before the intent (fetch, split)
+ are content-attributable and dead-letter material.
+----
+
+The engine's invariants are pinned by `IngestSyncProtocolTest` (skip tiers, replace without
+duplicates, shrink, both write strategies, crash convergence) and `SyncPassRunnerTest` (the
+deletion interlock, tombstone/pin behaviour over passes, dead-letter retry semantics).

--- a/extensions-support/langchain4j/runtime/pom.xml
+++ b/extensions-support/langchain4j/runtime/pom.xml
@@ -65,6 +65,18 @@
             <artifactId>camel-langchain4j-agent</artifactId>
             <optional>true</optional>
         </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions-support/langchain4j/runtime/pom.xml
+++ b/extensions-support/langchain4j/runtime/pom.xml
@@ -39,6 +39,14 @@
             <artifactId>quarkus-jackson</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.uuid</groupId>
+            <artifactId>java-uuid-generator</artifactId>
+            <!-- optional: only the ingestion engine (IngestIds) needs it, and that is not yet
+                 wired into any extension — consumers of this support module must not inherit
+                 the jar. The future langchain4j-ingest extension declares it explicitly. -->
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j</artifactId>
         </dependency>

--- a/extensions-support/langchain4j/runtime/src/main/java/org/apache/camel/quarkus/component/support/langchain4j/ingest/IngestIds.java
+++ b/extensions-support/langchain4j/runtime/src/main/java/org/apache/camel/quarkus/component/support/langchain4j/ingest/IngestIds.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.support.langchain4j.ingest;
+
+import java.util.UUID;
+
+import com.fasterxml.uuid.Generators;
+import com.fasterxml.uuid.impl.NameBasedGenerator;
+
+/**
+ * Deterministic, UUID-formatted segment ids: the same (pipeline, documentId, segmentIndex) always
+ * yields the same id, across runs and processes. On stores whose write is an upsert this makes
+ * re-ingestion overwrite instead of duplicate; it is the primitive the sync protocol builds on.
+ * RFC 4122 name-based UUID, version 5 (SHA-1) — via java-uuid-generator, because the JDK only
+ * offers version 3 ({@code UUID.nameUUIDFromBytes}).
+ */
+public final class IngestIds {
+
+    /**
+     * The namespace UUID the v5 derivation requires: its 16 bytes are hashed in front of every
+     * name, partitioning our ids from every other system's. Generated once (a random v4 UUID)
+     * for this module — the value carries no meaning, only its fixedness matters. It MUST NEVER
+     * CHANGE: a different namespace re-keys every corpus, so the next sync duplicates instead of
+     * replacing ({@code IngestIdsTest} pins the derived values).
+     */
+    private static final UUID NAMESPACE = UUID.fromString("2595ee11-cedf-4f54-9086-5ed8775cc26a");
+
+    /**
+     * Thread-local because JUG's {@code NameBasedGenerator.generate} synchronizes on one shared
+     * {@code MessageDigest} — a single static generator would serialize every segment id of
+     * every pipeline on one lock. Lazy per-thread construction also keeps a restricted crypto
+     * provider (no SHA-1) surfacing as a diagnosable exception at first use instead of an
+     * {@code ExceptionInInitializerError}.
+     */
+    private static final ThreadLocal<NameBasedGenerator> GENERATOR = ThreadLocal
+            .withInitial(() -> Generators.nameBasedGenerator(NAMESPACE));
+
+    private IngestIds() {
+    }
+
+    /**
+     * The hashed name length-prefixes the pipeline, so the pipeline↔documentId boundary is
+     * unambiguous: without it, {@code ("a|b", "c")} and {@code ("a", "b|c")} would hash the same
+     * name and two pipelines sharing a store could overwrite (and shrink-delete) each other's
+     * segments. The index needs no delimiter discipline — it is last and numeric.
+     */
+    public static String segmentId(String pipeline, String documentId, int segmentIndex) {
+        return GENERATOR.get()
+                .generate(pipeline.length() + ":" + pipeline + "|" + documentId + "|" + segmentIndex)
+                .toString();
+    }
+}

--- a/extensions-support/langchain4j/runtime/src/main/java/org/apache/camel/quarkus/component/support/langchain4j/ingest/IngestResult.java
+++ b/extensions-support/langchain4j/runtime/src/main/java/org/apache/camel/quarkus/component/support/langchain4j/ingest/IngestResult.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.support.langchain4j.ingest;
+
+import java.util.Locale;
+
+/**
+ * Outcome of one ingestion operation.
+ */
+public record IngestResult(String pipeline, String documentId, int segmentsWritten, Outcome outcome) {
+
+    public enum Outcome {
+        /** New document written. */
+        INGESTED,
+        /** Previous vectors overwritten/removed. */
+        REPLACED,
+        /** Change detection short-circuited — no read, no embedding, no store write. */
+        SKIPPED_UNCHANGED,
+        /** Blank document, nothing written. */
+        EMPTY,
+        /** Vectors removed. */
+        DELETED,
+        /** The document was explicitly deleted and stays deleted. */
+        SUPPRESSED_TOMBSTONE,
+        /** An API correction wins over the source until unpinned. */
+        SUPPRESSED_PINNED,
+        /** A poison document skipped because a previous attempt failed and its content is unchanged. */
+        DEAD_LETTERED;
+
+        /** The stable wire/log form, e.g. {@code skipped-unchanged}. */
+        public String label() {
+            return name().toLowerCase(Locale.ROOT).replace('_', '-');
+        }
+    }
+}

--- a/extensions-support/langchain4j/runtime/src/main/java/org/apache/camel/quarkus/component/support/langchain4j/ingest/IngestService.java
+++ b/extensions-support/langchain4j/runtime/src/main/java/org/apache/camel/quarkus/component/support/langchain4j/ingest/IngestService.java
@@ -1,0 +1,633 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.support.langchain4j.ingest;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.WeakHashMap;
+import java.util.function.Supplier;
+
+import dev.langchain4j.data.document.Document;
+import dev.langchain4j.data.document.DocumentSplitter;
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.document.splitter.DocumentSplitters;
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.exception.UnsupportedFeatureException;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import org.apache.camel.quarkus.component.support.langchain4j.tracker.IngestionTracker;
+import org.jboss.logging.Logger;
+
+/**
+ * Ingests documents into an embedding store with deterministic segment ids. Deliberately free of
+ * any Camel dependency — this package is the sync-engine core.
+ *
+ * <p>
+ * Two modes:
+ * <ul>
+ * <li><b>append</b> ({@code tracker == null}) — write-only; re-ingestion of an unchanged document
+ * costs a write (harmless on upsert-capable stores thanks to deterministic ids, duplicating on
+ * others).</li>
+ * <li><b>sync</b> — the full protocol: tier-1 fingerprint check, tier-2 content-hash check,
+ * tracker intent, write (per-store strategy), shrink-remove, tracker commit. Crash anywhere
+ * converges on the next delivery because the intent row is never skipped and the shrink bound is
+ * {@code max(committed, ever-intended)} — the invariants the crash-convergence tests pin.</li>
+ * </ul>
+ *
+ * <p>
+ * Failures are typed by where they happen, because the consequences differ:
+ * {@link ContentIngestException} (before the durable intent — fetching, splitting: attributable
+ * to the content, dead-letter material) versus {@link RetryableIngestException} (after the
+ * intent — embedding, store or tracker I/O: infrastructure, the row stays {@code in_progress}
+ * and the next delivery retries and converges). Conflating the two would let a transient
+ * provider outage permanently freeze — or, on remove-then-add stores, permanently drop — a
+ * document while passes report success.
+ *
+ * <p>
+ * <b>Concurrency:</b> writes are serialized per document id inside this instance (striped
+ * locks), which upholds the tracker's single-writer-per-{@code (pipeline, documentId)} invariant
+ * for the one instance a pipeline owns — the source pass and API/ingress writers share it.
+ * Across replicas there is no coordination by design: deterministic ids make concurrent writers
+ * converge; the duplicate cost is bounded and the tracker heals on the next pass.
+ */
+public class IngestService {
+
+    private static final Logger LOG = Logger.getLogger(IngestService.class);
+
+    /** Bumping this re-embeds every corpus; it is part of the content hash on purpose. */
+    static final String SCHEMA_VERSION = "1";
+    /** This release parses bytes as UTF-8 text; the parser identity is a hash input. */
+    static final String PARSER_ID = "text";
+
+    /** Retrieval-facing segment metadata: what citations and tenancy filters are built on. */
+    public static final String METADATA_PIPELINE = "cq_pipeline";
+    public static final String METADATA_DOCUMENT_ID = "cq_document_id";
+    public static final String METADATA_TENANT = "cq_tenant";
+
+    /** Stores enforce per-request id limits; removals are batched like writes are. */
+    static final int REMOVE_BATCH_SIZE = 256;
+
+    private static final int LOCK_STRIPES = 64;
+
+    /**
+     * Embedding rate limiting is scoped to the model instance, not the pipeline: two pipelines
+     * sharing one provider must share the budget, or the provider sees a multiple of the
+     * configured rate. Values are "earliest next call" {@code nanoTime} stamps. Weak keys, so
+     * models discarded by dev-mode reloads or tests are not pinned for the JVM lifetime;
+     * compound operations synchronize on the map itself.
+     */
+    private static final Map<EmbeddingModel, long[]> MODEL_CALL_GATES = Collections
+            .synchronizedMap(new WeakHashMap<>());
+
+    public enum WriteStrategy {
+        /** Same-id write overwrites (pgvector, qdrant, elasticsearch — measured behaviour). */
+        UPSERT,
+        /**
+         * Same-id write silently keeps or mixes old content (chroma, milvus, in-memory) — remove
+         * the previous generation's ids first.
+         */
+        REMOVE_THEN_ADD;
+
+        public static WriteStrategy of(String value) {
+            return switch (value) {
+            case "upsert" -> UPSERT;
+            case "remove-then-add" -> REMOVE_THEN_ADD;
+            default -> throw new IllegalArgumentException(
+                    "Unknown write-strategy '" + value + "'. Supported: upsert, remove-then-add");
+            };
+        }
+    }
+
+    /** A failure attributable to the document's content, raised before the durable intent. */
+    public static final class ContentIngestException extends RuntimeException {
+
+        private final String dedupFingerprint;
+        private final boolean committedVersionServes;
+
+        ContentIngestException(Throwable cause, String dedupFingerprint, boolean committedVersionServes) {
+            super(cause.getMessage(), cause);
+            this.dedupFingerprint = dedupFingerprint;
+            this.committedVersionServes = committedVersionServes;
+        }
+
+        /**
+         * What to record with {@link IngestionTracker#markFailed}: the effective fingerprint if
+         * the source supplied one, else the content hash if the content was readable, else
+         * {@code null} (no dead-letter gate — the failure is retried).
+         */
+        public String dedupFingerprint() {
+            return dedupFingerprint;
+        }
+
+        /** A previously committed version exists and keeps serving — stale, but valid. */
+        public boolean committedVersionServes() {
+            return committedVersionServes;
+        }
+    }
+
+    /**
+     * An infrastructure failure raised after the durable intent (embedding, store or tracker
+     * I/O). The tracker row remains {@code in_progress}, which change detection never skips, so
+     * the next delivery retries and converges — such failures must never be dead-lettered, or a
+     * transient outage would permanently freeze (or drop) the document.
+     */
+    public static final class RetryableIngestException extends RuntimeException {
+
+        private final boolean committedVersionServes;
+        private final boolean oldGenerationRemoved;
+
+        RetryableIngestException(Throwable cause, boolean committedVersionServes, boolean oldGenerationRemoved) {
+            super(cause.getMessage(), cause);
+            this.committedVersionServes = committedVersionServes;
+            this.oldGenerationRemoved = oldGenerationRemoved;
+        }
+
+        /** A previously committed version is still in the store and keeps serving. */
+        public boolean committedVersionServes() {
+            return committedVersionServes;
+        }
+
+        /**
+         * The remove-then-add strategy had already removed the old generation when the write
+         * failed: the document is offline until a retry succeeds.
+         */
+        public boolean oldGenerationRemoved() {
+            return oldGenerationRemoved;
+        }
+    }
+
+    private final String pipeline;
+    private final EmbeddingStore<TextSegment> store;
+    private final EmbeddingModel model;
+    private final DocumentSplitter splitter;
+    private final IngestionTracker tracker;
+    private final WriteStrategy writeStrategy;
+    private final String hashSuffix;
+    private final Object[] documentLocks;
+    private volatile int embeddingBatchSize = 32;
+    private volatile long minMillisBetweenEmbeddingCalls;
+
+    public IngestService(String pipeline, EmbeddingStore<TextSegment> store, EmbeddingModel model,
+            String splitterKind, int maxSegmentSize, int maxOverlapSize,
+            IngestionTracker tracker, WriteStrategy writeStrategy, String embeddingModelId) {
+        if (pipeline == null || pipeline.isBlank()) {
+            throw new IllegalArgumentException("An ingestion pipeline needs a non-blank name");
+        }
+        this.pipeline = pipeline;
+        this.store = Objects.requireNonNull(store, "store");
+        this.model = Objects.requireNonNull(model, "model");
+        this.tracker = tracker;
+        this.writeStrategy = Objects.requireNonNull(writeStrategy, "writeStrategy");
+        this.splitter = switch (splitterKind) {
+        case "recursive" -> DocumentSplitters.recursive(maxSegmentSize, maxOverlapSize);
+        case "none" -> null;
+        default -> throw new IllegalArgumentException(
+                "Unknown splitter '" + splitterKind + "' for ingestion pipeline '" + pipeline
+                        + "'. Supported: recursive, none");
+        };
+        // every non-content input that must invalidate change detection when it changes:
+        // model identity, splitter parameters, parser identity, schema version
+        this.hashSuffix = "\0" + embeddingModelId + "\0" + splitterKind + "\0" + maxSegmentSize
+                + "\0" + maxOverlapSize + "\0" + PARSER_ID + "\0" + SCHEMA_VERSION;
+        this.documentLocks = new Object[LOCK_STRIPES];
+        for (int i = 0; i < LOCK_STRIPES; i++) {
+            documentLocks[i] = new Object();
+        }
+        if (tracker != null) {
+            probeRemovalCapability();
+        }
+    }
+
+    /**
+     * Sync mode is built on id-addressed removal, but {@code EmbeddingStore.removeAll(ids)} is a
+     * default-throwing SPI method — a store may simply not have it. Probing once at construction
+     * (removing an id that cannot exist is a no-op on capable stores) turns "every document of
+     * every pass dead-letters, then the pass reports success" into a fail-fast with the store's
+     * name in it.
+     */
+    private void probeRemovalCapability() {
+        try {
+            // a random id cannot collide with any document's segments; removing a nonexistent id
+            // is a no-op on capable stores
+            store.removeAll(List.of(UUID.randomUUID().toString()));
+        } catch (UnsupportedFeatureException | UnsupportedOperationException e) {
+            throw new IllegalStateException(
+                    "The embedding store " + store.getClass().getName() + " does not support id-addressed "
+                            + "removal (removeAll(ids)), which sync mode's replacement and deletion are built "
+                            + "on. Use mode=append or a removal-capable store.",
+                    e);
+        } catch (RuntimeException e) {
+            // a store that is merely unreachable at startup is not an incapable store: let the
+            // first pass fail and retry rather than turning a blip into a hard startup failure
+            LOG.warnf(e, "Pipeline '%s': embedding store capability probe inconclusive (store not "
+                    + "reachable) — proceeding; the first synchronisation pass will retry", pipeline);
+        }
+    }
+
+    /** Who is writing: the pipeline's own source scan, or application code / the ingress. */
+    public enum Origin {
+        SOURCE(IngestionTracker.ORIGIN_SOURCE),
+        API(IngestionTracker.ORIGIN_API);
+
+        final String value;
+
+        Origin(String value) {
+            this.value = value;
+        }
+    }
+
+    /** No-fingerprint convenience (any mode): change detection falls back to the content hash. */
+    public IngestResult ingest(String documentId, String text) {
+        return ingest(documentId, null, text, Origin.SOURCE);
+    }
+
+    /** Source-origin convenience. */
+    public IngestResult ingest(String documentId, String fingerprint, String text) {
+        return ingest(documentId, fingerprint, text, Origin.SOURCE);
+    }
+
+    public IngestResult ingest(String documentId, String fingerprint, String text, Origin origin) {
+        return ingest(documentId, fingerprint, () -> text, origin, null);
+    }
+
+    public IngestResult ingest(String documentId, String fingerprint, String text, Origin origin, String tenant) {
+        return ingest(documentId, fingerprint, () -> text, origin, tenant);
+    }
+
+    public IngestResult ingest(String documentId, String fingerprint, Supplier<String> text, Origin origin) {
+        return ingest(documentId, fingerprint, text, origin, null);
+    }
+
+    /**
+     * The supplier form: content is only fetched when change detection cannot skip the document
+     * — an unchanged corpus costs neither read nor parse. The optional tenant is written as
+     * segment metadata for retrieval-side isolation and participates in change detection: a
+     * document re-assigned to another tenant is re-written, never skipped with stale metadata.
+     */
+    public IngestResult ingest(String documentId, String fingerprint, Supplier<String> text, Origin origin,
+            String tenant) {
+        if (documentId == null || documentId.isBlank()) {
+            throw new IllegalArgumentException(
+                    "A stable document id is required to ingest into pipeline '" + pipeline + "'");
+        }
+        if (tracker == null) {
+            String content = text.get();
+            if (content == null || content.isBlank()) {
+                return new IngestResult(pipeline, documentId, 0, IngestResult.Outcome.EMPTY);
+            }
+            return append(documentId, content, tenant);
+        }
+        // the source pass and API/ingress writers share this instance: serialize per document
+        synchronized (lockFor(documentId)) {
+            return sync(documentId, fingerprint, text, origin, tenant);
+        }
+    }
+
+    /**
+     * Serializes the whole read→intent→write→commit window per document id — the in-JVM half of
+     * the tracker's single-writer invariant. 64 fixed stripes bound memory (no per-id lock map);
+     * the same id always hashes to the same stripe, distinct ids rarely share one.
+     */
+    private Object lockFor(String documentId) {
+        return documentLocks[Math.floorMod(documentId.hashCode(), LOCK_STRIPES)];
+    }
+
+    /**
+     * Explicit delete: a tombstone recorded first, then vectors removed, so the document
+     * <em>stays</em> deleted even while its source file still exists — a legal hold that reverts
+     * on the next poll would be worse than none. The tombstone is written before the store is
+     * touched on purpose: a crash mid-delete then fails toward "suppressed, with lingering
+     * vectors" — recoverable by retrying the delete (or by unsuppress + re-ingest, which
+     * overwrites the leftovers) — never toward a delete that silently reverts. Lifted with
+     * {@link #unsuppress}.
+     */
+    public IngestResult delete(String documentId) {
+        requireSync("delete");
+        synchronized (lockFor(documentId)) {
+            Optional<IngestionTracker.TrackerRow> existing = tracker.read(pipeline, documentId);
+            // for a never-ingested document the tracker itself creates the pure suppression row
+            tracker.tombstone(pipeline, documentId);
+            int maxKnownCount = existing.map(IngestionTracker.TrackerRow::maxKnownCount).orElse(0);
+            if (maxKnownCount > 0) {
+                removeSegments(ids(documentId, maxKnownCount));
+            }
+            tracker.commit(pipeline, documentId, null, null, 0);
+            return new IngestResult(pipeline, documentId, 0, IngestResult.Outcome.DELETED);
+        }
+    }
+
+    /** Lifts a tombstone; the next source pass re-ingests the document if it still exists. */
+    public void unsuppress(String documentId) {
+        requireSync("unsuppress");
+        tracker.unsuppress(pipeline, documentId);
+    }
+
+    public void pin(String documentId) {
+        requireSync("pin");
+        tracker.pin(pipeline, documentId);
+    }
+
+    public void unpin(String documentId) {
+        requireSync("unpin");
+        tracker.unpin(pipeline, documentId);
+    }
+
+    private void requireSync(String operation) {
+        if (tracker == null) {
+            throw new IllegalStateException(
+                    "Operation '" + operation + "' needs mode=sync on pipeline '" + pipeline
+                            + "' (append mode has no tracker to record it in)");
+        }
+    }
+
+    /** Store-side removal by explicit ids — batched, stores enforce per-request id limits. */
+    void removeSegments(List<String> ids) {
+        for (int from = 0; from < ids.size(); from += REMOVE_BATCH_SIZE) {
+            store.removeAll(ids.subList(from, Math.min(from + REMOVE_BATCH_SIZE, ids.size())));
+        }
+    }
+
+    private IngestResult append(String documentId, String text, String tenant) {
+        List<TextSegment> segments = withMetadata(split(text), documentId, tenant);
+        write(segments, ids(documentId, segments.size()));
+        return new IngestResult(pipeline, documentId, segments.size(), IngestResult.Outcome.INGESTED);
+    }
+
+    private IngestResult sync(String documentId, String fingerprint, Supplier<String> textSupplier, Origin origin,
+            String tenant) {
+        Optional<IngestionTracker.TrackerRow> existing;
+        try {
+            existing = tracker.read(pipeline, documentId);
+        } catch (RuntimeException e) {
+            throw new RetryableIngestException(e, false, false);
+        }
+        boolean committedServes = existing.map(row -> row.done() && row.segmentCount() > 0).orElse(false);
+
+        // suppressions come first: an explicitly deleted document stays deleted (any writer),
+        // and a pinned document ignores its source until unpinned
+        if (existing.isPresent() && existing.get().tombstone()) {
+            return new IngestResult(pipeline, documentId, 0, IngestResult.Outcome.SUPPRESSED_TOMBSTONE);
+        }
+        if (existing.isPresent() && existing.get().pinned() && origin == Origin.SOURCE) {
+            return new IngestResult(pipeline, documentId, 0, IngestResult.Outcome.SUPPRESSED_PINNED);
+        }
+
+        // the tenant participates in identity: a re-assigned document must not be skipped, so
+        // the effective fingerprint (stored and compared) carries the tenant
+        String effectiveFingerprint = effectiveFingerprint(fingerprint, tenant);
+
+        // dead-letter: a previous attempt failed on exactly this content — skip until it changes,
+        // so a poison document does not fail identically on every pass, forever, at cost
+        if (existing.isPresent() && existing.get().failed() && effectiveFingerprint != null
+                && effectiveFingerprint.equals(existing.get().fingerprint())) {
+            return new IngestResult(pipeline, documentId, 0, IngestResult.Outcome.DEAD_LETTERED);
+        }
+
+        // an API write over a source-owned document is a correction: pin it, so the next source
+        // pass does not silently revert it (lifted with unpin)
+        boolean pinAfterWrite = origin == Origin.API && existing.isPresent()
+                && IngestionTracker.ORIGIN_SOURCE.equals(existing.get().origin());
+
+        // tier 1: cheap fingerprint — no read, no hash, no split, no embedding
+        if (effectiveFingerprint != null && existing.isPresent() && existing.get().done()
+                && effectiveFingerprint.equals(existing.get().fingerprint())) {
+            return new IngestResult(pipeline, documentId, 0, IngestResult.Outcome.SKIPPED_UNCHANGED);
+        }
+
+        String text;
+        try {
+            text = textSupplier.get();
+        } catch (RuntimeException e) {
+            // no content to attribute the failure to: dead-letter on the fingerprint if the
+            // source supplied one, otherwise retry on every pass
+            throw new ContentIngestException(e, effectiveFingerprint, committedServes);
+        }
+        if (text == null || text.isBlank()) {
+            // deliberately "keep the previous version": blank content is indistinguishable from a
+            // transient source glitch (truncated read, file mid-write), and emptying a knowledge
+            // base on a glitch would be worse than serving a stale document. An intentional
+            // removal is a delete (explicit, or the document disappearing from the source).
+            return new IngestResult(pipeline, documentId, 0, IngestResult.Outcome.EMPTY);
+        }
+
+        // tier 2: content hash (covers model/splitter/parser/schema/tenant changes exactly)
+        String contentHash = contentHash(text, tenant);
+        if (existing.isPresent() && existing.get().done() && contentHash.equals(existing.get().contentHash())) {
+            if (effectiveFingerprint != null) {
+                try {
+                    tracker.refreshFingerprint(pipeline, documentId, effectiveFingerprint);
+                } catch (RuntimeException e) {
+                    // tracker blip on an unchanged, correct document: retryable, never a reason
+                    // to dead-letter it and disable the pass's deletions
+                    throw new RetryableIngestException(e, committedServes, false);
+                }
+            }
+            return new IngestResult(pipeline, documentId, 0, IngestResult.Outcome.SKIPPED_UNCHANGED);
+        }
+
+        // dead-letter fallback for fingerprint-less sources: the failed attempt recorded the
+        // content hash in the fingerprint column, so the poison document is recognized after
+        // one cheap fetch + hash instead of re-splitting and re-embedding on every pass
+        if (existing.isPresent() && existing.get().failed()
+                && contentHash.equals(existing.get().fingerprint())) {
+            return new IngestResult(pipeline, documentId, 0, IngestResult.Outcome.DEAD_LETTERED);
+        }
+
+        List<TextSegment> segments;
+        try {
+            segments = withMetadata(split(text), documentId, tenant);
+        } catch (RuntimeException e) {
+            String dedup = effectiveFingerprint != null ? effectiveFingerprint : contentHash;
+            throw new ContentIngestException(e, dedup, committedServes);
+        }
+        int newCount = segments.size();
+        int maxKnownCount = existing.map(IngestionTracker.TrackerRow::maxKnownCount).orElse(0);
+        boolean replace = maxKnownCount > 0;
+
+        // 1. intent — durable before the store is touched; a crash from here on converges,
+        //    because this row is never skipped and the shrink bound below survives in it
+        try {
+            tracker.writeIntent(pipeline, documentId, effectiveFingerprint, contentHash, newCount, origin.value);
+        } catch (RuntimeException e) {
+            // tracker I/O is infrastructure: no durable intent means nothing was written and the
+            // row is unchanged — the next pass simply retries; dead-lettering here would freeze
+            // the changed document on a pool blip or a replica race
+            throw new RetryableIngestException(e, committedServes, false);
+        }
+
+        // from the intent on, failures are infrastructure: the in_progress row makes the next
+        // delivery retry and converge, so they must NOT be dead-lettered
+        boolean oldGenerationRemoved = false;
+        try {
+            // 2. the store write, by measured store capability
+            List<String> ids = ids(documentId, newCount);
+            if (writeStrategy == WriteStrategy.REMOVE_THEN_ADD && maxKnownCount > 0) {
+                removeSegments(ids(documentId, maxKnownCount));
+                oldGenerationRemoved = true;
+            }
+            write(segments, ids);
+
+            // 3. shrink-remove: ids beyond the new count, up to the largest count ever intended
+            if (writeStrategy == WriteStrategy.UPSERT && maxKnownCount > newCount) {
+                List<String> stale = new ArrayList<>(maxKnownCount - newCount);
+                for (int i = newCount; i < maxKnownCount; i++) {
+                    stale.add(IngestIds.segmentId(pipeline, documentId, i));
+                }
+                removeSegments(stale);
+            }
+
+            // 4. commit
+            tracker.commit(pipeline, documentId, effectiveFingerprint, contentHash, newCount);
+        } catch (RuntimeException e) {
+            throw new RetryableIngestException(e, committedServes && !oldGenerationRemoved, oldGenerationRemoved);
+        }
+
+        if (pinAfterWrite) {
+            tracker.pin(pipeline, documentId);
+        }
+
+        return new IngestResult(pipeline, documentId, newCount,
+                replace ? IngestResult.Outcome.REPLACED : IngestResult.Outcome.INGESTED);
+    }
+
+    /** The stored/compared fingerprint carries the tenant, so a tenant change is a change. */
+    static String effectiveFingerprint(String fingerprint, String tenant) {
+        if (fingerprint == null) {
+            return null;
+        }
+        return tenant == null || tenant.isBlank() ? fingerprint : fingerprint + "\0" + tenant;
+    }
+
+    private List<TextSegment> split(String text) {
+        return splitter == null
+                ? List.of(TextSegment.from(text))
+                : splitter.split(Document.from(text));
+    }
+
+    /** Retrieval-facing metadata: citations (which document answered) and tenancy filters. */
+    private List<TextSegment> withMetadata(List<TextSegment> segments, String documentId, String tenant) {
+        for (TextSegment segment : segments) {
+            Metadata metadata = segment.metadata()
+                    .put(METADATA_PIPELINE, pipeline)
+                    .put(METADATA_DOCUMENT_ID, documentId);
+            if (tenant != null && !tenant.isBlank()) {
+                metadata.put(METADATA_TENANT, tenant);
+            }
+        }
+        return segments;
+    }
+
+    private List<String> ids(String documentId, int count) {
+        List<String> ids = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            ids.add(IngestIds.segmentId(pipeline, documentId, i));
+        }
+        return ids;
+    }
+
+    /** Embedding batch size and optional rate limit; provider limits are real. */
+    public IngestService embeddingLimits(int batchSize, Integer requestsPerMinute) {
+        this.embeddingBatchSize = Math.max(1, batchSize);
+        this.minMillisBetweenEmbeddingCalls = requestsPerMinute == null || requestsPerMinute <= 0
+                ? 0
+                : 60_000L / requestsPerMinute;
+        return this;
+    }
+
+    private void write(List<TextSegment> segments, List<String> ids) {
+        int batchSize = embeddingBatchSize;
+        for (int from = 0; from < segments.size(); from += batchSize) {
+            int to = Math.min(from + batchSize, segments.size());
+            List<TextSegment> batch = segments.subList(from, to);
+            throttleEmbedding();
+            List<Embedding> embeddings = model.embedAll(batch).content();
+            store.addAll(ids.subList(from, to), embeddings, batch);
+        }
+    }
+
+    /**
+     * Claims the next call slot under a short lock, then sleeps outside it. The gate is shared
+     * by every pipeline using the same model instance — the provider budget is per provider,
+     * not per pipeline. Intervals are measured with {@code nanoTime} (monotonic — an NTP step
+     * must not stall embedding). An interrupt aborts the write (restoring the flag): during
+     * shutdown a half-issued batch is worse than none, and the in_progress row retries it
+     * anyway. Known trade-off: the sleep happens while the caller's document stripe lock is
+     * held, so with an aggressive limit unrelated documents sharing the stripe wait too —
+     * acceptable for a per-document write path, revisit if limits below ~10 rpm become common.
+     */
+    private void throttleEmbedding() {
+        long min = minMillisBetweenEmbeddingCalls;
+        if (min <= 0) {
+            return;
+        }
+        long minNanos = min * 1_000_000L;
+        long[] gate;
+        synchronized (MODEL_CALL_GATES) {
+            gate = MODEL_CALL_GATES.computeIfAbsent(model, m -> new long[] { Long.MIN_VALUE / 2 });
+        }
+        long wakeAt;
+        synchronized (gate) {
+            long now = System.nanoTime();
+            wakeAt = Math.max(now, gate[0] + minNanos);
+            gate[0] = wakeAt;
+        }
+        long waitNanos = wakeAt - System.nanoTime();
+        if (waitNanos > 0) {
+            try {
+                Thread.sleep(waitNanos / 1_000_000L, (int) (waitNanos % 1_000_000L));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException("Interrupted while rate-limiting embedding calls", e);
+            }
+        }
+    }
+
+    String contentHash(String text, String tenant) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            digest.update(text.getBytes(StandardCharsets.UTF_8));
+            digest.update(hashSuffix.getBytes(StandardCharsets.UTF_8));
+            if (tenant != null && !tenant.isBlank()) {
+                // the tenant lands in segment metadata, so it must invalidate the hash; absent
+                // tenant adds nothing, keeping hashes of untenanted corpora stable
+                digest.update(("\0" + tenant).getBytes(StandardCharsets.UTF_8));
+            }
+            return HexFormat.of().formatHex(digest.digest());
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    public String pipeline() {
+        return pipeline;
+    }
+
+    /** Null in append mode. */
+    public IngestionTracker tracker() {
+        return tracker;
+    }
+}

--- a/extensions-support/langchain4j/runtime/src/main/java/org/apache/camel/quarkus/component/support/langchain4j/ingest/SyncPassRunner.java
+++ b/extensions-support/langchain4j/runtime/src/main/java/org/apache/camel/quarkus/component/support/langchain4j/ingest/SyncPassRunner.java
@@ -1,0 +1,250 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.support.langchain4j.ingest;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import org.apache.camel.quarkus.component.support.langchain4j.tracker.IngestionTracker;
+import org.jboss.logging.Logger;
+
+/**
+ * One bounded synchronisation pass: process every enumerated document, then reconcile —
+ * documents the tracker knows but the source no longer lists are deleted. Reconciliation is
+ * tracker-versus-source; the store is never enumerated.
+ *
+ * <p>
+ * The safety interlock, because the failure mode of getting deletion wrong is an emptied
+ * knowledge base with a green log:
+ * <ul>
+ * <li><b>Enumeration completeness</b> — the caller only invokes this with a fully built listing;
+ * a failed enumeration must abort the pass before this class is reached.</li>
+ * <li><b>Zero-failure gate</b> — if any document failed to process, the pass is
+ * {@code partially-failed} and deletes nothing: an undelivered document is indistinguishable
+ * from a disappeared one.</li>
+ * <li><b>Bulk-delete floor</b> — deleting more than the configured fraction of the pipeline's
+ * pre-pass corpus in one pass requires explicit consent; a mistyped directory or a failed
+ * mount must be a refusal, not an incident. A threshold of {@code 0} means every deletion
+ * needs consent.</li>
+ * <li>Only {@code origin=source} rows are deletion candidates — API-written documents are never
+ * deleted for not appearing in a listing. Tombstoned rows are suppression records, not
+ * candidates.</li>
+ * </ul>
+ *
+ * <p>
+ * Failures during processing are handled by type: a {@link IngestService.RetryableIngestException}
+ * (infrastructure, after the durable intent) leaves the row {@code in_progress} so the next
+ * pass retries it — it is <em>not</em> dead-lettered, or a transient provider outage would
+ * permanently freeze or drop documents. Content-attributable failures are dead-lettered via
+ * {@link IngestionTracker#markFailed} and retried only when the content changes.
+ */
+public class SyncPassRunner {
+
+    private static final Logger LOG = Logger.getLogger(SyncPassRunner.class);
+
+    /** A source document as enumerated: cheap fingerprint now, content only on demand. */
+    public record SourceDocument(String fingerprint, Supplier<String> text, String tenant) {
+
+        public SourceDocument(String fingerprint, Supplier<String> text) {
+            this(fingerprint, text, null);
+        }
+    }
+
+    /**
+     * {@code status} is {@code succeeded}, {@code deletions-refused} (processing succeeded but
+     * the bulk-delete floor withheld deletions pending consent) or {@code partially-failed}.
+     */
+    public record PassOutcome(int processed, int failed, int ingested, int replaced, int skippedUnchanged,
+            int suppressed, int deadLettered, int staleRetained, int segmentsWritten, int deleted,
+            int deletionRefused, String status) {
+
+        /** Every listed document processed without failure — includes {@code deletions-refused}. */
+        public boolean succeeded() {
+            return !"partially-failed".equals(status);
+        }
+    }
+
+    private final IngestService service;
+    private final IngestionTracker tracker;
+    private final String pipeline;
+    private final double bulkDeleteThreshold;
+    private final boolean allowBulkDelete;
+    private final String bulkDeleteConsentHint;
+
+    /**
+     * @param bulkDeleteConsentHint appended to the refusal log line: tells the operator how to
+     *                              consent (the engine is deliberately ignorant of the consumer's
+     *                              configuration namespace)
+     */
+    public SyncPassRunner(IngestService service, IngestionTracker tracker, String pipeline,
+            double bulkDeleteThreshold, boolean allowBulkDelete, String bulkDeleteConsentHint) {
+        if (Double.isNaN(bulkDeleteThreshold) || bulkDeleteThreshold < 0 || bulkDeleteThreshold > 1) {
+            // NaN would silently disable the floor: Math.max(1, NaN) is NaN and n > NaN is false
+            throw new IllegalArgumentException(
+                    "bulkDeleteThreshold must be between 0 and 1, got " + bulkDeleteThreshold);
+        }
+        this.service = service;
+        this.tracker = tracker;
+        this.pipeline = pipeline;
+        this.bulkDeleteThreshold = bulkDeleteThreshold;
+        this.allowBulkDelete = allowBulkDelete;
+        this.bulkDeleteConsentHint = bulkDeleteConsentHint;
+    }
+
+    /**
+     * @param listing the complete enumeration of the source: documentId → document. The caller
+     *                guarantees completeness — on any enumeration error it must not call this.
+     */
+    public PassOutcome run(Map<String, SourceDocument> listing) {
+        // the floor's denominator is the corpus as it was BEFORE this pass: measuring against
+        // post-pass rows would let a large influx of new documents dilute a mass disappearance
+        // below the threshold
+        int prePassSourceOwned = 0;
+        for (IngestionTracker.TrackerRow row : tracker.listDocuments(pipeline)) {
+            if (IngestionTracker.ORIGIN_SOURCE.equals(row.origin()) && !row.tombstone()) {
+                prePassSourceOwned++;
+            }
+        }
+
+        int processed = 0;
+        int failed = 0;
+        int ingested = 0;
+        int replaced = 0;
+        int skippedUnchanged = 0;
+        int suppressed = 0;
+        int deadLettered = 0;
+        int staleRetained = 0;
+        int segmentsWritten = 0;
+
+        for (Map.Entry<String, SourceDocument> entry : listing.entrySet()) {
+            String documentId = entry.getKey();
+            SourceDocument document = entry.getValue();
+            try {
+                IngestResult result = service.ingest(documentId, document.fingerprint(),
+                        document.text(), IngestService.Origin.SOURCE, document.tenant());
+                processed++;
+                segmentsWritten += result.segmentsWritten();
+                switch (result.outcome()) {
+                case INGESTED -> ingested++;
+                case REPLACED -> replaced++;
+                case SKIPPED_UNCHANGED -> skippedUnchanged++;
+                case SUPPRESSED_TOMBSTONE, SUPPRESSED_PINNED -> suppressed++;
+                case DEAD_LETTERED -> deadLettered++;
+                default -> {
+                    // empty: nothing to count
+                }
+                }
+            } catch (IngestService.RetryableIngestException e) {
+                // infrastructure failure after the durable intent: the in_progress row makes the
+                // next pass retry and converge — dead-lettering here would freeze (or, after a
+                // remove-then-add, permanently drop) the document on a transient outage
+                failed++;
+                if (e.committedVersionServes()) {
+                    staleRetained++;
+                    LOG.errorf(e, "Pipeline '%s': failed to write '%s' after the intent — retried next "
+                            + "pass; the STALE previous version keeps serving; deletion disabled for this "
+                            + "pass", pipeline, documentId);
+                } else if (e.oldGenerationRemoved()) {
+                    LOG.errorf(e, "Pipeline '%s': failed to write '%s' after its previous generation was "
+                            + "removed — the document is UNAVAILABLE until a retry succeeds (next pass); "
+                            + "deletion disabled for this pass", pipeline, documentId);
+                } else {
+                    LOG.errorf(e, "Pipeline '%s': failed to write '%s' after the intent — retried next "
+                            + "pass; deletion disabled for this pass", pipeline, documentId);
+                }
+            } catch (Exception e) {
+                // content-attributable (or unexpected): dead-letter — retried when content changes
+                failed++;
+                // the stored fingerprint carries the tenant (see IngestService.effectiveFingerprint),
+                // so the recorded gate must too — a raw fingerprint would never match again and the
+                // poison document would be re-fetched and re-embedded on every pass
+                String dedupFingerprint = IngestService.effectiveFingerprint(document.fingerprint(),
+                        document.tenant());
+                boolean hadCommittedVersion;
+                if (e instanceof IngestService.ContentIngestException content) {
+                    dedupFingerprint = content.dedupFingerprint();
+                    hadCommittedVersion = content.committedVersionServes();
+                } else {
+                    hadCommittedVersion = tracker.read(pipeline, documentId)
+                            .map(row -> row.done() && row.segmentCount() > 0)
+                            .orElse(false);
+                }
+                if (hadCommittedVersion) {
+                    staleRetained++;
+                }
+                tracker.markFailed(pipeline, documentId, dedupFingerprint);
+                LOG.errorf(e, "Pipeline '%s': failed to process '%s' — dead-lettered (retried when its "
+                        + "content changes)%s; deletion disabled for this pass", pipeline, documentId,
+                        hadCommittedVersion ? "; the STALE previous version keeps serving" : "");
+            }
+        }
+
+        if (failed > 0) {
+            return new PassOutcome(processed, failed, ingested, replaced, skippedUnchanged, suppressed,
+                    deadLettered, staleRetained, segmentsWritten, 0, 0, "partially-failed");
+        }
+
+        // reconcile: tracker-versus-source
+        List<IngestionTracker.TrackerRow> rows = tracker.listDocuments(pipeline);
+        List<IngestionTracker.TrackerRow> candidates = new ArrayList<>();
+        for (IngestionTracker.TrackerRow row : rows) {
+            if (!IngestionTracker.ORIGIN_SOURCE.equals(row.origin()) || row.tombstone()) {
+                continue;
+            }
+            // any status is a candidate, including in_progress: a crashed mid-ingest row whose
+            // document then disappeared from the source would otherwise never be reclaimed —
+            // not in the listing (never re-processed), previously not a candidate either, its
+            // row and partially written vectors leaking forever. The interlock above already
+            // guarantees a complete, failure-free pass, and concurrent API writers are excluded
+            // by origin (an API writeIntent stamps origin=api).
+            if (!listing.containsKey(row.documentId())) {
+                candidates.add(row);
+            }
+        }
+
+        // threshold 0 = every deletion needs consent; otherwise deleting ONE document is never
+        // "bulk" — a single-document pipeline (an http url) could otherwise never delete at all,
+        // since 1 of 1 is always over any fractional threshold
+        double allowed = bulkDeleteThreshold == 0 ? 0 : Math.max(1, bulkDeleteThreshold * prePassSourceOwned);
+        if (!candidates.isEmpty() && !allowBulkDelete && candidates.size() > allowed) {
+            LOG.warnf("Pipeline '%s': refusing to delete %d of %d source documents in one pass "
+                    + "(threshold %.0f%%). If this is intended (corpus restructuring), %s.",
+                    pipeline, candidates.size(), prePassSourceOwned, bulkDeleteThreshold * 100,
+                    bulkDeleteConsentHint);
+            return new PassOutcome(processed, 0, ingested, replaced, skippedUnchanged, suppressed,
+                    deadLettered, staleRetained, segmentsWritten, 0, candidates.size(), "deletions-refused");
+        }
+
+        int deleted = 0;
+        for (IngestionTracker.TrackerRow row : candidates) {
+            List<String> ids = new ArrayList<>(row.maxKnownCount());
+            for (int i = 0; i < row.maxKnownCount(); i++) {
+                ids.add(IngestIds.segmentId(pipeline, row.documentId(), i));
+            }
+            service.removeSegments(ids);
+            tracker.deleteRow(pipeline, row.documentId());
+            deleted++;
+            LOG.infof("Pipeline '%s': document '%s' disappeared from the source — removed", pipeline,
+                    row.documentId());
+        }
+
+        return new PassOutcome(processed, 0, ingested, replaced, skippedUnchanged, suppressed,
+                deadLettered, staleRetained, segmentsWritten, deleted, 0, "succeeded");
+    }
+}

--- a/extensions-support/langchain4j/runtime/src/main/java/org/apache/camel/quarkus/component/support/langchain4j/tracker/IngestionTracker.java
+++ b/extensions-support/langchain4j/runtime/src/main/java/org/apache/camel/quarkus/component/support/langchain4j/tracker/IngestionTracker.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.support.langchain4j.tracker;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * The ingestion tracker: one row per document, the authority on what was ingested. The vector store is
+ * a projection that is never asked questions — losing the tracker costs re-ingestion (which
+ * converges thanks to deterministic segment ids), never correctness. Reconciliation is
+ * tracker-versus-source; the store is never enumerated.
+ *
+ * <p>
+ * <strong>Status: Experimental.</strong> Internal SPI — not a public API. No compatibility
+ * guarantees between releases; applications must not implement or call this interface, and it
+ * may change or be removed without a deprecation cycle. It exists so the implementation can be
+ * replaced wholesale: LangChain4j has no equivalent of LangChain-Python's {@code RecordManager} yet
+ * (<a href="https://github.com/langchain4j/langchain4j/issues/2931">langchain4j#2931</a>), and
+ * once one lands upstream, an adapter implementing this interface replaces the
+ * {@code tracker.jdbc} package while every consumer stays untouched. New implementations must
+ * pass the behavioural tests of {@code JdbcIngestionTrackerTest}, whose test methods are written
+ * against this SPI only and are meant to be extracted into a shared contract base class the day
+ * a second implementation exists.
+ *
+ * <p>
+ * Two method groups, by replaceability:
+ * <ul>
+ * <li><em>Tracker subset</em> — {@link #ensureSchema}, {@link #read}, {@link #listDocuments},
+ * {@link #refreshFingerprint}, {@link #deleteRow}: mirrors what an upstream record manager
+ * provides and would delegate to it directly.</li>
+ * <li><em>Camel Quarkus extensions</em> — the two-phase {@link #writeIntent}/{@link #commit}
+ * protocol, {@link #tombstone}/{@link #unsuppress}, {@link #pin}/{@link #unpin},
+ * {@link #markFailed}: product semantics an upstream tracker will not carry; an adapter keeps
+ * these in side storage keyed the same way.</li>
+ * </ul>
+ */
+public interface IngestionTracker {
+
+    String ORIGIN_SOURCE = "source";
+    String ORIGIN_API = "api";
+
+    /** Creates or migrates the backing schema. Called once before first use. */
+    void ensureSchema();
+
+    Optional<TrackerRow> read(String pipeline, String documentId);
+
+    /** All rows of a pipeline — the reconciliation input. */
+    List<TrackerRow> listDocuments(String pipeline);
+
+    /**
+     * Durably records the intent to (re)write a document <em>before</em> the store is touched.
+     * A row left {@code in_progress} by a crash is never skipped by change detection, so the
+     * next delivery of the document converges the store.
+     */
+    void writeIntent(String pipeline, String documentId, String fingerprint, String contentHash,
+            int committedCount, int intendedCount, String origin);
+
+    /** Marks the write complete. Only rows in {@code done} status participate in skip decisions. */
+    void commit(String pipeline, String documentId, String fingerprint, String contentHash, int segmentCount);
+
+    /**
+     * Refreshes the stored fingerprint of an already-{@code done} row whose content turned out
+     * unchanged (tier-2 hash match after a tier-1 fingerprint miss), so the cheaper tier-1 check
+     * skips the document next time.
+     */
+    void refreshFingerprint(String pipeline, String documentId, String fingerprint);
+
+    /**
+     * Marks an explicit delete: the row survives as a suppression record, so the document stays
+     * deleted even while its source file still exists. Lifted with {@link #unsuppress}.
+     */
+    void tombstone(String pipeline, String documentId);
+
+    void unsuppress(String pipeline, String documentId);
+
+    /** Pins a document: source updates are suppressed until {@link #unpin}. */
+    void pin(String pipeline, String documentId);
+
+    void unpin(String pipeline, String documentId);
+
+    /** Removes a row entirely — used by deletion-by-disappearance, where nothing needs remembering. */
+    void deleteRow(String pipeline, String documentId);
+
+    /**
+     * Dead-letters a document after a processing failure: records the fingerprint of the failed
+     * attempt so subsequent passes skip the poison document until its content changes, instead
+     * of failing identically forever at cost. Previous committed segments (a stale version that
+     * correctly keeps serving) stay untouched.
+     */
+    void markFailed(String pipeline, String documentId, String fingerprint);
+
+    /**
+     * @param status {@code done}, {@code in_progress} or {@code failed}
+     * @param origin {@link #ORIGIN_SOURCE} or {@link #ORIGIN_API}
+     */
+    record TrackerRow(String pipeline, String documentId, String fingerprint, String contentHash,
+            int segmentCount, int intendedCount, String status, String origin, boolean tombstone,
+            boolean pinned) {
+
+        public boolean done() {
+            return "done".equals(status);
+        }
+
+        public boolean failed() {
+            return "failed".equals(status);
+        }
+
+        /** The shrink bound: the largest segment index that may exist in the store, ever intended. */
+        public int maxKnownCount() {
+            return Math.max(segmentCount, intendedCount);
+        }
+    }
+}

--- a/extensions-support/langchain4j/runtime/src/main/java/org/apache/camel/quarkus/component/support/langchain4j/tracker/IngestionTracker.java
+++ b/extensions-support/langchain4j/runtime/src/main/java/org/apache/camel/quarkus/component/support/langchain4j/tracker/IngestionTracker.java
@@ -65,32 +65,48 @@ public interface IngestionTracker {
     /**
      * Durably records the intent to (re)write a document <em>before</em> the store is touched.
      * A row left {@code in_progress} by a crash is never skipped by change detection, so the
-     * next delivery of the document converges the store.
+     * next delivery of the document converges the store. The recorded intended count is
+     * <em>monotone until commit</em>: a re-intent never lowers it, because once an intent for N
+     * is durable, up to N segments may exist in the store and only a {@link #commit} proves the
+     * sweep happened.
      */
     void writeIntent(String pipeline, String documentId, String fingerprint, String contentHash,
-            int committedCount, int intendedCount, String origin);
+            int intendedCount, String origin);
 
-    /** Marks the write complete. Only rows in {@code done} status participate in skip decisions. */
+    /**
+     * Marks the write complete. Only rows in {@code done} status participate in skip decisions.
+     * Throws {@link IllegalStateException} when no row exists for the key — a commit without a
+     * preceding intent is a protocol violation, never a no-op.
+     */
     void commit(String pipeline, String documentId, String fingerprint, String contentHash, int segmentCount);
 
     /**
      * Refreshes the stored fingerprint of an already-{@code done} row whose content turned out
      * unchanged (tier-2 hash match after a tier-1 fingerprint miss), so the cheaper tier-1 check
-     * skips the document next time.
+     * skips the document next time. Deliberately a silent no-op for rows in any other status: on
+     * a {@code failed} row the fingerprint is the dead-letter gate — the fingerprint of the
+     * attempt that failed — and refreshing it would silently re-arm retries.
      */
     void refreshFingerprint(String pipeline, String documentId, String fingerprint);
 
     /**
      * Marks an explicit delete: the row survives as a suppression record, so the document stays
-     * deleted even while its source file still exists. Lifted with {@link #unsuppress}.
+     * deleted even while its source file still exists. When no row exists (a document deleted
+     * before its first ingest), a pure suppression row is created, so the suppression holds
+     * regardless. Lifted with {@link #unsuppress}.
      */
     void tombstone(String pipeline, String documentId);
 
+    /** Lifts a {@link #tombstone}. A no-op when no row exists. */
     void unsuppress(String pipeline, String documentId);
 
-    /** Pins a document: source updates are suppressed until {@link #unpin}. */
+    /**
+     * Pins a document: source updates are suppressed until {@link #unpin}. A no-op when no row
+     * exists — pinning a document that was never ingested has nothing to protect.
+     */
     void pin(String pipeline, String documentId);
 
+    /** Lifts a {@link #pin}. A no-op when no row exists. */
     void unpin(String pipeline, String documentId);
 
     /** Removes a row entirely — used by deletion-by-disappearance, where nothing needs remembering. */

--- a/extensions-support/langchain4j/runtime/src/main/java/org/apache/camel/quarkus/component/support/langchain4j/tracker/jdbc/JdbcIngestionTracker.java
+++ b/extensions-support/langchain4j/runtime/src/main/java/org/apache/camel/quarkus/component/support/langchain4j/tracker/jdbc/JdbcIngestionTracker.java
@@ -1,0 +1,288 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.support.langchain4j.tracker.jdbc;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import javax.sql.DataSource;
+
+import org.apache.camel.quarkus.component.support.langchain4j.tracker.IngestionTracker;
+
+/**
+ * JDBC-backed {@link IngestionTracker}. Deliberately dialect-free SQL (works on PostgreSQL and H2):
+ * upserts are update-then-insert rather than vendor MERGE/ON CONFLICT.
+ *
+ * <p>
+ * <strong>Concurrency assumption: at most one writer per {@code (pipeline, documentId)} at a
+ * time.</strong> The update-then-insert is not atomic (each statement auto-commits on its own,
+ * there is no transaction), so two concurrent writers for the same row can both see the
+ * {@code UPDATE} affect zero rows and then both attempt the {@code INSERT}, and one fails on the
+ * {@code (pipeline, doc_id)} primary key. Wrapping the two statements in a transaction would not
+ * remove this race without either {@code SERIALIZABLE} isolation or a dialect-specific upsert,
+ * both at odds with staying dialect-free; callers (the sync pass runner processes one document
+ * at a time per pipeline) are relied upon to hold this invariant instead.
+ *
+ * <p>
+ * <strong>Status: Experimental.</strong> See {@link IngestionTracker}.
+ */
+public class JdbcIngestionTracker implements IngestionTracker {
+
+    static final String TABLE = "cq_ingestion_tracker";
+
+    private final DataSource dataSource;
+
+    public JdbcIngestionTracker(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public void ensureSchema() {
+        String ddl = "CREATE TABLE IF NOT EXISTS " + TABLE + " ("
+                + "pipeline VARCHAR(128) NOT NULL, "
+                + "doc_id VARCHAR(512) NOT NULL, "
+                + "fingerprint VARCHAR(256), "
+                + "content_hash VARCHAR(64), "
+                + "segment_count INT DEFAULT 0 NOT NULL, "
+                + "intended_count INT DEFAULT 0 NOT NULL, "
+                + "status VARCHAR(16) NOT NULL, "
+                + "origin VARCHAR(16) DEFAULT 'source' NOT NULL, "
+                + "tombstone BOOLEAN DEFAULT FALSE NOT NULL, "
+                + "pinned BOOLEAN DEFAULT FALSE NOT NULL, "
+                + "updated_at TIMESTAMP, "
+                + "PRIMARY KEY (pipeline, doc_id))";
+        try (Connection connection = dataSource.getConnection()) {
+            connection.createStatement().execute(ddl);
+        } catch (SQLException e) {
+            throw new IllegalStateException(
+                    "Cannot create the ingestion tracker table '" + TABLE + "'. "
+                            + "mode=sync needs a working datasource — configure quarkus.datasource "
+                            + "(Dev Services provides one in dev mode) or use mode=append.",
+                    e);
+        }
+    }
+
+    private static final String ROW_COLUMNS = "fingerprint, content_hash, segment_count, intended_count, status, "
+            + "origin, tombstone, pinned";
+
+    @Override
+    public Optional<TrackerRow> read(String pipeline, String documentId) {
+        String sql = "SELECT " + ROW_COLUMNS + " FROM " + TABLE + " WHERE pipeline = ? AND doc_id = ?";
+        try (Connection connection = dataSource.getConnection();
+                PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, pipeline);
+            statement.setString(2, documentId);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                if (!resultSet.next()) {
+                    return Optional.empty();
+                }
+                return Optional.of(row(pipeline, documentId, resultSet));
+            }
+        } catch (SQLException e) {
+            throw new IllegalStateException("Tracker read failed for '" + documentId + "'", e);
+        }
+    }
+
+    @Override
+    public List<TrackerRow> listDocuments(String pipeline) {
+        String sql = "SELECT doc_id, " + ROW_COLUMNS + " FROM " + TABLE + " WHERE pipeline = ?";
+        try (Connection connection = dataSource.getConnection();
+                PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, pipeline);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                List<TrackerRow> rows = new ArrayList<>();
+                while (resultSet.next()) {
+                    String documentId = resultSet.getString(1);
+                    rows.add(new TrackerRow(pipeline, documentId,
+                            resultSet.getString(2), resultSet.getString(3),
+                            resultSet.getInt(4), resultSet.getInt(5), resultSet.getString(6),
+                            resultSet.getString(7), resultSet.getBoolean(8), resultSet.getBoolean(9)));
+                }
+                return rows;
+            }
+        } catch (SQLException e) {
+            throw new IllegalStateException("Tracker listing failed for pipeline '" + pipeline + "'", e);
+        }
+    }
+
+    private static TrackerRow row(String pipeline, String documentId, ResultSet resultSet) throws SQLException {
+        return new TrackerRow(pipeline, documentId,
+                resultSet.getString(1), resultSet.getString(2),
+                resultSet.getInt(3), resultSet.getInt(4), resultSet.getString(5),
+                resultSet.getString(6), resultSet.getBoolean(7), resultSet.getBoolean(8));
+    }
+
+    @Override
+    public void writeIntent(String pipeline, String documentId, String fingerprint, String contentHash,
+            int committedCount, int intendedCount, String origin) {
+        try (Connection connection = dataSource.getConnection()) {
+            String update = "UPDATE " + TABLE + " SET fingerprint = ?, content_hash = ?, "
+                    + "intended_count = ?, status = 'in_progress', origin = ?, updated_at = ? "
+                    + "WHERE pipeline = ? AND doc_id = ?";
+            int updated;
+            try (PreparedStatement statement = connection.prepareStatement(update)) {
+                statement.setString(1, fingerprint);
+                statement.setString(2, contentHash);
+                statement.setInt(3, intendedCount);
+                statement.setString(4, origin);
+                statement.setTimestamp(5, Timestamp.from(Instant.now()));
+                statement.setString(6, pipeline);
+                statement.setString(7, documentId);
+                updated = statement.executeUpdate();
+            }
+            if (updated == 0) {
+                String insert = "INSERT INTO " + TABLE
+                        + " (pipeline, doc_id, fingerprint, content_hash, segment_count, intended_count, "
+                        + "status, origin, updated_at) VALUES (?, ?, ?, ?, ?, ?, 'in_progress', ?, ?)";
+                try (PreparedStatement statement = connection.prepareStatement(insert)) {
+                    statement.setString(1, pipeline);
+                    statement.setString(2, documentId);
+                    statement.setString(3, fingerprint);
+                    statement.setString(4, contentHash);
+                    statement.setInt(5, committedCount);
+                    statement.setInt(6, intendedCount);
+                    statement.setString(7, origin);
+                    statement.setTimestamp(8, Timestamp.from(Instant.now()));
+                    statement.executeUpdate();
+                }
+            }
+        } catch (SQLException e) {
+            throw new IllegalStateException("Tracker intent write failed for '" + documentId + "'", e);
+        }
+    }
+
+    @Override
+    public void tombstone(String pipeline, String documentId) {
+        setFlag(pipeline, documentId, "tombstone", true);
+    }
+
+    @Override
+    public void unsuppress(String pipeline, String documentId) {
+        setFlag(pipeline, documentId, "tombstone", false);
+    }
+
+    @Override
+    public void pin(String pipeline, String documentId) {
+        setFlag(pipeline, documentId, "pinned", true);
+    }
+
+    @Override
+    public void unpin(String pipeline, String documentId) {
+        setFlag(pipeline, documentId, "pinned", false);
+    }
+
+    private void setFlag(String pipeline, String documentId, String column, boolean value) {
+        String sql = "UPDATE " + TABLE + " SET " + column + " = ?, updated_at = ? "
+                + "WHERE pipeline = ? AND doc_id = ?";
+        try (Connection connection = dataSource.getConnection();
+                PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setBoolean(1, value);
+            statement.setTimestamp(2, Timestamp.from(Instant.now()));
+            statement.setString(3, pipeline);
+            statement.setString(4, documentId);
+            statement.executeUpdate();
+        } catch (SQLException e) {
+            throw new IllegalStateException("Tracker " + column + " update failed for '" + documentId + "'", e);
+        }
+    }
+
+    @Override
+    public void markFailed(String pipeline, String documentId, String fingerprint) {
+        try (Connection connection = dataSource.getConnection()) {
+            String update = "UPDATE " + TABLE + " SET fingerprint = ?, status = 'failed', updated_at = ? "
+                    + "WHERE pipeline = ? AND doc_id = ?";
+            int updated;
+            try (PreparedStatement statement = connection.prepareStatement(update)) {
+                statement.setString(1, fingerprint);
+                statement.setTimestamp(2, Timestamp.from(Instant.now()));
+                statement.setString(3, pipeline);
+                statement.setString(4, documentId);
+                updated = statement.executeUpdate();
+            }
+            if (updated == 0) {
+                String insert = "INSERT INTO " + TABLE
+                        + " (pipeline, doc_id, fingerprint, status, origin, updated_at) "
+                        + "VALUES (?, ?, ?, 'failed', 'source', ?)";
+                try (PreparedStatement statement = connection.prepareStatement(insert)) {
+                    statement.setString(1, pipeline);
+                    statement.setString(2, documentId);
+                    statement.setString(3, fingerprint);
+                    statement.setTimestamp(4, Timestamp.from(Instant.now()));
+                    statement.executeUpdate();
+                }
+            }
+        } catch (SQLException e) {
+            throw new IllegalStateException("Tracker dead-letter update failed for '" + documentId + "'", e);
+        }
+    }
+
+    @Override
+    public void deleteRow(String pipeline, String documentId) {
+        String sql = "DELETE FROM " + TABLE + " WHERE pipeline = ? AND doc_id = ?";
+        try (Connection connection = dataSource.getConnection();
+                PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, pipeline);
+            statement.setString(2, documentId);
+            statement.executeUpdate();
+        } catch (SQLException e) {
+            throw new IllegalStateException("Tracker row deletion failed for '" + documentId + "'", e);
+        }
+    }
+
+    @Override
+    public void commit(String pipeline, String documentId, String fingerprint, String contentHash,
+            int segmentCount) {
+        String sql = "UPDATE " + TABLE + " SET fingerprint = ?, content_hash = ?, segment_count = ?, "
+                + "intended_count = ?, status = 'done', updated_at = ? WHERE pipeline = ? AND doc_id = ?";
+        try (Connection connection = dataSource.getConnection();
+                PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, fingerprint);
+            statement.setString(2, contentHash);
+            statement.setInt(3, segmentCount);
+            statement.setInt(4, segmentCount);
+            statement.setTimestamp(5, Timestamp.from(Instant.now()));
+            statement.setString(6, pipeline);
+            statement.setString(7, documentId);
+            statement.executeUpdate();
+        } catch (SQLException e) {
+            throw new IllegalStateException("Tracker commit failed for '" + documentId + "'", e);
+        }
+    }
+
+    @Override
+    public void refreshFingerprint(String pipeline, String documentId, String fingerprint) {
+        String sql = "UPDATE " + TABLE + " SET fingerprint = ?, updated_at = ? "
+                + "WHERE pipeline = ? AND doc_id = ? AND status = 'done'";
+        try (Connection connection = dataSource.getConnection();
+                PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, fingerprint);
+            statement.setTimestamp(2, Timestamp.from(Instant.now()));
+            statement.setString(3, pipeline);
+            statement.setString(4, documentId);
+            statement.executeUpdate();
+        } catch (SQLException e) {
+            throw new IllegalStateException("Tracker fingerprint refresh failed for '" + documentId + "'", e);
+        }
+    }
+}

--- a/extensions-support/langchain4j/runtime/src/main/java/org/apache/camel/quarkus/component/support/langchain4j/tracker/jdbc/JdbcIngestionTracker.java
+++ b/extensions-support/langchain4j/runtime/src/main/java/org/apache/camel/quarkus/component/support/langchain4j/tracker/jdbc/JdbcIngestionTracker.java
@@ -49,19 +49,45 @@ import org.apache.camel.quarkus.component.support.langchain4j.tracker.IngestionT
  */
 public class JdbcIngestionTracker implements IngestionTracker {
 
-    static final String TABLE = "cq_ingestion_tracker";
+    /**
+     * Concatenated into every statement: this must never become caller-supplied without strict
+     * identifier validation, or the class turns into an SQL injection vector.
+     */
+    static final String TABLE = "camel_quarkus_ingestion_tracker";
 
     private final DataSource dataSource;
+    private final boolean createTableIfNotExists;
 
     public JdbcIngestionTracker(DataSource dataSource) {
+        this(dataSource, true);
+    }
+
+    /**
+     * @param createTableIfNotExists when {@code false}, {@link #ensureSchema()} only probes that
+     *                               a pre-provisioned table exists, so the runtime DB user needs
+     *                               no DDL privilege (mirrors camel-sql's
+     *                               {@code JdbcMessageIdRepository}). When this surfaces as a
+     *                               configuration option it must be {@code ConfigPhase.RUN_TIME}.
+     */
+    public JdbcIngestionTracker(DataSource dataSource, boolean createTableIfNotExists) {
         this.dataSource = dataSource;
+        this.createTableIfNotExists = createTableIfNotExists;
     }
 
     @Override
     public void ensureSchema() {
+        if (!createTableIfNotExists) {
+            if (!tableExists()) {
+                throw new IllegalStateException(
+                        "The ingestion tracker table '" + TABLE + "' does not exist and table creation is "
+                                + "disabled. Pre-provision the table or enable createTableIfNotExists.");
+            }
+            return;
+        }
         String ddl = "CREATE TABLE IF NOT EXISTS " + TABLE + " ("
                 + "pipeline VARCHAR(128) NOT NULL, "
-                + "doc_id VARCHAR(512) NOT NULL, "
+                // 1024: the S3 object-key maximum; file paths and URLs used as ids fit as well
+                + "doc_id VARCHAR(1024) NOT NULL, "
                 + "fingerprint VARCHAR(256), "
                 + "content_hash VARCHAR(64), "
                 + "segment_count INT DEFAULT 0 NOT NULL, "
@@ -72,14 +98,26 @@ public class JdbcIngestionTracker implements IngestionTracker {
                 + "pinned BOOLEAN DEFAULT FALSE NOT NULL, "
                 + "updated_at TIMESTAMP, "
                 + "PRIMARY KEY (pipeline, doc_id))";
-        try (Connection connection = dataSource.getConnection()) {
-            connection.createStatement().execute(ddl);
+        try (Connection connection = dataSource.getConnection();
+                java.sql.Statement statement = connection.createStatement()) {
+            statement.execute(ddl);
         } catch (SQLException e) {
             throw new IllegalStateException(
                     "Cannot create the ingestion tracker table '" + TABLE + "'. "
                             + "mode=sync needs a working datasource — configure quarkus.datasource "
                             + "(Dev Services provides one in dev mode) or use mode=append.",
                     e);
+        }
+    }
+
+    private boolean tableExists() {
+        try (Connection connection = dataSource.getConnection();
+                PreparedStatement statement = connection.prepareStatement(
+                        "SELECT 1 FROM " + TABLE + " WHERE 1 = 0")) {
+            statement.executeQuery();
+            return true;
+        } catch (SQLException e) {
+            return false;
         }
     }
 
@@ -135,35 +173,39 @@ public class JdbcIngestionTracker implements IngestionTracker {
 
     @Override
     public void writeIntent(String pipeline, String documentId, String fingerprint, String contentHash,
-            int committedCount, int intendedCount, String origin) {
+            int intendedCount, String origin) {
         try (Connection connection = dataSource.getConnection()) {
+            // intended_count is monotone until commit: once an intent for N was durable, up to N
+            // segments may exist in the store, so a smaller re-intent must never lower the bound
+            // — only a commit, which runs after the sweep, may collapse it
             String update = "UPDATE " + TABLE + " SET fingerprint = ?, content_hash = ?, "
-                    + "intended_count = ?, status = 'in_progress', origin = ?, updated_at = ? "
+                    + "intended_count = CASE WHEN intended_count > ? THEN intended_count ELSE ? END, "
+                    + "status = 'in_progress', origin = ?, updated_at = ? "
                     + "WHERE pipeline = ? AND doc_id = ?";
             int updated;
             try (PreparedStatement statement = connection.prepareStatement(update)) {
                 statement.setString(1, fingerprint);
                 statement.setString(2, contentHash);
                 statement.setInt(3, intendedCount);
-                statement.setString(4, origin);
-                statement.setTimestamp(5, Timestamp.from(Instant.now()));
-                statement.setString(6, pipeline);
-                statement.setString(7, documentId);
+                statement.setInt(4, intendedCount);
+                statement.setString(5, origin);
+                statement.setTimestamp(6, Timestamp.from(Instant.now()));
+                statement.setString(7, pipeline);
+                statement.setString(8, documentId);
                 updated = statement.executeUpdate();
             }
             if (updated == 0) {
                 String insert = "INSERT INTO " + TABLE
                         + " (pipeline, doc_id, fingerprint, content_hash, segment_count, intended_count, "
-                        + "status, origin, updated_at) VALUES (?, ?, ?, ?, ?, ?, 'in_progress', ?, ?)";
+                        + "status, origin, updated_at) VALUES (?, ?, ?, ?, 0, ?, 'in_progress', ?, ?)";
                 try (PreparedStatement statement = connection.prepareStatement(insert)) {
                     statement.setString(1, pipeline);
                     statement.setString(2, documentId);
                     statement.setString(3, fingerprint);
                     statement.setString(4, contentHash);
-                    statement.setInt(5, committedCount);
-                    statement.setInt(6, intendedCount);
-                    statement.setString(7, origin);
-                    statement.setTimestamp(8, Timestamp.from(Instant.now()));
+                    statement.setInt(5, intendedCount);
+                    statement.setString(6, origin);
+                    statement.setTimestamp(7, Timestamp.from(Instant.now()));
                     statement.executeUpdate();
                 }
             }
@@ -174,7 +216,21 @@ public class JdbcIngestionTracker implements IngestionTracker {
 
     @Override
     public void tombstone(String pipeline, String documentId) {
-        setFlag(pipeline, documentId, "tombstone", true);
+        if (setFlag(pipeline, documentId, "tombstone", true) == 0) {
+            // deleted before ever ingested: create a pure suppression row so the tombstone holds
+            String insert = "INSERT INTO " + TABLE
+                    + " (pipeline, doc_id, segment_count, intended_count, status, origin, tombstone, "
+                    + "updated_at) VALUES (?, ?, 0, 0, 'done', 'api', TRUE, ?)";
+            try (Connection connection = dataSource.getConnection();
+                    PreparedStatement statement = connection.prepareStatement(insert)) {
+                statement.setString(1, pipeline);
+                statement.setString(2, documentId);
+                statement.setTimestamp(3, Timestamp.from(Instant.now()));
+                statement.executeUpdate();
+            } catch (SQLException e) {
+                throw new IllegalStateException("Tracker tombstone insert failed for '" + documentId + "'", e);
+            }
+        }
     }
 
     @Override
@@ -192,7 +248,7 @@ public class JdbcIngestionTracker implements IngestionTracker {
         setFlag(pipeline, documentId, "pinned", false);
     }
 
-    private void setFlag(String pipeline, String documentId, String column, boolean value) {
+    private int setFlag(String pipeline, String documentId, String column, boolean value) {
         String sql = "UPDATE " + TABLE + " SET " + column + " = ?, updated_at = ? "
                 + "WHERE pipeline = ? AND doc_id = ?";
         try (Connection connection = dataSource.getConnection();
@@ -201,7 +257,7 @@ public class JdbcIngestionTracker implements IngestionTracker {
             statement.setTimestamp(2, Timestamp.from(Instant.now()));
             statement.setString(3, pipeline);
             statement.setString(4, documentId);
-            statement.executeUpdate();
+            return statement.executeUpdate();
         } catch (SQLException e) {
             throw new IllegalStateException("Tracker " + column + " update failed for '" + documentId + "'", e);
         }
@@ -221,6 +277,10 @@ public class JdbcIngestionTracker implements IngestionTracker {
                 updated = statement.executeUpdate();
             }
             if (updated == 0) {
+                // a failed row with no prior intent can only originate from a source pass — a
+                // failure before the intent is written (e.g. the content supplier throwing) is
+                // dead-lettered by the pass runner, while API-path failures propagate
+                // synchronously to the caller and never reach markFailed — hence 'source'
                 String insert = "INSERT INTO " + TABLE
                         + " (pipeline, doc_id, fingerprint, status, origin, updated_at) "
                         + "VALUES (?, ?, ?, 'failed', 'source', ?)";
@@ -264,7 +324,11 @@ public class JdbcIngestionTracker implements IngestionTracker {
             statement.setTimestamp(5, Timestamp.from(Instant.now()));
             statement.setString(6, pipeline);
             statement.setString(7, documentId);
-            statement.executeUpdate();
+            if (statement.executeUpdate() == 0) {
+                throw new IllegalStateException(
+                        "Commit without a preceding intent for '" + documentId + "' in pipeline '"
+                                + pipeline + "' — the two-phase protocol requires writeIntent first");
+            }
         } catch (SQLException e) {
             throw new IllegalStateException("Tracker commit failed for '" + documentId + "'", e);
         }

--- a/extensions-support/langchain4j/runtime/src/test/java/org/apache/camel/quarkus/component/support/langchain4j/ingest/IngestIdsTest.java
+++ b/extensions-support/langchain4j/runtime/src/test/java/org/apache/camel/quarkus/component/support/langchain4j/ingest/IngestIdsTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.support.langchain4j.ingest;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+/**
+ * Determinism across releases is the persistent contract: these ids live in users' vector stores
+ * forever, and any change to the derivation (namespace UUID, separator, hash) silently re-keys
+ * every corpus — the next sync then duplicates instead of replacing. The golden values below must
+ * therefore never change; a failure here is a released-data compatibility break, not a test to
+ * update.
+ */
+class IngestIdsTest {
+
+    @Test
+    void goldenSegmentIdsNeverChange() {
+        // the expected UUIDs are pre-generated: they were produced by running segmentId() itself
+        // at the moment the derivation (namespace + length-prefixed name + UUIDv5) was frozen,
+        // and copied here verbatim — the assertions pin that historical output, they are not
+        // independently computed values
+        assertEquals("2de4b222-3db1-599f-9e7e-b1825adfe766", IngestIds.segmentId("p", "doc", 0));
+        assertEquals("4cea268f-02a9-5d9f-bfa9-940630ef23f0", IngestIds.segmentId("products", "manuals/spec.pdf", 3));
+    }
+
+    @Test
+    void separatorCannotShiftThePipelineDocumentBoundary() {
+        assertNotEquals(IngestIds.segmentId("a|b", "c", 0), IngestIds.segmentId("a", "b|c", 0),
+                "length-prefixing the pipeline must keep two pipelines sharing a store from colliding");
+    }
+
+    @Test
+    void idsAreDeterministicAndDistinct() {
+        assertEquals(IngestIds.segmentId("p", "doc", 1), IngestIds.segmentId("p", "doc", 1));
+        assertNotEquals(IngestIds.segmentId("p", "doc", 0), IngestIds.segmentId("p", "doc", 1));
+        assertNotEquals(IngestIds.segmentId("p", "doc", 0), IngestIds.segmentId("q", "doc", 0));
+        assertNotEquals(IngestIds.segmentId("p", "doc", 0), IngestIds.segmentId("p", "cod", 0));
+    }
+}

--- a/extensions-support/langchain4j/runtime/src/test/java/org/apache/camel/quarkus/component/support/langchain4j/ingest/IngestSyncProtocolTest.java
+++ b/extensions-support/langchain4j/runtime/src/test/java/org/apache/camel/quarkus/component/support/langchain4j/ingest/IngestSyncProtocolTest.java
@@ -1,0 +1,514 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.support.langchain4j.ingest;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.UUID;
+
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.output.Response;
+import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
+import dev.langchain4j.store.embedding.EmbeddingSearchResult;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import org.apache.camel.quarkus.component.support.langchain4j.tracker.IngestionTracker;
+import org.apache.camel.quarkus.component.support.langchain4j.tracker.jdbc.JdbcIngestionTracker;
+import org.h2.jdbcx.JdbcDataSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The sync protocol invariants, at the core level: skip tiers, replace without duplicates,
+ * shrink, both write strategies, and crash convergence.
+ */
+class IngestSyncProtocolTest {
+
+    JdbcDataSource dataSource;
+    IngestionTracker tracker;
+    UpsertFakeStore store;
+    FakeModel model = new FakeModel();
+
+    @BeforeEach
+    void setUp() {
+        dataSource = new JdbcDataSource();
+        dataSource.setURL("jdbc:h2:mem:" + UUID.randomUUID() + ";DB_CLOSE_DELAY=-1");
+        tracker = new JdbcIngestionTracker(dataSource);
+        tracker.ensureSchema();
+        store = new UpsertFakeStore();
+    }
+
+    /**
+     * Strategy convention: tests that exit before the write protocol (gates, skip tiers, blank
+     * content, dead-letter) or that write a first-ever document never reach a strategy-dependent
+     * branch — they pass {@code UPSERT} as an arbitrary default. Behaviours that genuinely fork
+     * per strategy (replace, shrink, crash convergence) are parameterized over both strategies
+     * via {@code @EnumSource} instead. If the strategy ever gets consulted earlier than the
+     * write protocol, this boundary must move with it.
+     */
+    IngestService syncService(IngestService.WriteStrategy strategy, EmbeddingStore<TextSegment> targetStore) {
+        return new IngestService("p", targetStore, model, "none", 500, 50, tracker, strategy, "model-1");
+    }
+
+    @Test
+    void ingestThenUnchangedFingerprintSkipsWithoutStoreAccess() {
+        IngestService service = syncService(IngestService.WriteStrategy.UPSERT, store);
+
+        IngestResult first = service.ingest("doc", "fp1", "hello world");
+        assertEquals(IngestResult.Outcome.INGESTED, first.outcome());
+        assertEquals(1, store.entries.size());
+        int writesAfterFirst = store.writeCalls;
+
+        IngestResult second = service.ingest("doc", "fp1", "hello world");
+        assertEquals(IngestResult.Outcome.SKIPPED_UNCHANGED, second.outcome());
+        assertEquals(writesAfterFirst, store.writeCalls, "tier-1 skip must not touch the store");
+    }
+
+    @Test
+    void changedFingerprintSameContentSkipsAndRefreshesFingerprint() {
+        IngestService service = syncService(IngestService.WriteStrategy.UPSERT, store);
+        service.ingest("doc", "fp1", "hello world");
+
+        IngestResult second = service.ingest("doc", "fp2", "hello world");
+        assertEquals(IngestResult.Outcome.SKIPPED_UNCHANGED, second.outcome());
+        assertEquals("fp2", tracker.read("p", "doc").orElseThrow().fingerprint(),
+                "tier-2 skip must refresh the fingerprint so tier-1 works next time");
+
+        int writes = store.writeCalls;
+        IngestResult third = service.ingest("doc", "fp2", "hello world");
+        assertEquals(IngestResult.Outcome.SKIPPED_UNCHANGED, third.outcome());
+        assertEquals(writes, store.writeCalls);
+    }
+
+    /** The behaviours below differ per write strategy, so each runs under both. */
+    static UpsertFakeStore storeFor(IngestService.WriteStrategy strategy) {
+        // each strategy is paired with the store behaviour it exists for: upsert with a store
+        // whose same-id write overwrites, remove-then-add with one whose same-id write duplicates
+        return strategy == IngestService.WriteStrategy.UPSERT ? new UpsertFakeStore() : new DuplicatingFakeStore();
+    }
+
+    @ParameterizedTest
+    @EnumSource(IngestService.WriteStrategy.class)
+    void changedContentReplacesInPlaceWithoutDuplicates(IngestService.WriteStrategy strategy) {
+        UpsertFakeStore target = storeFor(strategy);
+        IngestService service = syncService(strategy, target);
+        service.ingest("doc", "fp1", "old content");
+
+        IngestResult result = service.ingest("doc", "fp2", "new content");
+        assertEquals(IngestResult.Outcome.REPLACED, result.outcome());
+        assertEquals(1, target.entries.size(), "the replacement must not duplicate");
+        assertEquals("new content", target.entries.values().iterator().next().text());
+    }
+
+    @ParameterizedTest
+    @EnumSource(IngestService.WriteStrategy.class)
+    void shrinkRemovesStaleTailSegments(IngestService.WriteStrategy strategy) {
+        UpsertFakeStore target = storeFor(strategy);
+        IngestService service = new IngestService("p", target, model, "recursive", 12, 0, tracker,
+                strategy, "model-1");
+
+        service.ingest("doc", "fp1", "aaaa bbbb cccc dddd eeee");
+        int before = target.entries.size();
+        assertTrue(before > 1, "expected multiple segments, got " + before);
+
+        IngestResult result = service.ingest("doc", "fp2", "tiny");
+        assertEquals(IngestResult.Outcome.REPLACED, result.outcome());
+        assertEquals(1, target.entries.size(), "stale tail segments must be removed on shrink");
+    }
+
+    @ParameterizedTest
+    @EnumSource(IngestService.WriteStrategy.class)
+    void crashAfterIntentConvergesOnNextDelivery(IngestService.WriteStrategy strategy) {
+        UpsertFakeStore target = storeFor(strategy);
+        IngestService service = syncService(strategy, target);
+        service.ingest("doc", "fp1", "content v1");
+
+        // simulate a crash: intent written (larger intended count), store partially written, no commit
+        tracker.writeIntent("p", "doc", "fp2", "whatever", 5, IngestionTracker.ORIGIN_SOURCE);
+
+        // same fingerprint as the crashed attempt: an in_progress row must never be skipped
+        IngestResult result = service.ingest("doc", "fp2", "content v2");
+        assertEquals(IngestResult.Outcome.REPLACED, result.outcome());
+        assertTrue(tracker.read("p", "doc").orElseThrow().done());
+        assertEquals(1, target.entries.size());
+        assertEquals("content v2", target.entries.values().iterator().next().text());
+    }
+
+    @Test
+    void deleteOfANeverIngestedDocumentRecordsTheSuppression() {
+        IngestService service = syncService(IngestService.WriteStrategy.UPSERT, store);
+
+        IngestResult deleted = service.delete("ghost");
+        assertEquals(IngestResult.Outcome.DELETED, deleted.outcome());
+        assertTrue(tracker.read("p", "ghost").orElseThrow().tombstone());
+
+        // the suppression sticks: a source delivery of that id is refused
+        IngestResult attempt = service.ingest("ghost", "fp1", "content");
+        assertEquals(IngestResult.Outcome.SUPPRESSED_TOMBSTONE, attempt.outcome());
+        assertEquals(0, store.entries.size());
+    }
+
+    @Test
+    void goldenContentHashNeverChanges() {
+        IngestService service = syncService(IngestService.WriteStrategy.UPSERT, store);
+        // pins SCHEMA_VERSION, PARSER_ID, the NUL hash-domain separator and the suffix order
+        // (model id "model-1", splitter "none", 500/50 from syncService): a change here re-embeds
+        // every corpus on upgrade — it must be deliberate, never accidental
+        assertEquals("f8fd87004690c8078456de954623d9202c7a4e75786d152e526650ea5c5c32eb",
+                service.contentHash("hello world", null));
+    }
+
+    @Test
+    void metadataIsWrittenOnEverySegment() {
+        IngestService service = syncService(IngestService.WriteStrategy.UPSERT, store);
+        service.ingest("doc", "fp1", "hello world", IngestService.Origin.SOURCE, "acme");
+
+        TextSegment segment = store.entries.values().iterator().next();
+        assertEquals("p", segment.metadata().getString(IngestService.METADATA_PIPELINE));
+        assertEquals("doc", segment.metadata().getString(IngestService.METADATA_DOCUMENT_ID));
+        assertEquals("acme", segment.metadata().getString(IngestService.METADATA_TENANT));
+    }
+
+    @Test
+    void tenantChangeReplacesDespiteUnchangedContentAndFingerprint() {
+        // single-strategy on purpose although it triggers a replacement: the pinned concern is
+        // the skip-vs-replace DECISION, which is strategy-independent — the replacement
+        // mechanics are covered per strategy by changedContentReplacesInPlaceWithoutDuplicates
+        IngestService service = syncService(IngestService.WriteStrategy.UPSERT, store);
+        service.ingest("doc", "fp1", "hello world", IngestService.Origin.SOURCE, "acme");
+
+        IngestResult result = service.ingest("doc", "fp1", "hello world", IngestService.Origin.SOURCE, "globex");
+        assertEquals(IngestResult.Outcome.REPLACED, result.outcome(),
+                "the tenant lands in segment metadata, so a re-assignment must never be skipped");
+        assertEquals("globex",
+                store.entries.values().iterator().next().metadata().getString(IngestService.METADATA_TENANT));
+    }
+
+    @Test
+    void blankContentKeepsThePreviousVersion() {
+        // exits at the blank check, before the write protocol — strategy-independent (UPSERT is
+        // the arbitrary default, see the syncService javadoc)
+        IngestService service = syncService(IngestService.WriteStrategy.UPSERT, store);
+        service.ingest("doc", "fp1", "good version");
+
+        IngestResult result = service.ingest("doc", "fp2", "   ");
+        assertEquals(IngestResult.Outcome.EMPTY, result.outcome());
+        assertEquals(1, store.entries.size(), "a blank read must never empty the knowledge base");
+        assertEquals("good version", store.entries.values().iterator().next().text());
+    }
+
+    @Test
+    void appendModeWritesWithoutTracker() {
+        UpsertFakeStore appendStore = new UpsertFakeStore();
+        IngestService service = new IngestService("p", appendStore, model, "none", 500, 50,
+                null, IngestService.WriteStrategy.UPSERT, "model-1");
+
+        IngestResult result = service.ingest("doc", "some content");
+        assertEquals(IngestResult.Outcome.INGESTED, result.outcome());
+        assertEquals(1, appendStore.entries.size());
+        assertNull(service.tracker());
+    }
+
+    @Test
+    void transientFailureAfterIntentIsRetriedNotDeadLettered() {
+        FailingModel failing = new FailingModel();
+        IngestService service = new IngestService("p", store, failing, "none", 500, 50, tracker,
+                IngestService.WriteStrategy.UPSERT, "model-1");
+        service.ingest("doc", "fp1", "good version");
+
+        failing.failNext = true;
+        IngestService.RetryableIngestException e = assertThrows(IngestService.RetryableIngestException.class,
+                () -> service.ingest("doc", "fp2", "new version"));
+        assertTrue(e.committedVersionServes(), "the old generation is still in the store");
+        assertFalse(tracker.read("p", "doc").orElseThrow().failed(),
+                "an infrastructure failure must NOT dead-letter: the row stays in_progress and retries");
+        assertEquals("good version", store.entries.values().iterator().next().text());
+
+        IngestResult retry = service.ingest("doc", "fp2", "new version");
+        assertEquals(IngestResult.Outcome.REPLACED, retry.outcome());
+        assertEquals("new version", store.entries.values().iterator().next().text());
+    }
+
+    @Test
+    void removeThenAddTransientFailureRecoversOnRetry() {
+        DuplicatingFakeStore duplicating = new DuplicatingFakeStore();
+        FailingModel failing = new FailingModel();
+        IngestService service = new IngestService("p", duplicating, failing, "none", 500, 50, tracker,
+                IngestService.WriteStrategy.REMOVE_THEN_ADD, "model-1");
+        service.ingest("doc", "fp1", "good version");
+
+        failing.failNext = true;
+        IngestService.RetryableIngestException e = assertThrows(IngestService.RetryableIngestException.class,
+                () -> service.ingest("doc", "fp2", "new version"));
+        assertTrue(e.oldGenerationRemoved(), "the old generation was already removed when the write failed");
+        assertEquals(0, duplicating.entriesList().size(), "the document is offline until a retry succeeds");
+        assertFalse(tracker.read("p", "doc").orElseThrow().failed(),
+                "a transient outage must stay retryable — dead-lettering it would drop the document forever");
+
+        IngestResult retry = service.ingest("doc", "fp2", "new version");
+        assertEquals(IngestResult.Outcome.REPLACED, retry.outcome());
+        assertEquals("new version", duplicating.entriesList().get(0).text());
+    }
+
+    @Test
+    void trackerBlipDuringWriteIntentIsRetriedNotDeadLettered() {
+        BlippyTracker blippy = new BlippyTracker(dataSource);
+        IngestService service = new IngestService("p", store, model, "none", 500, 50, blippy,
+                IngestService.WriteStrategy.UPSERT, "model-1");
+        service.ingest("doc", "fp1", "good version");
+
+        blippy.failNextWriteIntent = true;
+        assertThrows(IngestService.RetryableIngestException.class,
+                () -> service.ingest("doc", "fp2", "new version"));
+        assertFalse(blippy.read("p", "doc").orElseThrow().failed(),
+                "a tracker blip is infrastructure — dead-lettering it would freeze the document");
+
+        IngestResult retry = service.ingest("doc", "fp2", "new version");
+        assertEquals(IngestResult.Outcome.REPLACED, retry.outcome());
+        assertEquals("new version", store.entries.values().iterator().next().text());
+    }
+
+    @Test
+    void tenantedPoisonDocumentIsDeadLetteredWithItsTenant() {
+        IngestService service = syncService(IngestService.WriteStrategy.UPSERT, store);
+
+        // first delivery of a tenanted document fails on read: the recorded gate must carry the
+        // tenant, exactly like the stored fingerprint does, or it never matches again
+        IngestService.ContentIngestException e = assertThrows(IngestService.ContentIngestException.class,
+                () -> service.ingest("doc", "fp1", () -> {
+                    throw new IllegalStateException("unreadable");
+                }, IngestService.Origin.SOURCE, "acme"));
+        tracker.markFailed("p", "doc", e.dedupFingerprint());
+
+        IngestResult second = service.ingest("doc", "fp1", "now readable", IngestService.Origin.SOURCE, "acme");
+        assertEquals(IngestResult.Outcome.DEAD_LETTERED, second.outcome(),
+                "the same tenanted content must be recognized as already failed");
+    }
+
+    @Test
+    void deadLetterFallsBackToTheContentHashForFingerprintlessSources() {
+        IngestService service = syncService(IngestService.WriteStrategy.UPSERT, store);
+        String hash = service.contentHash("poison content", null);
+        tracker.markFailed("p", "doc", hash);
+
+        IngestResult result = service.ingest("doc", null, "poison content");
+        assertEquals(IngestResult.Outcome.DEAD_LETTERED, result.outcome(),
+                "without a fingerprint the failed attempt's content hash gates the retry");
+    }
+
+    @Test
+    void syncModeRequiresARemovalCapableStore() {
+        IllegalStateException e = assertThrows(IllegalStateException.class,
+                () -> syncService(IngestService.WriteStrategy.UPSERT, new NoRemovalStore()));
+        assertTrue(e.getMessage().contains("NoRemovalStore"), e.getMessage());
+    }
+
+    @Test
+    void constructorGuardsMisconfiguration() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new IngestService(" ", store, model, "none", 500, 50, null,
+                        IngestService.WriteStrategy.UPSERT, "m"));
+        assertThrows(IllegalArgumentException.class, () -> IngestService.WriteStrategy.of("merge"));
+
+        IngestService append = new IngestService("p", store, model, "none", 500, 50, null,
+                IngestService.WriteStrategy.UPSERT, "m");
+        assertThrows(IllegalStateException.class, () -> append.delete("doc"),
+                "sync-only operations must refuse in append mode");
+        assertThrows(IllegalArgumentException.class, () -> append.ingest(" ", "content"));
+    }
+
+    // --- fakes -------------------------------------------------------------------------------
+
+    /** Same-id write overwrites — the measured pgvector/qdrant/elasticsearch behaviour. */
+    static class UpsertFakeStore implements EmbeddingStore<TextSegment> {
+        final Map<String, TextSegment> entries = new LinkedHashMap<>();
+        int writeCalls;
+
+        @Override
+        public void addAll(List<String> ids, List<Embedding> embeddings, List<TextSegment> segments) {
+            writeCalls++;
+            for (int i = 0; i < ids.size(); i++) {
+                entries.put(ids.get(i), segments.get(i));
+            }
+        }
+
+        @Override
+        public void removeAll(java.util.Collection<String> ids) {
+            ids.forEach(entries::remove);
+        }
+
+        @Override
+        public String add(Embedding embedding) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void add(String id, Embedding embedding) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String add(Embedding embedding, TextSegment segment) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<String> addAll(List<Embedding> embeddings) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public EmbeddingSearchResult<TextSegment> search(EmbeddingSearchRequest request) {
+            return new EmbeddingSearchResult<>(List.of());
+        }
+    }
+
+    /** Same-id write appends another row — the chroma/milvus/in-memory behaviour. */
+    static class DuplicatingFakeStore extends UpsertFakeStore {
+        final List<TextSegment> rows = new ArrayList<>();
+        final List<String> rowIds = new ArrayList<>();
+
+        @Override
+        public void addAll(List<String> ids, List<Embedding> embeddings, List<TextSegment> segments) {
+            writeCalls++;
+            for (int i = 0; i < ids.size(); i++) {
+                rowIds.add(ids.get(i));
+                rows.add(segments.get(i));
+            }
+            rebuild();
+        }
+
+        @Override
+        public void removeAll(java.util.Collection<String> ids) {
+            for (int i = rowIds.size() - 1; i >= 0; i--) {
+                if (ids.contains(rowIds.get(i))) {
+                    rowIds.remove(i);
+                    rows.remove(i);
+                }
+            }
+            rebuild();
+        }
+
+        List<TextSegment> entriesList() {
+            return rows;
+        }
+
+        private void rebuild() {
+            entries.clear();
+            for (int i = 0; i < rowIds.size(); i++) {
+                // duplicate ids collapse in the map, so expose the raw rows for assertions
+                entries.put(rowIds.get(i) + "#" + i, rows.get(i));
+            }
+        }
+    }
+
+    @Test
+    void embeddingBatchSizeIsRespected() {
+        FakeModel countingModel = new FakeModel();
+        IngestService service = new IngestService("p", store, countingModel, "recursive", 12, 0, tracker,
+                IngestService.WriteStrategy.UPSERT, "m1").embeddingLimits(2, null);
+
+        service.ingest("doc", "fp1", "aaaa bbbb cccc dddd eeee");
+
+        assertTrue(countingModel.batchSizes.size() > 1, "multiple batches expected");
+        assertTrue(countingModel.batchSizes.stream().allMatch(size -> size <= 2),
+                "no batch may exceed the configured size, got " + countingModel.batchSizes);
+    }
+
+    static class FakeModel implements EmbeddingModel {
+        final List<Integer> batchSizes = new ArrayList<>();
+
+        @Override
+        public Response<List<Embedding>> embedAll(List<TextSegment> segments) {
+            batchSizes.add(segments.size());
+            List<Embedding> out = new ArrayList<>(segments.size());
+            for (TextSegment segment : segments) {
+                out.add(embeddingFor(segment.text()));
+            }
+            return Response.from(out);
+        }
+
+        static Embedding embeddingFor(String text) {
+            try {
+                byte[] digest = MessageDigest.getInstance("SHA-256").digest(text.getBytes(StandardCharsets.UTF_8));
+                Random random = new Random(digest[0]);
+                float[] vector = new float[8];
+                for (int i = 0; i < vector.length; i++) {
+                    vector[i] = random.nextFloat();
+                }
+                return new Embedding(vector);
+            } catch (Exception e) {
+                throw new IllegalStateException(e);
+            }
+        }
+    }
+
+    /** Delegates to the real JDBC tracker, failing one writeIntent on demand — a pool blip. */
+    static class BlippyTracker extends JdbcIngestionTracker {
+        boolean failNextWriteIntent;
+
+        BlippyTracker(javax.sql.DataSource dataSource) {
+            super(dataSource);
+        }
+
+        @Override
+        public void writeIntent(String pipeline, String documentId, String fingerprint, String contentHash,
+                int intendedCount, String origin) {
+            if (failNextWriteIntent) {
+                failNextWriteIntent = false;
+                throw new IllegalStateException("simulated connection pool blip");
+            }
+            super.writeIntent(pipeline, documentId, fingerprint, contentHash, intendedCount, origin);
+        }
+    }
+
+    /** Fails the next embedAll call, then recovers — a transient provider outage. */
+    static class FailingModel extends FakeModel {
+        boolean failNext;
+
+        @Override
+        public Response<List<Embedding>> embedAll(List<TextSegment> segments) {
+            if (failNext) {
+                failNext = false;
+                throw new IllegalStateException("simulated provider outage (503)");
+            }
+            return super.embedAll(segments);
+        }
+    }
+
+    /** Writes work, id-addressed removal does not — the shape of cassandra/astra-db. */
+    static class NoRemovalStore extends UpsertFakeStore {
+        @Override
+        public void removeAll(java.util.Collection<String> ids) {
+            throw new UnsupportedOperationException("Not supported");
+        }
+    }
+}

--- a/extensions-support/langchain4j/runtime/src/test/java/org/apache/camel/quarkus/component/support/langchain4j/ingest/SyncPassRunnerTest.java
+++ b/extensions-support/langchain4j/runtime/src/test/java/org/apache/camel/quarkus/component/support/langchain4j/ingest/SyncPassRunnerTest.java
@@ -1,0 +1,295 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.support.langchain4j.ingest;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import org.apache.camel.quarkus.component.support.langchain4j.tracker.IngestionTracker;
+import org.apache.camel.quarkus.component.support.langchain4j.tracker.jdbc.JdbcIngestionTracker;
+import org.h2.jdbcx.JdbcDataSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The deletion interlock: a disappeared document is removed, but never on a
+ * partially-failed pass, never past the bulk-delete floor, never for API-origin documents, and
+ * tombstones/pins survive passes.
+ */
+class SyncPassRunnerTest {
+
+    IngestionTracker tracker;
+    IngestSyncProtocolTest.UpsertFakeStore store;
+    IngestService service;
+
+    @BeforeEach
+    void setUp() {
+        JdbcDataSource dataSource = new JdbcDataSource();
+        dataSource.setURL("jdbc:h2:mem:" + UUID.randomUUID() + ";DB_CLOSE_DELAY=-1");
+        tracker = new JdbcIngestionTracker(dataSource);
+        tracker.ensureSchema();
+        store = new IngestSyncProtocolTest.UpsertFakeStore();
+        service = new IngestService("p", store, new IngestSyncProtocolTest.FakeModel(), "none", 500, 50,
+                tracker, IngestService.WriteStrategy.UPSERT, "m1");
+    }
+
+    SyncPassRunner runner(double threshold, boolean allowBulk) {
+        return new SyncPassRunner(service, tracker, "p", threshold, allowBulk,
+                "consent to bulk deletion for one pass");
+    }
+
+    static Map<String, SyncPassRunner.SourceDocument> listing(String... idAndContentPairs) {
+        Map<String, SyncPassRunner.SourceDocument> listing = new LinkedHashMap<>();
+        for (int i = 0; i < idAndContentPairs.length; i += 2) {
+            String content = idAndContentPairs[i + 1];
+            listing.put(idAndContentPairs[i],
+                    new SyncPassRunner.SourceDocument("fp-" + content.hashCode(), () -> content));
+        }
+        return listing;
+    }
+
+    @Test
+    void disappearedDocumentIsDeleted() {
+        runner(0.9, false).run(listing("a.txt", "content a", "b.txt", "content b"));
+        assertEquals(2, store.entries.size());
+
+        SyncPassRunner.PassOutcome outcome = runner(0.9, false).run(listing("a.txt", "content a"));
+        assertEquals(1, outcome.deleted());
+        assertEquals(1, store.entries.size(), "b.txt segments must be removed");
+        assertTrue(tracker.read("p", "b.txt").isEmpty(), "b.txt row must be gone");
+    }
+
+    @Test
+    void partiallyFailedPassDeletesNothing() {
+        runner(0.9, false).run(listing("a.txt", "content a", "b.txt", "content b"));
+
+        Map<String, SyncPassRunner.SourceDocument> failing = new LinkedHashMap<>();
+        failing.put("a.txt", new SyncPassRunner.SourceDocument("fp-x", () -> {
+            throw new IllegalStateException("simulated read failure");
+        }));
+        // b.txt is missing from the listing AND a.txt fails: nothing may be deleted
+        SyncPassRunner.PassOutcome outcome = runner(0.9, false).run(failing);
+
+        assertEquals("partially-failed", outcome.status());
+        assertEquals(0, outcome.deleted());
+        assertEquals(2, store.entries.size(), "an undelivered document is indistinguishable from a "
+                + "disappeared one — nothing may be deleted");
+        assertTrue(tracker.read("p", "b.txt").isPresent());
+    }
+
+    @Test
+    void deletingASingleDocumentIsNeverBulk() {
+        // a single-document pipeline (an http url) must be able to delete its one document —
+        // 1 of 1 is over any fractional threshold, so the floor treats one deletion as non-bulk
+        runner(0.1, false).run(listing("only.txt", "the only document"));
+        SyncPassRunner.PassOutcome outcome = runner(0.1, false).run(listing());
+        assertEquals(1, outcome.deleted());
+        assertEquals(0, outcome.deletionRefused());
+    }
+
+    @Test
+    void bulkDeleteFloorRefusesWithoutConsentAndObeysWithIt() {
+        runner(0.9, false).run(listing("a.txt", "content a", "b.txt", "content b", "c.txt", "content c"));
+
+        // everything disappeared — way past a 10% threshold
+        SyncPassRunner.PassOutcome refused = runner(0.1, false).run(listing());
+        assertEquals(0, refused.deleted());
+        assertEquals(3, refused.deletionRefused());
+        assertEquals(3, store.entries.size(), "mass disappearance without consent must be refused");
+
+        SyncPassRunner.PassOutcome consented = runner(0.1, true).run(listing());
+        assertEquals(3, consented.deleted());
+        assertEquals(0, store.entries.size());
+    }
+
+    @Test
+    void apiOriginDocumentsSurviveReconciliation() {
+        service.ingest("api-doc", null, "an admin correction", IngestService.Origin.API);
+        runner(0.9, false).run(listing("a.txt", "content a"));
+
+        SyncPassRunner.PassOutcome outcome = runner(0.9, false).run(listing("a.txt", "content a"));
+        assertEquals(0, outcome.deleted(), "api-origin documents never appear in listings and must "
+                + "never be deleted for it");
+        assertTrue(tracker.read("p", "api-doc").isPresent());
+    }
+
+    @Test
+    void tombstoneSurvivesPassesAndUnsuppressLifts() {
+        runner(0.9, false).run(listing("a.txt", "content a"));
+        service.delete("a.txt");
+        assertEquals(0, store.entries.size());
+
+        // the file is still in the listing — the tombstone must keep it out
+        SyncPassRunner.PassOutcome pass = runner(0.9, false).run(listing("a.txt", "content a"));
+        assertEquals(1, pass.suppressed());
+        assertEquals(0, store.entries.size(), "delete must survive the next pass");
+
+        service.unsuppress("a.txt");
+        runner(0.9, false).run(listing("a.txt", "content a"));
+        assertEquals(1, store.entries.size(), "unsuppress must hand the document back to the source");
+    }
+
+    @Test
+    void apiUpsertOverSourceDocumentPinsAndUnpinReleases() {
+        runner(0.9, false).run(listing("a.txt", "source version"));
+
+        service.ingest("a.txt", null, "corrected version", IngestService.Origin.API);
+        assertTrue(tracker.read("p", "a.txt").orElseThrow().pinned(), "api write over a source doc must pin");
+
+        runner(0.9, false).run(listing("a.txt", "source version"));
+        assertEquals("corrected version", store.entries.values().iterator().next().text(),
+                "the pinned correction must survive the next source pass");
+
+        service.unpin("a.txt");
+        runner(0.9, false).run(listing("a.txt", "source version"));
+        assertEquals("source version", store.entries.values().iterator().next().text(),
+                "unpin must hand the document back to the source");
+    }
+
+    @Test
+    void poisonDocumentIsDeadLetteredUntilItsContentChanges() {
+        // first pass: the document fails to read
+        Map<String, SyncPassRunner.SourceDocument> failing = new LinkedHashMap<>();
+        failing.put("poison.txt", new SyncPassRunner.SourceDocument("fp-1", () -> {
+            throw new IllegalStateException("boom");
+        }));
+        SyncPassRunner.PassOutcome first = runner(0.9, false).run(failing);
+        assertEquals("partially-failed", first.status());
+        assertEquals(1, first.failed());
+        assertTrue(tracker.read("p", "poison.txt").orElseThrow().failed());
+
+        // second pass, same fingerprint: dead-lettered, NOT retried — and the pass can succeed
+        Map<String, SyncPassRunner.SourceDocument> same = new LinkedHashMap<>();
+        same.put("poison.txt", new SyncPassRunner.SourceDocument("fp-1", () -> {
+            throw new IllegalStateException("must not be read");
+        }));
+        SyncPassRunner.PassOutcome sameFp = runner(0.9, false).run(same);
+        assertEquals("succeeded", sameFp.status());
+        assertEquals(1, sameFp.deadLettered());
+
+        // changed fingerprint: retried, and this time it works
+        Map<String, SyncPassRunner.SourceDocument> fixed = new LinkedHashMap<>();
+        fixed.put("poison.txt", new SyncPassRunner.SourceDocument("fp-2", () -> "now readable"));
+        SyncPassRunner.PassOutcome retried = runner(0.9, false).run(fixed);
+        assertEquals("succeeded", retried.status());
+        assertEquals(1, retried.ingested() + retried.replaced());
+        assertTrue(tracker.read("p", "poison.txt").orElseThrow().done());
+    }
+
+    @Test
+    void changedDocumentThatFailsRetainsStaleVersionVisibly() {
+        runner(0.9, false).run(listing("doc.txt", "good version"));
+
+        Map<String, SyncPassRunner.SourceDocument> failingUpdate = new LinkedHashMap<>();
+        failingUpdate.put("doc.txt", new SyncPassRunner.SourceDocument("fp-new", () -> {
+            throw new IllegalStateException("unparseable update");
+        }));
+        SyncPassRunner.PassOutcome outcome = runner(0.9, false).run(failingUpdate);
+
+        assertEquals(1, outcome.staleRetained(),
+                "a changed document that fails must be visible — the corpus is going stale");
+        assertEquals(1, store.entries.size(), "the stale-but-good version must keep serving");
+        assertEquals("good version", store.entries.values().iterator().next().text());
+    }
+
+    @Test
+    void pinnedDocumentIsNotDeletedWhenItsSourceFileDisappears() {
+        runner(0.9, false).run(listing("a.txt", "source version"));
+        service.ingest("a.txt", null, "corrected version", IngestService.Origin.API);
+
+        // origin flipped to api by the correction; the file disappearing must not delete it
+        SyncPassRunner.PassOutcome outcome = runner(0.9, false).run(listing());
+        assertEquals(0, outcome.deleted());
+        assertFalse(store.entries.isEmpty(), "the pinned correction must survive source disappearance");
+    }
+
+    @Test
+    void constructorRejectsAnInvalidThreshold() {
+        // NaN would silently disable the floor: Math.max(1, NaN) is NaN and n > NaN is false
+        assertThrows(IllegalArgumentException.class, () -> runner(Double.NaN, false));
+        assertThrows(IllegalArgumentException.class, () -> runner(-0.1, false));
+        assertThrows(IllegalArgumentException.class, () -> runner(1.5, false));
+    }
+
+    @Test
+    void zeroThresholdRequiresConsentForEveryDeletion() {
+        runner(0, false).run(listing("only.txt", "the only document"));
+
+        SyncPassRunner.PassOutcome refused = runner(0, false).run(listing());
+        assertEquals(0, refused.deleted());
+        assertEquals(1, refused.deletionRefused());
+        assertEquals("deletions-refused", refused.status());
+        assertTrue(refused.succeeded(), "processing succeeded; only the deletion was withheld");
+
+        SyncPassRunner.PassOutcome consented = runner(0, true).run(listing());
+        assertEquals(1, consented.deleted());
+    }
+
+    @Test
+    void bulkFloorMeasuresAgainstThePrePassCorpus() {
+        runner(0.9, false).run(listing("a.txt", "content a", "b.txt", "content b"));
+
+        // an influx of new documents must not dilute a mass disappearance below the threshold:
+        // the pre-pass corpus is 2 and both disappeared — 2 of 2 gone is bulk, whatever arrived
+        SyncPassRunner.PassOutcome outcome = runner(0.5, false).run(
+                listing("c.txt", "content c", "d.txt", "content d", "e.txt", "content e"));
+        assertEquals(0, outcome.deleted());
+        assertEquals(2, outcome.deletionRefused());
+    }
+
+    @Test
+    void transientEmbeddingFailureIsRetriedNotDeadLettered() {
+        IngestSyncProtocolTest.FailingModel failing = new IngestSyncProtocolTest.FailingModel();
+        IngestService failingService = new IngestService("p", store, failing, "none", 500, 50,
+                tracker, IngestService.WriteStrategy.UPSERT, "m1");
+        SyncPassRunner failingRunner = new SyncPassRunner(failingService, tracker, "p", 0.9, false, "consent");
+
+        failingRunner.run(listing("doc.txt", "good version"));
+
+        failing.failNext = true;
+        SyncPassRunner.PassOutcome failedPass = failingRunner.run(listing("doc.txt", "new version"));
+        assertEquals("partially-failed", failedPass.status());
+        assertEquals(1, failedPass.failed());
+        assertEquals(0, failedPass.deadLettered(), "an infrastructure failure must not dead-letter");
+        assertEquals(1, failedPass.staleRetained(), "the stale committed version keeps serving — visibly");
+
+        SyncPassRunner.PassOutcome recovery = failingRunner.run(listing("doc.txt", "new version"));
+        assertTrue(recovery.succeeded());
+        assertEquals(1, recovery.replaced(), "a transient outage must be retried, never frozen");
+        assertEquals("new version", store.entries.values().iterator().next().text());
+    }
+
+    @Test
+    void crashedInFlightDocumentThatDisappearedIsReclaimed() {
+        runner(0.9, false).run(listing("a.txt", "content a", "b.txt", "content b"));
+
+        // a crash mid-ingest left an in_progress row; the document then vanished from the source
+        tracker.writeIntent("p", "ghost.txt", "fp", "h", 3, IngestionTracker.ORIGIN_SOURCE);
+
+        SyncPassRunner.PassOutcome outcome = runner(0.9, false).run(listing("a.txt", "content a",
+                "b.txt", "content b"));
+        assertEquals(1, outcome.deleted(), "a crashed in-flight row for a disappeared document "
+                + "must be reclaimed, or it leaks forever");
+        assertTrue(tracker.read("p", "ghost.txt").isEmpty());
+    }
+}

--- a/extensions-support/langchain4j/runtime/src/test/java/org/apache/camel/quarkus/component/support/langchain4j/tracker/jdbc/JdbcIngestionTrackerTest.java
+++ b/extensions-support/langchain4j/runtime/src/test/java/org/apache/camel/quarkus/component/support/langchain4j/tracker/jdbc/JdbcIngestionTrackerTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -60,7 +61,7 @@ class JdbcIngestionTrackerTest {
 
     @Test
     void intentIsDurableAndNeverSkippable() {
-        tracker.writeIntent("p", "doc", "fp1", "hash1", 0, 5, IngestionTracker.ORIGIN_SOURCE);
+        tracker.writeIntent("p", "doc", "fp1", "hash1", 5, IngestionTracker.ORIGIN_SOURCE);
 
         IngestionTracker.TrackerRow row = tracker.read("p", "doc").orElseThrow();
         assertFalse(row.done(), "an intent row must not count as done");
@@ -69,7 +70,7 @@ class JdbcIngestionTrackerTest {
 
     @Test
     void commitCompletesTheIntent() {
-        tracker.writeIntent("p", "doc", "fp1", "hash1", 0, 5, IngestionTracker.ORIGIN_SOURCE);
+        tracker.writeIntent("p", "doc", "fp1", "hash1", 5, IngestionTracker.ORIGIN_SOURCE);
         tracker.commit("p", "doc", "fp1", "hash1", 3);
 
         IngestionTracker.TrackerRow row = tracker.read("p", "doc").orElseThrow();
@@ -80,21 +81,39 @@ class JdbcIngestionTrackerTest {
     }
 
     @Test
+    void commitWithoutIntentThrows() {
+        IllegalStateException e = assertThrows(IllegalStateException.class,
+                () -> tracker.commit("p", "ghost", "fp", "h", 1));
+        assertTrue(e.getMessage().contains("preceding intent"), e.getMessage());
+    }
+
+    @Test
     void reintentKeepsTheLargestKnownCount() {
-        tracker.writeIntent("p", "doc", "fp1", "hash1", 0, 5, IngestionTracker.ORIGIN_SOURCE);
+        tracker.writeIntent("p", "doc", "fp1", "hash1", 5, IngestionTracker.ORIGIN_SOURCE);
         tracker.commit("p", "doc", "fp1", "hash1", 5);
         // a re-intent does not change what the store really holds — the five old segments are
         // still in it, so the committed count has to stay; only commit, which runs after the
         // stale tail was actually removed, may lower the bound
-        tracker.writeIntent("p", "doc", "fp2", "hash2", 5, 2, IngestionTracker.ORIGIN_SOURCE);
+        tracker.writeIntent("p", "doc", "fp2", "hash2", 2, IngestionTracker.ORIGIN_SOURCE);
 
         assertEquals(5, tracker.read("p", "doc").orElseThrow().maxKnownCount(),
                 "shrink must still see the previously committed tail");
     }
 
     @Test
+    void reintentBeforeCommitKeepsTheLargestIntendedCount() {
+        tracker.writeIntent("p", "doc", "fp1", "hash1", 5, IngestionTracker.ORIGIN_SOURCE);
+        // the consumer may have written up to 5 segments before dying without a commit; a
+        // smaller re-intent must not lower the sweep bound below what may exist in the store
+        tracker.writeIntent("p", "doc", "fp2", "hash2", 2, IngestionTracker.ORIGIN_SOURCE);
+
+        assertEquals(5, tracker.read("p", "doc").orElseThrow().maxKnownCount(),
+                "an uncommitted intent must never lower the sweep bound");
+    }
+
+    @Test
     void refreshFingerprintTouchesNothingElse() {
-        tracker.writeIntent("p", "doc", "fp1", "hash1", 0, 2, IngestionTracker.ORIGIN_SOURCE);
+        tracker.writeIntent("p", "doc", "fp1", "hash1", 2, IngestionTracker.ORIGIN_SOURCE);
         tracker.commit("p", "doc", "fp1", "hash1", 2);
         tracker.refreshFingerprint("p", "doc", "fp2");
 
@@ -106,10 +125,20 @@ class JdbcIngestionTrackerTest {
     }
 
     @Test
+    void refreshFingerprintIgnoresRowsThatAreNotDone() {
+        tracker.writeIntent("p", "doc", "fp1", "h1", 1, IngestionTracker.ORIGIN_SOURCE);
+        tracker.markFailed("p", "doc", "fp-failed");
+        tracker.refreshFingerprint("p", "doc", "fp-new");
+
+        assertEquals("fp-failed", tracker.read("p", "doc").orElseThrow().fingerprint(),
+                "a refresh must not re-arm the dead-letter gate of a failed row");
+    }
+
+    @Test
     void listDocumentsIsIsolatedByPipeline() {
-        tracker.writeIntent("p1", "a", "fp", "h", 0, 1, IngestionTracker.ORIGIN_SOURCE);
+        tracker.writeIntent("p1", "a", "fp", "h", 1, IngestionTracker.ORIGIN_SOURCE);
         tracker.commit("p1", "a", "fp", "h", 1);
-        tracker.writeIntent("p2", "b", "fp", "h", 0, 1, IngestionTracker.ORIGIN_SOURCE);
+        tracker.writeIntent("p2", "b", "fp", "h", 1, IngestionTracker.ORIGIN_SOURCE);
         tracker.commit("p2", "b", "fp", "h", 1);
 
         List<IngestionTracker.TrackerRow> rows = tracker.listDocuments("p1");
@@ -119,7 +148,7 @@ class JdbcIngestionTrackerTest {
 
     @Test
     void deleteRowForgetsTheDocument() {
-        tracker.writeIntent("p", "doc", "fp", "h", 0, 1, IngestionTracker.ORIGIN_SOURCE);
+        tracker.writeIntent("p", "doc", "fp", "h", 1, IngestionTracker.ORIGIN_SOURCE);
         tracker.commit("p", "doc", "fp", "h", 1);
         tracker.deleteRow("p", "doc");
 
@@ -129,7 +158,7 @@ class JdbcIngestionTrackerTest {
 
     @Test
     void tombstoneSurvivesAndLifts() {
-        tracker.writeIntent("p", "doc", "fp", "h", 0, 1, IngestionTracker.ORIGIN_SOURCE);
+        tracker.writeIntent("p", "doc", "fp", "h", 1, IngestionTracker.ORIGIN_SOURCE);
         tracker.commit("p", "doc", "fp", "h", 1);
 
         tracker.tombstone("p", "doc");
@@ -141,8 +170,19 @@ class JdbcIngestionTrackerTest {
     }
 
     @Test
+    void tombstoneOfANeverIngestedDocumentCreatesTheSuppressionRow() {
+        tracker.tombstone("p", "ghost");
+
+        IngestionTracker.TrackerRow row = tracker.read("p", "ghost").orElseThrow();
+        assertTrue(row.tombstone(), "a pure suppression row must be created, or the suppression "
+                + "would not survive for a document deleted before its first ingest");
+        assertTrue(row.done());
+        assertEquals(0, row.segmentCount());
+    }
+
+    @Test
     void pinSurvivesAndLifts() {
-        tracker.writeIntent("p", "doc", "fp", "h", 0, 1, IngestionTracker.ORIGIN_API);
+        tracker.writeIntent("p", "doc", "fp", "h", 1, IngestionTracker.ORIGIN_API);
         tracker.commit("p", "doc", "fp", "h", 1);
 
         tracker.pin("p", "doc");
@@ -154,7 +194,7 @@ class JdbcIngestionTrackerTest {
 
     @Test
     void markFailedRecordsTheAttemptAndKeepsCommittedState() {
-        tracker.writeIntent("p", "doc", "fp1", "h1", 0, 2, IngestionTracker.ORIGIN_SOURCE);
+        tracker.writeIntent("p", "doc", "fp1", "h1", 2, IngestionTracker.ORIGIN_SOURCE);
         tracker.commit("p", "doc", "fp1", "h1", 2);
         // the failed attempt's fingerprint has to be persisted, so the tracker knows it was fp2
         // that failed: passes skip the poison document while it still fingerprints as fp2 and
@@ -165,5 +205,30 @@ class JdbcIngestionTrackerTest {
         assertTrue(row.failed());
         assertEquals("fp2", row.fingerprint(), "the failed attempt's fingerprint gates retries");
         assertEquals(2, row.segmentCount(), "previously committed segments keep serving");
+    }
+
+    @Test
+    void markFailedFromInProgressKeepsTheBound() {
+        tracker.writeIntent("p", "doc", "fp1", "h1", 3, IngestionTracker.ORIGIN_SOURCE);
+        tracker.markFailed("p", "doc", "fp1");
+
+        IngestionTracker.TrackerRow row = tracker.read("p", "doc").orElseThrow();
+        assertTrue(row.failed());
+        assertEquals(0, row.segmentCount(), "nothing was ever committed");
+        assertEquals(3, row.maxKnownCount(),
+                "the failed intent's bound must survive — up to 3 segments may sit in the store");
+    }
+
+    @Test
+    void preProvisionedModeRequiresTheTableToExist() {
+        JdbcDataSource fresh = new JdbcDataSource();
+        fresh.setURL("jdbc:h2:mem:" + UUID.randomUUID() + ";DB_CLOSE_DELAY=-1");
+
+        JdbcIngestionTracker probing = new JdbcIngestionTracker(fresh, false);
+        assertThrows(IllegalStateException.class, probing::ensureSchema,
+                "without DDL rights the tracker must refuse loudly, not fail on first use");
+
+        new JdbcIngestionTracker(fresh).ensureSchema();
+        probing.ensureSchema();
     }
 }

--- a/extensions-support/langchain4j/runtime/src/test/java/org/apache/camel/quarkus/component/support/langchain4j/tracker/jdbc/JdbcIngestionTrackerTest.java
+++ b/extensions-support/langchain4j/runtime/src/test/java/org/apache/camel/quarkus/component/support/langchain4j/tracker/jdbc/JdbcIngestionTrackerTest.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.support.langchain4j.tracker.jdbc;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.apache.camel.quarkus.component.support.langchain4j.tracker.IngestionTracker;
+import org.h2.jdbcx.JdbcDataSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The behavioural contract of the {@link IngestionTracker} SPI, exercised against the JDBC
+ * implementation on H2. The test methods are deliberately written against the SPI only — nothing
+ * below {@link #setUpTracker()} references {@link JdbcIngestionTracker}.
+ *
+ * <p>
+ * The contract lives folded into this class only because a single implementation exists today.
+ * When a second one arrives — e.g. an adapter over a future upstream LangChain4j record manager
+ * (langchain4j#2931) — extract the test methods into an abstract {@code IngestionTrackerContract}
+ * base class with a {@code createTracker()} factory, and keep one {@code *Test} subclass per
+ * implementation: a replacement is a drop-in exactly when its subclass passes.
+ */
+class JdbcIngestionTrackerTest {
+
+    IngestionTracker tracker;
+
+    /** A fresh, empty tracker per test. */
+    @BeforeEach
+    void setUpTracker() {
+        JdbcDataSource dataSource = new JdbcDataSource();
+        dataSource.setURL("jdbc:h2:mem:" + UUID.randomUUID() + ";DB_CLOSE_DELAY=-1");
+        tracker = new JdbcIngestionTracker(dataSource);
+        tracker.ensureSchema();
+    }
+
+    @Test
+    void unknownDocumentReadsEmpty() {
+        assertTrue(tracker.read("p", "missing").isEmpty());
+    }
+
+    @Test
+    void intentIsDurableAndNeverSkippable() {
+        tracker.writeIntent("p", "doc", "fp1", "hash1", 0, 5, IngestionTracker.ORIGIN_SOURCE);
+
+        IngestionTracker.TrackerRow row = tracker.read("p", "doc").orElseThrow();
+        assertFalse(row.done(), "an intent row must not count as done");
+        assertEquals(5, row.maxKnownCount(), "the shrink bound must cover the intended count");
+    }
+
+    @Test
+    void commitCompletesTheIntent() {
+        tracker.writeIntent("p", "doc", "fp1", "hash1", 0, 5, IngestionTracker.ORIGIN_SOURCE);
+        tracker.commit("p", "doc", "fp1", "hash1", 3);
+
+        IngestionTracker.TrackerRow row = tracker.read("p", "doc").orElseThrow();
+        assertTrue(row.done());
+        assertEquals("fp1", row.fingerprint());
+        assertEquals("hash1", row.contentHash());
+        assertEquals(3, row.segmentCount());
+    }
+
+    @Test
+    void reintentKeepsTheLargestKnownCount() {
+        tracker.writeIntent("p", "doc", "fp1", "hash1", 0, 5, IngestionTracker.ORIGIN_SOURCE);
+        tracker.commit("p", "doc", "fp1", "hash1", 5);
+        // a re-intent does not change what the store really holds — the five old segments are
+        // still in it, so the committed count has to stay; only commit, which runs after the
+        // stale tail was actually removed, may lower the bound
+        tracker.writeIntent("p", "doc", "fp2", "hash2", 5, 2, IngestionTracker.ORIGIN_SOURCE);
+
+        assertEquals(5, tracker.read("p", "doc").orElseThrow().maxKnownCount(),
+                "shrink must still see the previously committed tail");
+    }
+
+    @Test
+    void refreshFingerprintTouchesNothingElse() {
+        tracker.writeIntent("p", "doc", "fp1", "hash1", 0, 2, IngestionTracker.ORIGIN_SOURCE);
+        tracker.commit("p", "doc", "fp1", "hash1", 2);
+        tracker.refreshFingerprint("p", "doc", "fp2");
+
+        IngestionTracker.TrackerRow row = tracker.read("p", "doc").orElseThrow();
+        assertEquals("fp2", row.fingerprint());
+        assertEquals("hash1", row.contentHash());
+        assertEquals(2, row.segmentCount());
+        assertTrue(row.done());
+    }
+
+    @Test
+    void listDocumentsIsIsolatedByPipeline() {
+        tracker.writeIntent("p1", "a", "fp", "h", 0, 1, IngestionTracker.ORIGIN_SOURCE);
+        tracker.commit("p1", "a", "fp", "h", 1);
+        tracker.writeIntent("p2", "b", "fp", "h", 0, 1, IngestionTracker.ORIGIN_SOURCE);
+        tracker.commit("p2", "b", "fp", "h", 1);
+
+        List<IngestionTracker.TrackerRow> rows = tracker.listDocuments("p1");
+        assertEquals(1, rows.size());
+        assertEquals("a", rows.get(0).documentId());
+    }
+
+    @Test
+    void deleteRowForgetsTheDocument() {
+        tracker.writeIntent("p", "doc", "fp", "h", 0, 1, IngestionTracker.ORIGIN_SOURCE);
+        tracker.commit("p", "doc", "fp", "h", 1);
+        tracker.deleteRow("p", "doc");
+
+        assertTrue(tracker.read("p", "doc").isEmpty());
+        assertTrue(tracker.listDocuments("p").isEmpty());
+    }
+
+    @Test
+    void tombstoneSurvivesAndLifts() {
+        tracker.writeIntent("p", "doc", "fp", "h", 0, 1, IngestionTracker.ORIGIN_SOURCE);
+        tracker.commit("p", "doc", "fp", "h", 1);
+
+        tracker.tombstone("p", "doc");
+        assertTrue(tracker.read("p", "doc").orElseThrow().tombstone(),
+                "a tombstoned row must survive as a suppression record");
+
+        tracker.unsuppress("p", "doc");
+        assertFalse(tracker.read("p", "doc").orElseThrow().tombstone());
+    }
+
+    @Test
+    void pinSurvivesAndLifts() {
+        tracker.writeIntent("p", "doc", "fp", "h", 0, 1, IngestionTracker.ORIGIN_API);
+        tracker.commit("p", "doc", "fp", "h", 1);
+
+        tracker.pin("p", "doc");
+        assertTrue(tracker.read("p", "doc").orElseThrow().pinned());
+
+        tracker.unpin("p", "doc");
+        assertFalse(tracker.read("p", "doc").orElseThrow().pinned());
+    }
+
+    @Test
+    void markFailedRecordsTheAttemptAndKeepsCommittedState() {
+        tracker.writeIntent("p", "doc", "fp1", "h1", 0, 2, IngestionTracker.ORIGIN_SOURCE);
+        tracker.commit("p", "doc", "fp1", "h1", 2);
+        // the failed attempt's fingerprint has to be persisted, so the tracker knows it was fp2
+        // that failed: passes skip the poison document while it still fingerprints as fp2 and
+        // retry only once the content changes (keeping fp1 would retry — and fail — every pass)
+        tracker.markFailed("p", "doc", "fp2");
+
+        IngestionTracker.TrackerRow row = tracker.read("p", "doc").orElseThrow();
+        assertTrue(row.failed());
+        assertEquals("fp2", row.fingerprint(), "the failed attempt's fingerprint gates retries");
+        assertEquals(2, row.segmentCount(), "previously committed segments keep serving");
+    }
+}

--- a/integration-tests/langchain4j-ingestion-tracker/pom.xml
+++ b/integration-tests/langchain4j-ingestion-tracker/pom.xml
@@ -27,7 +27,7 @@
     </parent>
 
     <artifactId>camel-quarkus-integration-test-langchain4j-ingestion-tracker</artifactId>
-    <name>Camel Quarkus :: Integration Tests :: LangChain4j Sync Tracker</name>
+    <name>Camel Quarkus :: Integration Tests :: LangChain4j Ingestion Tracker</name>
     <description>Integration tests for the JDBC ingestion tracker against a real PostgreSQL database</description>
 
     <dependencies>

--- a/integration-tests/langchain4j-ingestion-tracker/pom.xml
+++ b/integration-tests/langchain4j-ingestion-tracker/pom.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.camel.quarkus</groupId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
+        <version>3.39.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>camel-quarkus-integration-test-langchain4j-ingestion-tracker</artifactId>
+    <name>Camel Quarkus :: Integration Tests :: LangChain4j Sync Tracker</name>
+    <description>Integration tests for the JDBC ingestion tracker against a real PostgreSQL database</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-support-langchain4j</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jdbc-postgresql</artifactId>
+        </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <id>native</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <properties>
+                <quarkus.native.enabled>true</quarkus.native.enabled>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>virtualDependencies</id>
+            <activation>
+                <property>
+                    <name>!noVirtualDependencies</name>
+                </property>
+            </activation>
+            <dependencies>
+                <!-- The following dependencies guarantee that this module is built after them. You can update them by running `mvn process-resources -Pformat -N` from the source tree root directory -->
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-support-langchain4j-deployment</artifactId>
+                    <version>${project.version}</version>
+                    <type>pom</type>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>skip-testcontainers-tests</id>
+            <activation>
+                <property>
+                    <name>skip-testcontainers-tests</name>
+                </property>
+            </activation>
+            <properties>
+                <skipTests>true</skipTests>
+            </properties>
+        </profile>
+    </profiles>
+</project>

--- a/integration-tests/langchain4j-ingestion-tracker/src/main/java/org/apache/camel/quarkus/component/langchain4j/ingestiontracker/it/IngestionTrackerResource.java
+++ b/integration-tests/langchain4j-ingestion-tracker/src/main/java/org/apache/camel/quarkus/component/langchain4j/ingestiontracker/it/IngestionTrackerResource.java
@@ -20,7 +20,9 @@ import java.util.List;
 
 import javax.sql.DataSource;
 
-import jakarta.annotation.PostConstruct;
+import io.quarkus.runtime.StartupEvent;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
@@ -38,6 +40,7 @@ import org.apache.camel.quarkus.component.support.langchain4j.tracker.jdbc.JdbcI
  * directly injected test field because {@code @QuarkusIntegrationTest} runs the application as a
  * separate process and cannot use {@code @Inject}.
  */
+@ApplicationScoped
 @Path("/ingestion-tracker")
 public class IngestionTrackerResource {
 
@@ -46,8 +49,7 @@ public class IngestionTrackerResource {
 
     private IngestionTracker tracker;
 
-    @PostConstruct
-    void init() {
+    void init(@Observes StartupEvent startup) {
         tracker = new JdbcIngestionTracker(dataSource);
         tracker.ensureSchema();
     }
@@ -68,9 +70,8 @@ public class IngestionTrackerResource {
     @Path("/{pipeline}/{docId}/intent")
     public TrackerRow writeIntent(@PathParam("pipeline") String pipeline, @PathParam("docId") String docId,
             @QueryParam("fingerprint") String fingerprint, @QueryParam("contentHash") String contentHash,
-            @QueryParam("committedCount") int committedCount, @QueryParam("intendedCount") int intendedCount,
-            @QueryParam("origin") String origin) {
-        tracker.writeIntent(pipeline, docId, fingerprint, contentHash, committedCount, intendedCount, origin);
+            @QueryParam("intendedCount") int intendedCount, @QueryParam("origin") String origin) {
+        tracker.writeIntent(pipeline, docId, fingerprint, contentHash, intendedCount, origin);
         return read(pipeline, docId);
     }
 

--- a/integration-tests/langchain4j-ingestion-tracker/src/main/java/org/apache/camel/quarkus/component/langchain4j/ingestiontracker/it/IngestionTrackerResource.java
+++ b/integration-tests/langchain4j-ingestion-tracker/src/main/java/org/apache/camel/quarkus/component/langchain4j/ingestiontracker/it/IngestionTrackerResource.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.langchain4j.ingestiontracker.it;
+
+import java.util.List;
+
+import javax.sql.DataSource;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.QueryParam;
+import org.apache.camel.quarkus.component.support.langchain4j.tracker.IngestionTracker;
+import org.apache.camel.quarkus.component.support.langchain4j.tracker.IngestionTracker.TrackerRow;
+import org.apache.camel.quarkus.component.support.langchain4j.tracker.jdbc.JdbcIngestionTracker;
+
+/**
+ * Exercises {@link JdbcIngestionTracker} against a real datasource. A REST resource rather than a
+ * directly injected test field because {@code @QuarkusIntegrationTest} runs the application as a
+ * separate process and cannot use {@code @Inject}.
+ */
+@Path("/ingestion-tracker")
+public class IngestionTrackerResource {
+
+    @Inject
+    DataSource dataSource;
+
+    private IngestionTracker tracker;
+
+    @PostConstruct
+    void init() {
+        tracker = new JdbcIngestionTracker(dataSource);
+        tracker.ensureSchema();
+    }
+
+    @GET
+    @Path("/{pipeline}")
+    public List<TrackerRow> listDocuments(@PathParam("pipeline") String pipeline) {
+        return tracker.listDocuments(pipeline);
+    }
+
+    @GET
+    @Path("/{pipeline}/{docId}")
+    public TrackerRow read(@PathParam("pipeline") String pipeline, @PathParam("docId") String docId) {
+        return tracker.read(pipeline, docId).orElseThrow(NotFoundException::new);
+    }
+
+    @POST
+    @Path("/{pipeline}/{docId}/intent")
+    public TrackerRow writeIntent(@PathParam("pipeline") String pipeline, @PathParam("docId") String docId,
+            @QueryParam("fingerprint") String fingerprint, @QueryParam("contentHash") String contentHash,
+            @QueryParam("committedCount") int committedCount, @QueryParam("intendedCount") int intendedCount,
+            @QueryParam("origin") String origin) {
+        tracker.writeIntent(pipeline, docId, fingerprint, contentHash, committedCount, intendedCount, origin);
+        return read(pipeline, docId);
+    }
+
+    @POST
+    @Path("/{pipeline}/{docId}/commit")
+    public TrackerRow commit(@PathParam("pipeline") String pipeline, @PathParam("docId") String docId,
+            @QueryParam("fingerprint") String fingerprint, @QueryParam("contentHash") String contentHash,
+            @QueryParam("segmentCount") int segmentCount) {
+        tracker.commit(pipeline, docId, fingerprint, contentHash, segmentCount);
+        return read(pipeline, docId);
+    }
+
+    @POST
+    @Path("/{pipeline}/{docId}/refresh-fingerprint")
+    public TrackerRow refreshFingerprint(@PathParam("pipeline") String pipeline, @PathParam("docId") String docId,
+            @QueryParam("fingerprint") String fingerprint) {
+        tracker.refreshFingerprint(pipeline, docId, fingerprint);
+        return read(pipeline, docId);
+    }
+
+    @POST
+    @Path("/{pipeline}/{docId}/fail")
+    public TrackerRow markFailed(@PathParam("pipeline") String pipeline, @PathParam("docId") String docId,
+            @QueryParam("fingerprint") String fingerprint) {
+        tracker.markFailed(pipeline, docId, fingerprint);
+        return read(pipeline, docId);
+    }
+
+    @POST
+    @Path("/{pipeline}/{docId}/tombstone")
+    public TrackerRow tombstone(@PathParam("pipeline") String pipeline, @PathParam("docId") String docId) {
+        tracker.tombstone(pipeline, docId);
+        return read(pipeline, docId);
+    }
+
+    @POST
+    @Path("/{pipeline}/{docId}/unsuppress")
+    public TrackerRow unsuppress(@PathParam("pipeline") String pipeline, @PathParam("docId") String docId) {
+        tracker.unsuppress(pipeline, docId);
+        return read(pipeline, docId);
+    }
+
+    @POST
+    @Path("/{pipeline}/{docId}/pin")
+    public TrackerRow pin(@PathParam("pipeline") String pipeline, @PathParam("docId") String docId) {
+        tracker.pin(pipeline, docId);
+        return read(pipeline, docId);
+    }
+
+    @POST
+    @Path("/{pipeline}/{docId}/unpin")
+    public TrackerRow unpin(@PathParam("pipeline") String pipeline, @PathParam("docId") String docId) {
+        tracker.unpin(pipeline, docId);
+        return read(pipeline, docId);
+    }
+
+    @DELETE
+    @Path("/{pipeline}/{docId}")
+    public void deleteRow(@PathParam("pipeline") String pipeline, @PathParam("docId") String docId) {
+        tracker.deleteRow(pipeline, docId);
+    }
+}

--- a/integration-tests/langchain4j-ingestion-tracker/src/main/resources/application.properties
+++ b/integration-tests/langchain4j-ingestion-tracker/src/main/resources/application.properties
@@ -1,0 +1,19 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+quarkus.datasource.db-kind=postgresql
+quarkus.datasource.devservices.image-name=${postgres.container.image}

--- a/integration-tests/langchain4j-ingestion-tracker/src/test/java/org/apache/camel/quarkus/component/langchain4j/ingestiontracker/it/Langchain4jIngestionTrackerIT.java
+++ b/integration-tests/langchain4j-ingestion-tracker/src/test/java/org/apache/camel/quarkus/component/langchain4j/ingestiontracker/it/Langchain4jIngestionTrackerIT.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.langchain4j.ingestiontracker.it;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+class Langchain4jIngestionTrackerIT extends Langchain4jIngestionTrackerTest {
+}

--- a/integration-tests/langchain4j-ingestion-tracker/src/test/java/org/apache/camel/quarkus/component/langchain4j/ingestiontracker/it/Langchain4jIngestionTrackerTest.java
+++ b/integration-tests/langchain4j-ingestion-tracker/src/test/java/org/apache/camel/quarkus/component/langchain4j/ingestiontracker/it/Langchain4jIngestionTrackerTest.java
@@ -26,22 +26,23 @@ import static org.hamcrest.Matchers.hasSize;
 /**
  * Runs the {@code IngestionTracker} behavioural guarantees (mirrored from {@code JdbcIngestionTrackerTest})
  * against a real PostgreSQL server, provisioned by Quarkus Dev Services, through
- * {@link IngestionTrackerResource}.
+ * {@link IngestionTrackerResource}. Each test uses its own pipeline id — the database is shared
+ * across methods and never reset, so isolation comes from the keys.
  */
 @QuarkusTest
 class Langchain4jIngestionTrackerTest {
 
     @Test
     void unknownDocumentReadsEmpty() {
-        RestAssured.get("/ingestion-tracker/p/missing").then().statusCode(404);
+        RestAssured.get("/ingestion-tracker/p-unknown/missing").then().statusCode(404);
     }
 
     @Test
     void intentIsDurableAndNeverSkippable() {
         RestAssured.given()
                 .queryParam("fingerprint", "fp1").queryParam("contentHash", "hash1")
-                .queryParam("committedCount", 0).queryParam("intendedCount", 5).queryParam("origin", "source")
-                .post("/ingestion-tracker/p/doc/intent")
+                .queryParam("intendedCount", 5).queryParam("origin", "source")
+                .post("/ingestion-tracker/p-intent/doc/intent")
                 .then().statusCode(200)
                 .body("status", equalTo("in_progress"))
                 .body("intendedCount", equalTo(5));
@@ -49,11 +50,11 @@ class Langchain4jIngestionTrackerTest {
 
     @Test
     void commitCompletesTheIntent() {
-        writeIntent("p", "doc", "fp1", "hash1", 0, 5, "source");
+        writeIntent("p-commit", "doc", "fp1", "hash1", 5, "source");
 
         RestAssured.given()
                 .queryParam("fingerprint", "fp1").queryParam("contentHash", "hash1").queryParam("segmentCount", 3)
-                .post("/ingestion-tracker/p/doc/commit")
+                .post("/ingestion-tracker/p-commit/doc/commit")
                 .then().statusCode(200)
                 .body("status", equalTo("done"))
                 .body("fingerprint", equalTo("fp1"))
@@ -62,23 +63,41 @@ class Langchain4jIngestionTrackerTest {
     }
 
     @Test
+    void commitWithoutIntentFails() {
+        RestAssured.given()
+                .queryParam("fingerprint", "fp").queryParam("contentHash", "h").queryParam("segmentCount", 1)
+                .post("/ingestion-tracker/p-commit-ghost/ghost/commit")
+                .then().statusCode(500);
+    }
+
+    @Test
     void reintentKeepsTheLargestKnownCount() {
-        writeIntent("p", "doc", "fp1", "hash1", 0, 5, "source");
-        commit("p", "doc", "fp1", "hash1", 5);
-        writeIntent("p", "doc", "fp2", "hash2", 5, 2, "source");
+        writeIntent("p-reintent", "doc", "fp1", "hash1", 5, "source");
+        commit("p-reintent", "doc", "fp1", "hash1", 5);
+        writeIntent("p-reintent", "doc", "fp2", "hash2", 2, "source");
 
         // shrink must still see the previously committed tail
-        RestAssured.get("/ingestion-tracker/p/doc").then()
+        RestAssured.get("/ingestion-tracker/p-reintent/doc").then()
                 .body("segmentCount", equalTo(5));
     }
 
     @Test
+    void reintentBeforeCommitKeepsTheLargestIntendedCount() {
+        writeIntent("p-reintent-crash", "doc", "fp1", "hash1", 5, "source");
+        // no commit — the crashed attempt may have written up to 5 segments
+        writeIntent("p-reintent-crash", "doc", "fp2", "hash2", 2, "source");
+
+        RestAssured.get("/ingestion-tracker/p-reintent-crash/doc").then()
+                .body("intendedCount", equalTo(5));
+    }
+
+    @Test
     void refreshFingerprintTouchesNothingElse() {
-        writeIntent("p", "doc", "fp1", "hash1", 0, 2, "source");
-        commit("p", "doc", "fp1", "hash1", 2);
+        writeIntent("p-refresh", "doc", "fp1", "hash1", 2, "source");
+        commit("p-refresh", "doc", "fp1", "hash1", 2);
 
         RestAssured.given().queryParam("fingerprint", "fp2")
-                .post("/ingestion-tracker/p/doc/refresh-fingerprint")
+                .post("/ingestion-tracker/p-refresh/doc/refresh-fingerprint")
                 .then().statusCode(200)
                 .body("fingerprint", equalTo("fp2"))
                 .body("contentHash", equalTo("hash1"))
@@ -88,52 +107,61 @@ class Langchain4jIngestionTrackerTest {
 
     @Test
     void listDocumentsIsIsolatedByPipeline() {
-        writeIntent("p1", "a", "fp", "h", 0, 1, "source");
-        commit("p1", "a", "fp", "h", 1);
-        writeIntent("p2", "b", "fp", "h", 0, 1, "source");
-        commit("p2", "b", "fp", "h", 1);
+        writeIntent("p-list-a", "a", "fp", "h", 1, "source");
+        commit("p-list-a", "a", "fp", "h", 1);
+        writeIntent("p-list-b", "b", "fp", "h", 1, "source");
+        commit("p-list-b", "b", "fp", "h", 1);
 
-        RestAssured.get("/ingestion-tracker/p1").then()
+        RestAssured.get("/ingestion-tracker/p-list-a").then()
                 .body("", hasSize(1))
                 .body("[0].documentId", equalTo("a"));
     }
 
     @Test
     void deleteRowForgetsTheDocument() {
-        writeIntent("p", "doc", "fp", "h", 0, 1, "source");
-        commit("p", "doc", "fp", "h", 1);
+        writeIntent("p-delete", "doc", "fp", "h", 1, "source");
+        commit("p-delete", "doc", "fp", "h", 1);
 
-        RestAssured.delete("/ingestion-tracker/p/doc").then().statusCode(204);
+        RestAssured.delete("/ingestion-tracker/p-delete/doc").then().statusCode(204);
 
-        RestAssured.get("/ingestion-tracker/p/doc").then().statusCode(404);
-        RestAssured.get("/ingestion-tracker/p").then().body("", hasSize(0));
+        RestAssured.get("/ingestion-tracker/p-delete/doc").then().statusCode(404);
+        RestAssured.get("/ingestion-tracker/p-delete").then().body("", hasSize(0));
     }
 
     @Test
     void tombstoneSurvivesAndLifts() {
-        writeIntent("p", "doc", "fp", "h", 0, 1, "source");
-        commit("p", "doc", "fp", "h", 1);
+        writeIntent("p-tombstone", "doc", "fp", "h", 1, "source");
+        commit("p-tombstone", "doc", "fp", "h", 1);
 
-        RestAssured.post("/ingestion-tracker/p/doc/tombstone").then().body("tombstone", equalTo(true));
-        RestAssured.post("/ingestion-tracker/p/doc/unsuppress").then().body("tombstone", equalTo(false));
+        RestAssured.post("/ingestion-tracker/p-tombstone/doc/tombstone").then().body("tombstone", equalTo(true));
+        RestAssured.post("/ingestion-tracker/p-tombstone/doc/unsuppress").then().body("tombstone", equalTo(false));
+    }
+
+    @Test
+    void tombstoneOfANeverIngestedDocumentCreatesTheSuppressionRow() {
+        RestAssured.post("/ingestion-tracker/p-tombstone-ghost/ghost/tombstone")
+                .then().statusCode(200)
+                .body("tombstone", equalTo(true))
+                .body("status", equalTo("done"))
+                .body("segmentCount", equalTo(0));
     }
 
     @Test
     void pinSurvivesAndLifts() {
-        writeIntent("p", "doc", "fp", "h", 0, 1, "api");
-        commit("p", "doc", "fp", "h", 1);
+        writeIntent("p-pin", "doc", "fp", "h", 1, "api");
+        commit("p-pin", "doc", "fp", "h", 1);
 
-        RestAssured.post("/ingestion-tracker/p/doc/pin").then().body("pinned", equalTo(true));
-        RestAssured.post("/ingestion-tracker/p/doc/unpin").then().body("pinned", equalTo(false));
+        RestAssured.post("/ingestion-tracker/p-pin/doc/pin").then().body("pinned", equalTo(true));
+        RestAssured.post("/ingestion-tracker/p-pin/doc/unpin").then().body("pinned", equalTo(false));
     }
 
     @Test
     void markFailedRecordsTheAttemptAndKeepsCommittedState() {
-        writeIntent("p", "doc", "fp1", "h1", 0, 2, "source");
-        commit("p", "doc", "fp1", "h1", 2);
+        writeIntent("p-fail", "doc", "fp1", "h1", 2, "source");
+        commit("p-fail", "doc", "fp1", "h1", 2);
 
         RestAssured.given().queryParam("fingerprint", "fp2")
-                .post("/ingestion-tracker/p/doc/fail")
+                .post("/ingestion-tracker/p-fail/doc/fail")
                 .then().statusCode(200)
                 .body("status", equalTo("failed"))
                 // the failed attempt's fingerprint gates retries
@@ -143,10 +171,10 @@ class Langchain4jIngestionTrackerTest {
     }
 
     private static void writeIntent(String pipeline, String docId, String fingerprint, String contentHash,
-            int committedCount, int intendedCount, String origin) {
+            int intendedCount, String origin) {
         RestAssured.given()
                 .queryParam("fingerprint", fingerprint).queryParam("contentHash", contentHash)
-                .queryParam("committedCount", committedCount).queryParam("intendedCount", intendedCount)
+                .queryParam("intendedCount", intendedCount)
                 .queryParam("origin", origin)
                 .post("/ingestion-tracker/" + pipeline + "/" + docId + "/intent")
                 .then().statusCode(200);

--- a/integration-tests/langchain4j-ingestion-tracker/src/test/java/org/apache/camel/quarkus/component/langchain4j/ingestiontracker/it/Langchain4jIngestionTrackerTest.java
+++ b/integration-tests/langchain4j-ingestion-tracker/src/test/java/org/apache/camel/quarkus/component/langchain4j/ingestiontracker/it/Langchain4jIngestionTrackerTest.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.langchain4j.ingestiontracker.it;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+
+/**
+ * Runs the {@code IngestionTracker} behavioural guarantees (mirrored from {@code JdbcIngestionTrackerTest})
+ * against a real PostgreSQL server, provisioned by Quarkus Dev Services, through
+ * {@link IngestionTrackerResource}.
+ */
+@QuarkusTest
+class Langchain4jIngestionTrackerTest {
+
+    @Test
+    void unknownDocumentReadsEmpty() {
+        RestAssured.get("/ingestion-tracker/p/missing").then().statusCode(404);
+    }
+
+    @Test
+    void intentIsDurableAndNeverSkippable() {
+        RestAssured.given()
+                .queryParam("fingerprint", "fp1").queryParam("contentHash", "hash1")
+                .queryParam("committedCount", 0).queryParam("intendedCount", 5).queryParam("origin", "source")
+                .post("/ingestion-tracker/p/doc/intent")
+                .then().statusCode(200)
+                .body("status", equalTo("in_progress"))
+                .body("intendedCount", equalTo(5));
+    }
+
+    @Test
+    void commitCompletesTheIntent() {
+        writeIntent("p", "doc", "fp1", "hash1", 0, 5, "source");
+
+        RestAssured.given()
+                .queryParam("fingerprint", "fp1").queryParam("contentHash", "hash1").queryParam("segmentCount", 3)
+                .post("/ingestion-tracker/p/doc/commit")
+                .then().statusCode(200)
+                .body("status", equalTo("done"))
+                .body("fingerprint", equalTo("fp1"))
+                .body("contentHash", equalTo("hash1"))
+                .body("segmentCount", equalTo(3));
+    }
+
+    @Test
+    void reintentKeepsTheLargestKnownCount() {
+        writeIntent("p", "doc", "fp1", "hash1", 0, 5, "source");
+        commit("p", "doc", "fp1", "hash1", 5);
+        writeIntent("p", "doc", "fp2", "hash2", 5, 2, "source");
+
+        // shrink must still see the previously committed tail
+        RestAssured.get("/ingestion-tracker/p/doc").then()
+                .body("segmentCount", equalTo(5));
+    }
+
+    @Test
+    void refreshFingerprintTouchesNothingElse() {
+        writeIntent("p", "doc", "fp1", "hash1", 0, 2, "source");
+        commit("p", "doc", "fp1", "hash1", 2);
+
+        RestAssured.given().queryParam("fingerprint", "fp2")
+                .post("/ingestion-tracker/p/doc/refresh-fingerprint")
+                .then().statusCode(200)
+                .body("fingerprint", equalTo("fp2"))
+                .body("contentHash", equalTo("hash1"))
+                .body("segmentCount", equalTo(2))
+                .body("status", equalTo("done"));
+    }
+
+    @Test
+    void listDocumentsIsIsolatedByPipeline() {
+        writeIntent("p1", "a", "fp", "h", 0, 1, "source");
+        commit("p1", "a", "fp", "h", 1);
+        writeIntent("p2", "b", "fp", "h", 0, 1, "source");
+        commit("p2", "b", "fp", "h", 1);
+
+        RestAssured.get("/ingestion-tracker/p1").then()
+                .body("", hasSize(1))
+                .body("[0].documentId", equalTo("a"));
+    }
+
+    @Test
+    void deleteRowForgetsTheDocument() {
+        writeIntent("p", "doc", "fp", "h", 0, 1, "source");
+        commit("p", "doc", "fp", "h", 1);
+
+        RestAssured.delete("/ingestion-tracker/p/doc").then().statusCode(204);
+
+        RestAssured.get("/ingestion-tracker/p/doc").then().statusCode(404);
+        RestAssured.get("/ingestion-tracker/p").then().body("", hasSize(0));
+    }
+
+    @Test
+    void tombstoneSurvivesAndLifts() {
+        writeIntent("p", "doc", "fp", "h", 0, 1, "source");
+        commit("p", "doc", "fp", "h", 1);
+
+        RestAssured.post("/ingestion-tracker/p/doc/tombstone").then().body("tombstone", equalTo(true));
+        RestAssured.post("/ingestion-tracker/p/doc/unsuppress").then().body("tombstone", equalTo(false));
+    }
+
+    @Test
+    void pinSurvivesAndLifts() {
+        writeIntent("p", "doc", "fp", "h", 0, 1, "api");
+        commit("p", "doc", "fp", "h", 1);
+
+        RestAssured.post("/ingestion-tracker/p/doc/pin").then().body("pinned", equalTo(true));
+        RestAssured.post("/ingestion-tracker/p/doc/unpin").then().body("pinned", equalTo(false));
+    }
+
+    @Test
+    void markFailedRecordsTheAttemptAndKeepsCommittedState() {
+        writeIntent("p", "doc", "fp1", "h1", 0, 2, "source");
+        commit("p", "doc", "fp1", "h1", 2);
+
+        RestAssured.given().queryParam("fingerprint", "fp2")
+                .post("/ingestion-tracker/p/doc/fail")
+                .then().statusCode(200)
+                .body("status", equalTo("failed"))
+                // the failed attempt's fingerprint gates retries
+                .body("fingerprint", equalTo("fp2"))
+                // previously committed segments keep serving
+                .body("segmentCount", equalTo(2));
+    }
+
+    private static void writeIntent(String pipeline, String docId, String fingerprint, String contentHash,
+            int committedCount, int intendedCount, String origin) {
+        RestAssured.given()
+                .queryParam("fingerprint", fingerprint).queryParam("contentHash", contentHash)
+                .queryParam("committedCount", committedCount).queryParam("intendedCount", intendedCount)
+                .queryParam("origin", origin)
+                .post("/ingestion-tracker/" + pipeline + "/" + docId + "/intent")
+                .then().statusCode(200);
+    }
+
+    private static void commit(String pipeline, String docId, String fingerprint, String contentHash,
+            int segmentCount) {
+        RestAssured.given()
+                .queryParam("fingerprint", fingerprint).queryParam("contentHash", contentHash)
+                .queryParam("segmentCount", segmentCount)
+                .post("/ingestion-tracker/" + pipeline + "/" + docId + "/commit")
+                .then().statusCode(200);
+    }
+}

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -165,6 +165,7 @@
         <module>langchain4j-chat</module>
         <module>langchain4j-embeddings</module>
         <module>langchain4j-embeddingstore</module>
+        <module>langchain4j-ingestion-tracker</module>
         <module>langchain4j-rag-bridge-ql4j</module>
         <module>langchain4j-tokenizer</module>
         <module>langchain4j-tools</module>

--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,7 @@
         <jakarta.jms-api.version>${jakarta-jms-api-version}</jakarta.jms-api.version>
         <java-driver-query-builder.version>4.19.2</java-driver-query-builder.version><!-- @sync com.datastax.oss.quarkus:cassandra-quarkus-parent:${cassandra-quarkus.version} prop:java-driver.version -->
         <java-json-tools.json-patch.version>${json-patch-version}</java-json-tools.json-patch.version><!-- A replacement for com.github.fge:json-patch -->
+        <java-uuid-generator.version>5.2.0</java-uuid-generator.version>
         <jodatime.version>${jodatime2-version}</jodatime.version><!-- Mess in transitive dependencies of Splunk -->
         <javassist.version>${javassist-version}</javassist.version><!-- debezium -->
         <jetty.version>${jetty-version}</jetty.version>

--- a/poms/bom/pom.xml
+++ b/poms/bom/pom.xml
@@ -7496,6 +7496,11 @@
                 <version>${aalto-xml.version}</version>
             </dependency>
             <dependency>
+                <groupId>com.fasterxml.uuid</groupId>
+                <artifactId>java-uuid-generator</artifactId>
+                <version>${java-uuid-generator.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>com.github.java-json-tools</groupId>
                 <artifactId>json-patch</artifactId>
                 <version>${java-json-tools.json-patch.version}</version>

--- a/poms/bom/src/main/generated/flattened-full-pom.xml
+++ b/poms/bom/src/main/generated/flattened-full-pom.xml
@@ -7379,6 +7379,11 @@
         <version>1.3.3</version>
       </dependency>
       <dependency>
+        <groupId>com.fasterxml.uuid</groupId>
+        <artifactId>java-uuid-generator</artifactId>
+        <version>5.2.0</version>
+      </dependency>
+      <dependency>
         <groupId>com.github.java-json-tools</groupId>
         <artifactId>json-patch</artifactId>
         <version>1.13</version>

--- a/poms/bom/src/main/generated/flattened-reduced-pom.xml
+++ b/poms/bom/src/main/generated/flattened-reduced-pom.xml
@@ -346,6 +346,11 @@
         <version>1.3.3</version>
       </dependency>
       <dependency>
+        <groupId>com.fasterxml.uuid</groupId>
+        <artifactId>java-uuid-generator</artifactId>
+        <version>5.2.0</version>
+      </dependency>
+      <dependency>
         <groupId>com.fasterxml.woodstox</groupId>
         <artifactId>woodstox-core</artifactId>
         <version>7.2.1</version>

--- a/poms/bom/src/main/generated/flattened-reduced-verbose-pom.xml
+++ b/poms/bom/src/main/generated/flattened-reduced-verbose-pom.xml
@@ -346,6 +346,11 @@
         <version>1.3.3</version>
       </dependency>
       <dependency>
+        <groupId>com.fasterxml.uuid</groupId>
+        <artifactId>java-uuid-generator</artifactId>
+        <version>5.2.0</version>
+      </dependency>
+      <dependency>
         <groupId>com.fasterxml.woodstox</groupId>
         <artifactId>woodstox-core</artifactId>
         <version>7.2.1</version>

--- a/tooling/scripts/test-categories.yaml
+++ b/tooling/scripts/test-categories.yaml
@@ -51,6 +51,7 @@ group-02:
   - langchain4j-agent
   - langchain4j-agent-bean-binding-ql4j
   - langchain4j-agent-ql4j
+  - langchain4j-ingestion-tracker
   - oaipmh
   - ocsf
   - pubnub


### PR DESCRIPTION
based on https://github.com/apache/camel-quarkus/pull/9006

  Second groundwork PR toward declarative AI document ingestion, building directly on the `IngestionTracker` from #9003: the tracker records what was ingested — this adds the engine that acts on it, as Camel-free support code in  `org.apache.camel.quarkus.component.support.langchain4j.ingest`.

  - `IngestService` — the write path for one document: two-tier change detection (cheap source  fingerprint, then content hash — both tenant-aware, so re-assigning a document to another tenant is never skipped with stale metadata), deterministic UUIDv5 segment ids, and the crash-safe `writeIntent` → store write → shrink-remove → `commit` protocol. Failures are typed by where they happen: content-attributable failures (fetch, split) are dead-lettered and retried only when the content changes, while infrastructure failures (embedding provider, store, tracker I/O) leave the row `in_progress` and are retried on the next pass — a transient outage can never freeze or drop a document. Includes a per-store write strategy (`upsert` vs `remove-then-add`, from measured store behaviour), a startup capability probe (a store without id-addressed removal fails fast with its name instead of dead-lettering the corpus), model-scoped embedding batching/rate limiting, and per-document write serialization.
  - `SyncPassRunner` — one bounded synchronisation pass ending in tracker-versus-source reconciliation (the store is never enumerated), behind the safety interlock: a pass with any failure deletes nothing, a bulk-delete floor (measured against the pre-pass corpus) refuses mass deletion without explicit consent, and only source-origin documents are candidates.
  - `IngestIds` — deterministic RFC 4122 v5 segment ids over a length-prefixed name (two pipelines sharing a store cannot collide); golden-value tests freeze the derivation, since  these ids live in users' vector stores permanently.
  - `IngestResult` — the per-document outcome.

  The module README documents the full document-state machine and the write-path decision diagram. Invariants are pinned by 40 new unit tests, including transient-outage recovery for both write strategies and crash-convergence scenarios.

  This work is not plugged into any existing code: no current extension or code path changes behaviour, the module is purely additive and is the second piece of groundwork for the upcoming declarative `langchain4j-ingest` extension (`sync` mode). Like #9003, it is  **experimental, internal SPI** with no compatibility promise — together with the tracker it  forms the unit that could be replaced by (or proposed to) an upstream LangChain4j record-manager mechanism (langchain4j/langchain4j#2931).

  Dependency note: `java-uuid-generator` (UUIDv5; the JDK only offers v3) is `<optional>` in the support module, so no existing extension inherits it — the future `langchain4j-ingest`  extension declares it explicitly.

  Depends on #9006 — this branch stacks on it and should be rebased/merged after it.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Uncomment and fill this section if your PR is not trivial
[ ] An issue should be filed for the change unless this is a trivial change (fixing a typo or similar). One issue should ideally be fixed by not more than one commit and the other way round, each commit should fix just one issue, without pulling in other changes.
[ ] Each commit in the pull request should have a meaningful and properly spelled subject line and body. Copying the title of the associated issue is typically enough. Please include the issue number in the commit message prefixed by #.
[ ] The pull request description should explain what the pull request does, how, and why. If the info is available in the associated issue or some other external document, a link is enough.
[ ] Phrases like Fix #<issueNumber> or Fixes #<issueNumber> will auto-close the named issue upon merging the pull request. Using them is typically a good idea.
[ ] Please run mvn process-resources -Pformat (and amend the changes if necessary) before sending the pull request.
[ ] Contributor guide is your good friend: https://camel.apache.org/camel-quarkus/latest/contributor-guide.html
-->