### PR TITLE
Fix AWS2 native substitution conflict with Quarkus Amazon Services

### DIFF
--- a/extensions-support/aws2/runtime/src/main/java/org/apache/camel/quarkus/component/aws/commons/ChecksumProviderSubstitutions.java
+++ b/extensions-support/aws2/runtime/src/main/java/org/apache/camel/quarkus/component/aws/commons/ChecksumProviderSubstitutions.java
@@ -37,7 +37,10 @@ final class AwsChecksumSubstitutions {
 /**
  * Avoids references to types that are only available if aws-crt is on the classpath.
  */
-@TargetClass(value = ChecksumProvider.class, onlyWith = ChecksumProviderSubstitutions.AwsCrtIsAbsent.class)
+@TargetClass(value = ChecksumProvider.class, onlyWith = {
+        ChecksumProviderSubstitutions.AwsCrtIsAbsent.class,
+        ChecksumProviderSubstitutions.QuarkusAmazonCrtSubstitutionsAbsent.class
+})
 final class ChecksumProviderSubstitutions {
     @Substitute
     static SdkChecksum crc64NvmeCrtImplementation() {
@@ -63,6 +66,23 @@ final class ChecksumProviderSubstitutions {
         public boolean getAsBoolean() {
             try {
                 Thread.currentThread().getContextClassLoader().loadClass(CRT_CRC64NVME_PATH);
+                return false;
+            } catch (ClassNotFoundException e) {
+                return true;
+            }
+        }
+    }
+
+    /**
+     * Skip these substitutions when Quarkus Amazon Services already registers an equivalent
+     * (and broader) ChecksumProvider substitution.
+     */
+    public static final class QuarkusAmazonCrtSubstitutionsAbsent implements BooleanSupplier {
+        @Override
+        public boolean getAsBoolean() {
+            try {
+                Thread.currentThread().getContextClassLoader()
+                        .loadClass("io.quarkiverse.amazon.common.runtime.CrtSubstitutions");
                 return false;
             } catch (ClassNotFoundException e) {
                 return true;


### PR DESCRIPTION
## Description

Fixes #9010.

### Problem

When a Camel Quarkus AWS2 application is built as a native executable together
with Quarkus Amazon Services, both Camel Quarkus and Quarkus Amazon Services can
register GraalVM substitutions for the same AWS SDK `ChecksumProvider` methods.

This causes the native-image build to fail with a duplicate substitution error.

### Solution

Update the Camel Quarkus AWS2 `ChecksumProvider` substitution to also check
whether Quarkus Amazon Services' `CrtSubstitutions` is present.

Camel Quarkus substitutions are now enabled only when both AWS CRT and the
Quarkus Amazon Services substitution are absent.

This preserves the existing Camel-only AWS2 behavior while avoiding duplicate
GraalVM substitutions when Quarkus Amazon Services provides the equivalent
substitution.

### Test

Added an isolated native-image regression scenario to the AWS2 CloudWatch
integration test by adding `quarkus-amazon-sns`.

The S3 dependency is excluded from the compile-scoped AWS2 test-support
dependency so that `aws-crt` remains absent and the CRT-absent substitution
scenario is exercised.

Verified:

- `git diff --check`
- AWS2 CloudWatch native build: BUILD SUCCESS
- Full Maven build: BUILD SUCCESS
- `./mvnw process-resources -Pformat`: SUCCESS