### PR TITLE
Harden the Jolokia agent access controls

### DIFF
--- a/docs/modules/ROOT/pages/migration-guide/3.39.0.adoc
+++ b/docs/modules/ROOT/pages/migration-guide/3.39.0.adoc
@@ -4,37 +4,83 @@ The following guide outlines how to adapt your code to changes that were made in
 
 == Jolokia extension changes
 
-=== Default bind address changed to localhost
+Jolokia is now locked down by default. In `prod` mode the agent binds to `localhost`, accepts requests only from the local machine, and denies cross-origin requests. Previously it bound to all interfaces and accepted every client.
 
-The Jolokia agent HTTP server now binds to `localhost` by default in production mode (previously `0.0.0.0`). Dev and test modes already defaulted to `localhost`. Remote dev mode and WSL environments continue to default to `0.0.0.0`. This means Jolokia is only accessible from the local machine in production unless explicitly configured otherwise.
+Jolokia now honours `Sec-Fetch-*` headers, rejecting browser requests marked as anything other than an explicit top-level navigation, which affects neither command line clients such as `curl` nor the calls Hawtio makes.
 
-=== Remote access blocked by default
+Refer to the xref:reference/extensions/jolokia.adoc#extensions-jolokia-usage-security[Jolokia extension documentation] for details of the options below.
 
-The default Camel Jolokia restrictor now blocks connections from non-loopback (remote) addresses. This provides defense-in-depth: even if the server host is configured to bind to all interfaces, remote requests are rejected unless the `remote-access-allowed` property is explicitly set to `true`.
+=== Remote clients are refused
 
-=== Cross-origin requests (CORS) blocked by default
+To allow clients from other hosts again.
 
-The default Camel Jolokia restrictor now denies all cross-origin requests from non-loopback origins. If you rely on browser-based monitoring tools connecting cross-origin, configure a https://jolokia.org/reference/html/manual/security.html[Jolokia access policy] (`jolokia-access.xml`) with a `<cors>` section, or use a custom restrictor. See the xref:reference/extensions/jolokia.adoc[Jolokia extension documentation] for details.
-
-=== CamelJolokiaRestrictor no longer extends AllowAllRestrictor
-
-`CamelJolokiaRestrictor` now implements `Restrictor` directly instead of extending Jolokia's `AllowAllRestrictor`. If you have a custom restrictor that extends `AllowAllRestrictor`, consider switching to `extends CamelJolokiaRestrictor` to inherit the secure defaults (remote access control, CORS blocking, MBean domain filtering, `jolokia-access.xml` policy delegation).
-
-=== Jolokia access policy (jolokia-access.xml) delegation
-
-The default Camel Jolokia restrictor now loads `jolokia-access.xml` from the classpath if present and delegates remote access, CORS, HTTP method, and request type checks to it for non-loopback requests. This allows fine-grained access control alongside the Camel MBean domain filtering. The policy location can be configured via `quarkus.camel.jolokia.additional-properties."policyLocation"`.
-
-=== Required configuration for Kubernetes remote management
-
-If you use tools such as https://hawt.io/[Hawtio] or https://github.com/hawtio/hawtio-online[hawtio-online] to connect to Jolokia running on Kubernetes or OpenShift, you must add the following configuration to `application.properties`.
-
-[source]
+[source,properties]
 ----
 quarkus.camel.jolokia.server.host=0.0.0.0
 quarkus.camel.jolokia.remote-access-allowed=true
 ----
 
-This is safe when combined with SSL client authentication (enabled by default in Kubernetes environments), which ensures only clients presenting a valid certificate can connect. Refer to the xref:reference/extensions/jolokia.adoc[Jolokia extension documentation] for full details.
+IMPORTANT: This exposes an agent that authenticates nobody. Confine it to a trusted network, or configure xref:reference/extensions/jolokia.adoc#extensions-jolokia-usage-authentication[authentication], which the extension has always been able to do through `additional-properties` and which is now documented.
+
+Where SSL client authentication is configured, which is the default on OpenShift, the agent still binds `0.0.0.0` and still accepts remote clients. Plain Kubernetes has no service CA certificate, so client authentication cannot be configured there and the agent binds `localhost`. Binding it elsewhere now fails startup rather than warning, unless you acknowledge that nothing authenticates the agent. Switching client authentication off through `additional-properties` does the same, since the agent still binds `0.0.0.0` there.
+
+[source,properties]
+----
+quarkus.camel.jolokia.server.host=0.0.0.0
+quarkus.camel.jolokia.kubernetes.client-authentication-enabled=false
+----
+
+=== Cross-origin requests are denied
+
+Requests with no `Origin` header and those from a loopback origin are still accepted. List any other origin.
+
+[source,properties]
+----
+quarkus.camel.jolokia.allowed-origins=https://hawtio.example.com
+----
+
+`*` is a wildcard, so `*://*.example.com` covers a domain and `*` accepts any origin. `remote-access-allowed` no longer affects origins.
+
+On OpenShift, setting a client principal restricts access to one service identity and also accepts the cross-origin requests that identity forwards, so `allowed-origins` does not have to list the console.
+
+[source,properties]
+----
+quarkus.camel.jolokia.kubernetes.client-principal=cn=hawtio-online.hawtio.svc
+----
+
+=== jolokia-access.xml is now applied
+
+A policy file was previously ignored whenever the Camel restrictor was registered, which is the default. Review yours before upgrading.
+
+* A `<remote>` section decides client addresses outright, so one that does not list `127.0.0.1` refuses local clients too. A policy without that section says nothing about addresses and leaves the loopback default and `quarkus.camel.jolokia.remote-access-allowed` to decide them.
+* The `<cors>` section is not used at all. Move `<allow-origin>` values to `quarkus.camel.jolokia.allowed-origins`, which takes the same wildcard syntax, and replace `<ignore-scheme/>` with `quarkus.camel.jolokia.ignore-origin-scheme=true`.
+* A `policyLocation` pointing at nothing now fails startup. A policy that cannot be parsed denies all access.
+
+=== Proxy headers are part of the client address chain
+
+Jolokia now adds any `Forwarded`, `X-Forwarded-For` and `X-Real-IP` values to the chain of client addresses passed to the restrictor, whatever `trustProxyHeaders` is set to, and every address in the chain has to be allowed. A request claiming to be forwarded on behalf of a remote client is therefore now refused even when it arrives over loopback.
+
+This affects a reverse proxy in front of the agent. The real client is now visible and subject to the same rules as any other, so allow it.
+
+[source,properties]
+----
+quarkus.camel.jolokia.remote-access-allowed=true
+----
+
+WARNING: Every address in the chain must also satisfy a `<remote>` section in an access policy. Hawtio adds the browser's address as `X-Forwarded-For` by default, so a policy restricting addresses to a cluster subnet rejects its requests unless the browser's address is allowed too.
+
+=== Native mode now refuses an HTTPS origin over a plain HTTP agent
+
+Jolokia refuses a request whose `Origin` uses `https` when the agent itself serves plain `http`, responding with a status of `403`, whatever `quarkus.camel.jolokia.allowed-origins` lists. That rule has always applied in JVM mode and now applies in native mode too, so a native application whose agent serves plain HTTP behind an HTTPS console starts returning `403` after upgrading. Either serve the agent over HTTPS, or turn the check off.
+
+[source,properties]
+----
+quarkus.camel.jolokia.ignore-origin-scheme=true
+----
+
+WARNING: Only do this where something in front of the agent terminates TLS. Otherwise, a page loaded over HTTPS ends up driving an agent that is not.
+
+This does not arise on Kubernetes or OpenShift where SSL client authentication is configured, since the agent then serves HTTPS.
 
 == CassandraQL extension changes
 

--- a/docs/modules/ROOT/pages/reference/extensions/jolokia.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/jolokia.adoc
@@ -44,13 +44,13 @@ This extension adds https://jolokia.org/[Jolokia] support to your application.
 [id="extensions-jolokia-usage-jolokia-http-endpoints"]
 === Jolokia HTTP endpoints
 
-Jolokia is accessible at the following URL.
+Jolokia is accessible at http://localhost:8778/jolokia/.
 
-* http://localhost:8778/jolokia/
+The agent HTTP server binds to `localhost`, except in remote dev mode, in dev and test mode on WSL, and on Kubernetes with <<extensions-jolokia-usage-ssl-client-authentication,SSL client authentication>> configured, where it binds to `0.0.0.0`.
 
-By default, the Jolokia agent HTTP server binds to `localhost`. Remote dev mode and WSL environments default to `0.0.0.0`.
+NOTE: Binding `0.0.0.0` in remote dev mode, and on WSL, does not on its own allow remote clients. Client addresses are restricted to loopback in every mode, so reaching the agent from another host also needs `quarkus.camel.jolokia.remote-access-allowed=true`. See <<extensions-jolokia-usage-allowing-remote-clients,Allowing remote clients>>.
 
-If you want to disable Jolokia entirely, then add the following configuration to `application.properties`.
+To disable Jolokia entirely, add the following to `application.properties`.
 
 [source]
 ----
@@ -60,10 +60,9 @@ quarkus.camel.jolokia.enabled=false
 [id="extensions-jolokia-usage-jolokia-configuration"]
 === Jolokia configuration
 
-Any of the https://jolokia.org/reference/html/manual/agents.html[Jolokia configuration options] can be configured via the `quarkus.camel.jolokia.additional-properties.<jolokia-property-name>` option.
-Where `<jolokia-property-name>` is the name of the Jolokia configuration option you want to set.
+Any of the https://jolokia.org/reference/html/manual/agents.html[Jolokia configuration options] can be set via `quarkus.camel.jolokia.additional-properties.<jolokia-property-name>`.
 
-For example, the following configuration added to `application.properties` enables Jolokia debugging and sets the max depth for traversing bean properties.
+For example, to enable Jolokia debugging and set the max depth for traversing bean properties.
 
 [source]
 ----
@@ -71,113 +70,50 @@ quarkus.camel.jolokia.additional-properties.debug=true
 quarkus.camel.jolokia.additional-properties.maxDepth=10
 ----
 
-[id="extensions-jolokia-usage-jolokia-restrictor"]
-=== Jolokia restrictor
-
-By default, a Jolokia restrictor is automatically registered that exposes access to only a specific set of MBean domains.
-
-* `org.apache.camel`
-* `java.lang`
-* `java.nio`
-
-If this is too restrictive, then you can either specify your own MBean domains, disable the default restrictor, or create a custom restrictor.
-
-[id="extensions-jolokia-usage-default-restrictor-mbean-domains"]
-==== Default restrictor MBean domains
-
-You can modify the set of MBean domains referenced by the default restrictor by adding configuration like the following to `application.properties`.
-
-[source]
-----
-quarkus.camel.jolokia.camel-restrictor-allowed-mbean-domains=org.apache.camel
-----
-
-[id="extensions-jolokia-usage-disabling-the-default-restrictor"]
-==== Disabling the default restrictor
-
-The following configuration added to `application.properties` disables the default restrictor.
-
-[source]
-----
-quarkus.camel.jolokia.register-camel-restrictor=false
-----
-
-[id="extensions-jolokia-usage-create-a-custom-restrictor"]
-==== Create a custom restrictor
-
-You can create your own restrictor class and register it with Jolokia. Extending `CamelJolokiaRestrictor` inherits the secure defaults (remote access control, CORS blocking, MBean domain filtering).
-
-[source,java]
-----
-public class CustomRestrictor extends CamelJolokiaRestrictor {
-    // Override methods to apply custom restrictions
-}
-----
-
-Register the restrictor with Jolokia by adding the following configuration to `application.properties`.
-
-[source]
-----
-quarkus.camel.jolokia.additional-properties.restrictorClass=org.acme.CustomRestrictor
-----
-
-[id="extensions-jolokia-usage-kubernetes-openshift-support"]
-=== Kubernetes & OpenShift support
-
-[id="extensions-jolokia-usage-generated-kubernetes-manifests"]
-==== Generated Kubernetes manifests
-
-If the `quarkus-kubernetes` or `quarkus-openshift` extensions are present, a container port named `jolokia` will be added automatically to the pod configuration within the generated Kubernetes manifest resources.
-
-This can be disabled by adding the following configuration to `application.properties`.
-
-[source]
-----
-quarkus.camel.jolokia.kubernetes.expose-container-port=false
-----
-
-[id="extensions-jolokia-usage-automatic-enablement-of-ssl-client-authentication"]
-==== Automatic enablement of SSL client authentication
-
-If the application detects that it is running on Kubernetes or OpenShift, then Jolokia is automatically configured for SSL client authentication.
-This is useful if you use tools like https://hawt.io/[Hawtio] to discover and connect to your running application pod.
-
-This functionality can be disabled by adding the following configuration to `application.properties`.
-
-[source]
-----
-quarkus.camel.jolokia.kubernetes.client-authentication-enabled=false
-----
-
-[id="extensions-jolokia-usage-configuring-jolokia-for-remote-management-tools"]
-==== Configuring Jolokia for remote management tools
-
-Tools such as https://hawt.io/[Hawtio] and https://github.com/hawtio/hawtio-online[hawtio-online] connect to Jolokia via the pod IP address, which is a non-loopback address. By default, the Jolokia agent binds to `localhost` and the default restrictor blocks connections from non-loopback addresses.
-
-To allow remote management tools to connect to Jolokia in Kubernetes, add the following configuration to `application.properties`.
-
-[source]
-----
-quarkus.camel.jolokia.server.host=0.0.0.0
-quarkus.camel.jolokia.remote-access-allowed=true
-----
-
-This is safe when combined with SSL client authentication (enabled by default in Kubernetes), which ensures that only clients presenting a valid certificate signed by the service CA can connect. If you use hawtio-online, you must also configure the Jolokia client principal.
-
-[source]
-----
-quarkus.camel.jolokia.kubernetes.client-principal=cn=hawtio-online.hawtio.svc
-----
-
 [id="extensions-jolokia-usage-security"]
-=== Security
+== Security
 
-NOTE: Even when bound to `localhost`, Jolokia does not require authentication by default. On shared hosts or in container environments where localhost may be reachable from other containers, consider using a custom restrictor or Jolokia access policy to restrict access further.
+By default, Jolokia is reachable only from the machine the application runs on, and exposes only Camel and JVM MBeans. The defaults are applied by `CamelJolokiaRestrictor`, which is registered automatically.
 
-[id="extensions-jolokia-usage-network-binding"]
-==== Network binding
+[width="100%",cols="20,50,30",options="header"]
+|===
+| | Default | Configured by
 
-By default, the Jolokia agent HTTP server binds to `localhost`, making it accessible only from the local machine. If you need to expose Jolokia to remote hosts, you must explicitly configure the bind address and enable remote access.
+| Bind address
+| `localhost`, or `0.0.0.0` on Kubernetes with SSL client authentication
+| `quarkus.camel.jolokia.server.host`
+
+| Client addresses
+| Loopback addresses only, such as `127.0.0.1` and `::1`, regardless of the bind address. Lifted on Kubernetes with SSL client authentication, which authenticates every client
+| `quarkus.camel.jolokia.remote-access-allowed`
+
+| Cross-origin requests
+| Denied, except loopback origins and requests carrying no `Origin` header. Lifted on Kubernetes when `kubernetes.client-principal` is set and no origins are listed here
+| `quarkus.camel.jolokia.allowed-origins`
+
+| MBean domains
+| `org.apache.camel`, `java.lang`, `java.nio`
+| `quarkus.camel.jolokia.camel-restrictor-allowed-mbean-domains`
+|===
+
+[id="extensions-jolokia-usage-authentication"]
+=== Authentication
+
+Jolokia can require HTTP basic authentication. It is off by default and is configured through the agent's own options.
+
+[source]
+----
+quarkus.camel.jolokia.additional-properties.authMode=basic
+quarkus.camel.jolokia.additional-properties.user=jolokia
+quarkus.camel.jolokia.additional-properties.password=${JOLOKIA_PASSWORD}
+----
+
+IMPORTANT: Basic authentication sends the password on every request, so serve the agent over HTTPS or keep it off untrusted networks. On Kubernetes and OpenShift, <<extensions-jolokia-usage-ssl-client-authentication,SSL client authentication>> is the better option and is already enabled by default.
+
+[id="extensions-jolokia-usage-allowing-remote-clients"]
+=== Allowing remote clients
+
+To reach the agent from another host, open up both the bind address and remote access.
 
 [source]
 ----
@@ -185,24 +121,84 @@ quarkus.camel.jolokia.server.host=0.0.0.0
 quarkus.camel.jolokia.remote-access-allowed=true
 ----
 
-[id="extensions-jolokia-usage-remote-access-control"]
-==== Remote access control
+This opens up client addresses only. Cross-origin requests remain restricted, so a browser based console needs its origin listed as well. See <<extensions-jolokia-usage-allowing-cross-origin-requests,Allowing cross-origin requests>>.
 
-The default Camel Jolokia restrictor blocks connections from non-loopback addresses. This is controlled by the `quarkus.camel.jolokia.remote-access-allowed` property (default `false`). When set to `false`, only connections from loopback addresses (e.g. `127.0.0.1`, `::1`) are accepted, regardless of the server bind address.
+A reverse proxy in front of the agent needs this too, even on the same host, since the client address it forwards is not a loopback address.
 
-[id="extensions-jolokia-usage-cross-origin-requests-cors"]
-==== Cross-origin requests (CORS)
+NOTE: Turning on `quarkus.camel.jolokia.additional-properties.allowDnsReverseLookup`, which Jolokia leaves off, adds the name the client address resolves back to. A host whose loopback address resolves to something other than `localhost` then refuses local clients too, answering `No access from client [chain: myhost -> 127.0.0.1] allowed`. Allow the name through the `<remote>` section of an <<extensions-jolokia-usage-access-policy-files,access policy>>.
 
-The default Camel Jolokia restrictor denies all cross-origin requests. If you need to allow specific origins (e.g. for a browser-based monitoring tool connecting cross-origin), you can use a https://jolokia.org/reference/html/manual/security.html[Jolokia access policy] (`jolokia-access.xml`) with a `<cors>` section, or configure a custom restrictor that overrides `isOriginAllowed()`.
+IMPORTANT: This exposes an agent that authenticates nobody. Anyone who can reach it gets full access to the allowed MBean domains, which by default means invoking Camel management operations such as `sendStringBody`, which sends a message to any endpoint the application can resolve, and stopping the `CamelContext`. Confine the agent to a trusted network, or configure <<extensions-jolokia-usage-authentication,authentication>>.
 
-[id="extensions-jolokia-usage-jolokia-access-policy"]
-==== Jolokia access policy
+[id="extensions-jolokia-usage-allowing-cross-origin-requests"]
+=== Allowing cross-origin requests
 
-Jolokia supports fine-grained access control via an XML policy file (`jolokia-access.xml`). This can restrict access by IP address, CORS origin, HTTP method, and MBean operation.
+To let a browser based tool such as https://hawt.io/[Hawtio] drive the agent, list its origin.
 
-The default Camel restrictor automatically loads `jolokia-access.xml` from the classpath if present. Place the file in `src/main/resources/jolokia-access.xml` to use it alongside the Camel restrictor. The Camel restrictor always allows loopback connections. For non-loopback requests, it delegates remote access, CORS, allowed request types (`<commands>`), and HTTP method (`<http>`) checks to the policy file, while continuing to enforce MBean domain filtering.
+[source]
+----
+quarkus.camel.jolokia.allowed-origins=https://hawtio.example.com
+----
 
-For example, the following `jolokia-access.xml` allows access from the `10.0.0.0/8` subnet, CORS requests from a monitoring tool, and restricts Jolokia to read-only operations over HTTP GET.
+Matching is case insensitive, and `*` is a wildcard, exactly as in the `<allow-origin>` rules of a Jolokia access policy. So a whole domain can be covered in one entry.
+
+[source]
+----
+quarkus.camel.jolokia.allowed-origins=*://*.example.com
+----
+
+A value of `*` on its own accepts any origin.
+
+Each value is matched against the scheme, host and port of the request origin, so a path or query in the entry never matches. A port that is the default for the scheme is optional, so `https://hawtio.example.com` and `https://hawtio.example.com:443` are interchangeable. Any other port has to be listed, since `https://hawtio.example.com:8443` is a different origin. An internationalised host has to be listed in its punycode form, such as `https://xn--e1afmkfd.example`, since that is what a browser sends. A host containing an underscore cannot be matched at all, as it is not a valid host name, so such an origin is always refused.
+
+Loopback origins are always accepted, so that a console on the same machine needs no configuration. That still applies once `quarkus.camel.jolokia.remote-access-allowed` has opened the agent to other hosts, so a page served from `localhost` in any browser that can reach the agent is accepted as well.
+
+IMPORTANT: This property is the only way to allow an origin. The `<cors>` section of a `jolokia-access.xml` access policy is *not* used at all. If you are bringing an existing policy file, copy its `<allow-origin>` values here unchanged, replace `<ignore-scheme/>` with `quarkus.camel.jolokia.ignore-origin-scheme=true`, and delete the section.
+
+[id="extensions-jolokia-usage-requests-with-no-origin"]
+==== Requests with no origin
+
+A request carrying neither an `Origin` nor a `Referer` header is accepted, so that command line clients such as `curl` keep working. There is no equivalent of the `<strict-checking/>` element of an access policy to turn that off.
+
+Browsers are stopped from exploiting this by Jolokia's handling of the `Sec-Fetch-*` headers, which refuses anything a browser marks as other than an explicit top-level navigation. Leave that in place.
+
+[source]
+----
+# Do not do this
+quarkus.camel.jolokia.additional-properties.useFetchMetadata=false
+----
+
+[id="extensions-jolokia-usage-https-origins-and-a-plain-http-agent"]
+==== HTTPS origins and a plain HTTP agent
+
+Jolokia refuses a request whose `Origin` uses `https` when the agent itself serves plain `http`, responding with a status of `403`, whatever `allowed-origins` lists.
+
+Either serve the agent over HTTPS, or turn the check off.
+
+[source]
+----
+quarkus.camel.jolokia.ignore-origin-scheme=true
+----
+
+WARNING: Only do this where something in front of the agent terminates TLS. Otherwise, a page loaded over HTTPS ends up driving an agent that is not.
+
+This does not arise where <<extensions-jolokia-usage-ssl-client-authentication,SSL client authentication>> is configured, since the agent then serves HTTPS.
+
+[id="extensions-jolokia-usage-mbean-domains"]
+=== MBean domains
+
+The restrictor hides MBeans outside the allowed domains, and denies reads, writes and operations against them. Adjust the set as needed.
+
+[source]
+----
+quarkus.camel.jolokia.camel-restrictor-allowed-mbean-domains=org.apache.camel,java.lang
+----
+
+[id="extensions-jolokia-usage-access-policy-files"]
+=== Access policy files
+
+Jolokia supports fine grained access control via an XML policy file, which can restrict access by IP address, HTTP method, request type and MBean operation. Refer to the https://jolokia.org/reference/html/manual/security.html[Jolokia security documentation] for the full format.
+
+Place the file at `src/main/resources/jolokia-access.xml` and it is picked up automatically. For example, the following policy allows the `10.0.0.0/8` subnet and restricts Jolokia to read-only operations over HTTP GET.
 
 [source,xml]
 ----
@@ -211,9 +207,6 @@ For example, the following `jolokia-access.xml` allows access from the `10.0.0.0
     <remote>
         <host>10.0.0.0/8</host>
     </remote>
-    <cors>
-        <allow-origin>http://monitoring.example.com</allow-origin>
-    </cors>
     <commands>
         <command>read</command>
         <command>list</command>
@@ -226,28 +219,179 @@ For example, the following `jolokia-access.xml` allows access from the `10.0.0.0
 </restrict>
 ----
 
-Refer to the https://jolokia.org/reference/html/manual/security.html[Jolokia security documentation] for the full policy file format.
-
-To load the policy file from a different location, such as a file path mounted from a Kubernetes ConfigMap, configure the `policyLocation` property.
+To load the policy from elsewhere, such as a file mounted from a Kubernetes ConfigMap, set `policyLocation`.
 
 [source]
 ----
 quarkus.camel.jolokia.additional-properties."policyLocation"=file:/etc/jolokia/jolokia-access.xml
 ----
 
-As an alternative, you can disable the default Camel restrictor entirely and let Jolokia manage the policy file directly. This gives full control to `jolokia-access.xml` (including MBean-level rules) but loses the Camel MBean domain filtering.
+[id="extensions-jolokia-usage-how-a-policy-combines-with-the-restrictor"]
+==== How a policy combines with the restrictor
+
+The policy's `<remote>`, `<commands>`, `<http>` and MBean level rules (`<allow>`, `<deny>`, `<filter>`) all apply. MBean domain filtering applies on top of them.
+
+* A `<remote>` section decides client addresses. `quarkus.camel.jolokia.remote-access-allowed` and the loopback default no longer apply, so a `<remote>` section that does not list `127.0.0.1` refuses local clients too.
+* A policy with no `<remote>` section says nothing about addresses, so the loopback default and `quarkus.camel.jolokia.remote-access-allowed` still decide them. A `<remote>` section listing `0.0.0.0/0` is read the same way, since it grants no more than saying nothing does.
+* The `<cors>` section is not consulted at all. Use `quarkus.camel.jolokia.allowed-origins` in place of `<allow-origin>`, and `quarkus.camel.jolokia.ignore-origin-scheme` in place of `<ignore-scheme/>`. `<strict-checking/>` has no equivalent.
+* Where a proxy forwards the client address in a `Forwarded`, `X-Forwarded-For` or `X-Real-IP` header, `<remote>` has to allow that address as well. Hawtio forwards the browser address by default.
+
+[id="extensions-jolokia-usage-loading-failures"]
+==== Loading failures
+
+A `policyLocation` that is configured but points at nothing fails the application at startup. This covers a `classpath:` location that was not packaged, and a `file:` location that is not there, such as a ConfigMap that failed to mount.
+
+A policy that is found but cannot be read or parsed denies all Jolokia access and logs an error.
+
+In native mode, a policy at the default `jolokia-access.xml` location is registered as a resource automatically. A policy loaded from any other `classpath:` location must be registered by your application.
+
+[source]
+----
+quarkus.native.resources.includes=my-jolokia-access.xml
+----
+
+[id="extensions-jolokia-usage-custom-restrictors"]
+=== Custom restrictors
+
+Extending `CamelJolokiaRestrictor` inherits the secure defaults described above, including access policy handling.
+
+The access checks are `final`. A subclass adds restrictions through the `allows*` hooks, which are called only once the inherited checks have allowed the request.
+
+[source,java]
+----
+public class CustomRestrictor extends CamelJolokiaRestrictor {
+    @Override
+    protected boolean allowsOperation(ObjectName objectName, String operation) {
+        return operation.startsWith("dump");
+    }
+}
+----
+
+Each hook returns `true` to keep the inherited decision and `false` to refuse, so a subclass can only narrow what the defaults permit.
+
+[width="100%",cols="45,55",options="header"]
+|===
+| Hook | Narrows
+
+| `allowsRemoteAccess(String...)` | Which client addresses may reach the agent
+| `allowsOrigin(String, boolean)` | Which origins may reach the agent
+| `allowsHttpMethod(HttpMethod)` | Which HTTP methods may be used
+| `allowsRequestType(RequestType)` | Which Jolokia request types may be used
+| `allowsAttributeRead(ObjectName, String)` | Which attributes may be read
+| `allowsAttributeWrite(ObjectName, String)` | Which attributes may be written
+| `allowsOperation(ObjectName, String)` | Which operations may be invoked
+| `allowsObjectName(ObjectName)` | Which MBeans are listed
+|===
+
+`isAllowedDomain(ObjectName)` is `protected`, for a hook that needs the domain restriction. The inherited checks apply it already.
+
+To grant access, use the configuration options above. Implementing Jolokia's `Restrictor` interface directly replaces these decisions and inherits none of the defaults.
+
+[source]
+----
+quarkus.camel.jolokia.additional-properties.restrictorClass=org.acme.CustomRestrictor
+----
+
+Alternatively, disabling the Camel restrictor hands full control to `jolokia-access.xml`, including its `<cors>` section and MBean level rules, but loses MBean domain filtering and every property described above.
 
 [source]
 ----
 quarkus.camel.jolokia.register-camel-restrictor=false
 ----
 
-If you are building a native executable, the policy file must be explicitly included as a native resource.
+WARNING: With no restrictor and no access policy, Jolokia is unrestricted.
+
+[id="extensions-jolokia-usage-kubernetes-openshift"]
+== Kubernetes & OpenShift
+
+[id="extensions-jolokia-usage-generated-kubernetes-manifests"]
+=== Generated Kubernetes manifests
+
+If the `quarkus-kubernetes` or `quarkus-openshift` extensions are present, a production build adds a container port named `jolokia` to the container spec of the generated manifests. To disable this.
 
 [source]
 ----
-quarkus.native.resources.includes=jolokia-access.xml
+quarkus.camel.jolokia.kubernetes.expose-container-port=false
 ----
+
+[id="extensions-jolokia-usage-ssl-client-authentication"]
+=== SSL client authentication
+
+On Kubernetes and OpenShift, Jolokia is configured for SSL client authentication wherever the service CA certificate is present, so that only clients presenting a certificate signed by it can connect. This is the default on OpenShift.
+
+Because every client is then authenticated by the transport, the agent binds `0.0.0.0` rather than `localhost` and the loopback restriction on client addresses does not apply.
+
+The certificate is checked against the service CA only, so unless a client principal is configured, any client holding a certificate the CA happened to sign is accepted. Restrict this to a specific service identity.
+
+[source]
+----
+quarkus.camel.jolokia.kubernetes.client-principal=cn=hawtio-online.hawtio.svc
+----
+
+Once a client principal is set, the authenticated peer is a known identity rather than any certificate holder, so cross-origin requests it forwards are accepted and <<extensions-jolokia-usage-allowing-cross-origin-requests,`allowed-origins`>> does not have to list the console. Setting `allowed-origins` anyway still takes effect, being the more specific instruction.
+
+NOTE: Only `quarkus.camel.jolokia.kubernetes.client-principal` accepts those cross-origin requests. Jolokia reads the same value from a `clientPrincipal` option, and from `clientPrincipal.1`, `clientPrincipal.2` and so on for several identities, either of which can be set through `quarkus.camel.jolokia.additional-properties`. Both restrict which certificate is accepted, but the restrictor does not read them, so cross-origin requests stay restricted. The `Origins:` value in the Jolokia line logged at startup shows which applies.
+
+Without a client principal, cross-origin requests remain restricted to loopback origins and whatever `allowed-origins` lists. A startup warning says so.
+
+To disable SSL client authentication entirely.
+
+[source]
+----
+quarkus.camel.jolokia.kubernetes.client-authentication-enabled=false
+----
+
+WARNING: Disabling it opts out of the only thing authenticating clients. The agent then falls back to binding `localhost` and accepting loopback clients only, exactly as it does off Kubernetes. Opening it up again with `server.host` and `remote-access-allowed` would expose an unauthenticated agent to the pod network.
+
+NOTE: The default `service-ca-cert` path is written by the OpenShift service CA operator and is absent on vanilla Kubernetes, where none of the above applies unless `quarkus.camel.jolokia.kubernetes.service-ca-cert` is pointed at a CA certificate you mount yourself.
+
+Where client authentication is enabled but not in effect, because the certificate is absent or `additional-properties` overrode one of the options it is made of, the application fails to start unless the agent is bound to `localhost`. Mount a certificate, bind to `localhost`, or set `client-authentication-enabled=false`.
+
+[id="extensions-jolokia-usage-hawtio-hawtio-online"]
+== Hawtio & Hawtio Online
+
+https://hawt.io/[Hawtio] and https://github.com/hawtio/hawtio-online[Hawtio Online] proxy browser requests to the agent, forwarding the browser `Origin` header and adding the browser address as `X-Forwarded-For`.
+
+Hawtio running on the same machine as the application needs no configuration. Both the origin it forwards and the address it adds are loopback, so the defaults accept them. Everything below concerns reaching an agent on another host, which is how Hawtio Online always connects, via the pod IP address.
+
+Hawtio lists MBeans beyond those of Camel and the JVM. Add any other domain it should show, such as `org.apache.activemq.artemis`, to <<extensions-jolokia-usage-mbean-domains,`camel-restrictor-allowed-mbean-domains`>>.
+
+[id="extensions-jolokia-usage-on-kubernetes-openshift"]
+=== On Kubernetes & OpenShift
+
+<<extensions-jolokia-usage-ssl-client-authentication,SSL client authentication>> already covers the bind address, the client addresses and, once the client principal is pinned, the console origin. A deployment following the Hawtio Online instructions therefore needs one property.
+
+[source]
+----
+quarkus.camel.jolokia.kubernetes.client-principal=cn=hawtio-online.hawtio.svc
+----
+
+This is the subject of the client certificate Hawtio Online presents, which its `generate-proxying.sh` issues with a CN of `hawtio-online.hawtio.svc` by default, where `hawtio` is the namespace. Adjust it if the certificate was generated with a different CN or namespace.
+
+To restrict which console origins are accepted on top of that, list them.
+
+[source]
+----
+quarkus.camel.jolokia.allowed-origins=https://hawtio-online.apps.example.com
+----
+
+The origin to list is the address the browser uses for the Hawtio console, not the address of the agent.
+
+[id="extensions-jolokia-usage-anywhere-else"]
+=== Anywhere else
+
+With nothing authenticating clients, the agent has to be opened up explicitly.
+
+[source]
+----
+quarkus.camel.jolokia.server.host=0.0.0.0
+quarkus.camel.jolokia.remote-access-allowed=true
+quarkus.camel.jolokia.allowed-origins=https://hawtio.example.com
+----
+
+On plain Kubernetes, add `quarkus.camel.jolokia.kubernetes.client-authentication-enabled=false` as well. SSL client authentication is enabled by default and cannot be configured there, so binding to a non-loopback address otherwise fails at startup.
+
+The agent serves plain HTTP here, so an `https` console origin is refused whatever `allowed-origins` lists. See <<extensions-jolokia-usage-https-origins-and-a-plain-http-agent,HTTPS origins and a plain HTTP agent>>.
 
 
 [id="extensions-jolokia-camel-quarkus-limitations"]
@@ -260,6 +404,13 @@ JMX in GraalVM is still *experimental*. Therefore, some features are not availab
 
 Refer to the Camel Quarkus Management extension xref:reference/extensions/management.adoc#extensions-management-limitations-native-mode[limitations] section for more details.
 
+
+[id="extensions-jolokia-ssl-in-native-mode"]
+== SSL in native mode
+
+This extension auto-enables SSL support in native mode. Hence you do not need to add
+`quarkus.ssl.native=true` to your `application.properties` yourself. See also
+https://quarkus.io/guides/native-and-ssl[Quarkus SSL guide].
 
 [id="extensions-jolokia-additional-camel-quarkus-configuration"]
 == Additional Camel Quarkus configuration
@@ -305,8 +456,8 @@ This can be done via `@Inject CamelQuarkusJolokiaServer` and then invoking the `
 a| [[quarkus-camel-jolokia-server-host]]`link:#quarkus-camel-jolokia-server-host[quarkus.camel.jolokia.server.host]`
 
 The host address to which the Jolokia agent HTTP server should bind.
-When unspecified, the default is localhost in all modes except remote dev,
-where it defaults to 0.0.0.0.
+When unspecified, the default is localhost, except in remote dev mode, in dev and test mode on WSL,
+and on Kubernetes with SSL client authentication configured, where it defaults to 0.0.0.0.
 | `string`
 | 
 
@@ -340,7 +491,12 @@ Absolute path of the CA certificate Jolokia should use for SSL client authentica
 
 a| [[quarkus-camel-jolokia-kubernetes-client-principal]]`link:#quarkus-camel-jolokia-kubernetes-client-principal[quarkus.camel.jolokia.kubernetes.client-principal]`
 
-The principal which must be given in a client certificate to allow access to Jolokia.
+The principal which must be given in a client certificate to allow access to Jolokia. For example
+`cn=hawtio-online.hawtio.svc`.
+
+Without it, any client holding a certificate signed by the service CA is accepted. Setting it also
+lets the default Camel Jolokia restrictor accept cross-origin requests forwarded by that client,
+since the authenticated peer is then a known identity.
 | `string`
 | 
 
@@ -369,8 +525,64 @@ a| [[quarkus-camel-jolokia-remote-access-allowed]]`link:#quarkus-camel-jolokia-r
 
 When `true`, the default Camel Jolokia restrictor allows connections from non-loopback (remote) addresses.
 When `false` (the default), only connections from loopback addresses (e.g. 127.0.0.1, ::1) are permitted.
-This provides defense-in-depth: even if the server host is configured to bind to all interfaces,
-remote requests are rejected unless this property is explicitly set to `true`.
+
+This controls client addresses only. Cross-origin requests remain restricted to loopback origins and
+whatever `quarkus.camel.jolokia.allowed-origins` lists.
+
+This option only takes effect when `register-camel-restrictor` is `true` and a custom restrictor class
+is not configured via `quarkus.camel.jolokia.additional-properties."restrictorClass"`. It is ignored when a
+Jolokia access policy (`jolokia-access.xml`) carries a `<remote>` section, since that section decides
+client addresses outright. A policy with no `<remote>` section says nothing about addresses, so this
+option still applies.
+
+It is not needed on Kubernetes when
+`quarkus.camel.jolokia.kubernetes.client-authentication-enabled` is `true` and the service CA certificate
+is present, since SSL client authentication then authenticates every client and non-loopback addresses are
+already accepted.
+| `boolean`
+| `false`
+
+a| [[quarkus-camel-jolokia-allowed-origins]]`link:#quarkus-camel-jolokia-allowed-origins[quarkus.camel.jolokia.allowed-origins]`
+
+Origins from which the default Camel Jolokia restrictor accepts cross-origin requests, in addition to
+loopback origins and requests that carry no `Origin` header. That loopback exception still applies once
+`quarkus.camel.jolokia.remote-access-allowed` has opened the agent to clients on other hosts.
+
+Each value is matched against the scheme, host and port of the request `Origin` header, for example
+`https://myhost.example.com`. A port that is the default for the scheme is optional. Matching is
+case-insensitive and `*` is a wildcard, as in the `<allow-origin>` rules of a Jolokia access policy, so
+`*://*.example.com` covers a whole domain and `*` on its own accepts any origin.
+
+Jolokia falls back to the `Referer` header when a request carries no `Origin`. Such a value is reduced to
+its origin before being matched, so only the origin needs listing.
+
+This is the only way to allow an origin. The `<cors>` section of a Jolokia access policy
+(`jolokia-access.xml`) is not used, though `<allow-origin>` values can be copied here unchanged and
+`<ignore-scheme/>` has an equivalent in `quarkus.camel.jolokia.ignore-origin-scheme`. The rest of a
+policy is applied as normal.
+
+Note that Jolokia itself rejects a request whose `Origin` uses `https` when the agent is serving plain
+`http`, whatever this option is set to.
+
+On Kubernetes, cross-origin requests are accepted without this option once
+`quarkus.camel.jolokia.kubernetes.client-principal` pins which client identity may connect. Setting it
+anyway restores the origin check, since an explicit list is the more specific instruction.
+
+This option only takes effect when `register-camel-restrictor` is `true` and a custom restrictor class
+is not configured via `quarkus.camel.jolokia.additional-properties."restrictorClass"`.
+| List of `string`
+| 
+
+a| [[quarkus-camel-jolokia-ignore-origin-scheme]]`link:#quarkus-camel-jolokia-ignore-origin-scheme[quarkus.camel.jolokia.ignore-origin-scheme]`
+
+When `true`, Jolokia stops refusing a request whose `Origin` uses `https` while the agent itself serves
+plain `http`. That rule applies whatever `quarkus.camel.jolokia.allowed-origins` lists.
+
+Enable it only where the agent sits behind something that terminates TLS, since it otherwise allows a
+page loaded over HTTPS to be served by an agent that is not.
+
+This is the equivalent of `<ignore-scheme/>` in the `<cors>` section of a Jolokia access policy, which is
+not consulted.
 
 This option only takes effect when `register-camel-restrictor` is `true` and a custom restrictor class
 is not configured via `quarkus.camel.jolokia.additional-properties."restrictorClass"`.

--- a/extensions/jolokia/deployment/src/main/java/org/apache/camel/quarkus/jolokia/deployment/JolokiaProcessor.java
+++ b/extensions/jolokia/deployment/src/main/java/org/apache/camel/quarkus/jolokia/deployment/JolokiaProcessor.java
@@ -33,6 +33,7 @@ import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.ApplicationInfoBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
+import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.IndexDependencyBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
@@ -76,6 +77,11 @@ public class JolokiaProcessor {
     @BuildStep
     FeatureBuildItem feature() {
         return new FeatureBuildItem(FEATURE);
+    }
+
+    @BuildStep
+    ExtensionSslNativeSupportBuildItem sslNativeSupport() {
+        return new ExtensionSslNativeSupportBuildItem(FEATURE);
     }
 
     @BuildStep
@@ -198,6 +204,11 @@ public class JolokiaProcessor {
         // Include Jolokia static configuration defaults
         nativeImageResource.produce(new NativeImageResourceBuildItem("default-jolokia-agent.properties"));
         nativeImageResource.produce(new NativeImageResourceBuildItem("version.properties"));
+
+        // Include the access policy from the default location, so that it is not silently absent at runtime.
+        // A policy at a location configured via additional-properties."policyLocation" has to be registered by
+        // the application, and CamelJolokiaRestrictor fails startup if it does not resolve
+        nativeImageResource.produce(new NativeImageResourceBuildItem("jolokia-access.xml"));
     }
 
     private static void configureJolokiaServiceNativeSupport(

--- a/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/CamelJolokiaRestrictorAllowOriginParityTest.java
+++ b/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/CamelJolokiaRestrictorAllowOriginParityTest.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.jolokia;
+
+import java.util.List;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import io.quarkus.test.QuarkusUnitTest;
+import org.apache.camel.quarkus.jolokia.restrictor.CamelJolokiaRestrictor;
+import org.jolokia.server.core.restrictor.policy.CorsChecker;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The documentation says the `<allow-origin>` values of a Jolokia access policy can be moved to
+ * `allowed-origins` unchanged, which holds only while both compile a value the same way. Jolokia is not
+ * obliged to keep that syntax, so this compares the two rather than trusting them to stay aligned. A failure
+ * means the wildcard syntax has diverged upstream and the documentation no longer holds.
+ *
+ * Only the subset where the two are meant to agree is compared. The restrictor deliberately differs elsewhere:
+ * it reduces a value to a scheme, host and port before matching, matches a default port in either spelling,
+ * lowercases the request, and allows loopback origins outright, none of which Jolokia does. So the origins
+ * below are lowercase, carry no path, no credentials, no default port, and no loopback host.
+ */
+class CamelJolokiaRestrictorAllowOriginParityTest {
+
+    private static final List<String> ALLOW_ORIGINS = List.of(
+            "https://console.example.com",
+            "*://*.wild.example.com",
+            "https://*.example.org",
+            "http://fixed.example.net:8080");
+
+    private static final List<String> ORIGINS = List.of(
+            // Exact matches and near misses
+            "https://console.example.com",
+            "https://other.example.com",
+            "http://console.example.com",
+            "https://console.example.com.evil.example",
+            "https://evil.example",
+            // Wildcard scheme and host
+            "https://a.wild.example.com",
+            "http://a.wild.example.com",
+            "https://a.b.wild.example.com",
+            "https://wild.example.com",
+            "https://wild.example.com.evil.example",
+            // Wildcard host only
+            "https://x.example.org",
+            "http://x.example.org",
+            "https://example.org",
+            // Explicit non default port
+            "http://fixed.example.net:8080",
+            "http://fixed.example.net:8081",
+            "http://fixed.example.net");
+
+    @RegisterExtension
+    static final QuarkusUnitTest CONFIG = new QuarkusUnitTest()
+            .overrideConfigKey("quarkus.camel.jolokia.allowed-origins", String.join(",", ALLOW_ORIGINS));
+
+    @Test
+    void wildcardSyntaxMatchesJolokia() throws Exception {
+        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
+        CorsChecker corsChecker = corsCheckerFor(ALLOW_ORIGINS);
+
+        for (String origin : ORIGINS) {
+            assertEquals(corsChecker.check(origin, false), restrictor.isOriginAllowed(origin, true),
+                    "Jolokia and the Camel restrictor disagree on " + origin
+                            + ", so an <allow-origin> value no longer means the same in allowed-origins");
+        }
+    }
+
+    /**
+     * A corpus that only ever produced one verdict would agree with anything, including a restrictor that
+     * refused everything.
+     */
+    @Test
+    void corpusCoversBothVerdicts() {
+        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
+        long allowed = ORIGINS.stream().filter(origin -> restrictor.isOriginAllowed(origin, true)).count();
+
+        assertTrue(allowed > 0, "No origin in the corpus is allowed");
+        assertTrue(allowed < ORIGINS.size(), "Every origin in the corpus is allowed");
+    }
+
+    /**
+     * Builds the policy document Jolokia's own checker expects, so that the comparison runs against the real
+     * implementation rather than a copy of it. The document is assembled rather than parsed, so no XML is read.
+     */
+    private static CorsChecker corsCheckerFor(List<String> allowOrigins) throws Exception {
+        Document document = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+        Element restrict = document.createElement("restrict");
+        document.appendChild(restrict);
+
+        Element cors = document.createElement("cors");
+        restrict.appendChild(cors);
+
+        for (String allowOrigin : allowOrigins) {
+            Element element = document.createElement("allow-origin");
+            element.setTextContent(allowOrigin);
+            cors.appendChild(element);
+        }
+
+        return new CorsChecker(document);
+    }
+}

--- a/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/CamelJolokiaRestrictorAllowedOriginsTest.java
+++ b/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/CamelJolokiaRestrictorAllowedOriginsTest.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.jolokia;
+
+import io.quarkus.test.QuarkusUnitTest;
+import org.apache.camel.quarkus.jolokia.restrictor.CamelJolokiaRestrictor;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Cross-origin access is granted by Camel Quarkus configuration rather than by reinterpreting the allow-origin
+ * rules of a Jolokia access policy, which do not grant access on a plain Jolokia agent either.
+ */
+class CamelJolokiaRestrictorAllowedOriginsTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest CONFIG = new QuarkusUnitTest()
+            .overrideConfigKey("quarkus.camel.jolokia.allowed-origins",
+                    "https://domain.example.com,https://monitoring.example.com");
+
+    @Test
+    void configuredOriginsAllowed() {
+        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
+        assertTrue(restrictor.isOriginAllowed("https://domain.example.com", true));
+        assertTrue(restrictor.isOriginAllowed("https://monitoring.example.com", true));
+    }
+
+    @Test
+    void originMatchingIsCaseInsensitive() {
+        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
+        assertTrue(restrictor.isOriginAllowed("HTTPS://domain.Example.COM", true));
+    }
+
+    @Test
+    void unlistedOriginsDenied() {
+        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
+        assertFalse(restrictor.isOriginAllowed("https://untrusted.example", true));
+        // Matched in full, so neither a prefix nor a suffix of a listed origin is enough
+        assertFalse(restrictor.isOriginAllowed("https://domain.example.com.untrusted.example", true));
+        assertFalse(restrictor.isOriginAllowed("https://bad.domain.example.com", true));
+        assertFalse(restrictor.isOriginAllowed("https://domain.example.com:8443", true));
+        // A different scheme is a different origin
+        assertFalse(restrictor.isOriginAllowed("http://domain.example.com", true));
+    }
+
+    /**
+     * Jolokia falls back to the Referer header when a request carries no Origin, which happens for any
+     * same-origin GET a console proxies through. A Referer carries a path, so the value has to be reduced to an
+     * origin before being matched, or a listed origin would be refused.
+     */
+    @Test
+    void refererStyleValuesMatchTheListedOrigin() {
+        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
+        assertTrue(restrictor.isOriginAllowed("https://domain.example.com/", true));
+        assertTrue(restrictor.isOriginAllowed("https://domain.example.com/jolokia/read/java.lang:type=Memory", true));
+        assertTrue(restrictor.isOriginAllowed("https://domain.example.com/x?y=z#frag", true));
+        // Reducing to an origin must not turn a foreign host into a listed one
+        assertFalse(restrictor.isOriginAllowed("https://untrusted.example/https://domain.example.com", true));
+    }
+
+    /**
+     * A port that is the default for the scheme is left out, matching how a browser serialises an origin.
+     */
+    @Test
+    void defaultPortsAreEquivalentToNoPort() {
+        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
+        assertTrue(restrictor.isOriginAllowed("https://domain.example.com:443", true));
+        assertFalse(restrictor.isOriginAllowed("https://domain.example.com:80", true));
+    }
+
+    @Test
+    void valuesThatAreNotOriginsDenied() {
+        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
+        // Opaque origin, sent by sandboxed frames and some redirects
+        assertFalse(restrictor.isOriginAllowed("null", true));
+        assertFalse(restrictor.isOriginAllowed("", true));
+        assertFalse(restrictor.isOriginAllowed("//domain.example.com", true));
+        assertFalse(restrictor.isOriginAllowed("domain.example.com", true));
+    }
+
+    @Test
+    void loopbackAndNullOriginsStillAllowed() {
+        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
+        assertTrue(restrictor.isOriginAllowed(null, true));
+        assertTrue(restrictor.isOriginAllowed("http://localhost:8080", true));
+    }
+
+    @Test
+    void remoteAccessUnaffected() {
+        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
+        assertFalse(restrictor.isRemoteAccessAllowed("10.0.0.1"));
+    }
+}

--- a/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/CamelJolokiaRestrictorAnyOriginTest.java
+++ b/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/CamelJolokiaRestrictorAnyOriginTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.jolokia;
+
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+
+import io.quarkus.test.QuarkusUnitTest;
+import org.apache.camel.quarkus.jolokia.restrictor.CamelJolokiaRestrictor;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Accepting any origin is asked for explicitly rather than arrived at by leaving `allowed-origins` unset, so
+ * that the configuration says what it does.
+ */
+class CamelJolokiaRestrictorAnyOriginTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest CONFIG = new QuarkusUnitTest()
+            .withEmptyApplication()
+            .overrideConfigKey("quarkus.camel.jolokia.remote-access-allowed", "true")
+            .overrideConfigKey("quarkus.camel.jolokia.allowed-origins", "*");
+
+    @Test
+    void anyOriginAllowed() {
+        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
+        assertTrue(restrictor.isOriginAllowed("https://untrusted.example", true));
+        assertTrue(restrictor.isOriginAllowed("http://192.168.1.1:8080", true));
+        assertTrue(restrictor.isOriginAllowed("https://anything.example.com/with/a/path", true));
+        assertTrue(restrictor.isOriginAllowed(null, true));
+    }
+
+    /**
+     * Still an origin check, so a value that is not an origin is refused even here.
+     */
+    @Test
+    void valuesThatAreNotOriginsStillDenied() {
+        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
+        assertFalse(restrictor.isOriginAllowed("null", true));
+        assertFalse(restrictor.isOriginAllowed("https://untrusted.example@localhost", true));
+    }
+
+    @Test
+    void mbeanDomainFilteringStillEnforced() throws MalformedObjectNameException {
+        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
+        assertFalse(restrictor.isOperationAllowed(new ObjectName("com.example:type=Test"), "doSomething"));
+    }
+}

--- a/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/CamelJolokiaRestrictorDefaultPortOriginsTest.java
+++ b/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/CamelJolokiaRestrictorDefaultPortOriginsTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.jolokia;
+
+import io.quarkus.test.QuarkusUnitTest;
+import org.apache.camel.quarkus.jolokia.restrictor.CamelJolokiaRestrictor;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * An origin listed with the default port for its scheme has to work, since that is how an address bar and the
+ * `<allow-origin>` rules of an access policy may spell it, while a browser sends the origin without it. Both
+ * denote the same origin, so a configured value that includes the port must not silently match nothing.
+ */
+class CamelJolokiaRestrictorDefaultPortOriginsTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest CONFIG = new QuarkusUnitTest()
+            .overrideConfigKey("quarkus.camel.jolokia.allowed-origins",
+                    "https://secure.example.com:443,http://plain.example.com:80,*://*.wild.example.com:443");
+
+    @Test
+    void listedWithDefaultPortMatchesBrowserOrigin() {
+        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
+        assertTrue(restrictor.isOriginAllowed("https://secure.example.com", true));
+        assertTrue(restrictor.isOriginAllowed("http://plain.example.com", true));
+    }
+
+    @Test
+    void listedWithDefaultPortMatchesTheSameSpelling() {
+        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
+        assertTrue(restrictor.isOriginAllowed("https://secure.example.com:443", true));
+        assertTrue(restrictor.isOriginAllowed("http://plain.example.com:80", true));
+    }
+
+    /**
+     * A wildcard entry cannot be reduced to a URI, so the request has to be matched against both spellings
+     * rather than the configured value being rewritten.
+     */
+    @Test
+    void wildcardEntriesWithDefaultPortMatchToo() {
+        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
+        assertTrue(restrictor.isOriginAllowed("https://console.wild.example.com", true));
+        assertTrue(restrictor.isOriginAllowed("https://console.wild.example.com:443", true));
+    }
+
+    /**
+     * Only the default port for the scheme is interchangeable. Everything else stays a distinct origin.
+     */
+    @Test
+    void otherPortsRemainDistinctOrigins() {
+        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
+        assertFalse(restrictor.isOriginAllowed("https://secure.example.com:8443", true));
+        assertFalse(restrictor.isOriginAllowed("http://plain.example.com:8080", true));
+        // The default port of the other scheme is not the default of this one
+        assertFalse(restrictor.isOriginAllowed("https://secure.example.com:80", true));
+        assertFalse(restrictor.isOriginAllowed("http://plain.example.com:443", true));
+        // A matching port does not make a foreign host listed
+        assertFalse(restrictor.isOriginAllowed("https://untrusted.example:443", true));
+    }
+
+    /**
+     * Matching both spellings must not let a scheme through that was never listed.
+     */
+    @Test
+    void schemeStillMatters() {
+        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
+        assertFalse(restrictor.isOriginAllowed("http://secure.example.com", true));
+        assertFalse(restrictor.isOriginAllowed("https://plain.example.com", true));
+    }
+}

--- a/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/CamelJolokiaRestrictorIgnoreOriginSchemeTest.java
+++ b/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/CamelJolokiaRestrictorIgnoreOriginSchemeTest.java
@@ -14,20 +14,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.quarkus.component.jolokia.it;
+package org.apache.camel.quarkus.jolokia;
 
-import javax.management.ObjectName;
-
+import io.quarkus.test.QuarkusUnitTest;
 import org.apache.camel.quarkus.jolokia.restrictor.CamelJolokiaRestrictor;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Only allows MBean operation sendStringBody, on top of everything CamelJolokiaRestrictor already enforces.
+ * Replaces the `ignore-scheme` element of an access policy, so that turning off the rule against answering a
+ * secure origin over plain HTTP does not require introducing a policy file for one flag.
  */
-public class CustomRestrictor extends CamelJolokiaRestrictor {
-    @Override
-    protected boolean allowsOperation(ObjectName pName, String pOperation) {
-        // Asked only once the inherited checks have allowed the operation, so the MBean domain restriction
-        // still applies whatever this returns
-        return pOperation.startsWith("sendStringBody");
+class CamelJolokiaRestrictorIgnoreOriginSchemeTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest CONFIG = new QuarkusUnitTest()
+            .withEmptyApplication()
+            .overrideConfigKey("quarkus.camel.jolokia.ignore-origin-scheme", "true");
+
+    @Test
+    void schemeCheckDisabled() {
+        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
+        assertTrue(restrictor.ignoreScheme());
     }
 }

--- a/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/CamelJolokiaRestrictorInterfaceCoverageTest.java
+++ b/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/CamelJolokiaRestrictorInterfaceCoverageTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.jolokia;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.camel.quarkus.jolokia.restrictor.CamelJolokiaRestrictor;
+import org.jolokia.server.core.service.api.Restrictor;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The Camel restrictor implements Restrictor directly, so a method added to that interface with a permissive
+ * default implementation would be inherited rather than delegated, and the restriction would silently not apply.
+ * Nothing in the language prevents that, so it is asserted here. A failure after a Jolokia upgrade means the new
+ * method has to be implemented, not that this test is wrong.
+ */
+class CamelJolokiaRestrictorInterfaceCoverageTest {
+
+    @Test
+    void everyRestrictorMethodIsImplemented() {
+        List<String> missing = new ArrayList<>();
+        for (Class<?> implementation : restrictorImplementations()) {
+            for (Method method : Restrictor.class.getMethods()) {
+                if (method.isSynthetic() || Modifier.isStatic(method.getModifiers())) {
+                    continue;
+                }
+                if (!isImplementedBy(implementation, method)) {
+                    missing.add(implementation.getSimpleName() + "." + method.getName());
+                }
+            }
+        }
+        assertTrue(missing.isEmpty(), "Restrictor methods not implemented, so the inherited default applies: " + missing);
+    }
+
+    /**
+     * The Camel restrictor and the delegates it declares. The delegates are where the access decisions are made,
+     * so they carry the same risk.
+     */
+    private static List<Class<?>> restrictorImplementations() {
+        List<Class<?>> implementations = new ArrayList<>();
+        implementations.add(CamelJolokiaRestrictor.class);
+        for (Class<?> nested : CamelJolokiaRestrictor.class.getDeclaredClasses()) {
+            if (Restrictor.class.isAssignableFrom(nested)) {
+                implementations.add(nested);
+            }
+        }
+        return implementations;
+    }
+
+    private static boolean isImplementedBy(Class<?> implementation, Method method) {
+        for (Class<?> type = implementation; type != null && type != Object.class; type = type.getSuperclass()) {
+            try {
+                type.getDeclaredMethod(method.getName(), method.getParameterTypes());
+                return true;
+            } catch (NoSuchMethodException e) {
+                // Declared further up the hierarchy, or not at all
+            }
+        }
+        return false;
+    }
+}

--- a/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/CamelJolokiaRestrictorMbeanPolicyTest.java
+++ b/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/CamelJolokiaRestrictorMbeanPolicyTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.jolokia;
+
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+
+import io.quarkus.test.QuarkusUnitTest;
+import org.apache.camel.quarkus.jolokia.restrictor.CamelJolokiaRestrictor;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CamelJolokiaRestrictorMbeanPolicyTest {
+
+    private static final String JOLOKIA_ACCESS_XML = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <restrict>
+                <deny>
+                    <mbean>
+                        <name>java.lang:type=Runtime</name>
+                        <attribute>Uptime</attribute>
+                    </mbean>
+                    <mbean>
+                        <name>java.lang:type=Memory</name>
+                        <operation>gc</operation>
+                    </mbean>
+                </deny>
+                <filter>
+                    <mbean>java.nio:type=BufferPool,*</mbean>
+                </filter>
+            </restrict>
+            """;
+
+    @RegisterExtension
+    static final QuarkusUnitTest CONFIG = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource(new StringAsset(JOLOKIA_ACCESS_XML), "jolokia-access.xml"));
+
+    @Test
+    void deniedAttributeBlocked() throws MalformedObjectNameException {
+        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
+        assertFalse(restrictor.isAttributeReadAllowed(new ObjectName("java.lang:type=Runtime"), "Uptime"));
+    }
+
+    @Test
+    void otherAttributesOnSameMbeanAllowed() throws MalformedObjectNameException {
+        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
+        assertTrue(restrictor.isAttributeReadAllowed(new ObjectName("java.lang:type=Runtime"), "Name"));
+    }
+
+    @Test
+    void deniedOperationBlocked() throws MalformedObjectNameException {
+        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
+        assertFalse(restrictor.isOperationAllowed(new ObjectName("java.lang:type=Memory"), "gc"));
+    }
+
+    @Test
+    void mbeanDomainFilteringStillEnforced() throws MalformedObjectNameException {
+        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
+        assertFalse(restrictor.isAttributeReadAllowed(new ObjectName("com.example:type=Test"), "Value"));
+        assertTrue(restrictor.isObjectNameHidden(new ObjectName("com.example:type=Test")));
+    }
+
+    @Test
+    void policyFilteredObjectNameHidden() throws MalformedObjectNameException {
+        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
+        assertTrue(restrictor.isObjectNameHidden(new ObjectName("java.nio:type=BufferPool,name=direct")));
+        assertFalse(restrictor.isObjectNameHidden(new ObjectName("java.lang:type=Runtime")));
+    }
+}

--- a/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/CamelJolokiaRestrictorMissingFilePolicyTest.java
+++ b/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/CamelJolokiaRestrictorMissingFilePolicyTest.java
@@ -20,30 +20,31 @@ import io.quarkus.test.QuarkusUnitTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 /**
- * There is no service CA certificate, which is the plain Kubernetes case, so client authentication was never on
- * offer. The failure has to say that rather than report an enabled feature as broken, since the operator never
- * enabled anything.
+ * A `file:` policy that is not there fails startup like a `classpath:` one that is not packaged. Both are the
+ * same packaging error, and a ConfigMap that failed to mount is the likeliest way to arrive at it.
+ *
+ * Denying every request instead would start the application and answer with "No access from client [chain:
+ * 127.0.0.1] allowed", which points at the loopback control rather than at the missing file.
  */
-class JolokiaKubernetesTlsFailureTest {
+class CamelJolokiaRestrictorMissingFilePolicyTest {
+
     @RegisterExtension
     static final QuarkusUnitTest CONFIG = new QuarkusUnitTest()
             .withEmptyApplication()
-            .overrideConfigKey("kubernetes.service.host", "fake-host")
-            .overrideConfigKey("quarkus.camel.jolokia.kubernetes.service-ca-cert", "/non/existent/ca.crt")
-            .overrideConfigKey("quarkus.camel.jolokia.server.host", "0.0.0.0")
+            .overrideConfigKey("quarkus.camel.jolokia.additional-properties.policyLocation",
+                    "file:/etc/jolokia/not-mounted.xml")
             .assertException(t -> {
-                if (t.getMessage() == null
-                        || !t.getMessage().contains("not available on this cluster")
-                        || !t.getMessage().contains("/non/existent/ca.crt")
-                        || !t.getMessage().contains("0.0.0.0")) {
-                    throw new AssertionError(
-                            "Expected RuntimeException naming the absent service CA certificate, got: " + t, t);
-                }
+                assertTrue(t instanceof IllegalStateException, "Expected the pre-check to throw, got: " + t);
+                assertTrue(t.getMessage().contains("could not be resolved"), t.getMessage());
+                assertTrue(t.getMessage().contains("not-mounted.xml"), t.getMessage());
             });
 
     @Test
-    void applicationShouldFailToStart() {
-        // The application should not start — the assertException above validates the failure
+    void applicationShouldNotStart() {
+        fail("The application should not have started with a policy location that does not exist");
     }
 }

--- a/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/CamelJolokiaRestrictorOriginSpoofingTest.java
+++ b/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/CamelJolokiaRestrictorOriginSpoofingTest.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.jolokia;
+
+import io.quarkus.test.QuarkusUnitTest;
+import org.apache.camel.quarkus.jolokia.restrictor.CamelJolokiaRestrictor;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The origin check is what stops a page on another site from driving the agent through a visitor's browser, so
+ * a request must not be able to dress itself up as a listed origin. The request is matched against the origin
+ * both without and with the default port for its scheme, and this asserts that the extra spelling grants
+ * nothing beyond the origin the request already had.
+ */
+class CamelJolokiaRestrictorOriginSpoofingTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest CONFIG = new QuarkusUnitTest()
+            .overrideConfigKey("quarkus.camel.jolokia.allowed-origins",
+                    "https://good.example.com,http://plain.example.com:80,*://*.wild.example.com");
+
+    /**
+     * The two spellings of one origin, which is the whole point of matching both.
+     */
+    @Test
+    void bothSpellingsOfTheListedOriginAllowed() {
+        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
+        assertTrue(restrictor.isOriginAllowed("https://good.example.com", true));
+        assertTrue(restrictor.isOriginAllowed("https://good.example.com:443", true));
+        assertTrue(restrictor.isOriginAllowed("http://plain.example.com", true));
+        assertTrue(restrictor.isOriginAllowed("http://plain.example.com:80", true));
+    }
+
+    /**
+     * A default port belongs to its own scheme only. Appending one must never let a request satisfy a rule
+     * written for the other scheme.
+     */
+    @Test
+    void defaultPortDoesNotCrossSchemes() {
+        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
+        // 443 is not the default for http, so no `:443` spelling is produced for an http request
+        assertFalse(restrictor.isOriginAllowed("http://good.example.com", true));
+        assertFalse(restrictor.isOriginAllowed("http://good.example.com:443", true));
+        // 80 is not the default for https
+        assertFalse(restrictor.isOriginAllowed("https://plain.example.com", true));
+        assertFalse(restrictor.isOriginAllowed("https://plain.example.com:80", true));
+    }
+
+    /**
+     * The extra spelling is only produced when the port is absent or already the default, so a request on any
+     * other port keeps exactly one spelling and cannot borrow a rule meant for the default port.
+     */
+    @Test
+    void otherPortsGainNothing() {
+        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
+        assertFalse(restrictor.isOriginAllowed("https://good.example.com:8443", true));
+        assertFalse(restrictor.isOriginAllowed("https://good.example.com:4433", true));
+        assertFalse(restrictor.isOriginAllowed("https://good.example.com:44", true));
+        assertFalse(restrictor.isOriginAllowed("https://good.example.com:0", true));
+        assertFalse(restrictor.isOriginAllowed("http://plain.example.com:8080", true));
+    }
+
+    /**
+     * A foreign host is still foreign however the origin is spelled.
+     */
+    @Test
+    void foreignHostsDeniedInEitherSpelling() {
+        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
+        assertFalse(restrictor.isOriginAllowed("https://untrusted.example", true));
+        assertFalse(restrictor.isOriginAllowed("https://untrusted.example:443", true));
+        // Suffix and prefix of a listed host
+        assertFalse(restrictor.isOriginAllowed("https://good.example.com.untrusted.example", true));
+        assertFalse(restrictor.isOriginAllowed("https://good.example.com.untrusted.example:443", true));
+        assertFalse(restrictor.isOriginAllowed("https://evil-good.example.com", true));
+        // A trailing dot is a different host, and must not be normalised into the listed one
+        assertFalse(restrictor.isOriginAllowed("https://good.example.com.", true));
+        assertFalse(restrictor.isOriginAllowed("https://good.example.com.:443", true));
+    }
+
+    /**
+     * Credentials never appear in an origin, so their presence is an attempt to make a foreign host read as a
+     * listed one. Appending a default port must not give such a value a second chance to match.
+     */
+    @Test
+    void userInfoTricksDeniedInEitherSpelling() {
+        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
+        assertFalse(restrictor.isOriginAllowed("https://good.example.com@untrusted.example", true));
+        assertFalse(restrictor.isOriginAllowed("https://good.example.com@untrusted.example:443", true));
+        assertFalse(restrictor.isOriginAllowed("https://good.example.com:443@untrusted.example", true));
+        assertFalse(restrictor.isOriginAllowed("https://untrusted.example@good.example.com", true));
+    }
+
+    /**
+     * A Referer is reduced to its origin, which must not let a listed origin appearing in a path or query grant
+     * access to the host that actually sent the request.
+     */
+    @Test
+    void listedOriginInsideAPathGrantsNothing() {
+        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
+        assertFalse(restrictor.isOriginAllowed("https://untrusted.example/https://good.example.com", true));
+        assertFalse(restrictor.isOriginAllowed("https://untrusted.example/?x=https://good.example.com:443", true));
+        assertFalse(restrictor.isOriginAllowed("https://untrusted.example#https://good.example.com", true));
+        // The listed origin with a path is still the listed origin
+        assertTrue(restrictor.isOriginAllowed("https://good.example.com/jolokia/read", true));
+        assertTrue(restrictor.isOriginAllowed("https://good.example.com:443/jolokia/read", true));
+    }
+
+    /**
+     * A wildcard entry carries no port, so both spellings of a matching request have to be accepted while a
+     * host outside the pattern stays denied.
+     */
+    @Test
+    void wildcardEntriesBoundedByTheirPattern() {
+        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
+        assertTrue(restrictor.isOriginAllowed("https://console.wild.example.com", true));
+        assertTrue(restrictor.isOriginAllowed("https://console.wild.example.com:443", true));
+        assertTrue(restrictor.isOriginAllowed("http://console.wild.example.com", true));
+        // Outside the wildcard
+        assertFalse(restrictor.isOriginAllowed("https://wild.example.com.untrusted.example", true));
+        assertFalse(restrictor.isOriginAllowed("https://console.wild.example.com.evil.example", true));
+        // The wildcard covers the host, not the port
+        assertFalse(restrictor.isOriginAllowed("https://console.wild.example.com:8443", true));
+    }
+
+    /**
+     * Values that are not origins must not acquire one by having a default port appended.
+     */
+    @Test
+    void malformedValuesStillDenied() {
+        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
+        assertFalse(restrictor.isOriginAllowed("good.example.com", true));
+        assertFalse(restrictor.isOriginAllowed("//good.example.com", true));
+        assertFalse(restrictor.isOriginAllowed("https://", true));
+        assertFalse(restrictor.isOriginAllowed("https://good.example.com:443:443", true));
+        assertFalse(restrictor.isOriginAllowed("https://good.example.com:notaport", true));
+        assertFalse(restrictor.isOriginAllowed("null", true));
+        assertFalse(restrictor.isOriginAllowed("", true));
+        assertFalse(restrictor.isOriginAllowed("   ", true));
+        // A wildcard is not a host a request can come from
+        assertFalse(restrictor.isOriginAllowed("https://*.wild.example.com", true));
+    }
+
+    /**
+     * Case folding applies to both spellings, and cannot be used to smuggle a foreign host past the check.
+     */
+    @Test
+    void caseFoldingIsBounded() {
+        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
+        assertTrue(restrictor.isOriginAllowed("HTTPS://GOOD.EXAMPLE.COM", true));
+        assertTrue(restrictor.isOriginAllowed("HttPs://Good.Example.Com:443", true));
+        assertFalse(restrictor.isOriginAllowed("HTTPS://UNTRUSTED.EXAMPLE", true));
+    }
+}

--- a/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/CamelJolokiaRestrictorPolicyAllowingEveryAddressTest.java
+++ b/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/CamelJolokiaRestrictorPolicyAllowingEveryAddressTest.java
@@ -16,68 +16,48 @@
  */
 package org.apache.camel.quarkus.jolokia;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-
 import io.quarkus.test.QuarkusUnitTest;
 import org.apache.camel.quarkus.jolokia.restrictor.CamelJolokiaRestrictor;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class CamelJolokiaRestrictorFilePolicyTest {
+/**
+ * Pins the one case where a `remote` section is read as saying nothing.
+ *
+ * Whether a policy restricts addresses is settled by asking it about an address reserved for documentation, which
+ * a policy granting every address matches as readily as one with no `remote` section at all. The two are the same
+ * instruction written differently, and both leave `remote-access-allowed` to answer, which is the stricter
+ * reading. An operator who meant every address says so with the property.
+ *
+ * If Jolokia ever exposes its network checker, or whether the section is present, this becomes exact and the
+ * `10.0.0.1` assertion below flips.
+ */
+class CamelJolokiaRestrictorPolicyAllowingEveryAddressTest {
 
     private static final String JOLOKIA_ACCESS_XML = """
             <?xml version="1.0" encoding="UTF-8"?>
             <restrict>
                 <remote>
-                    <host>10.0.0.0/8</host>
+                    <host>0.0.0.0/0</host>
                 </remote>
             </restrict>
             """;
 
-    static final File POLICY_FILE;
-
-    static {
-        try {
-            POLICY_FILE = Files.createTempFile("jolokia-access", ".xml").toFile();
-            POLICY_FILE.deleteOnExit();
-            Files.writeString(POLICY_FILE.toPath(), JOLOKIA_ACCESS_XML);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
     @RegisterExtension
     static final QuarkusUnitTest CONFIG = new QuarkusUnitTest()
-            .overrideConfigKey("quarkus.camel.jolokia.additional-properties.policyLocation",
-                    POLICY_FILE.toURI().toString());
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource(new StringAsset(JOLOKIA_ACCESS_XML), "jolokia-access.xml"));
 
     @Test
-    void filePolicyAllowsConfiguredSubnet() {
+    void readAsSayingNothingSoTheLoopbackDefaultApplies() {
         CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
-        assertTrue(restrictor.isRemoteAccessAllowed("10.0.0.1"));
-        assertTrue(restrictor.isRemoteAccessAllowed("10.255.255.255"));
-    }
-
-    @Test
-    void filePolicyDeniesOtherAddresses() {
-        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
-        assertFalse(restrictor.isRemoteAccessAllowed("192.168.1.1"));
-        assertFalse(restrictor.isRemoteAccessAllowed("172.16.0.1"));
-    }
-
-    /**
-     * Loopback is not in the subnet the policy allows, and the policy decides addresses outright, so it is
-     * refused like any other address outside it.
-     */
-    @Test
-    void loopbackDeniedByPolicy() {
-        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
-        assertFalse(restrictor.isRemoteAccessAllowed("127.0.0.1"));
-        assertFalse(restrictor.isRemoteAccessAllowed("::1"));
+        assertTrue(restrictor.isRemoteAccessAllowed("127.0.0.1"));
+        assertFalse(restrictor.isRemoteAccessAllowed("10.0.0.1"));
     }
 }

--- a/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/CamelJolokiaRestrictorPolicyCorsIgnoredTest.java
+++ b/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/CamelJolokiaRestrictorPolicyCorsIgnoredTest.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.jolokia;
+
+import io.quarkus.test.QuarkusUnitTest;
+import org.apache.camel.quarkus.jolokia.restrictor.CamelJolokiaRestrictor;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jolokia.server.core.util.RequestType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The cors section of an access policy is not consulted, so that the origins which may reach the agent are
+ * configured in one place. Everything else in the policy still applies.
+ */
+class CamelJolokiaRestrictorPolicyCorsIgnoredTest {
+
+    private static final String JOLOKIA_ACCESS_XML = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <restrict>
+                <cors>
+                    <allow-origin>https://policy-only.example.com</allow-origin>
+                    <strict-checking/>
+                    <ignore-scheme/>
+                </cors>
+                <commands>
+                    <command>read</command>
+                </commands>
+            </restrict>
+            """;
+
+    @RegisterExtension
+    static final QuarkusUnitTest CONFIG = new QuarkusUnitTest()
+            .overrideConfigKey("quarkus.camel.jolokia.allowed-origins", "https://domain.example.com")
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource(new StringAsset(JOLOKIA_ACCESS_XML), "jolokia-access.xml"));
+
+    /**
+     * Listing an origin in the policy does not grant it access, even with strict-checking enabled.
+     */
+    @Test
+    void policyAllowOriginDoesNotGrantAccess() {
+        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
+        assertFalse(restrictor.isOriginAllowed("https://policy-only.example.com", true));
+        assertFalse(restrictor.isOriginAllowed("https://policy-only.example.com", false));
+    }
+
+    /**
+     * A policy enabling strict-checking would otherwise reject every origin it does not list, including a null
+     * origin. The configured origins are unaffected by it.
+     */
+    @Test
+    void policyStrictCheckingDoesNotNarrowTheConfiguredOrigins() {
+        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
+        assertTrue(restrictor.isOriginAllowed("https://domain.example.com", true));
+        assertTrue(restrictor.isOriginAllowed("http://localhost:8080", true));
+        assertTrue(restrictor.isOriginAllowed(null, true));
+    }
+
+    @Test
+    void unlistedOriginsStillDenied() {
+        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
+        assertFalse(restrictor.isOriginAllowed("https://untrusted.example", true));
+    }
+
+    /**
+     * The whole section is skipped, including ignore-scheme, so it can be deleted from a policy without
+     * changing anything. `quarkus.camel.jolokia.ignore-origin-scheme` replaces it.
+     */
+    @Test
+    void policyIgnoreSchemeHasNoEffect() {
+        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
+        assertFalse(restrictor.ignoreScheme());
+    }
+
+    /**
+     * Only the cors section is skipped. The rest of the policy is still delegated to.
+     */
+    @Test
+    void remainderOfThePolicyStillApplies() {
+        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
+        assertTrue(restrictor.isTypeAllowed(RequestType.READ));
+        assertFalse(restrictor.isTypeAllowed(RequestType.EXEC));
+    }
+}

--- a/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/CamelJolokiaRestrictorPolicyDelegationTest.java
+++ b/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/CamelJolokiaRestrictorPolicyDelegationTest.java
@@ -56,15 +56,18 @@ class CamelJolokiaRestrictorPolicyDelegationTest {
 
     @RegisterExtension
     static final QuarkusUnitTest CONFIG = new QuarkusUnitTest()
-            .overrideConfigKey("quarkus.camel.jolokia.server.port", "0")
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addAsResource(new StringAsset(JOLOKIA_ACCESS_XML), "jolokia-access.xml"));
 
+    /**
+     * The policy restricts addresses to 10.0.0.0/8, which loopback is not in. The framework must not widen a
+     * restriction the operator asked for, so loopback is refused like any other address outside the subnet.
+     */
     @Test
-    void loopbackAlwaysAllowed() {
+    void loopbackDeniedByPolicySubnet() {
         CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
-        assertTrue(restrictor.isRemoteAccessAllowed("127.0.0.1"));
-        assertTrue(restrictor.isRemoteAccessAllowed("::1"));
+        assertFalse(restrictor.isRemoteAccessAllowed("127.0.0.1"));
+        assertFalse(restrictor.isRemoteAccessAllowed("::1"));
     }
 
     @Test
@@ -81,16 +84,40 @@ class CamelJolokiaRestrictorPolicyDelegationTest {
         assertFalse(restrictor.isRemoteAccessAllowed("172.16.0.1"));
     }
 
+    /**
+     * The cors section of the policy is not consulted, so listing an origin there does not grant it access. It
+     * has to be listed in quarkus.camel.jolokia.allowed-origins.
+     */
     @Test
-    void policyAllowedCorsOriginAllowed() {
+    void policyAllowOriginDoesNotGrantAccess() {
         CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
-        assertTrue(restrictor.isOriginAllowed("http://example.host.com", false));
+        assertFalse(restrictor.isOriginAllowed("http://example.host.com", false));
+        assertFalse(restrictor.isOriginAllowed("http://example.host.com", true));
     }
 
     @Test
     void nonPolicyCorsOriginDenied() {
         CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
         assertFalse(restrictor.isOriginAllowed("http://untrusted.example", false));
+    }
+
+    @Test
+    void nonPolicyCorsOriginDeniedWithStrictCheck() {
+        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
+        assertFalse(restrictor.isOriginAllowed("http://untrusted.example", true));
+    }
+
+    @Test
+    void userInfoOriginCannotBypassPolicyCors() {
+        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
+        assertFalse(restrictor.isOriginAllowed("http://untrusted.example@localhost", true));
+    }
+
+    @Test
+    void spoofedLoopbackInAddressChainDeniedByPolicy() {
+        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
+        assertFalse(restrictor.isRemoteAccessAllowed("127.0.0.1", "192.168.1.1"));
+        assertTrue(restrictor.isRemoteAccessAllowed("10.0.0.1", "10.0.0.2"));
     }
 
     @Test
@@ -103,8 +130,9 @@ class CamelJolokiaRestrictorPolicyDelegationTest {
     @Test
     void loopbackOriginStillAllowed() {
         CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
+        assertTrue(restrictor.isOriginAllowed("http://localhost:8080", true));
         assertTrue(restrictor.isOriginAllowed("http://localhost:8080", false));
-        assertTrue(restrictor.isOriginAllowed("http://127.0.0.1:9090", false));
+        assertTrue(restrictor.isOriginAllowed("http://127.0.0.1:9090", true));
     }
 
     @Test

--- a/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/CamelJolokiaRestrictorPolicyLoadFailureTest.java
+++ b/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/CamelJolokiaRestrictorPolicyLoadFailureTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.jolokia;
+
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+
+import io.quarkus.test.QuarkusUnitTest;
+import org.apache.camel.quarkus.jolokia.restrictor.CamelJolokiaRestrictor;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jolokia.server.core.util.HttpMethod;
+import org.jolokia.server.core.util.RequestType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A policy that is there but cannot be parsed denies everything, rather than being treated as absent. A policy
+ * exists to restrict something, so silently carrying on without it would apply the opposite of what was asked
+ * for. This is distinct from a location that points at nothing, which fails startup instead.
+ */
+class CamelJolokiaRestrictorPolicyLoadFailureTest {
+
+    private static final String MALFORMED_JOLOKIA_ACCESS_XML = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <restrict>
+                <remote>
+                    <host>10.0.0.0/8</host>
+            </restrict>
+            """;
+
+    @RegisterExtension
+    static final QuarkusUnitTest CONFIG = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource(new StringAsset(MALFORMED_JOLOKIA_ACCESS_XML), "jolokia-access.xml"))
+            .overrideConfigKey("quarkus.camel.jolokia.additional-properties.policyLocation",
+                    "classpath:/jolokia-access.xml")
+            .overrideConfigKey("quarkus.camel.jolokia.remote-access-allowed", "true");
+
+    @Test
+    void unloadablePolicyDeniesEverything() {
+        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
+        assertFalse(restrictor.isRemoteAccessAllowed("127.0.0.1"));
+        assertFalse(restrictor.isRemoteAccessAllowed("10.0.0.1"));
+        assertFalse(restrictor.isOriginAllowed(null, true));
+        assertFalse(restrictor.isOriginAllowed("http://localhost:8080", false));
+        assertFalse(restrictor.isHttpMethodAllowed(HttpMethod.GET));
+        assertFalse(restrictor.isTypeAllowed(RequestType.READ));
+    }
+
+    @Test
+    void unloadablePolicyDeniesMbeanAccess() throws MalformedObjectNameException {
+        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
+        ObjectName camelMBean = new ObjectName("org.apache.camel:context=camel-1,type=context,name=\"camel-1\"");
+        assertFalse(restrictor.isAttributeReadAllowed(camelMBean, "Uptime"));
+        assertFalse(restrictor.isAttributeWriteAllowed(camelMBean, "Tracing"));
+        assertFalse(restrictor.isOperationAllowed(camelMBean, "sendStringBody"));
+        assertTrue(restrictor.isObjectNameHidden(camelMBean));
+    }
+}

--- a/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/CamelJolokiaRestrictorPolicyOverridesRemoteAccessTest.java
+++ b/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/CamelJolokiaRestrictorPolicyOverridesRemoteAccessTest.java
@@ -16,19 +16,22 @@
  */
 package org.apache.camel.quarkus.jolokia;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-
 import io.quarkus.test.QuarkusUnitTest;
 import org.apache.camel.quarkus.jolokia.restrictor.CamelJolokiaRestrictor;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class CamelJolokiaRestrictorFilePolicyTest {
+/**
+ * An explicit access policy takes precedence over remote-access-allowed, so that its remote and CORS
+ * rules are not silently discarded.
+ */
+class CamelJolokiaRestrictorPolicyOverridesRemoteAccessTest {
 
     private static final String JOLOKIA_ACCESS_XML = """
             <?xml version="1.0" encoding="UTF-8"?>
@@ -36,48 +39,46 @@ class CamelJolokiaRestrictorFilePolicyTest {
                 <remote>
                     <host>10.0.0.0/8</host>
                 </remote>
+                <cors>
+                    <allow-origin>https://domain.example.com</allow-origin>
+                </cors>
             </restrict>
             """;
 
-    static final File POLICY_FILE;
-
-    static {
-        try {
-            POLICY_FILE = Files.createTempFile("jolokia-access", ".xml").toFile();
-            POLICY_FILE.deleteOnExit();
-            Files.writeString(POLICY_FILE.toPath(), JOLOKIA_ACCESS_XML);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
     @RegisterExtension
     static final QuarkusUnitTest CONFIG = new QuarkusUnitTest()
-            .overrideConfigKey("quarkus.camel.jolokia.additional-properties.policyLocation",
-                    POLICY_FILE.toURI().toString());
+            .overrideConfigKey("quarkus.camel.jolokia.remote-access-allowed", "true")
+            .overrideConfigKey("quarkus.camel.jolokia.allowed-origins", "https://domain.example.com")
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource(new StringAsset(JOLOKIA_ACCESS_XML), "jolokia-access.xml"));
 
     @Test
-    void filePolicyAllowsConfiguredSubnet() {
+    void policyRemoteRulesApply() {
         CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
         assertTrue(restrictor.isRemoteAccessAllowed("10.0.0.1"));
-        assertTrue(restrictor.isRemoteAccessAllowed("10.255.255.255"));
+        assertFalse(restrictor.isRemoteAccessAllowed("192.168.1.1"));
     }
 
     @Test
-    void filePolicyDeniesOtherAddresses() {
+    void configuredOriginAllowed() {
         CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
-        assertFalse(restrictor.isRemoteAccessAllowed("192.168.1.1"));
-        assertFalse(restrictor.isRemoteAccessAllowed("172.16.0.1"));
+        assertTrue(restrictor.isOriginAllowed("https://domain.example.com", true));
+        assertFalse(restrictor.isOriginAllowed("http://untrusted.example", true));
     }
 
     /**
-     * Loopback is not in the subnet the policy allows, and the policy decides addresses outright, so it is
-     * refused like any other address outside it.
+     * The policy decides addresses outright, and loopback is not among the ones it lists. Neither
+     * `remote-access-allowed` nor a loopback exemption reinstates it.
      */
     @Test
-    void loopbackDeniedByPolicy() {
+    void loopbackClientDeniedByPolicy() {
         CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
         assertFalse(restrictor.isRemoteAccessAllowed("127.0.0.1"));
-        assertFalse(restrictor.isRemoteAccessAllowed("::1"));
+    }
+
+    @Test
+    void loopbackOriginStillAllowed() {
+        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
+        assertTrue(restrictor.isOriginAllowed("http://localhost:8080", true));
     }
 }

--- a/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/CamelJolokiaRestrictorPolicyWithoutCorsTest.java
+++ b/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/CamelJolokiaRestrictorPolicyWithoutCorsTest.java
@@ -16,19 +16,23 @@
  */
 package org.apache.camel.quarkus.jolokia;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-
 import io.quarkus.test.QuarkusUnitTest;
 import org.apache.camel.quarkus.jolokia.restrictor.CamelJolokiaRestrictor;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class CamelJolokiaRestrictorFilePolicyTest {
+/**
+ * A Jolokia access policy that declares no allow-origin rule permits every origin. Delegating to it would turn
+ * the deny by default stance into allow all for anybody who adds a policy purely to widen the remote rules, so
+ * the default origin handling is kept instead.
+ */
+class CamelJolokiaRestrictorPolicyWithoutCorsTest {
 
     private static final String JOLOKIA_ACCESS_XML = """
             <?xml version="1.0" encoding="UTF-8"?>
@@ -39,45 +43,30 @@ class CamelJolokiaRestrictorFilePolicyTest {
             </restrict>
             """;
 
-    static final File POLICY_FILE;
-
-    static {
-        try {
-            POLICY_FILE = Files.createTempFile("jolokia-access", ".xml").toFile();
-            POLICY_FILE.deleteOnExit();
-            Files.writeString(POLICY_FILE.toPath(), JOLOKIA_ACCESS_XML);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
     @RegisterExtension
     static final QuarkusUnitTest CONFIG = new QuarkusUnitTest()
-            .overrideConfigKey("quarkus.camel.jolokia.additional-properties.policyLocation",
-                    POLICY_FILE.toURI().toString());
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource(new StringAsset(JOLOKIA_ACCESS_XML), "jolokia-access.xml"));
 
     @Test
-    void filePolicyAllowsConfiguredSubnet() {
+    void remoteRulesStillDelegatedToPolicy() {
         CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
         assertTrue(restrictor.isRemoteAccessAllowed("10.0.0.1"));
-        assertTrue(restrictor.isRemoteAccessAllowed("10.255.255.255"));
-    }
-
-    @Test
-    void filePolicyDeniesOtherAddresses() {
-        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
         assertFalse(restrictor.isRemoteAccessAllowed("192.168.1.1"));
-        assertFalse(restrictor.isRemoteAccessAllowed("172.16.0.1"));
     }
 
-    /**
-     * Loopback is not in the subnet the policy allows, and the policy decides addresses outright, so it is
-     * refused like any other address outside it.
-     */
     @Test
-    void loopbackDeniedByPolicy() {
+    void crossOriginRequestsStillDenied() {
         CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
-        assertFalse(restrictor.isRemoteAccessAllowed("127.0.0.1"));
-        assertFalse(restrictor.isRemoteAccessAllowed("::1"));
+        assertFalse(restrictor.isOriginAllowed("http://untrusted.example", true));
+        assertFalse(restrictor.isOriginAllowed("http://untrusted.example@localhost", true));
+    }
+
+    @Test
+    void loopbackAndNullOriginsAllowed() {
+        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
+        assertTrue(restrictor.isOriginAllowed(null, true));
+        assertTrue(restrictor.isOriginAllowed("http://localhost:8080", true));
+        assertTrue(restrictor.isOriginAllowed("http://127.0.0.1:9090", true));
     }
 }

--- a/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/CamelJolokiaRestrictorPolicyWithoutRemoteAllowsRemoteAccessTest.java
+++ b/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/CamelJolokiaRestrictorPolicyWithoutRemoteAllowsRemoteAccessTest.java
@@ -16,68 +16,54 @@
  */
 package org.apache.camel.quarkus.jolokia;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-
 import io.quarkus.test.QuarkusUnitTest;
 import org.apache.camel.quarkus.jolokia.restrictor.CamelJolokiaRestrictor;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jolokia.server.core.util.RequestType;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class CamelJolokiaRestrictorFilePolicyTest {
+/**
+ * A policy that says nothing about client addresses leaves `remote-access-allowed` to answer them, so bringing a
+ * policy to restrict something else does not take the property away from an operator who is also relying on it.
+ */
+class CamelJolokiaRestrictorPolicyWithoutRemoteAllowsRemoteAccessTest {
 
     private static final String JOLOKIA_ACCESS_XML = """
             <?xml version="1.0" encoding="UTF-8"?>
             <restrict>
-                <remote>
-                    <host>10.0.0.0/8</host>
-                </remote>
+                <commands>
+                    <command>list</command>
+                    <command>read</command>
+                </commands>
             </restrict>
             """;
 
-    static final File POLICY_FILE;
-
-    static {
-        try {
-            POLICY_FILE = Files.createTempFile("jolokia-access", ".xml").toFile();
-            POLICY_FILE.deleteOnExit();
-            Files.writeString(POLICY_FILE.toPath(), JOLOKIA_ACCESS_XML);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
     @RegisterExtension
     static final QuarkusUnitTest CONFIG = new QuarkusUnitTest()
-            .overrideConfigKey("quarkus.camel.jolokia.additional-properties.policyLocation",
-                    POLICY_FILE.toURI().toString());
+            .overrideConfigKey("quarkus.camel.jolokia.remote-access-allowed", "true")
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource(new StringAsset(JOLOKIA_ACCESS_XML), "jolokia-access.xml"));
 
     @Test
-    void filePolicyAllowsConfiguredSubnet() {
+    void remoteAccessAllowedStillApplies() {
         CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
         assertTrue(restrictor.isRemoteAccessAllowed("10.0.0.1"));
-        assertTrue(restrictor.isRemoteAccessAllowed("10.255.255.255"));
-    }
-
-    @Test
-    void filePolicyDeniesOtherAddresses() {
-        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
-        assertFalse(restrictor.isRemoteAccessAllowed("192.168.1.1"));
-        assertFalse(restrictor.isRemoteAccessAllowed("172.16.0.1"));
+        assertTrue(restrictor.isRemoteAccessAllowed("127.0.0.1"));
     }
 
     /**
-     * Loopback is not in the subnet the policy allows, and the policy decides addresses outright, so it is
-     * refused like any other address outside it.
+     * The rest of the policy is unaffected by who answers addresses.
      */
     @Test
-    void loopbackDeniedByPolicy() {
+    void policyCommandsStillNarrowAccess() {
         CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
-        assertFalse(restrictor.isRemoteAccessAllowed("127.0.0.1"));
-        assertFalse(restrictor.isRemoteAccessAllowed("::1"));
+        assertTrue(restrictor.isTypeAllowed(RequestType.LIST));
+        assertFalse(restrictor.isTypeAllowed(RequestType.EXEC));
     }
 }

--- a/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/CamelJolokiaRestrictorPolicyWithoutRemoteTest.java
+++ b/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/CamelJolokiaRestrictorPolicyWithoutRemoteTest.java
@@ -16,68 +16,56 @@
  */
 package org.apache.camel.quarkus.jolokia;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-
 import io.quarkus.test.QuarkusUnitTest;
 import org.apache.camel.quarkus.jolokia.restrictor.CamelJolokiaRestrictor;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class CamelJolokiaRestrictorFilePolicyTest {
+/**
+ * A policy with no `remote` section says nothing about client addresses, so the configured rules still answer
+ * them and the loopback default holds.
+ *
+ * Jolokia reads an absent section as allowing every address. Applying that reading here would mean a policy
+ * brought to restrict something else, such as the commands in use, silently withdrew the loopback default while
+ * `remote-access-allowed` stayed `false` and read as though it were still in force. A policy that does carry a
+ * `remote` section decides addresses outright, which
+ * {@link CamelJolokiaRestrictorPolicyOverridesRemoteAccessTest} covers.
+ */
+class CamelJolokiaRestrictorPolicyWithoutRemoteTest {
 
     private static final String JOLOKIA_ACCESS_XML = """
             <?xml version="1.0" encoding="UTF-8"?>
             <restrict>
-                <remote>
-                    <host>10.0.0.0/8</host>
-                </remote>
+                <commands>
+                    <command>list</command>
+                    <command>read</command>
+                </commands>
             </restrict>
             """;
 
-    static final File POLICY_FILE;
-
-    static {
-        try {
-            POLICY_FILE = Files.createTempFile("jolokia-access", ".xml").toFile();
-            POLICY_FILE.deleteOnExit();
-            Files.writeString(POLICY_FILE.toPath(), JOLOKIA_ACCESS_XML);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
     @RegisterExtension
     static final QuarkusUnitTest CONFIG = new QuarkusUnitTest()
-            .overrideConfigKey("quarkus.camel.jolokia.additional-properties.policyLocation",
-                    POLICY_FILE.toURI().toString());
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource(new StringAsset(JOLOKIA_ACCESS_XML), "jolokia-access.xml"));
 
     @Test
-    void filePolicyAllowsConfiguredSubnet() {
+    void loopbackDefaultStillApplies() {
         CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
-        assertTrue(restrictor.isRemoteAccessAllowed("10.0.0.1"));
-        assertTrue(restrictor.isRemoteAccessAllowed("10.255.255.255"));
-    }
-
-    @Test
-    void filePolicyDeniesOtherAddresses() {
-        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
+        assertTrue(restrictor.isRemoteAccessAllowed("127.0.0.1"));
+        assertFalse(restrictor.isRemoteAccessAllowed("10.0.0.1"));
         assertFalse(restrictor.isRemoteAccessAllowed("192.168.1.1"));
-        assertFalse(restrictor.isRemoteAccessAllowed("172.16.0.1"));
     }
 
-    /**
-     * Loopback is not in the subnet the policy allows, and the policy decides addresses outright, so it is
-     * refused like any other address outside it.
-     */
     @Test
-    void loopbackDeniedByPolicy() {
+    void policyCommandsStillNarrowAccess() {
         CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
-        assertFalse(restrictor.isRemoteAccessAllowed("127.0.0.1"));
-        assertFalse(restrictor.isRemoteAccessAllowed("::1"));
+        assertTrue(restrictor.isTypeAllowed(org.jolokia.server.core.util.RequestType.LIST));
+        assertFalse(restrictor.isTypeAllowed(org.jolokia.server.core.util.RequestType.EXEC));
     }
 }

--- a/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/CamelJolokiaRestrictorQuotedPolicyLocationTest.java
+++ b/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/CamelJolokiaRestrictorQuotedPolicyLocationTest.java
@@ -28,7 +28,11 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class CamelJolokiaRestrictorFilePolicyTest {
+/**
+ * The policy location is a key of the additional-properties map, so it may be written with or without quotes.
+ * Both forms must be honoured by the restrictor.
+ */
+class CamelJolokiaRestrictorQuotedPolicyLocationTest {
 
     private static final String JOLOKIA_ACCESS_XML = """
             <?xml version="1.0" encoding="UTF-8"?>
@@ -53,31 +57,13 @@ class CamelJolokiaRestrictorFilePolicyTest {
 
     @RegisterExtension
     static final QuarkusUnitTest CONFIG = new QuarkusUnitTest()
-            .overrideConfigKey("quarkus.camel.jolokia.additional-properties.policyLocation",
+            .overrideConfigKey("quarkus.camel.jolokia.additional-properties.\"policyLocation\"",
                     POLICY_FILE.toURI().toString());
 
     @Test
-    void filePolicyAllowsConfiguredSubnet() {
+    void quotedPolicyLocationIsLoaded() {
         CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
         assertTrue(restrictor.isRemoteAccessAllowed("10.0.0.1"));
-        assertTrue(restrictor.isRemoteAccessAllowed("10.255.255.255"));
-    }
-
-    @Test
-    void filePolicyDeniesOtherAddresses() {
-        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
         assertFalse(restrictor.isRemoteAccessAllowed("192.168.1.1"));
-        assertFalse(restrictor.isRemoteAccessAllowed("172.16.0.1"));
-    }
-
-    /**
-     * Loopback is not in the subnet the policy allows, and the policy decides addresses outright, so it is
-     * refused like any other address outside it.
-     */
-    @Test
-    void loopbackDeniedByPolicy() {
-        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
-        assertFalse(restrictor.isRemoteAccessAllowed("127.0.0.1"));
-        assertFalse(restrictor.isRemoteAccessAllowed("::1"));
     }
 }

--- a/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/CamelJolokiaRestrictorRemoteAccessWithAllowedOriginsTest.java
+++ b/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/CamelJolokiaRestrictorRemoteAccessWithAllowedOriginsTest.java
@@ -27,52 +27,47 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class CamelJolokiaRestrictorRemoteAccessEnabledTest {
+/**
+ * Remote access is a control over client addresses, so enabling it must not discard the origins an operator
+ * configured. Without a listed origin the two would otherwise be set together and only one of them take effect.
+ */
+class CamelJolokiaRestrictorRemoteAccessWithAllowedOriginsTest {
 
     @RegisterExtension
     static final QuarkusUnitTest CONFIG = new QuarkusUnitTest()
             .withEmptyApplication()
-            .overrideConfigKey("quarkus.camel.jolokia.remote-access-allowed", "true");
+            .overrideConfigKey("quarkus.camel.jolokia.remote-access-allowed", "true")
+            .overrideConfigKey("quarkus.camel.jolokia.allowed-origins", "https://domain.example.com");
 
     @Test
-    void allRemoteAddressesAllowed() {
+    void remoteAddressesStillAllowed() {
         CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
         assertTrue(restrictor.isRemoteAccessAllowed("192.168.1.1"));
         assertTrue(restrictor.isRemoteAccessAllowed("10.0.0.1"));
-        assertTrue(restrictor.isRemoteAccessAllowed("172.16.0.1"));
-    }
-
-    @Test
-    void loopbackStillAllowed() {
-        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
         assertTrue(restrictor.isRemoteAccessAllowed("127.0.0.1"));
-        assertTrue(restrictor.isRemoteAccessAllowed("::1"));
-    }
-
-    /**
-     * Remote access is a control over client addresses. Lifting it must not also stop a browser on another site
-     * from driving the agent, which is a separate question answered by `allowed-origins`.
-     */
-    @Test
-    void originsStillRestricted() {
-        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
-        assertFalse(restrictor.isOriginAllowed("http://untrusted.example", false));
-        assertFalse(restrictor.isOriginAllowed("http://192.168.1.1:8080", false));
-        assertFalse(restrictor.isOriginAllowed("http://example.com", true));
+        // Remote access is not conditional on the chain being loopback, so a proxied chain passes too
+        assertTrue(restrictor.isRemoteAccessAllowed("10.0.0.1", "127.0.0.1"));
     }
 
     @Test
-    void loopbackOriginsStillAllowed() {
+    void configuredOriginAllowed() {
         CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
-        assertTrue(restrictor.isOriginAllowed("http://localhost:8080", true));
-        assertTrue(restrictor.isOriginAllowed("http://127.0.0.1:9090", true));
+        assertTrue(restrictor.isOriginAllowed("https://domain.example.com", true));
+        assertTrue(restrictor.isOriginAllowed("https://domain.example.com", false));
     }
 
     @Test
-    void nullOriginAllowed() {
+    void unlistedOriginDenied() {
         CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
-        assertTrue(restrictor.isOriginAllowed(null, false));
+        assertFalse(restrictor.isOriginAllowed("https://untrusted.example", true));
+        assertFalse(restrictor.isOriginAllowed("http://192.168.1.1:8080", true));
+    }
+
+    @Test
+    void loopbackAndNullOriginsStillAllowed() {
+        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
         assertTrue(restrictor.isOriginAllowed(null, true));
+        assertTrue(restrictor.isOriginAllowed("http://localhost:8080", true));
     }
 
     @Test

--- a/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/CamelJolokiaRestrictorSubclassNarrowsOnlyTest.java
+++ b/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/CamelJolokiaRestrictorSubclassNarrowsOnlyTest.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.jolokia;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+
+import io.quarkus.test.QuarkusUnitTest;
+import org.apache.camel.quarkus.jolokia.restrictor.CamelJolokiaRestrictor;
+import org.jolokia.server.core.service.api.Restrictor;
+import org.jolokia.server.core.util.HttpMethod;
+import org.jolokia.server.core.util.RequestType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A subclass of the Camel restrictor must be able to restrict further, and nothing else. The access checks are
+ * final and a subclass contributes through the `allows*` hooks, so a custom restrictor cannot give up the
+ * defaults by overriding a check and not calling `super`.
+ */
+class CamelJolokiaRestrictorSubclassNarrowsOnlyTest {
+    @RegisterExtension
+    static final QuarkusUnitTest CONFIG = new QuarkusUnitTest()
+            .withEmptyApplication();
+
+    /**
+     * The invariant the hooks rest on. A check left non-final could be overridden to return true, which would
+     * discard the MBean domain restriction and the whole delegate along with it.
+     */
+    @Test
+    void everyAccessCheckIsFinal() {
+        List<String> overridable = new ArrayList<>();
+        for (Method method : Restrictor.class.getMethods()) {
+            if (method.isSynthetic() || Modifier.isStatic(method.getModifiers())) {
+                continue;
+            }
+            try {
+                Method declared = CamelJolokiaRestrictor.class.getDeclaredMethod(method.getName(),
+                        method.getParameterTypes());
+                if (!Modifier.isFinal(declared.getModifiers())) {
+                    overridable.add(declared.getName());
+                }
+            } catch (NoSuchMethodException e) {
+                // Reported by CamelJolokiaRestrictorInterfaceCoverageTest
+            }
+        }
+        assertTrue(overridable.isEmpty(),
+                "Access checks a subclass could override and widen: " + overridable);
+    }
+
+    /**
+     * Hooks that permit everything leave the inherited restrictions exactly as they were.
+     */
+    @Test
+    void permissiveHooksCannotWiden() throws MalformedObjectNameException {
+        CamelJolokiaRestrictor restrictor = new PermissiveSubclass();
+        ObjectName foreignDomain = new ObjectName("com.example:type=Foreign");
+
+        assertFalse(restrictor.isRemoteAccessAllowed("192.168.1.1"));
+        assertFalse(restrictor.isOriginAllowed("http://untrusted.example", false));
+        assertFalse(restrictor.isOperationAllowed(foreignDomain, "anything"));
+        assertFalse(restrictor.isAttributeReadAllowed(foreignDomain, "anything"));
+        assertFalse(restrictor.isAttributeWriteAllowed(foreignDomain, "anything"));
+        assertTrue(restrictor.isObjectNameHidden(foreignDomain));
+    }
+
+    /**
+     * Hooks that refuse take effect on top of what the inherited checks allowed.
+     */
+    @Test
+    void restrictiveHooksNarrow() throws MalformedObjectNameException {
+        CamelJolokiaRestrictor restrictor = new RestrictiveSubclass();
+        ObjectName camelDomain = new ObjectName("org.apache.camel:type=context");
+
+        assertFalse(restrictor.isRemoteAccessAllowed("127.0.0.1"));
+        assertFalse(restrictor.isOriginAllowed("http://localhost:8080", false));
+        assertFalse(restrictor.isHttpMethodAllowed(HttpMethod.GET));
+        assertFalse(restrictor.isTypeAllowed(RequestType.READ));
+        assertFalse(restrictor.isOperationAllowed(camelDomain, "dumpRoutesAsXml"));
+        assertFalse(restrictor.isAttributeReadAllowed(camelDomain, "CamelId"));
+        assertFalse(restrictor.isAttributeWriteAllowed(camelDomain, "CamelId"));
+        assertTrue(restrictor.isObjectNameHidden(camelDomain));
+    }
+
+    /**
+     * A subclass that adds nothing behaves exactly like the restrictor it extends.
+     */
+    @Test
+    void defaultHooksChangeNothing() throws MalformedObjectNameException {
+        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor() {
+        };
+        ObjectName camelDomain = new ObjectName("org.apache.camel:type=context");
+
+        assertTrue(restrictor.isRemoteAccessAllowed("127.0.0.1"));
+        assertTrue(restrictor.isOperationAllowed(camelDomain, "dumpRoutesAsXml"));
+        assertFalse(restrictor.isObjectNameHidden(camelDomain));
+    }
+
+    static final class PermissiveSubclass extends CamelJolokiaRestrictor {
+        @Override
+        protected boolean allowsRemoteAccess(String... hostOrAddress) {
+            return true;
+        }
+
+        @Override
+        protected boolean allowsOrigin(String origin, boolean strictCheck) {
+            return true;
+        }
+
+        @Override
+        protected boolean allowsOperation(ObjectName objectName, String operation) {
+            return true;
+        }
+
+        @Override
+        protected boolean allowsAttributeRead(ObjectName objectName, String attribute) {
+            return true;
+        }
+
+        @Override
+        protected boolean allowsAttributeWrite(ObjectName objectName, String attribute) {
+            return true;
+        }
+
+        @Override
+        protected boolean allowsObjectName(ObjectName objectName) {
+            return true;
+        }
+    }
+
+    static final class RestrictiveSubclass extends CamelJolokiaRestrictor {
+        @Override
+        protected boolean allowsRemoteAccess(String... hostOrAddress) {
+            return false;
+        }
+
+        @Override
+        protected boolean allowsOrigin(String origin, boolean strictCheck) {
+            return false;
+        }
+
+        @Override
+        protected boolean allowsHttpMethod(HttpMethod method) {
+            return false;
+        }
+
+        @Override
+        protected boolean allowsRequestType(RequestType type) {
+            return false;
+        }
+
+        @Override
+        protected boolean allowsOperation(ObjectName objectName, String operation) {
+            return false;
+        }
+
+        @Override
+        protected boolean allowsAttributeRead(ObjectName objectName, String attribute) {
+            return false;
+        }
+
+        @Override
+        protected boolean allowsAttributeWrite(ObjectName objectName, String attribute) {
+            return false;
+        }
+
+        @Override
+        protected boolean allowsObjectName(ObjectName objectName) {
+            return false;
+        }
+    }
+}

--- a/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/CamelJolokiaRestrictorSubclassUnresolvablePolicyTest.java
+++ b/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/CamelJolokiaRestrictorSubclassUnresolvablePolicyTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.jolokia;
+
+import io.quarkus.test.QuarkusUnitTest;
+import org.apache.camel.quarkus.jolokia.restrictor.CamelJolokiaRestrictor;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Extending the restrictor is the documented way of customising it, and the subclass resolves the access policy
+ * in the same inherited constructor. The policy therefore has to be checked before the server is created for a
+ * subclass too, since the constructor runs after the agent port is bound and throwing there would leave it held
+ * for the lifetime of the JVM.
+ *
+ * The failure has to arrive from the pre-check rather than from Jolokia instantiating the restrictor, which is
+ * what the message assertion distinguishes.
+ */
+class CamelJolokiaRestrictorSubclassUnresolvablePolicyTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest CONFIG = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClasses(SubclassedRestrictor.class))
+            .overrideConfigKey("quarkus.camel.jolokia.additional-properties.restrictorClass",
+                    SubclassedRestrictor.class.getName())
+            .overrideConfigKey("quarkus.camel.jolokia.additional-properties.policyLocation",
+                    "classpath:/jolokia-access-not-packaged.xml")
+            .assertException(t -> {
+                assertTrue(t instanceof IllegalStateException,
+                        "Expected the pre-check to throw directly, not Jolokia to fail creating the restrictor: " + t);
+                assertTrue(t.getMessage().contains("could not be resolved"), t.getMessage());
+            });
+
+    @Test
+    void applicationShouldNotStart() {
+        fail("The application should not have started with an unresolvable access policy");
+    }
+
+    public static class SubclassedRestrictor extends CamelJolokiaRestrictor {
+    }
+}

--- a/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/CamelJolokiaRestrictorTest.java
+++ b/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/CamelJolokiaRestrictorTest.java
@@ -65,6 +65,46 @@ class CamelJolokiaRestrictorTest {
     }
 
     @Test
+    void loopbackOnlyAddressChainAllowed() {
+        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
+        assertTrue(restrictor.isRemoteAccessAllowed("localhost", "127.0.0.1"));
+    }
+
+    @Test
+    void spoofedLoopbackInAddressChainRejected() {
+        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
+        assertFalse(restrictor.isRemoteAccessAllowed("127.0.0.1", "192.168.1.1"));
+        assertFalse(restrictor.isRemoteAccessAllowed("192.168.1.1", "127.0.0.1"));
+        assertFalse(restrictor.isRemoteAccessAllowed("localhost", "192.168.1.1"));
+        assertFalse(restrictor.isRemoteAccessAllowed("192.168.1.1", "::1"));
+    }
+
+    @Test
+    void ipv6LoopbackLiteralsAllowed() {
+        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
+        assertTrue(restrictor.isRemoteAccessAllowed("::1"));
+        assertTrue(restrictor.isRemoteAccessAllowed("0:0:0:0:0:0:0:1"));
+        assertTrue(restrictor.isRemoteAccessAllowed("::ffff:127.0.0.1"));
+        assertTrue(restrictor.isRemoteAccessAllowed("::1%lo0"));
+        assertTrue(restrictor.isRemoteAccessAllowed("::1%lo"));
+    }
+
+    /**
+     * A colon does not make a value an IPv6 literal. InetAddress.getByName falls back to the name service for
+     * anything it cannot read as a literal, so a client supplied host name carrying a colon must be rejected
+     * without a lookup rather than being handed to the resolver.
+     */
+    @Test
+    void hostNamesCarryingAColonRejectedWithoutResolving() {
+        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
+        assertFalse(restrictor.isRemoteAccessAllowed("untrusted.example:1"));
+        assertFalse(restrictor.isRemoteAccessAllowed("localhost:80"));
+        assertFalse(restrictor.isRemoteAccessAllowed("::ffff:8.8.8.8"));
+        assertFalse(restrictor.isRemoteAccessAllowed(".::1"));
+        assertFalse(restrictor.isRemoteAccessAllowed(".0:0:0:0:0:0:0:1"));
+    }
+
+    @Test
     void nullArgsRejected() {
         CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
         assertFalse(restrictor.isRemoteAccessAllowed((String[]) null));
@@ -113,6 +153,13 @@ class CamelJolokiaRestrictorTest {
     void remoteOriginRejectedWithStrictCheck() {
         CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
         assertFalse(restrictor.isOriginAllowed("http://untrusted.example", true));
+    }
+
+    @Test
+    void originWithUserInfoRejected() {
+        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
+        assertFalse(restrictor.isOriginAllowed("http://untrusted.example@localhost", true));
+        assertFalse(restrictor.isOriginAllowed("http://untrusted.example@127.0.0.1", true));
     }
 
     @Test

--- a/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/CamelJolokiaRestrictorUnresolvablePolicyTest.java
+++ b/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/CamelJolokiaRestrictorUnresolvablePolicyTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.jolokia;
+
+import io.quarkus.test.QuarkusUnitTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * An explicitly configured classpath policy that does not resolve fails the application at startup, rather than
+ * falling back to the remote-access-allowed handling. Without this, a native executable built without
+ * registering the policy as a resource would silently run with no policy at all, and with remote-access-allowed
+ * set that means every origin and every MBean operation is permitted.
+ */
+class CamelJolokiaRestrictorUnresolvablePolicyTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest CONFIG = new QuarkusUnitTest()
+            .overrideConfigKey("quarkus.camel.jolokia.additional-properties.policyLocation",
+                    "classpath:/jolokia-access-not-packaged.xml")
+            .overrideConfigKey("quarkus.camel.jolokia.remote-access-allowed", "true")
+            .assertException(t -> {
+                IllegalStateException cause = null;
+                for (Throwable current = t; current != null; current = current.getCause()) {
+                    if (current instanceof IllegalStateException illegalState) {
+                        cause = illegalState;
+                        break;
+                    }
+                }
+                assertNotNull(cause, "Expected an IllegalStateException in the cause chain, got: " + t);
+                assertTrue(cause.getMessage().contains("jolokia-access-not-packaged.xml"), cause.getMessage());
+                assertTrue(cause.getMessage().contains("quarkus.native.resources.includes"), cause.getMessage());
+            });
+
+    @Test
+    void applicationShouldNotStart() {
+        fail("The application should not have started with an unresolvable access policy");
+    }
+}

--- a/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/CamelJolokiaRestrictorWildcardOriginsTest.java
+++ b/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/CamelJolokiaRestrictorWildcardOriginsTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.jolokia;
+
+import io.quarkus.test.QuarkusUnitTest;
+import org.apache.camel.quarkus.jolokia.restrictor.CamelJolokiaRestrictor;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Origins are compiled the same way Jolokia compiles an access policy `allow-origin` rule, so the values of an
+ * existing policy file can be moved to `allowed-origins` unchanged.
+ */
+class CamelJolokiaRestrictorWildcardOriginsTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest CONFIG = new QuarkusUnitTest()
+            .overrideConfigKey("quarkus.camel.jolokia.allowed-origins",
+                    "*://*.example.com,https://fixed.example.org");
+
+    @Test
+    void wildcardMatchesAnySchemeAndSubdomain() {
+        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
+        assertTrue(restrictor.isOriginAllowed("https://hawtio.example.com", true));
+        assertTrue(restrictor.isOriginAllowed("http://monitoring.example.com", true));
+        assertTrue(restrictor.isOriginAllowed("https://a.b.example.com", true));
+    }
+
+    @Test
+    void wildcardStillAnchoredAtBothEnds() {
+        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
+        assertFalse(restrictor.isOriginAllowed("https://example.com.untrusted.example", true));
+        assertFalse(restrictor.isOriginAllowed("https://hawtio.example.com.evil.test", true));
+        // The wildcard covers a subdomain label, not the bare domain
+        assertFalse(restrictor.isOriginAllowed("https://example.com", true));
+    }
+
+    @Test
+    void wildcardAppliesToRefererStyleValues() {
+        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
+        assertTrue(restrictor.isOriginAllowed("https://hawtio.example.com/hawtio/jmx", true));
+    }
+
+    @Test
+    void nonWildcardEntriesUnaffected() {
+        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
+        assertTrue(restrictor.isOriginAllowed("https://fixed.example.org", true));
+        assertFalse(restrictor.isOriginAllowed("https://other.example.org", true));
+    }
+}

--- a/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/JolokiaFetchMetadataDisabledOnLoopbackTest.java
+++ b/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/JolokiaFetchMetadataDisabledOnLoopbackTest.java
@@ -16,35 +16,33 @@
  */
 package org.apache.camel.quarkus.jolokia;
 
-import java.net.URI;
+import java.util.logging.Level;
 
 import io.quarkus.test.QuarkusUnitTest;
-import io.restassured.RestAssured;
-import org.apache.camel.quarkus.jolokia.util.JolokiaHostUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class JolokiaDefaultHostLocalhostTest {
+/**
+ * The Fetch Metadata warning is about a browser reaching the agent, so there is nothing to warn about while the
+ * agent is bound to loopback. Without this the warning would fire on every local development setup that turns
+ * the headers off, and a warning that appears when there is no problem is one nobody reads.
+ */
+class JolokiaFetchMetadataDisabledOnLoopbackTest {
+
     @RegisterExtension
     static final QuarkusUnitTest CONFIG = new QuarkusUnitTest()
-            .withEmptyApplication();
+            .withEmptyApplication()
+            .overrideConfigKey("quarkus.camel.jolokia.server.host", "localhost")
+            .overrideConfigKey("quarkus.camel.jolokia.additional-properties.\"useFetchMetadata\"", "false")
+            .setLogRecordPredicate(record -> record.getLevel().equals(Level.WARNING))
+            .assertLogRecords(records -> assertTrue(
+                    records.stream().noneMatch(r -> r.getMessage().contains("Fetch Metadata handling is disabled")),
+                    "Expected no Fetch Metadata warning while the agent is bound to loopback"));
 
     @Test
-    void defaultHostIsLoopback() {
-        RestAssured.port = 8778;
-        String url = RestAssured.get("/jolokia/")
-                .then()
-                .statusCode(200)
-                .extract()
-                .body()
-                .jsonPath()
-                .getString("value.details.url");
-
-        // URI.getHost keeps the brackets of an IPv6 URL, which isLoopbackAddress strips
-        String host = URI.create(url).getHost();
-        assertTrue(JolokiaHostUtils.isLoopbackAddress(host),
-                "Default host should resolve to a loopback address, but got: " + host);
+    void applicationStartsWithoutFetchMetadataWarning() {
+        // The assertLogRecords callback above verifies no warning was logged.
     }
 }

--- a/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/JolokiaFetchMetadataDisabledWarningTest.java
+++ b/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/JolokiaFetchMetadataDisabledWarningTest.java
@@ -16,35 +16,34 @@
  */
 package org.apache.camel.quarkus.jolokia;
 
-import java.net.URI;
+import java.util.logging.Level;
 
 import io.quarkus.test.QuarkusUnitTest;
-import io.restassured.RestAssured;
-import org.apache.camel.quarkus.jolokia.util.JolokiaHostUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class JolokiaDefaultHostLocalhostTest {
+/**
+ * A request carrying neither an Origin nor a Referer header is accepted, and Jolokia's Sec-Fetch-* handling is
+ * what prevents a browser from making one. Turning it off on an agent that other hosts can reach therefore
+ * removes the only thing guarding that path, which is worth reporting at startup rather than only in the
+ * documentation.
+ */
+class JolokiaFetchMetadataDisabledWarningTest {
+
     @RegisterExtension
     static final QuarkusUnitTest CONFIG = new QuarkusUnitTest()
-            .withEmptyApplication();
+            .withEmptyApplication()
+            .overrideConfigKey("quarkus.camel.jolokia.server.host", "0.0.0.0")
+            .overrideConfigKey("quarkus.camel.jolokia.additional-properties.\"useFetchMetadata\"", "false")
+            .setLogRecordPredicate(record -> record.getLevel().equals(Level.WARNING))
+            .assertLogRecords(records -> assertTrue(
+                    records.stream().anyMatch(r -> r.getMessage().contains("Fetch Metadata handling is disabled")),
+                    "Expected a warning that Fetch Metadata handling is disabled"));
 
     @Test
-    void defaultHostIsLoopback() {
-        RestAssured.port = 8778;
-        String url = RestAssured.get("/jolokia/")
-                .then()
-                .statusCode(200)
-                .extract()
-                .body()
-                .jsonPath()
-                .getString("value.details.url");
-
-        // URI.getHost keeps the brackets of an IPv6 URL, which isLoopbackAddress strips
-        String host = URI.create(url).getHost();
-        assertTrue(JolokiaHostUtils.isLoopbackAddress(host),
-                "Default host should resolve to a loopback address, but got: " + host);
+    void applicationStartsWithFetchMetadataWarning() {
+        // The assertLogRecords callback above verifies the warning was logged.
     }
 }

--- a/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/JolokiaKubernetesClientAuthRemoteAccessTest.java
+++ b/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/JolokiaKubernetesClientAuthRemoteAccessTest.java
@@ -28,24 +28,23 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class CamelJolokiaRestrictorFilePolicyTest {
+/**
+ * Kubernetes SSL client authentication authenticates every client at the transport, so the restrictor does not
+ * also confine them to loopback. Consoles reaching the agent on the pod IP are the reason client authentication
+ * is configured at all.
+ *
+ * A client principal is configured here, so the authenticated peer is a known identity rather than any holder of
+ * a service CA signed certificate. Origins would therefore be lifted too, except that `allowed-origins` is set
+ * and the explicit list wins.
+ */
+class JolokiaKubernetesClientAuthRemoteAccessTest {
 
-    private static final String JOLOKIA_ACCESS_XML = """
-            <?xml version="1.0" encoding="UTF-8"?>
-            <restrict>
-                <remote>
-                    <host>10.0.0.0/8</host>
-                </remote>
-            </restrict>
-            """;
-
-    static final File POLICY_FILE;
+    static final File CA_CERT;
 
     static {
         try {
-            POLICY_FILE = Files.createTempFile("jolokia-access", ".xml").toFile();
-            POLICY_FILE.deleteOnExit();
-            Files.writeString(POLICY_FILE.toPath(), JOLOKIA_ACCESS_XML);
+            CA_CERT = Files.createTempFile("fake-ca", ".crt").toFile();
+            CA_CERT.deleteOnExit();
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -53,31 +52,29 @@ class CamelJolokiaRestrictorFilePolicyTest {
 
     @RegisterExtension
     static final QuarkusUnitTest CONFIG = new QuarkusUnitTest()
-            .overrideConfigKey("quarkus.camel.jolokia.additional-properties.policyLocation",
-                    POLICY_FILE.toURI().toString());
+            .withEmptyApplication()
+            .overrideConfigKey("kubernetes.service.host", "fake-host")
+            .overrideConfigKey("quarkus.camel.jolokia.kubernetes.service-ca-cert", CA_CERT.getAbsolutePath())
+            .overrideConfigKey("quarkus.camel.jolokia.kubernetes.client-principal", "cn=hawtio-online.hawtio.svc")
+            .overrideConfigKey("quarkus.camel.jolokia.allowed-origins", "https://hawtio.example.com");
 
     @Test
-    void filePolicyAllowsConfiguredSubnet() {
+    void remoteAddressesAllowed() {
         CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
-        assertTrue(restrictor.isRemoteAccessAllowed("10.0.0.1"));
-        assertTrue(restrictor.isRemoteAccessAllowed("10.255.255.255"));
+        assertTrue(restrictor.isRemoteAccessAllowed("10.128.4.7"));
+        assertTrue(restrictor.isRemoteAccessAllowed("127.0.0.1"));
     }
 
     @Test
-    void filePolicyDeniesOtherAddresses() {
+    void originsStillRestricted() {
         CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
-        assertFalse(restrictor.isRemoteAccessAllowed("192.168.1.1"));
-        assertFalse(restrictor.isRemoteAccessAllowed("172.16.0.1"));
+        assertTrue(restrictor.isOriginAllowed("https://hawtio.example.com", true));
+        assertFalse(restrictor.isOriginAllowed("https://untrusted.example", true));
     }
 
-    /**
-     * Loopback is not in the subnet the policy allows, and the policy decides addresses outright, so it is
-     * refused like any other address outside it.
-     */
     @Test
-    void loopbackDeniedByPolicy() {
+    void mbeanDomainsStillRestricted() throws Exception {
         CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
-        assertFalse(restrictor.isRemoteAccessAllowed("127.0.0.1"));
-        assertFalse(restrictor.isRemoteAccessAllowed("::1"));
+        assertTrue(restrictor.isObjectNameHidden(new javax.management.ObjectName("com.example:type=Test")));
     }
 }

--- a/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/JolokiaKubernetesClientPrincipalOriginsTest.java
+++ b/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/JolokiaKubernetesClientPrincipalOriginsTest.java
@@ -25,27 +25,25 @@ import org.apache.camel.quarkus.jolokia.restrictor.CamelJolokiaRestrictor;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class CamelJolokiaRestrictorFilePolicyTest {
+/**
+ * With a client principal pinning which identity may connect, the authenticated peer is a known console rather
+ * than any holder of a certificate the service CA happened to sign, so cross-origin requests it forwards are
+ * accepted without the origin having to be listed.
+ *
+ * This is what lets a Hawtio Online deployment upgrade untouched. 3.38.0 already required the client principal
+ * and applied no origin check at all, so the one property such a deployment already carries is the one that
+ * keeps its console working.
+ */
+class JolokiaKubernetesClientPrincipalOriginsTest {
 
-    private static final String JOLOKIA_ACCESS_XML = """
-            <?xml version="1.0" encoding="UTF-8"?>
-            <restrict>
-                <remote>
-                    <host>10.0.0.0/8</host>
-                </remote>
-            </restrict>
-            """;
-
-    static final File POLICY_FILE;
+    static final File CA_CERT;
 
     static {
         try {
-            POLICY_FILE = Files.createTempFile("jolokia-access", ".xml").toFile();
-            POLICY_FILE.deleteOnExit();
-            Files.writeString(POLICY_FILE.toPath(), JOLOKIA_ACCESS_XML);
+            CA_CERT = Files.createTempFile("fake-ca", ".crt").toFile();
+            CA_CERT.deleteOnExit();
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -53,31 +51,27 @@ class CamelJolokiaRestrictorFilePolicyTest {
 
     @RegisterExtension
     static final QuarkusUnitTest CONFIG = new QuarkusUnitTest()
-            .overrideConfigKey("quarkus.camel.jolokia.additional-properties.policyLocation",
-                    POLICY_FILE.toURI().toString());
+            .withEmptyApplication()
+            .overrideConfigKey("kubernetes.service.host", "fake-host")
+            .overrideConfigKey("quarkus.camel.jolokia.kubernetes.service-ca-cert", CA_CERT.getAbsolutePath())
+            .overrideConfigKey("quarkus.camel.jolokia.kubernetes.client-principal", "cn=hawtio-online.hawtio.svc");
 
     @Test
-    void filePolicyAllowsConfiguredSubnet() {
+    void anyOriginAllowedWhenClientIdentityIsPinned() {
         CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
-        assertTrue(restrictor.isRemoteAccessAllowed("10.0.0.1"));
-        assertTrue(restrictor.isRemoteAccessAllowed("10.255.255.255"));
+        assertTrue(restrictor.isOriginAllowed("https://hawtio-online.apps.example.com", true));
+        assertTrue(restrictor.isOriginAllowed("https://anything.example", true));
     }
 
     @Test
-    void filePolicyDeniesOtherAddresses() {
+    void remoteAddressesAllowed() {
         CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
-        assertFalse(restrictor.isRemoteAccessAllowed("192.168.1.1"));
-        assertFalse(restrictor.isRemoteAccessAllowed("172.16.0.1"));
+        assertTrue(restrictor.isRemoteAccessAllowed("10.128.4.7"));
     }
 
-    /**
-     * Loopback is not in the subnet the policy allows, and the policy decides addresses outright, so it is
-     * refused like any other address outside it.
-     */
     @Test
-    void loopbackDeniedByPolicy() {
+    void mbeanDomainsStillRestricted() throws Exception {
         CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
-        assertFalse(restrictor.isRemoteAccessAllowed("127.0.0.1"));
-        assertFalse(restrictor.isRemoteAccessAllowed("::1"));
+        assertTrue(restrictor.isObjectNameHidden(new javax.management.ObjectName("com.example:type=Test")));
     }
 }

--- a/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/JolokiaKubernetesClientPrincipalWithPolicyOriginsTest.java
+++ b/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/JolokiaKubernetesClientPrincipalWithPolicyOriginsTest.java
@@ -22,13 +22,23 @@ import java.nio.file.Files;
 
 import io.quarkus.test.QuarkusUnitTest;
 import org.apache.camel.quarkus.jolokia.restrictor.CamelJolokiaRestrictor;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class CamelJolokiaRestrictorFilePolicyTest {
+/**
+ * An access policy governs client addresses and what a client may do. It says nothing about origins, since the
+ * `cors` section is not consulted, so bringing one must not withdraw the origins a client principal allows.
+ *
+ * The policy here restricts addresses, and that restriction is expected to take effect while origins stay lifted.
+ * The two controls are answered independently.
+ */
+class JolokiaKubernetesClientPrincipalWithPolicyOriginsTest {
 
     private static final String JOLOKIA_ACCESS_XML = """
             <?xml version="1.0" encoding="UTF-8"?>
@@ -39,13 +49,12 @@ class CamelJolokiaRestrictorFilePolicyTest {
             </restrict>
             """;
 
-    static final File POLICY_FILE;
+    static final File CA_CERT;
 
     static {
         try {
-            POLICY_FILE = Files.createTempFile("jolokia-access", ".xml").toFile();
-            POLICY_FILE.deleteOnExit();
-            Files.writeString(POLICY_FILE.toPath(), JOLOKIA_ACCESS_XML);
+            CA_CERT = Files.createTempFile("fake-ca", ".crt").toFile();
+            CA_CERT.deleteOnExit();
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -53,31 +62,23 @@ class CamelJolokiaRestrictorFilePolicyTest {
 
     @RegisterExtension
     static final QuarkusUnitTest CONFIG = new QuarkusUnitTest()
-            .overrideConfigKey("quarkus.camel.jolokia.additional-properties.policyLocation",
-                    POLICY_FILE.toURI().toString());
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource(new StringAsset(JOLOKIA_ACCESS_XML), "jolokia-access.xml"))
+            .overrideConfigKey("kubernetes.service.host", "fake-host")
+            .overrideConfigKey("quarkus.camel.jolokia.kubernetes.service-ca-cert", CA_CERT.getAbsolutePath())
+            .overrideConfigKey("quarkus.camel.jolokia.kubernetes.client-principal", "cn=hawtio-online.hawtio.svc");
 
     @Test
-    void filePolicyAllowsConfiguredSubnet() {
+    void originLiftSurvivesAnAccessPolicy() {
+        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
+        assertTrue(restrictor.isOriginAllowed("https://hawtio-online.apps.example.com", true));
+        assertTrue(restrictor.isOriginAllowed("https://anything.example", true));
+    }
+
+    @Test
+    void policyStillDecidesAddresses() {
         CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
         assertTrue(restrictor.isRemoteAccessAllowed("10.0.0.1"));
-        assertTrue(restrictor.isRemoteAccessAllowed("10.255.255.255"));
-    }
-
-    @Test
-    void filePolicyDeniesOtherAddresses() {
-        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
         assertFalse(restrictor.isRemoteAccessAllowed("192.168.1.1"));
-        assertFalse(restrictor.isRemoteAccessAllowed("172.16.0.1"));
-    }
-
-    /**
-     * Loopback is not in the subnet the policy allows, and the policy decides addresses outright, so it is
-     * refused like any other address outside it.
-     */
-    @Test
-    void loopbackDeniedByPolicy() {
-        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
-        assertFalse(restrictor.isRemoteAccessAllowed("127.0.0.1"));
-        assertFalse(restrictor.isRemoteAccessAllowed("::1"));
     }
 }

--- a/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/JolokiaKubernetesClientPrincipalWithRemoteAccessOriginsTest.java
+++ b/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/JolokiaKubernetesClientPrincipalWithRemoteAccessOriginsTest.java
@@ -25,27 +25,24 @@ import org.apache.camel.quarkus.jolokia.restrictor.CamelJolokiaRestrictor;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class CamelJolokiaRestrictorFilePolicyTest {
+/**
+ * Asking for remote clients must not withdraw the origins a client principal allows.
+ *
+ * `remote-access-allowed` is a control over client addresses and nothing else, so setting it on Kubernetes says
+ * nothing about origins. It is also a reasonable thing to set there, being what the documentation prescribes
+ * everywhere else, and a deployment that sets both must not find its console refused for having asked for
+ * something unrelated.
+ */
+class JolokiaKubernetesClientPrincipalWithRemoteAccessOriginsTest {
 
-    private static final String JOLOKIA_ACCESS_XML = """
-            <?xml version="1.0" encoding="UTF-8"?>
-            <restrict>
-                <remote>
-                    <host>10.0.0.0/8</host>
-                </remote>
-            </restrict>
-            """;
-
-    static final File POLICY_FILE;
+    static final File CA_CERT;
 
     static {
         try {
-            POLICY_FILE = Files.createTempFile("jolokia-access", ".xml").toFile();
-            POLICY_FILE.deleteOnExit();
-            Files.writeString(POLICY_FILE.toPath(), JOLOKIA_ACCESS_XML);
+            CA_CERT = Files.createTempFile("fake-ca", ".crt").toFile();
+            CA_CERT.deleteOnExit();
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -53,31 +50,22 @@ class CamelJolokiaRestrictorFilePolicyTest {
 
     @RegisterExtension
     static final QuarkusUnitTest CONFIG = new QuarkusUnitTest()
-            .overrideConfigKey("quarkus.camel.jolokia.additional-properties.policyLocation",
-                    POLICY_FILE.toURI().toString());
+            .withEmptyApplication()
+            .overrideConfigKey("kubernetes.service.host", "fake-host")
+            .overrideConfigKey("quarkus.camel.jolokia.kubernetes.service-ca-cert", CA_CERT.getAbsolutePath())
+            .overrideConfigKey("quarkus.camel.jolokia.kubernetes.client-principal", "cn=hawtio-online.hawtio.svc")
+            .overrideConfigKey("quarkus.camel.jolokia.remote-access-allowed", "true");
 
     @Test
-    void filePolicyAllowsConfiguredSubnet() {
+    void originLiftSurvivesRemoteAccessAllowed() {
         CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
-        assertTrue(restrictor.isRemoteAccessAllowed("10.0.0.1"));
-        assertTrue(restrictor.isRemoteAccessAllowed("10.255.255.255"));
+        assertTrue(restrictor.isOriginAllowed("https://hawtio-online.apps.example.com", true));
+        assertTrue(restrictor.isOriginAllowed("https://anything.example", true));
     }
 
     @Test
-    void filePolicyDeniesOtherAddresses() {
+    void remoteAddressesAllowed() {
         CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
-        assertFalse(restrictor.isRemoteAccessAllowed("192.168.1.1"));
-        assertFalse(restrictor.isRemoteAccessAllowed("172.16.0.1"));
-    }
-
-    /**
-     * Loopback is not in the subnet the policy allows, and the policy decides addresses outright, so it is
-     * refused like any other address outside it.
-     */
-    @Test
-    void loopbackDeniedByPolicy() {
-        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
-        assertFalse(restrictor.isRemoteAccessAllowed("127.0.0.1"));
-        assertFalse(restrictor.isRemoteAccessAllowed("::1"));
+        assertTrue(restrictor.isRemoteAccessAllowed("10.128.4.7"));
     }
 }

--- a/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/JolokiaKubernetesNoClientAuthLoopbackTest.java
+++ b/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/JolokiaKubernetesNoClientAuthLoopbackTest.java
@@ -16,35 +16,39 @@
  */
 package org.apache.camel.quarkus.jolokia;
 
-import java.net.URI;
-
 import io.quarkus.test.QuarkusUnitTest;
 import io.restassured.RestAssured;
-import org.apache.camel.quarkus.jolokia.util.JolokiaHostUtils;
+import org.apache.camel.quarkus.jolokia.restrictor.CamelJolokiaRestrictor;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
-class JolokiaDefaultHostLocalhostTest {
+/**
+ * Turning SSL client authentication off on Kubernetes is an explicit opt-out, so nothing authenticates clients
+ * and the agent falls back to the same loopback defaults it uses everywhere else. It must not inherit the
+ * Kubernetes bind address or the lifted address restriction.
+ */
+class JolokiaKubernetesNoClientAuthLoopbackTest {
     @RegisterExtension
     static final QuarkusUnitTest CONFIG = new QuarkusUnitTest()
-            .withEmptyApplication();
+            .withEmptyApplication()
+            .overrideConfigKey("kubernetes.service.host", "fake-host")
+            .overrideConfigKey("quarkus.camel.jolokia.kubernetes.client-authentication-enabled", "false");
 
     @Test
-    void defaultHostIsLoopback() {
+    void remoteAddressesStillDenied() {
+        CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
+        assertFalse(restrictor.isRemoteAccessAllowed("10.128.4.7"));
+    }
+
+    @Test
+    void agentStillServesPlainHttpOnLoopback() {
         RestAssured.port = 8778;
-        String url = RestAssured.get("/jolokia/")
+        RestAssured.get("/jolokia/")
                 .then()
                 .statusCode(200)
-                .extract()
-                .body()
-                .jsonPath()
-                .getString("value.details.url");
-
-        // URI.getHost keeps the brackets of an IPv6 URL, which isLoopbackAddress strips
-        String host = URI.create(url).getHost();
-        assertTrue(JolokiaHostUtils.isLoopbackAddress(host),
-                "Default host should resolve to a loopback address, but got: " + host);
+                .body("status", equalTo(200));
     }
 }

--- a/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/JolokiaKubernetesNoClientPrincipalOriginsTest.java
+++ b/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/JolokiaKubernetesNoClientPrincipalOriginsTest.java
@@ -28,24 +28,19 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class CamelJolokiaRestrictorFilePolicyTest {
+/**
+ * Without a client principal, any certificate the service CA signed is accepted, so the authenticated peer is
+ * not a known identity and cross-origin requests stay restricted. Addresses are still lifted, since the client
+ * has at least been authenticated.
+ */
+class JolokiaKubernetesNoClientPrincipalOriginsTest {
 
-    private static final String JOLOKIA_ACCESS_XML = """
-            <?xml version="1.0" encoding="UTF-8"?>
-            <restrict>
-                <remote>
-                    <host>10.0.0.0/8</host>
-                </remote>
-            </restrict>
-            """;
-
-    static final File POLICY_FILE;
+    static final File CA_CERT;
 
     static {
         try {
-            POLICY_FILE = Files.createTempFile("jolokia-access", ".xml").toFile();
-            POLICY_FILE.deleteOnExit();
-            Files.writeString(POLICY_FILE.toPath(), JOLOKIA_ACCESS_XML);
+            CA_CERT = Files.createTempFile("fake-ca", ".crt").toFile();
+            CA_CERT.deleteOnExit();
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -53,31 +48,26 @@ class CamelJolokiaRestrictorFilePolicyTest {
 
     @RegisterExtension
     static final QuarkusUnitTest CONFIG = new QuarkusUnitTest()
-            .overrideConfigKey("quarkus.camel.jolokia.additional-properties.policyLocation",
-                    POLICY_FILE.toURI().toString());
+            .withEmptyApplication()
+            .overrideConfigKey("kubernetes.service.host", "fake-host")
+            .overrideConfigKey("quarkus.camel.jolokia.kubernetes.service-ca-cert", CA_CERT.getAbsolutePath());
 
     @Test
-    void filePolicyAllowsConfiguredSubnet() {
+    void unlistedOriginsDenied() {
         CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
-        assertTrue(restrictor.isRemoteAccessAllowed("10.0.0.1"));
-        assertTrue(restrictor.isRemoteAccessAllowed("10.255.255.255"));
+        assertFalse(restrictor.isOriginAllowed("https://hawtio-online.apps.example.com", true));
     }
 
     @Test
-    void filePolicyDeniesOtherAddresses() {
+    void loopbackOriginsAndNoOriginStillAllowed() {
         CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
-        assertFalse(restrictor.isRemoteAccessAllowed("192.168.1.1"));
-        assertFalse(restrictor.isRemoteAccessAllowed("172.16.0.1"));
+        assertTrue(restrictor.isOriginAllowed(null, true));
+        assertTrue(restrictor.isOriginAllowed("http://localhost:8080", true));
     }
 
-    /**
-     * Loopback is not in the subnet the policy allows, and the policy decides addresses outright, so it is
-     * refused like any other address outside it.
-     */
     @Test
-    void loopbackDeniedByPolicy() {
+    void remoteAddressesStillAllowed() {
         CamelJolokiaRestrictor restrictor = new CamelJolokiaRestrictor();
-        assertFalse(restrictor.isRemoteAccessAllowed("127.0.0.1"));
-        assertFalse(restrictor.isRemoteAccessAllowed("::1"));
+        assertTrue(restrictor.isRemoteAccessAllowed("10.128.4.7"));
     }
 }

--- a/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/JolokiaKubernetesTlsDisabledByOverrideFailureTest.java
+++ b/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/JolokiaKubernetesTlsDisabledByOverrideFailureTest.java
@@ -16,29 +16,45 @@
  */
 package org.apache.camel.quarkus.jolokia;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
 import io.quarkus.test.QuarkusUnitTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
- * There is no service CA certificate, which is the plain Kubernetes case, so client authentication was never on
- * offer. The failure has to say that rather than report an enabled feature as broken, since the operator never
- * enabled anything.
+ * The service CA certificate exists, so client authentication would normally be configured, but
+ * `additional-properties` switches it back off. Since those properties win over everything the extension
+ * sets, the agent would otherwise serve plain HTTP to the pod network with no authentication.
  */
-class JolokiaKubernetesTlsFailureTest {
+class JolokiaKubernetesTlsDisabledByOverrideFailureTest {
+
+    static final File CA_CERT;
+
+    static {
+        try {
+            CA_CERT = Files.createTempFile("fake-ca", ".crt").toFile();
+            CA_CERT.deleteOnExit();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     @RegisterExtension
     static final QuarkusUnitTest CONFIG = new QuarkusUnitTest()
             .withEmptyApplication()
             .overrideConfigKey("kubernetes.service.host", "fake-host")
-            .overrideConfigKey("quarkus.camel.jolokia.kubernetes.service-ca-cert", "/non/existent/ca.crt")
+            .overrideConfigKey("quarkus.camel.jolokia.kubernetes.service-ca-cert", CA_CERT.getAbsolutePath())
             .overrideConfigKey("quarkus.camel.jolokia.server.host", "0.0.0.0")
+            .overrideConfigKey("quarkus.camel.jolokia.additional-properties.useSslClientAuthentication", "false")
             .assertException(t -> {
                 if (t.getMessage() == null
-                        || !t.getMessage().contains("not available on this cluster")
-                        || !t.getMessage().contains("/non/existent/ca.crt")
-                        || !t.getMessage().contains("0.0.0.0")) {
+                        || !t.getMessage().contains("Kubernetes SSL client authentication is enabled")
+                        || !t.getMessage().contains("additional-properties")) {
                     throw new AssertionError(
-                            "Expected RuntimeException naming the absent service CA certificate, got: " + t, t);
+                            "Expected startup to fail because client authentication was overridden off, got: " + t, t);
                 }
             });
 

--- a/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/JolokiaKubernetesTlsHostOverrideFailureTest.java
+++ b/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/JolokiaKubernetesTlsHostOverrideFailureTest.java
@@ -21,24 +21,24 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
- * There is no service CA certificate, which is the plain Kubernetes case, so client authentication was never on
- * offer. The failure has to say that rather than report an enabled feature as broken, since the operator never
- * enabled anything.
+ * The bind address is checked after `additional-properties` has been merged in. Setting Jolokia's own `host`
+ * option there overrides `quarkus.camel.jolokia.server.host`, so checking the latter would report a loopback
+ * bind while the agent listened on every interface.
  */
-class JolokiaKubernetesTlsFailureTest {
+class JolokiaKubernetesTlsHostOverrideFailureTest {
     @RegisterExtension
     static final QuarkusUnitTest CONFIG = new QuarkusUnitTest()
             .withEmptyApplication()
             .overrideConfigKey("kubernetes.service.host", "fake-host")
             .overrideConfigKey("quarkus.camel.jolokia.kubernetes.service-ca-cert", "/non/existent/ca.crt")
-            .overrideConfigKey("quarkus.camel.jolokia.server.host", "0.0.0.0")
+            // Deliberately left at its localhost default, so only the override below opens the agent up
+            .overrideConfigKey("quarkus.camel.jolokia.additional-properties.host", "0.0.0.0")
             .assertException(t -> {
                 if (t.getMessage() == null
                         || !t.getMessage().contains("not available on this cluster")
-                        || !t.getMessage().contains("/non/existent/ca.crt")
                         || !t.getMessage().contains("0.0.0.0")) {
                     throw new AssertionError(
-                            "Expected RuntimeException naming the absent service CA certificate, got: " + t, t);
+                            "Expected startup to fail because the merged bind address is not loopback, got: " + t, t);
                 }
             });
 

--- a/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/JolokiaRecorderTest.java
+++ b/extensions/jolokia/deployment/src/test/java/org/apache/camel/quarkus/jolokia/JolokiaRecorderTest.java
@@ -16,8 +16,10 @@
  */
 package org.apache.camel.quarkus.jolokia;
 
+import org.jolokia.server.core.config.ConfigKey;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -71,6 +73,78 @@ class JolokiaRecorderTest {
     @Test
     void ipv6LongFormLoopbackIsLoopback() {
         assertTrue(JolokiaRecorder.isLoopbackHost("0:0:0:0:0:0:0:1"));
+    }
+
+    @Test
+    void ipv4MappedIpv6LoopbackIsLoopback() {
+        assertTrue(JolokiaRecorder.isLoopbackHost("::ffff:127.0.0.1"));
+    }
+
+    @Test
+    void ipv6ScopedLoopbackIsLoopback() {
+        // No scope id is resolved, so none of these depend on the interfaces this host has
+        assertTrue(JolokiaRecorder.isLoopbackHost("::1%lo0"));
+        assertTrue(JolokiaRecorder.isLoopbackHost("::1%lo"));
+        assertTrue(JolokiaRecorder.isLoopbackHost("::1%1"));
+        assertTrue(JolokiaRecorder.isLoopbackHost("[::1%eth0]"));
+    }
+
+    @Test
+    void ipv6ScopedNonLoopbackIsNotLoopback() {
+        assertFalse(JolokiaRecorder.isLoopbackHost("fe80::1%lo0"));
+    }
+
+    @Test
+    void ipv6MalformedScopeIsNotLoopback() {
+        assertFalse(JolokiaRecorder.isLoopbackHost("::1%"));
+        assertFalse(JolokiaRecorder.isLoopbackHost("::1%lo0/x"));
+    }
+
+    @Test
+    void ipv6LeadingZeroLoopbackIsLoopback() {
+        assertTrue(JolokiaRecorder.isLoopbackHost("0:0:0:0:0:0:0:0001"));
+    }
+
+    /**
+     * Resolving a malformed literal would let the local name service decide whether the agent counts as exposed.
+     */
+    @Test
+    void malformedAddressLiteralIsNotLoopbackWithoutResolving() {
+        assertFalse(JolokiaRecorder.isLoopbackHost(".::1"));
+        assertFalse(JolokiaRecorder.isLoopbackHost("127.0.0.1.5"));
+        assertFalse(JolokiaRecorder.isLoopbackHost("127.0.0"));
+    }
+
+    @Test
+    void ipv6NonLoopbackIsNotLoopback() {
+        assertFalse(JolokiaRecorder.isLoopbackHost("fe80::1"));
+        assertFalse(JolokiaRecorder.isLoopbackHost("foo:bar"));
+    }
+
+    @Test
+    void ipv4LoopbackWithSignedOctetIsNotLoopback() {
+        assertFalse(JolokiaRecorder.isLoopbackHost("127.0.0.+1"));
+    }
+
+    @Test
+    void loopbackNameInRootFormIsLoopback() {
+        assertTrue(JolokiaRecorder.isLoopbackHost("localhost."));
+        assertTrue(JolokiaRecorder.isLoopbackHost("localhost.localdomain."));
+    }
+
+    @Test
+    void ipv4LoopbackWithTrailingDotIsNotLoopback() {
+        assertFalse(JolokiaRecorder.isLoopbackHost("127.0.0.1."));
+    }
+
+    /**
+     * Jolokia prepends the name the client address resolves back to when this is on, and a host whose loopback
+     * address does not resolve to `localhost` then refuses local clients. If this fails after a Jolokia
+     * upgrade, that lookup became the default and the extension documentation needs to say so.
+     */
+    @Test
+    void dnsReverseLookupIsOffByDefault() {
+        assertEquals("false", ConfigKey.ALLOW_DNS_REVERSE_LOOKUP.getDefaultValue());
     }
 
     @Test

--- a/extensions/jolokia/runtime/src/main/doc/usage.adoc
+++ b/extensions/jolokia/runtime/src/main/doc/usage.adoc
@@ -2,13 +2,13 @@ This extension adds https://jolokia.org/[Jolokia] support to your application.
 
 === Jolokia HTTP endpoints
 
-Jolokia is accessible at the following URL.
+Jolokia is accessible at http://localhost:8778/jolokia/.
 
-* http://localhost:8778/jolokia/
+The agent HTTP server binds to `localhost`, except in remote dev mode, in dev and test mode on WSL, and on Kubernetes with <<extensions-jolokia-usage-ssl-client-authentication,SSL client authentication>> configured, where it binds to `0.0.0.0`.
 
-By default, the Jolokia agent HTTP server binds to `localhost`. Remote dev mode and WSL environments default to `0.0.0.0`.
+NOTE: Binding `0.0.0.0` in remote dev mode, and on WSL, does not on its own allow remote clients. Client addresses are restricted to loopback in every mode, so reaching the agent from another host also needs `quarkus.camel.jolokia.remote-access-allowed=true`. See <<extensions-jolokia-usage-allowing-remote-clients,Allowing remote clients>>.
 
-If you want to disable Jolokia entirely, then add the following configuration to `application.properties`.
+To disable Jolokia entirely, add the following to `application.properties`.
 
 [source]
 ----
@@ -17,10 +17,9 @@ quarkus.camel.jolokia.enabled=false
 
 === Jolokia configuration
 
-Any of the https://jolokia.org/reference/html/manual/agents.html[Jolokia configuration options] can be configured via the `quarkus.camel.jolokia.additional-properties.<jolokia-property-name>` option.
-Where `<jolokia-property-name>` is the name of the Jolokia configuration option you want to set.
+Any of the https://jolokia.org/reference/html/manual/agents.html[Jolokia configuration options] can be set via `quarkus.camel.jolokia.additional-properties.<jolokia-property-name>`.
 
-For example, the following configuration added to `application.properties` enables Jolokia debugging and sets the max depth for traversing bean properties.
+For example, to enable Jolokia debugging and set the max depth for traversing bean properties.
 
 [source]
 ----
@@ -28,82 +27,47 @@ quarkus.camel.jolokia.additional-properties.debug=true
 quarkus.camel.jolokia.additional-properties.maxDepth=10
 ----
 
-=== Jolokia restrictor
+== Security
 
-By default, a Jolokia restrictor is automatically registered that exposes access to only a specific set of MBean domains.
+By default, Jolokia is reachable only from the machine the application runs on, and exposes only Camel and JVM MBeans. The defaults are applied by `CamelJolokiaRestrictor`, which is registered automatically.
 
-* `org.apache.camel`
-* `java.lang`
-* `java.nio`
+[width="100%",cols="20,50,30",options="header"]
+|===
+| | Default | Configured by
 
-If this is too restrictive, then you can either specify your own MBean domains, disable the default restrictor, or create a custom restrictor.
+| Bind address
+| `localhost`, or `0.0.0.0` on Kubernetes with SSL client authentication
+| `quarkus.camel.jolokia.server.host`
 
-==== Default restrictor MBean domains
+| Client addresses
+| Loopback addresses only, such as `127.0.0.1` and `::1`, regardless of the bind address. Lifted on Kubernetes with SSL client authentication, which authenticates every client
+| `quarkus.camel.jolokia.remote-access-allowed`
 
-You can modify the set of MBean domains referenced by the default restrictor by adding configuration like the following to `application.properties`.
+| Cross-origin requests
+| Denied, except loopback origins and requests carrying no `Origin` header. Lifted on Kubernetes when `kubernetes.client-principal` is set and no origins are listed here
+| `quarkus.camel.jolokia.allowed-origins`
 
-[source]
-----
-quarkus.camel.jolokia.camel-restrictor-allowed-mbean-domains=org.apache.camel
-----
+| MBean domains
+| `org.apache.camel`, `java.lang`, `java.nio`
+| `quarkus.camel.jolokia.camel-restrictor-allowed-mbean-domains`
+|===
 
-==== Disabling the default restrictor
+=== Authentication
 
-The following configuration added to `application.properties` disables the default restrictor.
-
-[source]
-----
-quarkus.camel.jolokia.register-camel-restrictor=false
-----
-
-==== Create a custom restrictor
-
-You can create your own restrictor class and register it with Jolokia. Extending `CamelJolokiaRestrictor` inherits the secure defaults (remote access control, CORS blocking, MBean domain filtering).
-
-[source,java]
-----
-public class CustomRestrictor extends CamelJolokiaRestrictor {
-    // Override methods to apply custom restrictions
-}
-----
-
-Register the restrictor with Jolokia by adding the following configuration to `application.properties`.
+Jolokia can require HTTP basic authentication. It is off by default and is configured through the agent's own options.
 
 [source]
 ----
-quarkus.camel.jolokia.additional-properties.restrictorClass=org.acme.CustomRestrictor
+quarkus.camel.jolokia.additional-properties.authMode=basic
+quarkus.camel.jolokia.additional-properties.user=jolokia
+quarkus.camel.jolokia.additional-properties.password=${JOLOKIA_PASSWORD}
 ----
 
-=== Kubernetes & OpenShift support
+IMPORTANT: Basic authentication sends the password on every request, so serve the agent over HTTPS or keep it off untrusted networks. On Kubernetes and OpenShift, <<extensions-jolokia-usage-ssl-client-authentication,SSL client authentication>> is the better option and is already enabled by default.
 
-==== Generated Kubernetes manifests
+=== Allowing remote clients
 
-If the `quarkus-kubernetes` or `quarkus-openshift` extensions are present, a container port named `jolokia` will be added automatically to the pod configuration within the generated Kubernetes manifest resources.
-
-This can be disabled by adding the following configuration to `application.properties`.
-
-[source]
-----
-quarkus.camel.jolokia.kubernetes.expose-container-port=false
-----
-
-==== Automatic enablement of SSL client authentication
-
-If the application detects that it is running on Kubernetes or OpenShift, then Jolokia is automatically configured for SSL client authentication.
-This is useful if you use tools like https://hawt.io/[Hawtio] to discover and connect to your running application pod.
-
-This functionality can be disabled by adding the following configuration to `application.properties`.
-
-[source]
-----
-quarkus.camel.jolokia.kubernetes.client-authentication-enabled=false
-----
-
-==== Configuring Jolokia for remote management tools
-
-Tools such as https://hawt.io/[Hawtio] and https://github.com/hawtio/hawtio-online[hawtio-online] connect to Jolokia via the pod IP address, which is a non-loopback address. By default, the Jolokia agent binds to `localhost` and the default restrictor blocks connections from non-loopback addresses.
-
-To allow remote management tools to connect to Jolokia in Kubernetes, add the following configuration to `application.properties`.
+To reach the agent from another host, open up both the bind address and remote access.
 
 [source]
 ----
@@ -111,42 +75,79 @@ quarkus.camel.jolokia.server.host=0.0.0.0
 quarkus.camel.jolokia.remote-access-allowed=true
 ----
 
-This is safe when combined with SSL client authentication (enabled by default in Kubernetes), which ensures that only clients presenting a valid certificate signed by the service CA can connect. If you use hawtio-online, you must also configure the Jolokia client principal.
+This opens up client addresses only. Cross-origin requests remain restricted, so a browser based console needs its origin listed as well. See <<extensions-jolokia-usage-allowing-cross-origin-requests,Allowing cross-origin requests>>.
+
+A reverse proxy in front of the agent needs this too, even on the same host, since the client address it forwards is not a loopback address.
+
+NOTE: Turning on `quarkus.camel.jolokia.additional-properties.allowDnsReverseLookup`, which Jolokia leaves off, adds the name the client address resolves back to. A host whose loopback address resolves to something other than `localhost` then refuses local clients too, answering `No access from client [chain: myhost -> 127.0.0.1] allowed`. Allow the name through the `<remote>` section of an <<extensions-jolokia-usage-access-policy-files,access policy>>.
+
+IMPORTANT: This exposes an agent that authenticates nobody. Anyone who can reach it gets full access to the allowed MBean domains, which by default means invoking Camel management operations such as `sendStringBody`, which sends a message to any endpoint the application can resolve, and stopping the `CamelContext`. Confine the agent to a trusted network, or configure <<extensions-jolokia-usage-authentication,authentication>>.
+
+=== Allowing cross-origin requests
+
+To let a browser based tool such as https://hawt.io/[Hawtio] drive the agent, list its origin.
 
 [source]
 ----
-quarkus.camel.jolokia.kubernetes.client-principal=cn=hawtio-online.hawtio.svc
+quarkus.camel.jolokia.allowed-origins=https://hawtio.example.com
 ----
 
-=== Security
-
-NOTE: Even when bound to `localhost`, Jolokia does not require authentication by default. On shared hosts or in container environments where localhost may be reachable from other containers, consider using a custom restrictor or Jolokia access policy to restrict access further.
-
-==== Network binding
-
-By default, the Jolokia agent HTTP server binds to `localhost`, making it accessible only from the local machine. If you need to expose Jolokia to remote hosts, you must explicitly configure the bind address and enable remote access.
+Matching is case insensitive, and `*` is a wildcard, exactly as in the `<allow-origin>` rules of a Jolokia access policy. So a whole domain can be covered in one entry.
 
 [source]
 ----
-quarkus.camel.jolokia.server.host=0.0.0.0
-quarkus.camel.jolokia.remote-access-allowed=true
+quarkus.camel.jolokia.allowed-origins=*://*.example.com
 ----
 
-==== Remote access control
+A value of `*` on its own accepts any origin.
 
-The default Camel Jolokia restrictor blocks connections from non-loopback addresses. This is controlled by the `quarkus.camel.jolokia.remote-access-allowed` property (default `false`). When set to `false`, only connections from loopback addresses (e.g. `127.0.0.1`, `::1`) are accepted, regardless of the server bind address.
+Each value is matched against the scheme, host and port of the request origin, so a path or query in the entry never matches. A port that is the default for the scheme is optional, so `https://hawtio.example.com` and `https://hawtio.example.com:443` are interchangeable. Any other port has to be listed, since `https://hawtio.example.com:8443` is a different origin. An internationalised host has to be listed in its punycode form, such as `https://xn--e1afmkfd.example`, since that is what a browser sends. A host containing an underscore cannot be matched at all, as it is not a valid host name, so such an origin is always refused.
 
-==== Cross-origin requests (CORS)
+Loopback origins are always accepted, so that a console on the same machine needs no configuration. That still applies once `quarkus.camel.jolokia.remote-access-allowed` has opened the agent to other hosts, so a page served from `localhost` in any browser that can reach the agent is accepted as well.
 
-The default Camel Jolokia restrictor denies all cross-origin requests. If you need to allow specific origins (e.g. for a browser-based monitoring tool connecting cross-origin), you can use a https://jolokia.org/reference/html/manual/security.html[Jolokia access policy] (`jolokia-access.xml`) with a `<cors>` section, or configure a custom restrictor that overrides `isOriginAllowed()`.
+IMPORTANT: This property is the only way to allow an origin. The `<cors>` section of a `jolokia-access.xml` access policy is *not* used at all. If you are bringing an existing policy file, copy its `<allow-origin>` values here unchanged, replace `<ignore-scheme/>` with `quarkus.camel.jolokia.ignore-origin-scheme=true`, and delete the section.
 
-==== Jolokia access policy
+==== Requests with no origin
 
-Jolokia supports fine-grained access control via an XML policy file (`jolokia-access.xml`). This can restrict access by IP address, CORS origin, HTTP method, and MBean operation.
+A request carrying neither an `Origin` nor a `Referer` header is accepted, so that command line clients such as `curl` keep working. There is no equivalent of the `<strict-checking/>` element of an access policy to turn that off.
 
-The default Camel restrictor automatically loads `jolokia-access.xml` from the classpath if present. Place the file in `src/main/resources/jolokia-access.xml` to use it alongside the Camel restrictor. The Camel restrictor always allows loopback connections. For non-loopback requests, it delegates remote access, CORS, allowed request types (`<commands>`), and HTTP method (`<http>`) checks to the policy file, while continuing to enforce MBean domain filtering.
+Browsers are stopped from exploiting this by Jolokia's handling of the `Sec-Fetch-*` headers, which refuses anything a browser marks as other than an explicit top-level navigation. Leave that in place.
 
-For example, the following `jolokia-access.xml` allows access from the `10.0.0.0/8` subnet, CORS requests from a monitoring tool, and restricts Jolokia to read-only operations over HTTP GET.
+[source]
+----
+# Do not do this
+quarkus.camel.jolokia.additional-properties.useFetchMetadata=false
+----
+
+==== HTTPS origins and a plain HTTP agent
+
+Jolokia refuses a request whose `Origin` uses `https` when the agent itself serves plain `http`, responding with a status of `403`, whatever `allowed-origins` lists.
+
+Either serve the agent over HTTPS, or turn the check off.
+
+[source]
+----
+quarkus.camel.jolokia.ignore-origin-scheme=true
+----
+
+WARNING: Only do this where something in front of the agent terminates TLS. Otherwise, a page loaded over HTTPS ends up driving an agent that is not.
+
+This does not arise where <<extensions-jolokia-usage-ssl-client-authentication,SSL client authentication>> is configured, since the agent then serves HTTPS.
+
+=== MBean domains
+
+The restrictor hides MBeans outside the allowed domains, and denies reads, writes and operations against them. Adjust the set as needed.
+
+[source]
+----
+quarkus.camel.jolokia.camel-restrictor-allowed-mbean-domains=org.apache.camel,java.lang
+----
+
+=== Access policy files
+
+Jolokia supports fine grained access control via an XML policy file, which can restrict access by IP address, HTTP method, request type and MBean operation. Refer to the https://jolokia.org/reference/html/manual/security.html[Jolokia security documentation] for the full format.
+
+Place the file at `src/main/resources/jolokia-access.xml` and it is picked up automatically. For example, the following policy allows the `10.0.0.0/8` subnet and restricts Jolokia to read-only operations over HTTP GET.
 
 [source,xml]
 ----
@@ -155,9 +156,6 @@ For example, the following `jolokia-access.xml` allows access from the `10.0.0.0
     <remote>
         <host>10.0.0.0/8</host>
     </remote>
-    <cors>
-        <allow-origin>http://monitoring.example.com</allow-origin>
-    </cors>
     <commands>
         <command>read</command>
         <command>list</command>
@@ -170,25 +168,167 @@ For example, the following `jolokia-access.xml` allows access from the `10.0.0.0
 </restrict>
 ----
 
-Refer to the https://jolokia.org/reference/html/manual/security.html[Jolokia security documentation] for the full policy file format.
-
-To load the policy file from a different location, such as a file path mounted from a Kubernetes ConfigMap, configure the `policyLocation` property.
+To load the policy from elsewhere, such as a file mounted from a Kubernetes ConfigMap, set `policyLocation`.
 
 [source]
 ----
 quarkus.camel.jolokia.additional-properties."policyLocation"=file:/etc/jolokia/jolokia-access.xml
 ----
 
-As an alternative, you can disable the default Camel restrictor entirely and let Jolokia manage the policy file directly. This gives full control to `jolokia-access.xml` (including MBean-level rules) but loses the Camel MBean domain filtering.
+==== How a policy combines with the restrictor
+
+The policy's `<remote>`, `<commands>`, `<http>` and MBean level rules (`<allow>`, `<deny>`, `<filter>`) all apply. MBean domain filtering applies on top of them.
+
+* A `<remote>` section decides client addresses. `quarkus.camel.jolokia.remote-access-allowed` and the loopback default no longer apply, so a `<remote>` section that does not list `127.0.0.1` refuses local clients too.
+* A policy with no `<remote>` section says nothing about addresses, so the loopback default and `quarkus.camel.jolokia.remote-access-allowed` still decide them. A `<remote>` section listing `0.0.0.0/0` is read the same way, since it grants no more than saying nothing does.
+* The `<cors>` section is not consulted at all. Use `quarkus.camel.jolokia.allowed-origins` in place of `<allow-origin>`, and `quarkus.camel.jolokia.ignore-origin-scheme` in place of `<ignore-scheme/>`. `<strict-checking/>` has no equivalent.
+* Where a proxy forwards the client address in a `Forwarded`, `X-Forwarded-For` or `X-Real-IP` header, `<remote>` has to allow that address as well. Hawtio forwards the browser address by default.
+
+==== Loading failures
+
+A `policyLocation` that is configured but points at nothing fails the application at startup. This covers a `classpath:` location that was not packaged, and a `file:` location that is not there, such as a ConfigMap that failed to mount.
+
+A policy that is found but cannot be read or parsed denies all Jolokia access and logs an error.
+
+In native mode, a policy at the default `jolokia-access.xml` location is registered as a resource automatically. A policy loaded from any other `classpath:` location must be registered by your application.
+
+[source]
+----
+quarkus.native.resources.includes=my-jolokia-access.xml
+----
+
+=== Custom restrictors
+
+Extending `CamelJolokiaRestrictor` inherits the secure defaults described above, including access policy handling.
+
+The access checks are `final`. A subclass adds restrictions through the `allows*` hooks, which are called only once the inherited checks have allowed the request.
+
+[source,java]
+----
+public class CustomRestrictor extends CamelJolokiaRestrictor {
+    @Override
+    protected boolean allowsOperation(ObjectName objectName, String operation) {
+        return operation.startsWith("dump");
+    }
+}
+----
+
+Each hook returns `true` to keep the inherited decision and `false` to refuse, so a subclass can only narrow what the defaults permit.
+
+[width="100%",cols="45,55",options="header"]
+|===
+| Hook | Narrows
+
+| `allowsRemoteAccess(String...)` | Which client addresses may reach the agent
+| `allowsOrigin(String, boolean)` | Which origins may reach the agent
+| `allowsHttpMethod(HttpMethod)` | Which HTTP methods may be used
+| `allowsRequestType(RequestType)` | Which Jolokia request types may be used
+| `allowsAttributeRead(ObjectName, String)` | Which attributes may be read
+| `allowsAttributeWrite(ObjectName, String)` | Which attributes may be written
+| `allowsOperation(ObjectName, String)` | Which operations may be invoked
+| `allowsObjectName(ObjectName)` | Which MBeans are listed
+|===
+
+`isAllowedDomain(ObjectName)` is `protected`, for a hook that needs the domain restriction. The inherited checks apply it already.
+
+To grant access, use the configuration options above. Implementing Jolokia's `Restrictor` interface directly replaces these decisions and inherits none of the defaults.
+
+[source]
+----
+quarkus.camel.jolokia.additional-properties.restrictorClass=org.acme.CustomRestrictor
+----
+
+Alternatively, disabling the Camel restrictor hands full control to `jolokia-access.xml`, including its `<cors>` section and MBean level rules, but loses MBean domain filtering and every property described above.
 
 [source]
 ----
 quarkus.camel.jolokia.register-camel-restrictor=false
 ----
 
-If you are building a native executable, the policy file must be explicitly included as a native resource.
+WARNING: With no restrictor and no access policy, Jolokia is unrestricted.
+
+== Kubernetes & OpenShift
+
+=== Generated Kubernetes manifests
+
+If the `quarkus-kubernetes` or `quarkus-openshift` extensions are present, a production build adds a container port named `jolokia` to the container spec of the generated manifests. To disable this.
 
 [source]
 ----
-quarkus.native.resources.includes=jolokia-access.xml
+quarkus.camel.jolokia.kubernetes.expose-container-port=false
 ----
+
+=== SSL client authentication
+
+On Kubernetes and OpenShift, Jolokia is configured for SSL client authentication wherever the service CA certificate is present, so that only clients presenting a certificate signed by it can connect. This is the default on OpenShift.
+
+Because every client is then authenticated by the transport, the agent binds `0.0.0.0` rather than `localhost` and the loopback restriction on client addresses does not apply.
+
+The certificate is checked against the service CA only, so unless a client principal is configured, any client holding a certificate the CA happened to sign is accepted. Restrict this to a specific service identity.
+
+[source]
+----
+quarkus.camel.jolokia.kubernetes.client-principal=cn=hawtio-online.hawtio.svc
+----
+
+Once a client principal is set, the authenticated peer is a known identity rather than any certificate holder, so cross-origin requests it forwards are accepted and <<extensions-jolokia-usage-allowing-cross-origin-requests,`allowed-origins`>> does not have to list the console. Setting `allowed-origins` anyway still takes effect, being the more specific instruction.
+
+NOTE: Only `quarkus.camel.jolokia.kubernetes.client-principal` accepts those cross-origin requests. Jolokia reads the same value from a `clientPrincipal` option, and from `clientPrincipal.1`, `clientPrincipal.2` and so on for several identities, either of which can be set through `quarkus.camel.jolokia.additional-properties`. Both restrict which certificate is accepted, but the restrictor does not read them, so cross-origin requests stay restricted. The `Origins:` value in the Jolokia line logged at startup shows which applies.
+
+Without a client principal, cross-origin requests remain restricted to loopback origins and whatever `allowed-origins` lists. A startup warning says so.
+
+To disable SSL client authentication entirely.
+
+[source]
+----
+quarkus.camel.jolokia.kubernetes.client-authentication-enabled=false
+----
+
+WARNING: Disabling it opts out of the only thing authenticating clients. The agent then falls back to binding `localhost` and accepting loopback clients only, exactly as it does off Kubernetes. Opening it up again with `server.host` and `remote-access-allowed` would expose an unauthenticated agent to the pod network.
+
+NOTE: The default `service-ca-cert` path is written by the OpenShift service CA operator and is absent on vanilla Kubernetes, where none of the above applies unless `quarkus.camel.jolokia.kubernetes.service-ca-cert` is pointed at a CA certificate you mount yourself.
+
+Where client authentication is enabled but not in effect, because the certificate is absent or `additional-properties` overrode one of the options it is made of, the application fails to start unless the agent is bound to `localhost`. Mount a certificate, bind to `localhost`, or set `client-authentication-enabled=false`.
+
+== Hawtio & Hawtio Online
+
+https://hawt.io/[Hawtio] and https://github.com/hawtio/hawtio-online[Hawtio Online] proxy browser requests to the agent, forwarding the browser `Origin` header and adding the browser address as `X-Forwarded-For`.
+
+Hawtio running on the same machine as the application needs no configuration. Both the origin it forwards and the address it adds are loopback, so the defaults accept them. Everything below concerns reaching an agent on another host, which is how Hawtio Online always connects, via the pod IP address.
+
+Hawtio lists MBeans beyond those of Camel and the JVM. Add any other domain it should show, such as `org.apache.activemq.artemis`, to <<extensions-jolokia-usage-mbean-domains,`camel-restrictor-allowed-mbean-domains`>>.
+
+=== On Kubernetes & OpenShift
+
+<<extensions-jolokia-usage-ssl-client-authentication,SSL client authentication>> already covers the bind address, the client addresses and, once the client principal is pinned, the console origin. A deployment following the Hawtio Online instructions therefore needs one property.
+
+[source]
+----
+quarkus.camel.jolokia.kubernetes.client-principal=cn=hawtio-online.hawtio.svc
+----
+
+This is the subject of the client certificate Hawtio Online presents, which its `generate-proxying.sh` issues with a CN of `hawtio-online.hawtio.svc` by default, where `hawtio` is the namespace. Adjust it if the certificate was generated with a different CN or namespace.
+
+To restrict which console origins are accepted on top of that, list them.
+
+[source]
+----
+quarkus.camel.jolokia.allowed-origins=https://hawtio-online.apps.example.com
+----
+
+The origin to list is the address the browser uses for the Hawtio console, not the address of the agent.
+
+=== Anywhere else
+
+With nothing authenticating clients, the agent has to be opened up explicitly.
+
+[source]
+----
+quarkus.camel.jolokia.server.host=0.0.0.0
+quarkus.camel.jolokia.remote-access-allowed=true
+quarkus.camel.jolokia.allowed-origins=https://hawtio.example.com
+----
+
+On plain Kubernetes, add `quarkus.camel.jolokia.kubernetes.client-authentication-enabled=false` as well. SSL client authentication is enabled by default and cannot be configured there, so binding to a non-loopback address otherwise fails at startup.
+
+The agent serves plain HTTP here, so an `https` console origin is refused whatever `allowed-origins` lists. See <<extensions-jolokia-usage-https-origins-and-a-plain-http-agent,HTTPS origins and a plain HTTP agent>>.

--- a/extensions/jolokia/runtime/src/main/java/org/apache/camel/quarkus/jolokia/JolokiaRecorder.java
+++ b/extensions/jolokia/runtime/src/main/java/org/apache/camel/quarkus/jolokia/JolokiaRecorder.java
@@ -17,9 +17,10 @@
 package org.apache.camel.quarkus.jolokia;
 
 import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.RuntimeValue;
@@ -32,11 +33,13 @@ import org.apache.camel.quarkus.jolokia.config.JolokiaRuntimeConfig.Kubernetes;
 import org.apache.camel.quarkus.jolokia.config.JolokiaRuntimeConfig.Server;
 import org.apache.camel.quarkus.jolokia.restrictor.CamelJolokiaRestrictor;
 import org.apache.camel.quarkus.jolokia.util.JolokiaHostUtils;
+import org.apache.camel.quarkus.jolokia.util.JolokiaKubernetesUtils;
 import org.apache.camel.util.CollectionHelper;
 import org.apache.camel.util.ObjectHelper;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.logging.Logger;
 import org.jolokia.core.api.LogHandler;
+import org.jolokia.core.util.ClassUtil;
 import org.jolokia.jvmagent.JolokiaServer;
 import org.jolokia.jvmagent.JolokiaServerConfig;
 import org.jolokia.server.core.config.ConfigKey;
@@ -47,6 +50,11 @@ import static io.smallrye.common.os.Linux.isWSL;
 public class JolokiaRecorder {
     private static final String ALL_INTERFACES = "0.0.0.0";
     private static final String LOCALHOST = "localhost";
+    private static final String HOST = "host";
+    private static final String PROTOCOL = "protocol";
+    private static final String USE_SSL_CLIENT_AUTHENTICATION = "useSslClientAuthentication";
+    private static final String CA_CERT = "caCert";
+    private static final String CLIENT_PRINCIPAL = "clientPrincipal";
     private static final Logger LOG = Logger.getLogger(JolokiaRecorder.class);
 
     private final JolokiaBuildTimeConfig buildTimeConfig;
@@ -62,6 +70,13 @@ public class JolokiaRecorder {
         Server server = runtimeConfig.getValue().server();
         Kubernetes kubernetes = runtimeConfig.getValue().kubernetes();
 
+        boolean onKubernetes = ConfigProvider.getConfig()
+                .getOptionalValue("kubernetes.service.host", String.class)
+                .isPresent();
+        // Every client is authenticated by SSL client authentication in this case, so the agent can be reached
+        // from the pod network without being exposed to anything unauthenticated
+        boolean kubernetesClientAuthentication = JolokiaKubernetesUtils.isClientAuthenticationConfigured(kubernetes);
+
         // Configure Jolokia HTTP server host, port & context path
         String host = runtimeConfig.getValue().server().host().orElse(null);
         if (ObjectHelper.isEmpty(host)) {
@@ -73,57 +88,49 @@ public class JolokiaRecorder {
                 } else {
                     host = ALL_INTERFACES;
                 }
+            } else if (kubernetesClientAuthentication) {
+                host = ALL_INTERFACES;
             } else {
                 host = LOCALHOST;
             }
         }
 
         Map<String, String> serverOptions = new HashMap<>();
-        serverOptions.put("host", host);
+        serverOptions.put(HOST, host);
         serverOptions.put("port", String.valueOf(server.port()));
         serverOptions.put(ConfigKey.AGENT_CONTEXT.getKeyValue(), "/" + buildTimeConfig.path());
 
         // Attempt Kubernetes configuration
-        Optional<String> kubernetesServiceHost = ConfigProvider.getConfig().getOptionalValue("kubernetes.service.host",
-                String.class);
-        if (kubernetesServiceHost.isPresent()) {
-            if (kubernetes.clientAuthenticationEnabled() && kubernetes.serviceCaCert().exists()) {
-                serverOptions.put(ConfigKey.DISCOVERY_ENABLED.getKeyValue(), "false");
-                serverOptions.put("protocol", "https");
-                serverOptions.put("useSslClientAuthentication", "true");
-                serverOptions.put("extendedClientCheck", "true");
-                serverOptions.put("caCert", kubernetes.serviceCaCert().getAbsolutePath());
-                if (kubernetes.clientPrincipal().isPresent()) {
-                    serverOptions.put("clientPrincipal", kubernetes.clientPrincipal().get());
-                } else {
-                    LOG.warn("Kubernetes SSL client authentication is enabled but no client principal is configured"
-                            + " ('quarkus.camel.jolokia.kubernetes.client-principal'). Any pod presenting a valid"
-                            + " certificate signed by the service CA can access Jolokia. Set a client principal"
-                            + " to restrict access to a specific service identity.");
-                }
-            } else if (kubernetes.clientAuthenticationEnabled()) {
-                if (!isLoopbackHost(host)) {
-                    throw new RuntimeException(
-                            String.format("Kubernetes SSL client authentication is enabled but the service CA certificate"
-                                    + " '%s' does not exist. The Jolokia server is configured to bind to '%s'"
-                                    + " which would expose it without authentication. Either provide the CA certificate,"
-                                    + " set 'quarkus.camel.jolokia.kubernetes.client-authentication-enabled=false',"
-                                    + " or bind to localhost with 'quarkus.camel.jolokia.server.host=localhost'.",
-                                    kubernetes.serviceCaCert(), host));
-                }
-                LOG.warnf("Kubernetes SSL client authentication is enabled but the service CA certificate"
-                        + " '%s' does not exist. Proceeding without TLS since the Jolokia server is bound to"
-                        + " the loopback interface.", kubernetes.serviceCaCert());
-            }
+        if (kubernetesClientAuthentication) {
+            serverOptions.put(ConfigKey.DISCOVERY_ENABLED.getKeyValue(), "false");
+            serverOptions.put(PROTOCOL, "https");
+            serverOptions.put(USE_SSL_CLIENT_AUTHENTICATION, "true");
+            serverOptions.put("extendedClientCheck", "true");
+            serverOptions.put(CA_CERT, kubernetes.serviceCaCert().getAbsolutePath());
+            kubernetes.clientPrincipal().ifPresent(principal -> serverOptions.put(CLIENT_PRINCIPAL, principal));
         }
 
         // Merge configuration with any arbitrary values provided via quarkus.camel.jolokia.additional-properties
         Map<String, String> combinedOptions = CollectionHelper.mergeMaps(serverOptions,
                 runtimeConfig.getValue().additionalProperties());
 
+        // Check the merged options rather than the values set above, since additional-properties takes
+        // precedence over both and can override the bind address and every option client authentication is
+        // made of
+        if (onKubernetes && kubernetes.clientAuthenticationEnabled()) {
+            verifyKubernetesClientAuthentication(combinedOptions, kubernetes);
+        }
+
+        warnIfFetchMetadataDisabled(combinedOptions);
+
         // Configure CamelJolokiaRestrictor if an existing restrictor is not already provided
         if (runtimeConfig.getValue().registerCamelRestrictor()) {
             combinedOptions.putIfAbsent(ConfigKey.RESTRICTOR_CLASS.getKeyValue(), CamelJolokiaRestrictor.class.getName());
+        }
+
+        // Resolve the access policy before the server is created, since creating it binds the agent port
+        if (isCamelRestrictor(combinedOptions.get(ConfigKey.RESTRICTOR_CLASS.getKeyValue()))) {
+            CamelJolokiaRestrictor.verifyPolicyLocationResolvable();
         }
 
         // Enable discovery based on the provided mode
@@ -170,8 +177,151 @@ public class JolokiaRecorder {
         return new RuntimeValue<>(new CamelQuarkusJolokiaServer(jolokiaServer.getValue()));
     }
 
+    /**
+     * Fails the application when SSL client authentication is enabled on Kubernetes, the effective
+     * configuration does not enforce it, and the agent is not confined to the loopback interface. That
+     * combination would serve the agent to the pod network with no authentication at all.
+     *
+     * The options are the merged ones, so this holds however client authentication came to be disabled,
+     * whether the service CA certificate is absent or `additional-properties` overrode one of the options
+     * it is made of.
+     */
+    private static void verifyKubernetesClientAuthentication(Map<String, String> options, Kubernetes kubernetes) {
+        if (isClientAuthenticationEnforced(options)) {
+            if (ObjectHelper.isEmpty(options.get(CLIENT_PRINCIPAL))) {
+                LOG.warn("Kubernetes SSL client authentication is enabled but no client principal is configured"
+                        + " ('quarkus.camel.jolokia.kubernetes.client-principal'). Any pod presenting a valid"
+                        + " certificate signed by the service CA can access Jolokia. Set a client principal"
+                        + " to restrict access to a specific service identity. Until then cross-origin requests"
+                        + " remain restricted to the origins listed by 'quarkus.camel.jolokia.allowed-origins',"
+                        + " since the authenticated peer is not a known one.");
+            }
+            return;
+        }
+
+        // The two causes are not the same mistake, so they are not reported as one. An overridden option is a
+        // working setup taken apart, while a missing service CA certificate means client authentication was never
+        // on offer, and telling that operator to disable it would name something they never enabled
+        boolean serviceCaCertPresent = kubernetes.serviceCaCert().exists();
+        String reason = serviceCaCertPresent
+                ? String.format("Kubernetes SSL client authentication is enabled but the effective Jolokia"
+                        + " configuration does not enforce it. The '%s', '%s' or '%s' option has been overridden"
+                        + " via 'quarkus.camel.jolokia.additional-properties'.",
+                        PROTOCOL, USE_SSL_CLIENT_AUTHENTICATION, CA_CERT)
+                : String.format("Jolokia SSL client authentication is not available on this cluster. There is no"
+                        + " service CA certificate at '%s', which is written by the OpenShift service CA operator"
+                        + " and is absent on plain Kubernetes.", kubernetes.serviceCaCert());
+
+        String host = options.get(HOST);
+        if (!isLoopbackHost(host)) {
+            String remedy = serviceCaCertPresent
+                    ? "Either correct that, set"
+                            + " 'quarkus.camel.jolokia.kubernetes.client-authentication-enabled=false', or bind to"
+                            + " localhost with 'quarkus.camel.jolokia.server.host=localhost'."
+                    : "Set 'quarkus.camel.jolokia.kubernetes.client-authentication-enabled=false' to acknowledge"
+                            + " that the agent authenticates nobody, bind to localhost with"
+                            + " 'quarkus.camel.jolokia.server.host=localhost', or point"
+                            + " 'quarkus.camel.jolokia.kubernetes.service-ca-cert' at a CA certificate you mount"
+                            + " yourself.";
+            throw new RuntimeException(String.format(
+                    "%s Binding to '%s' would expose the agent without authentication. %s", reason, host, remedy));
+        }
+
+        LOG.warnf("%s Proceeding since the Jolokia agent is bound to '%s'.", reason, host);
+    }
+
+    /**
+     * Warns when Jolokia's Fetch Metadata handling has been turned off on an agent that is reachable from off
+     * the machine.
+     *
+     * A request carrying neither an Origin nor a Referer header is accepted, so that command line clients keep
+     * working, and there is no equivalent of an access policy's &lt;strict-checking/&gt; to turn that off.
+     * Jolokia's Sec-Fetch-* handling is what prevents a browser from making such a request on a visitor's
+     * behalf, so disabling it leaves that path with nothing guarding it.
+     *
+     * This warns rather than fails, unlike the Kubernetes check above. That check reports a configuration
+     * which asked for authentication and did not get it, whereas this one reports an explicit instruction to
+     * switch a protection off, which is the operator's to give.
+     */
+    private static void warnIfFetchMetadataDisabled(Map<String, String> options) {
+        String useFetchMetadata = options.get(ConfigKey.USE_FETCH_METADATA_HEADERS.getKeyValue());
+        if (useFetchMetadata == null || Boolean.parseBoolean(useFetchMetadata)) {
+            return;
+        }
+
+        String host = options.get(HOST);
+        if (isLoopbackHost(host)) {
+            return;
+        }
+
+        LOG.warnf("Jolokia Fetch Metadata handling is disabled via"
+                + " 'quarkus.camel.jolokia.additional-properties.\"%s\"' while the agent is bound to '%s'."
+                + " Requests carrying neither an Origin nor a Referer header are accepted, and the Sec-Fetch-*"
+                + " headers are what prevent a browser from making one. Re-enable it unless the agent is"
+                + " confined to the local machine.",
+                ConfigKey.USE_FETCH_METADATA_HEADERS.getKeyValue(), host);
+    }
+
+    private static boolean isClientAuthenticationEnforced(Map<String, String> options) {
+        return "https".equals(options.get(PROTOCOL))
+                && Boolean.parseBoolean(options.get(USE_SSL_CLIENT_AUTHENTICATION))
+                && ObjectHelper.isNotEmpty(options.get(CA_CERT));
+    }
+
+    /**
+     * Whether the configured restrictor is `CamelJolokiaRestrictor` or a subclass of it.
+     *
+     * Comparing names would miss the documented way of customising the restrictor, and a subclass resolves the
+     * access policy in the same inherited constructor, so it needs the same pre-check. Resolution goes through
+     * Jolokia's own class lookup, which is what will load the class moments later. A name that does not resolve
+     * is left alone, since Jolokia reports that itself when it creates the restrictor.
+     */
+    private static boolean isCamelRestrictor(String restrictorClassName) {
+        if (ObjectHelper.isEmpty(restrictorClassName)) {
+            return false;
+        }
+        Class<?> restrictorClass = ClassUtil.classForName(restrictorClassName);
+        return restrictorClass != null && CamelJolokiaRestrictor.class.isAssignableFrom(restrictorClass);
+    }
+
     static boolean isLoopbackHost(String host) {
-        return JolokiaHostUtils.isLoopbackAddress(host);
+        if (ObjectHelper.isEmpty(host)) {
+            return false;
+        }
+        if (JolokiaHostUtils.isLoopbackAddress(host)) {
+            return true;
+        }
+        // A literal was classified above, so only a name is resolved, recognising loopback aliases such as
+        // ip6-localhost. Unlike a client supplied address, the bind host comes from configuration
+        if (isAddressLiteral(host)) {
+            return false;
+        }
+
+        try {
+            return InetAddress.getByName(host).isLoopbackAddress();
+        } catch (UnknownHostException e) {
+            return false;
+        }
+    }
+
+    /**
+     * A colon appears only in an IPv6 literal, and digits and dots alone only in an IPv4 one. Neither is a name.
+     */
+    private static boolean isAddressLiteral(String host) {
+        if (host.indexOf(':') != -1) {
+            return true;
+        }
+
+        boolean dotted = false;
+        for (int i = 0; i < host.length(); i++) {
+            char c = host.charAt(i);
+            if (c == '.') {
+                dotted = true;
+            } else if (c < '0' || c > '9') {
+                return false;
+            }
+        }
+        return dotted;
     }
 
     static final class CamelQuarkusJolokiaAgent extends JolokiaServer {

--- a/extensions/jolokia/runtime/src/main/java/org/apache/camel/quarkus/jolokia/config/JolokiaRuntimeConfig.java
+++ b/extensions/jolokia/runtime/src/main/java/org/apache/camel/quarkus/jolokia/config/JolokiaRuntimeConfig.java
@@ -17,6 +17,7 @@
 package org.apache.camel.quarkus.jolokia.config;
 
 import java.io.File;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -61,14 +62,69 @@ public interface JolokiaRuntimeConfig {
     /**
      * When `true`, the default Camel Jolokia restrictor allows connections from non-loopback (remote) addresses.
      * When `false` (the default), only connections from loopback addresses (e.g. 127.0.0.1, ::1) are permitted.
-     * This provides defense-in-depth: even if the server host is configured to bind to all interfaces,
-     * remote requests are rejected unless this property is explicitly set to `true`.
+     *
+     * This controls client addresses only. Cross-origin requests remain restricted to loopback origins and
+     * whatever `quarkus.camel.jolokia.allowed-origins` lists.
+     *
+     * This option only takes effect when `register-camel-restrictor` is `true` and a custom restrictor class
+     * is not configured via `quarkus.camel.jolokia.additional-properties."restrictorClass"`. It is ignored when a
+     * Jolokia access policy (`jolokia-access.xml`) carries a `<remote>` section, since that section decides
+     * client addresses outright. A policy with no `<remote>` section says nothing about addresses, so this
+     * option still applies.
+     *
+     * It is not needed on Kubernetes when
+     * `quarkus.camel.jolokia.kubernetes.client-authentication-enabled` is `true` and the service CA certificate
+     * is present, since SSL client authentication then authenticates every client and non-loopback addresses are
+     * already accepted.
+     */
+    @WithDefault("false")
+    boolean remoteAccessAllowed();
+
+    /**
+     * Origins from which the default Camel Jolokia restrictor accepts cross-origin requests, in addition to
+     * loopback origins and requests that carry no `Origin` header. That loopback exception still applies once
+     * `quarkus.camel.jolokia.remote-access-allowed` has opened the agent to clients on other hosts.
+     *
+     * Each value is matched against the scheme, host and port of the request `Origin` header, for example
+     * `https://myhost.example.com`. A port that is the default for the scheme is optional. Matching is
+     * case-insensitive and `*` is a wildcard, as in the `<allow-origin>` rules of a Jolokia access policy, so
+     * `*://*.example.com` covers a whole domain and `*` on its own accepts any origin.
+     *
+     * Jolokia falls back to the `Referer` header when a request carries no `Origin`. Such a value is reduced to
+     * its origin before being matched, so only the origin needs listing.
+     *
+     * This is the only way to allow an origin. The `<cors>` section of a Jolokia access policy
+     * (`jolokia-access.xml`) is not used, though `<allow-origin>` values can be copied here unchanged and
+     * `<ignore-scheme/>` has an equivalent in `quarkus.camel.jolokia.ignore-origin-scheme`. The rest of a
+     * policy is applied as normal.
+     *
+     * Note that Jolokia itself rejects a request whose `Origin` uses `https` when the agent is serving plain
+     * `http`, whatever this option is set to.
+     *
+     * On Kubernetes, cross-origin requests are accepted without this option once
+     * `quarkus.camel.jolokia.kubernetes.client-principal` pins which client identity may connect. Setting it
+     * anyway restores the origin check, since an explicit list is the more specific instruction.
+     *
+     * This option only takes effect when `register-camel-restrictor` is `true` and a custom restrictor class
+     * is not configured via `quarkus.camel.jolokia.additional-properties."restrictorClass"`.
+     */
+    Optional<List<String>> allowedOrigins();
+
+    /**
+     * When `true`, Jolokia stops refusing a request whose `Origin` uses `https` while the agent itself serves
+     * plain `http`. That rule applies whatever `quarkus.camel.jolokia.allowed-origins` lists.
+     *
+     * Enable it only where the agent sits behind something that terminates TLS, since it otherwise allows a
+     * page loaded over HTTPS to be served by an agent that is not.
+     *
+     * This is the equivalent of `<ignore-scheme/>` in the `<cors>` section of a Jolokia access policy, which is
+     * not consulted.
      *
      * This option only takes effect when `register-camel-restrictor` is `true` and a custom restrictor class
      * is not configured via `quarkus.camel.jolokia.additional-properties."restrictorClass"`.
      */
     @WithDefault("false")
-    boolean remoteAccessAllowed();
+    boolean ignoreOriginScheme();
 
     interface Server {
         /**
@@ -81,8 +137,8 @@ public interface JolokiaRuntimeConfig {
 
         /**
          * The host address to which the Jolokia agent HTTP server should bind.
-         * When unspecified, the default is localhost in all modes except remote dev,
-         * where it defaults to 0.0.0.0.
+         * When unspecified, the default is localhost, except in remote dev mode, in dev and test mode on WSL,
+         * and on Kubernetes with SSL client authentication configured, where it defaults to 0.0.0.0.
          */
         Optional<String> host();
 
@@ -123,7 +179,12 @@ public interface JolokiaRuntimeConfig {
         File serviceCaCert();
 
         /**
-         * The principal which must be given in a client certificate to allow access to Jolokia.
+         * The principal which must be given in a client certificate to allow access to Jolokia. For example
+         * `cn=hawtio-online.hawtio.svc`.
+         *
+         * Without it, any client holding a certificate signed by the service CA is accepted. Setting it also
+         * lets the default Camel Jolokia restrictor accept cross-origin requests forwarded by that client,
+         * since the authenticated peer is then a known identity.
          */
         Optional<String> clientPrincipal();
     }

--- a/extensions/jolokia/runtime/src/main/java/org/apache/camel/quarkus/jolokia/restrictor/CamelJolokiaRestrictor.java
+++ b/extensions/jolokia/runtime/src/main/java/org/apache/camel/quarkus/jolokia/restrictor/CamelJolokiaRestrictor.java
@@ -16,26 +16,61 @@
  */
 package org.apache.camel.quarkus.jolokia.restrictor;
 
+import java.io.FileNotFoundException;
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import javax.management.ObjectName;
 
 import io.smallrye.config.SmallRyeConfig;
 import org.apache.camel.quarkus.jolokia.config.JolokiaBuildTimeConfig;
+import org.apache.camel.quarkus.jolokia.config.JolokiaRuntimeConfig;
 import org.apache.camel.quarkus.jolokia.util.JolokiaHostUtils;
+import org.apache.camel.quarkus.jolokia.util.JolokiaKubernetesUtils;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.logging.Logger;
+import org.jolokia.server.core.config.ConfigKey;
+import org.jolokia.server.core.restrictor.DenyAllRestrictor;
 import org.jolokia.server.core.restrictor.RestrictorFactory;
 import org.jolokia.server.core.restrictor.policy.PolicyRestrictor;
 import org.jolokia.server.core.service.api.Restrictor;
 import org.jolokia.server.core.util.HttpMethod;
 import org.jolokia.server.core.util.RequestType;
 
+/**
+ * Restricts Jolokia access to the configured MBean domains, on top of a delegate that decides everything else.
+ *
+ * The delegate is built once, so that each access mode is expressed in one place rather than as flags tested by
+ * every check. Client addresses and origins are answered independently, so asking for one never withdraws the
+ * other:
+ *
+ * <ul>
+ * <li>an access policy that could not be loaded denies everything, and one that was explicitly configured but
+ * does not resolve fails the application at startup</li>
+ * <li>by default access is restricted to loopback clients, plus the origins listed by `allowed-origins`</li>
+ * <li>`remote-access-allowed` lifts the address restriction and nothing else, so cross-origin requests stay
+ * restricted whether or not it is set</li>
+ * <li>Kubernetes SSL client authentication lifts the address restriction too, since the transport has already
+ * authenticated the client. It lifts the origin restriction as well only once `client-principal` pins which
+ * identity may connect, and only while `allowed-origins` lists nothing</li>
+ * <li>a loaded access policy narrows what is left through its `&lt;commands&gt;`, `&lt;http&gt;` and MBean
+ * rules. It decides client addresses outright when it carries a `&lt;remote&gt;` section, since those rules are
+ * how operators are expected to restrict addresses; a policy without one says nothing about addresses and
+ * leaves the rules above to answer. Its `&lt;cors&gt;` section is not consulted at all, since origins are
+ * configured by `allowed-origins` and the scheme rule by `ignore-origin-scheme`</li>
+ * </ul>
+ *
+ * The checks themselves are final. A subclass restricts further through the `allows*` hooks, which are asked
+ * only once the inherited checks have allowed the request, so extending this class can narrow what it permits
+ * but never widen it.
+ */
 public class CamelJolokiaRestrictor implements Restrictor {
-    private static final String DEFAULT_POLICY_LOCATION = "classpath:/jolokia-access.xml";
     private static final Logger LOG = Logger.getLogger(CamelJolokiaRestrictor.class);
 
     private final Set<String> ALLOWED_DOMAINS = Collections.unmodifiableSet(
@@ -44,114 +79,446 @@ public class CamelJolokiaRestrictor implements Restrictor {
                     .getConfigMapping(JolokiaBuildTimeConfig.class)
                     .camelRestrictorAllowedMbeanDomains());
 
-    private final boolean remoteAccessAllowed = ConfigProvider.getConfig()
-            .getOptionalValue("quarkus.camel.jolokia.remote-access-allowed", Boolean.class)
-            .orElse(false);
+    private final boolean ignoreOriginScheme = runtimeConfig().ignoreOriginScheme();
 
-    private final PolicyRestrictor policyRestrictor;
+    private final Restrictor delegate;
 
     public CamelJolokiaRestrictor() {
-        this.policyRestrictor = loadPolicyRestrictor();
+        this.delegate = createDelegate();
     }
 
     @Override
-    public boolean isRemoteAccessAllowed(String... hostOrAddress) {
-        if (remoteAccessAllowed) {
-            return true;
-        }
-        if (hostOrAddress != null) {
-            for (String addr : hostOrAddress) {
-                if (isLoopbackAddress(addr)) {
-                    return true;
-                }
-            }
-        }
-        if (policyRestrictor != null) {
-            return policyRestrictor.isRemoteAccessAllowed(hostOrAddress);
-        }
-        return false;
+    public final boolean isRemoteAccessAllowed(String... hostOrAddress) {
+        return delegate.isRemoteAccessAllowed(hostOrAddress) && allowsRemoteAccess(hostOrAddress);
     }
 
     @Override
-    public boolean isHttpMethodAllowed(HttpMethod method) {
-        if (policyRestrictor != null) {
-            return policyRestrictor.isHttpMethodAllowed(method);
-        }
+    public final boolean isOriginAllowed(String origin, boolean strictCheck) {
+        return delegate.isOriginAllowed(origin, strictCheck) && allowsOrigin(origin, strictCheck);
+    }
+
+    @Override
+    public final boolean isHttpMethodAllowed(HttpMethod method) {
+        return delegate.isHttpMethodAllowed(method) && allowsHttpMethod(method);
+    }
+
+    @Override
+    public final boolean isTypeAllowed(RequestType type) {
+        return delegate.isTypeAllowed(type) && allowsRequestType(type);
+    }
+
+    @Override
+    public final boolean ignoreScheme() {
+        return ignoreOriginScheme;
+    }
+
+    @Override
+    public final boolean isAttributeReadAllowed(ObjectName objectName, String attribute) {
+        return isAllowedDomain(objectName)
+                && delegate.isAttributeReadAllowed(objectName, attribute)
+                && allowsAttributeRead(objectName, attribute);
+    }
+
+    @Override
+    public final boolean isAttributeWriteAllowed(ObjectName objectName, String attribute) {
+        return isAllowedDomain(objectName)
+                && delegate.isAttributeWriteAllowed(objectName, attribute)
+                && allowsAttributeWrite(objectName, attribute);
+    }
+
+    @Override
+    public final boolean isOperationAllowed(ObjectName objectName, String operation) {
+        return isAllowedDomain(objectName)
+                && delegate.isOperationAllowed(objectName, operation)
+                && allowsOperation(objectName, operation);
+    }
+
+    @Override
+    public final boolean isObjectNameHidden(ObjectName objectName) {
+        return !isAllowedDomain(objectName)
+                || delegate.isObjectNameHidden(objectName)
+                || !allowsObjectName(objectName);
+    }
+
+    /**
+     * Whether a client address chain the inherited checks accepted may reach the agent.
+     */
+    protected boolean allowsRemoteAccess(String... hostOrAddress) {
         return true;
     }
 
-    @Override
-    public boolean isTypeAllowed(RequestType type) {
-        if (policyRestrictor != null) {
-            return policyRestrictor.isTypeAllowed(type);
-        }
+    /**
+     * Whether an origin the inherited checks accepted may reach the agent.
+     */
+    protected boolean allowsOrigin(String origin, boolean strictCheck) {
         return true;
     }
 
-    @Override
-    public boolean isOriginAllowed(String origin, boolean strictCheck) {
-        if (origin == null || remoteAccessAllowed) {
-            return true;
-        }
-        try {
-            String host = new URI(origin).getHost();
-            if (isLoopbackAddress(host)) {
-                return true;
-            }
-        } catch (URISyntaxException e) {
-            return false;
-        }
-        if (policyRestrictor != null) {
-            return policyRestrictor.isOriginAllowed(origin, strictCheck);
-        }
-        return false;
+    /**
+     * Whether an HTTP method the inherited checks accepted may be used.
+     */
+    protected boolean allowsHttpMethod(HttpMethod method) {
+        return true;
     }
 
-    @Override
-    public boolean ignoreScheme() {
-        if (policyRestrictor != null) {
-            return policyRestrictor.ignoreScheme();
-        }
-        return false;
+    /**
+     * Whether a request type the inherited checks accepted may be used.
+     */
+    protected boolean allowsRequestType(RequestType type) {
+        return true;
     }
 
-    @Override
-    public boolean isAttributeReadAllowed(ObjectName objectName, String attribute) {
-        return isAllowedDomain(objectName) && isTypeAllowed(RequestType.READ);
+    /**
+     * Whether an attribute the inherited checks accepted may be read.
+     */
+    protected boolean allowsAttributeRead(ObjectName objectName, String attribute) {
+        return true;
     }
 
-    @Override
-    public boolean isAttributeWriteAllowed(ObjectName objectName, String attribute) {
-        return isAllowedDomain(objectName) && isTypeAllowed(RequestType.WRITE);
+    /**
+     * Whether an attribute the inherited checks accepted may be written.
+     */
+    protected boolean allowsAttributeWrite(ObjectName objectName, String attribute) {
+        return true;
     }
 
-    @Override
-    public boolean isOperationAllowed(ObjectName objectName, String operation) {
-        return isAllowedDomain(objectName) && isTypeAllowed(RequestType.EXEC);
+    /**
+     * Whether an operation the inherited checks accepted may be invoked.
+     */
+    protected boolean allowsOperation(ObjectName objectName, String operation) {
+        return true;
     }
 
-    @Override
-    public boolean isObjectNameHidden(ObjectName objectName) {
-        return !isAllowedDomain(objectName);
+    /**
+     * Whether an MBean the inherited checks left visible may be listed. Returning `false` hides it, keeping the
+     * `false` means less access reading of every other hook.
+     */
+    protected boolean allowsObjectName(ObjectName objectName) {
+        return true;
     }
 
-    private boolean isAllowedDomain(ObjectName objectName) {
+    /**
+     * Whether the MBean is in one of the domains `camel-restrictor-allowed-mbean-domains` lists.
+     *
+     * Applied by the checks above already. Exposed so that a hook can consult it, not so that it can be
+     * reapplied.
+     */
+    protected final boolean isAllowedDomain(ObjectName objectName) {
         return ALLOWED_DOMAINS.contains(objectName.getDomain());
     }
 
-    private static boolean isLoopbackAddress(String hostOrAddress) {
-        return JolokiaHostUtils.isLoopbackAddress(hostOrAddress);
+    /**
+     * Fails the application when an explicitly configured access policy cannot be resolved.
+     *
+     * This runs while the Jolokia server configuration is assembled, before the server itself is created. The
+     * server binds the agent port in its constructor and only releases it once `start()` has completed, so
+     * throwing later, as the restrictor is built during `start()`, would leave the port bound for the lifetime
+     * of the JVM.
+     */
+    public static void verifyPolicyLocationResolvable() {
+        JolokiaRuntimeConfig config = runtimeConfig();
+        if (!config.additionalProperties().containsKey(ConfigKey.POLICY_LOCATION.getKeyValue())) {
+            return;
+        }
+
+        String location = policyLocation(config);
+        PolicyRestrictor policy;
+        try {
+            policy = RestrictorFactory.lookupPolicyRestrictor(location);
+        } catch (MalformedURLException | FileNotFoundException e) {
+            // Nothing is there. A `classpath:` location reports that by returning null below, while every other
+            // scheme raises one of these, so the two are the same packaging error and fail the same way
+            throw unresolvablePolicy(location);
+        } catch (Exception e) {
+            // A policy that resolves but cannot be read denies all access instead of failing startup, which
+            // createDelegate() reports when the restrictor is built
+            return;
+        }
+
+        if (policy == null) {
+            throw unresolvablePolicy(location);
+        }
     }
 
-    private static PolicyRestrictor loadPolicyRestrictor() {
-        String location = ConfigProvider.getConfig()
-                .getOptionalValue("quarkus.camel.jolokia.additional-properties.policyLocation", String.class)
-                .orElse(DEFAULT_POLICY_LOCATION);
+    private static Restrictor createDelegate() {
+        JolokiaRuntimeConfig config = runtimeConfig();
+        String location = policyLocation(config);
+
+        PolicyRestrictor policy;
         try {
-            return RestrictorFactory.lookupPolicyRestrictor(location);
+            policy = RestrictorFactory.lookupPolicyRestrictor(location);
         } catch (Exception e) {
-            LOG.warnf("Failed to load Jolokia policy file from %s, policy delegation disabled", location, e);
-            return null;
+            LOG.errorf(e, "Failed to load the Jolokia access policy from %s. Denying all Jolokia access", location);
+            return new DenyAllRestrictor();
+        }
+
+        if (policy == null && config.additionalProperties().containsKey(ConfigKey.POLICY_LOCATION.getKeyValue())) {
+            throw unresolvablePolicy(location);
+        }
+
+        List<Pattern> allowedOrigins = allowedOrigins(config);
+        boolean clientAuthenticated = JolokiaKubernetesUtils.isClientAuthenticationConfigured(config.kubernetes());
+
+        boolean anyAddressAllowed = config.remoteAccessAllowed() || clientAuthenticated;
+
+        // An explicit origin list is the more specific instruction, so it wins
+        boolean anyOriginAllowed = clientAuthenticated
+                && config.kubernetes().clientPrincipal().isPresent()
+                && allowedOrigins.isEmpty();
+
+        LoopbackRestrictor restrictor = new LoopbackRestrictor(policy, allowedOrigins, anyAddressAllowed,
+                anyOriginAllowed);
+
+        // The policy is loaded here rather than by RestrictorFactory, so nothing else reports that one was found
+        LOG.infof("Jolokia %s. Client addresses: %s. Origins: %s",
+                policy == null
+                        ? "found no access policy at " + location
+                        : "loaded the access policy " + location,
+                addressSourceDescription(config, restrictor, anyAddressAllowed),
+                originSourceDescription(allowedOrigins, anyOriginAllowed));
+
+        return restrictor;
+    }
+
+    private static String addressSourceDescription(JolokiaRuntimeConfig config, LoopbackRestrictor restrictor,
+            boolean anyAddressAllowed) {
+        if (restrictor.policyDecidesAddresses) {
+            return "decided by the access policy <remote> section";
+        }
+        if (anyAddressAllowed) {
+            return config.remoteAccessAllowed()
+                    ? "any, since remote-access-allowed is set"
+                    : "any, since Kubernetes SSL client authentication verifies every client";
+        }
+        return "loopback only";
+    }
+
+    private static String originSourceDescription(List<Pattern> allowedOrigins, boolean anyOriginAllowed) {
+        if (anyOriginAllowed) {
+            return "any, since a Kubernetes client principal pins which identity may connect";
+        }
+        if (allowedOrigins.isEmpty()) {
+            return "loopback only";
+        }
+        return "loopback plus the " + allowedOrigins.size()
+                + (allowedOrigins.size() == 1 ? " origin" : " origins") + " listed by allowed-origins";
+    }
+
+    private static List<Pattern> allowedOrigins(JolokiaRuntimeConfig config) {
+        return config.allowedOrigins()
+                .orElseGet(List::of)
+                .stream()
+                .map(origin -> origin.trim().toLowerCase(Locale.ROOT))
+                .filter(origin -> !origin.isEmpty())
+                .map(CamelJolokiaRestrictor::originPattern)
+                .toList();
+    }
+
+    /**
+     * Compiles a configured origin the same way Jolokia compiles an `&lt;allow-origin&gt;` rule, so that the
+     * values of a policy file can be moved across unchanged and `*` keeps the meaning it has there.
+     */
+    private static Pattern originPattern(String origin) {
+        return Pattern.compile("^" + Pattern.quote(origin).replace("*", "\\E.*\\Q") + "$");
+    }
+
+    private static JolokiaRuntimeConfig runtimeConfig() {
+        return ConfigProvider.getConfig()
+                .unwrap(SmallRyeConfig.class)
+                .getConfigMapping(JolokiaRuntimeConfig.class);
+    }
+
+    private static IllegalStateException unresolvablePolicy(String location) {
+        return new IllegalStateException(String.format(
+                "The configured Jolokia access policy '%s' could not be resolved."
+                        + " A 'classpath:' location in a native executable has to be registered with"
+                        + " 'quarkus.native.resources.includes'. Any other location has to exist, so check that"
+                        + " a mounted file is where it is expected. Otherwise correct or remove"
+                        + " 'quarkus.camel.jolokia.additional-properties.\"policyLocation\"'.",
+                location));
+    }
+
+    private static String policyLocation(JolokiaRuntimeConfig config) {
+        return config.additionalProperties()
+                .getOrDefault(ConfigKey.POLICY_LOCATION.getKeyValue(), ConfigKey.POLICY_LOCATION.getDefaultValue());
+    }
+
+    /**
+     * Allows loopback clients, or every client when `remote-access-allowed` is set, plus the configured origins,
+     * narrowed by an optional Jolokia access policy.
+     */
+    static final class LoopbackRestrictor implements Restrictor {
+        /**
+         * TEST-NET-1, reserved for documentation by RFC 5737, so no policy lists it to grant anyone access.
+         * Asking a policy about it reveals whether it restricts addresses at all.
+         */
+        private static final String UNROUTABLE_PROBE_ADDRESS = "192.0.2.1";
+
+        private final PolicyRestrictor policy;
+        private final List<Pattern> allowedOrigins;
+        private final boolean anyAddressAllowed;
+        private final boolean anyOriginAllowed;
+        private final boolean policyDecidesAddresses;
+
+        LoopbackRestrictor(PolicyRestrictor policy, List<Pattern> allowedOrigins, boolean anyAddressAllowed,
+                boolean anyOriginAllowed) {
+            this.policy = policy;
+            this.allowedOrigins = allowedOrigins;
+            this.anyAddressAllowed = anyAddressAllowed;
+            this.anyOriginAllowed = anyOriginAllowed;
+            // A policy listing 0.0.0.0/0 reads the same as one with no `<remote>` section, which is the
+            // stricter reading of the two. Jolokia exposes no way to ask about the section directly
+            this.policyDecidesAddresses = policy != null && !policy.isRemoteAccessAllowed(UNROUTABLE_PROBE_ADDRESS);
+        }
+
+        /**
+         * A policy that restricts addresses answers this on its own. Its `&lt;remote&gt;` rules are the mechanism
+         * operators are expected to restrict addresses with, so exempting loopback from them would let the
+         * framework widen a restriction that was asked for explicitly.
+         *
+         * A policy with no `&lt;remote&gt;` section says nothing about addresses, so the configured rules answer
+         * instead. Letting Jolokia's reading of an absent section apply here would mean a policy brought to
+         * restrict something else, such as the commands in use, silently withdrew the loopback default and left
+         * `remote-access-allowed` reading as though it still applied.
+         */
+        @Override
+        public boolean isRemoteAccessAllowed(String... hostOrAddress) {
+            if (policyDecidesAddresses) {
+                return policy.isRemoteAccessAllowed(hostOrAddress);
+            }
+            return anyAddressAllowed || isLoopbackChain(hostOrAddress);
+        }
+
+        /**
+         * Requests carrying no Origin header, loopback origins, and the origins listed by `allowed-origins` are
+         * permitted. Every other origin is denied, so that a browser on another site cannot drive the agent.
+         *
+         * The value is reduced to a scheme, host and port before being matched. Jolokia falls back to the
+         * Referer header when there is no Origin, and a Referer carries a path, so comparing what arrives
+         * verbatim would refuse a request from an origin that is listed. A default port is matched whether or
+         * not the configured value spells it out, since the two are the same origin.
+         *
+         * The `&lt;cors&gt;` section of an access policy is deliberately not consulted, for either this check or
+         * the Access-Control-Allow-Origin response header, so that the origins which may reach the agent are
+         * configured in one place. Reading `&lt;allow-origin&gt;` as an allowlist would give it a meaning it does
+         * not have on a plain Jolokia agent, where it does not grant access, and honouring its actual meaning
+         * would require the same origin to be listed both here and in the policy. `strictCheck` is unused for the
+         * same reason: it selects between those two policy behaviours.
+         */
+        @Override
+        public boolean isOriginAllowed(String origin, boolean strictCheck) {
+            if (anyOriginAllowed || origin == null) {
+                return true;
+            }
+
+            URI uri;
+            try {
+                uri = new URI(origin.trim());
+            } catch (URISyntaxException e) {
+                return false;
+            }
+
+            // An origin is a scheme, host and port. User information in particular never appears in one, so its
+            // presence is an attempt to make a foreign host read as an allowed one
+            if (uri.getScheme() == null || uri.getHost() == null || uri.getUserInfo() != null) {
+                return false;
+            }
+
+            if (JolokiaHostUtils.isLoopbackAddress(uri.getHost())) {
+                return true;
+            }
+
+            for (String requestOrigin : originSpellings(uri)) {
+                for (Pattern allowedOrigin : allowedOrigins) {
+                    if (allowedOrigin.matcher(requestOrigin).matches()) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
+        /**
+         * Renders the scheme, host and port of the given URI as an origin, both without and with the default
+         * port for the scheme.
+         *
+         * A browser leaves that port out, while a value copied from an address bar or from the
+         * `&lt;allow-origin&gt;` rules of an access policy may spell it out. The two denote the same origin, so
+         * both are matched and either may be configured.
+         */
+        private static List<String> originSpellings(URI uri) {
+            String scheme = uri.getScheme().toLowerCase(Locale.ROOT);
+            String host = uri.getHost().toLowerCase(Locale.ROOT);
+            int port = uri.getPort();
+            int defaultPort = defaultPort(scheme);
+            if (port != -1 && port != defaultPort) {
+                return List.of(scheme + "://" + host + ":" + port);
+            }
+
+            String origin = scheme + "://" + host;
+            return defaultPort == -1 ? List.of(origin) : List.of(origin, origin + ":" + defaultPort);
+        }
+
+        private static int defaultPort(String scheme) {
+            switch (scheme) {
+            case "http":
+                return 80;
+            case "https":
+                return 443;
+            default:
+                return -1;
+            }
+        }
+
+        @Override
+        public boolean isHttpMethodAllowed(HttpMethod method) {
+            return policy == null || policy.isHttpMethodAllowed(method);
+        }
+
+        @Override
+        public boolean isTypeAllowed(RequestType type) {
+            return policy == null || policy.isTypeAllowed(type);
+        }
+
+        /**
+         * Never consulted, since the enclosing restrictor answers this from configuration. Declared rather than
+         * inherited so that the interface default cannot quietly become the answer.
+         */
+        @Override
+        public boolean ignoreScheme() {
+            return false;
+        }
+
+        @Override
+        public boolean isAttributeReadAllowed(ObjectName objectName, String attribute) {
+            return policy == null || policy.isAttributeReadAllowed(objectName, attribute);
+        }
+
+        @Override
+        public boolean isAttributeWriteAllowed(ObjectName objectName, String attribute) {
+            return policy == null || policy.isAttributeWriteAllowed(objectName, attribute);
+        }
+
+        @Override
+        public boolean isOperationAllowed(ObjectName objectName, String operation) {
+            return policy == null || policy.isOperationAllowed(objectName, operation);
+        }
+
+        @Override
+        public boolean isObjectNameHidden(ObjectName objectName) {
+            return policy != null && policy.isObjectNameHidden(objectName);
+        }
+
+        private static boolean isLoopbackChain(String... hostOrAddress) {
+            if (hostOrAddress == null || hostOrAddress.length == 0) {
+                return false;
+            }
+            for (String addr : hostOrAddress) {
+                if (!JolokiaHostUtils.isLoopbackAddress(addr)) {
+                    return false;
+                }
+            }
+            return true;
         }
     }
 }

--- a/extensions/jolokia/runtime/src/main/java/org/apache/camel/quarkus/jolokia/util/JolokiaHostUtils.java
+++ b/extensions/jolokia/runtime/src/main/java/org/apache/camel/quarkus/jolokia/util/JolokiaHostUtils.java
@@ -16,12 +16,22 @@
  */
 package org.apache.camel.quarkus.jolokia.util;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
 public final class JolokiaHostUtils {
 
     private JolokiaHostUtils() {
         // Utility class
     }
 
+    /**
+     * Determines whether the given host name or address identifies the loopback interface.
+     *
+     * Host names are never resolved, since this is used to classify client supplied values and a name that
+     * resolves to a loopback address must not be treated as local. Only the well known loopback names are
+     * recognized.
+     */
     public static boolean isLoopbackAddress(String hostOrAddress) {
         if (hostOrAddress == null || hostOrAddress.isEmpty()) {
             return false;
@@ -32,35 +42,101 @@ public final class JolokiaHostUtils {
             host = host.substring(1, host.length() - 1);
         }
 
-        if ("localhost".equalsIgnoreCase(host) || "localhost.localdomain".equalsIgnoreCase(host)) {
+        // A trailing dot is the root form of the same name
+        String name = host.endsWith(".") ? host.substring(0, host.length() - 1) : host;
+        if ("localhost".equalsIgnoreCase(name) || "localhost.localdomain".equalsIgnoreCase(name)) {
             return true;
         }
 
-        if (host.startsWith("127.")) {
-            return isIPv4Loopback(host);
+        if (host.indexOf(':') != -1) {
+            // The scope id names a local interface, so dropping it keeps the verdict independent of the
+            // interfaces this host has
+            int scope = host.indexOf('%');
+            if (scope >= 0) {
+                if (!isScopeId(host.substring(scope + 1))) {
+                    return false;
+                }
+                host = host.substring(0, scope);
+            }
+            if (!isIPv6LiteralCharacterSet(host)) {
+                return false;
+            }
+            // InetAddress resolves anything it cannot read as a literal, and only reads one beginning with a
+            // hex digit or a colon. Brackets and this guard keep a client supplied value away from the resolver
+            char first = host.charAt(0);
+            if (first != ':' && !isHexDigit(first)) {
+                return false;
+            }
+            try {
+                return InetAddress.getByName("[" + host + "]").isLoopbackAddress();
+            } catch (UnknownHostException e) {
+                return false;
+            }
         }
 
-        return "::1".equals(host) || "0:0:0:0:0:0:0:1".equals(host);
+        return isIPv4Loopback(host);
+    }
+
+    private static boolean isScopeId(String scopeId) {
+        if (scopeId.isEmpty()) {
+            return false;
+        }
+        for (int i = 0; i < scopeId.length(); i++) {
+            char c = scopeId.charAt(i);
+            boolean allowed = (c >= '0' && c <= '9') || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+                    || c == '.' || c == '-' || c == '_';
+            if (!allowed) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean isIPv6LiteralCharacterSet(String address) {
+        if (address.isEmpty()) {
+            return false;
+        }
+        for (int i = 0; i < address.length(); i++) {
+            char c = address.charAt(i);
+            if (!isHexDigit(c) && c != ':' && c != '.') {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean isHexDigit(char c) {
+        return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
     }
 
     private static boolean isIPv4Loopback(String ip) {
-        String[] parts = ip.split("\\.");
+        String[] parts = ip.split("\\.", -1);
         if (parts.length != 4) {
             return false;
         }
-        try {
-            if (Integer.parseInt(parts[0]) != 127) {
-                return false;
-            }
-            for (int i = 1; i < 4; i++) {
-                int octet = Integer.parseInt(parts[i]);
-                if (octet < 0 || octet > 255) {
-                    return false;
-                }
-            }
-            return true;
-        } catch (NumberFormatException e) {
+        if (parseOctet(parts[0]) != 127) {
             return false;
         }
+        for (int i = 1; i < 4; i++) {
+            if (parseOctet(parts[i]) < 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static int parseOctet(String value) {
+        if (value.isEmpty() || value.length() > 3) {
+            return -1;
+        }
+        int octet = 0;
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            if (c < '0' || c > '9') {
+                return -1;
+            }
+            octet = octet * 10 + (c - '0');
+        }
+        return octet <= 255 ? octet : -1;
     }
 }

--- a/extensions/jolokia/runtime/src/main/java/org/apache/camel/quarkus/jolokia/util/JolokiaKubernetesUtils.java
+++ b/extensions/jolokia/runtime/src/main/java/org/apache/camel/quarkus/jolokia/util/JolokiaKubernetesUtils.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.jolokia.util;
+
+import org.apache.camel.quarkus.jolokia.config.JolokiaRuntimeConfig.Kubernetes;
+import org.eclipse.microprofile.config.ConfigProvider;
+
+public final class JolokiaKubernetesUtils {
+
+    private JolokiaKubernetesUtils() {
+        // Utility class
+    }
+
+    /**
+     * Determines whether the agent authenticates its clients with Kubernetes SSL client authentication.
+     *
+     * Both the bind address default and the restrictor depend on this, and they must agree, so it is derived
+     * in one place rather than at each of them.
+     *
+     * The result describes what the extension configures. `additional-properties` could still switch client
+     * authentication back off, but `JolokiaRecorder` fails startup when that leaves a non-loopback bind
+     * unauthenticated, so anything reachable from off the machine has been authenticated by the time this is
+     * consulted.
+     */
+    public static boolean isClientAuthenticationConfigured(Kubernetes kubernetes) {
+        return ConfigProvider.getConfig().getOptionalValue("kubernetes.service.host", String.class).isPresent()
+                && kubernetes.clientAuthenticationEnabled()
+                && kubernetes.serviceCaCert().exists();
+    }
+}

--- a/integration-tests/jolokia/src/test/java/org/apache/camel/quarkus/component/jolokia/it/JolokiaCustomRestrictorTest.java
+++ b/integration-tests/jolokia/src/test/java/org/apache/camel/quarkus/component/jolokia/it/JolokiaCustomRestrictorTest.java
@@ -60,6 +60,23 @@ class JolokiaCustomRestrictorTest {
                 .body("status", equalTo(403));
     }
 
+    /**
+     * The custom restrictor narrows the inherited check rather than replacing it, so the MBean domain
+     * restriction still applies to an operation whose name it would otherwise permit.
+     */
+    @Test
+    void customRestrictorKeepsMbeanDomainFiltering() {
+        String payload = "{\"type\":\"exec\",\"mbean\":\"java.util.logging:type=Logging\","
+                + "\"operation\":\"sendStringBody\",\"arguments\":[]}";
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body(payload)
+                .post("/jolokia/")
+                .then()
+                .statusCode(200)
+                .body("status", equalTo(403));
+    }
+
     public static final class JolokiaCustomRestrictorProfile implements QuarkusTestProfile {
         @Override
         public Map<String, String> getConfigOverrides() {

--- a/integration-tests/jolokia/src/test/java/org/apache/camel/quarkus/component/jolokia/it/JolokiaIgnoreOriginSchemeIT.java
+++ b/integration-tests/jolokia/src/test/java/org/apache/camel/quarkus/component/jolokia/it/JolokiaIgnoreOriginSchemeIT.java
@@ -16,18 +16,8 @@
  */
 package org.apache.camel.quarkus.component.jolokia.it;
 
-import javax.management.ObjectName;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-import org.apache.camel.quarkus.jolokia.restrictor.CamelJolokiaRestrictor;
-
-/**
- * Only allows MBean operation sendStringBody, on top of everything CamelJolokiaRestrictor already enforces.
- */
-public class CustomRestrictor extends CamelJolokiaRestrictor {
-    @Override
-    protected boolean allowsOperation(ObjectName pName, String pOperation) {
-        // Asked only once the inherited checks have allowed the operation, so the MBean domain restriction
-        // still applies whatever this returns
-        return pOperation.startsWith("sendStringBody");
-    }
+@QuarkusIntegrationTest
+class JolokiaIgnoreOriginSchemeIT extends JolokiaIgnoreOriginSchemeTest {
 }

--- a/integration-tests/jolokia/src/test/java/org/apache/camel/quarkus/component/jolokia/it/JolokiaIgnoreOriginSchemeTest.java
+++ b/integration-tests/jolokia/src/test/java/org/apache/camel/quarkus/component/jolokia/it/JolokiaIgnoreOriginSchemeTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.jolokia.it;
+
+import java.util.Map;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Jolokia refuses an https Origin over a plain http connection before any origin configuration is consulted.
+ * This is the property that turns that off, in place of the ignore-scheme element of an access policy.
+ */
+@TestProfile(JolokiaIgnoreOriginSchemeTest.IgnoreOriginSchemeProfile.class)
+@QuarkusTest
+class JolokiaIgnoreOriginSchemeTest {
+    @BeforeEach
+    public void beforeEach() {
+        RestAssured.port = 8778;
+    }
+
+    @Test
+    void httpsOriginAcceptedOverPlainHttp() {
+        RestAssured.given()
+                .header("Origin", "https://secure.example.com")
+                .get("/jolokia/")
+                .then()
+                .statusCode(200)
+                .body("status", equalTo(200));
+    }
+
+    @Test
+    void unlistedOriginStillDenied() {
+        RestAssured.given()
+                .header("Origin", "https://untrusted.example")
+                .get("/jolokia/")
+                .then()
+                .statusCode(200)
+                .body("status", equalTo(403));
+    }
+
+    public static final class IgnoreOriginSchemeProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    "quarkus.camel.jolokia.ignore-origin-scheme", "true",
+                    "quarkus.camel.jolokia.allowed-origins", "https://secure.example.com");
+        }
+    }
+}

--- a/integration-tests/jolokia/src/test/java/org/apache/camel/quarkus/component/jolokia/it/JolokiaRemoteAccessAllowedTest.java
+++ b/integration-tests/jolokia/src/test/java/org/apache/camel/quarkus/component/jolokia/it/JolokiaRemoteAccessAllowedTest.java
@@ -44,6 +44,56 @@ class JolokiaRemoteAccessAllowedTest {
                 .body("status", equalTo(200));
     }
 
+    /**
+     * Remote access is a control over client addresses only, so an unlisted origin is still refused.
+     */
+    @Test
+    void unlistedOriginDenied() {
+        RestAssured.given()
+                .header("Origin", "http://domain.example.com")
+                .get("/jolokia/")
+                .then()
+                .statusCode(200)
+                .body("status", equalTo(403));
+    }
+
+    @Test
+    void listedOriginAllowed() {
+        RestAssured.given()
+                .header("Origin", "http://allowed.example.com")
+                .get("/jolokia/")
+                .then()
+                .statusCode(200)
+                .body("status", equalTo(200));
+    }
+
+    /**
+     * Jolokia falls back to Referer when there is no Origin, and a Referer carries a path.
+     */
+    @Test
+    void listedOriginAllowedFromReferer() {
+        RestAssured.given()
+                .header("Referer", "http://allowed.example.com/console/index.html")
+                .get("/jolokia/")
+                .then()
+                .statusCode(200)
+                .body("status", equalTo(200));
+    }
+
+    /**
+     * The origin is listed, so the restrictor permits it. Jolokia refuses it anyway, because answering a secure
+     * origin over a plain HTTP connection would downgrade it.
+     */
+    @Test
+    void httpsOriginRejectedByJolokiaOverPlainHttp() {
+        RestAssured.given()
+                .header("Origin", "https://secure.example.com")
+                .get("/jolokia/")
+                .then()
+                .statusCode(200)
+                .body("status", equalTo(403));
+    }
+
     @Test
     void mbeanAccessStillRestrictedByDomain() {
         RestAssured.given()
@@ -56,7 +106,10 @@ class JolokiaRemoteAccessAllowedTest {
     public static final class RemoteAccessAllowedProfile implements QuarkusTestProfile {
         @Override
         public Map<String, String> getConfigOverrides() {
-            return Map.of("quarkus.camel.jolokia.remote-access-allowed", "true");
+            return Map.of(
+                    "quarkus.camel.jolokia.remote-access-allowed", "true",
+                    "quarkus.camel.jolokia.allowed-origins",
+                    "http://allowed.example.com,https://secure.example.com");
         }
     }
 }

--- a/integration-tests/jolokia/src/test/java/org/apache/camel/quarkus/component/jolokia/it/JolokiaTest.java
+++ b/integration-tests/jolokia/src/test/java/org/apache/camel/quarkus/component/jolokia/it/JolokiaTest.java
@@ -37,6 +37,35 @@ class JolokiaTest {
         RestAssured.port = 8778;
     }
 
+    /**
+     * Pins which client addresses Jolokia passes to the restrictor. Since Jolokia 2.6.1, Forwarded,
+     * X-Forwarded-For and X-Real-IP values join the address chain whatever trustProxyHeaders is set to, and
+     * CamelJolokiaRestrictor requires every address in the chain to be loopback. A client that claims to be
+     * forwarding for a remote address is therefore refused, even though it connected over loopback.
+     *
+     * If this test fails after a Jolokia upgrade, the address chain semantics have changed and the migration
+     * guide needs to describe it.
+     */
+    @Test
+    void spoofedProxyHeaderDeniesAccess() {
+        RestAssured.given()
+                .header("X-Forwarded-For", "10.1.2.3")
+                .get("/jolokia/")
+                .then()
+                .statusCode(200)
+                .body("status", equalTo(403));
+    }
+
+    @Test
+    void loopbackProxyHeaderAllowed() {
+        RestAssured.given()
+                .header("X-Forwarded-For", "127.0.0.1")
+                .get("/jolokia/")
+                .then()
+                .statusCode(200)
+                .body("status", equalTo(200));
+    }
+
     @Test
     void defaultConfiguration() {
         // Read the configured discovery mode to determine expected discoveryEnabled value


### PR DESCRIPTION
Follows on from #8944.

* Apply a `jolokia-access.xml` policy instead of ignoring it whenever the Camel restrictor is registered, and fail startup when `policyLocation` resolves to nothing
* Let a policy `<remote>` section decide client addresses outright, falling back to the loopback default and `remote-access-allowed` when it has none
* Stop consulting the policy `<cors>` section, replacing it with the `quarkus.camel.jolokia.allowed-origins` option, which takes the same wildcard syntax, and `quarkus.camel.jolokia.ignore-origin-scheme`
* Decide client addresses and origins independently, so `remote-access-allowed` no longer accepts every origin
* Restrict a `CamelJolokiaRestrictor` subclass to narrowing what it inherits, rather than widening it
* Bind `0.0.0.0` on Kubernetes only where SSL client authentication is configured, accept the cross-origin requests a configured `client-principal` forwards, and fail startup on an unauthenticated non-loopback bind
* Declare SSL native support so the Jolokia HTTPS origin check behaves the same in native mode
* Log what the restrictor decided, and warn when Fetch Metadata handling is disabled on an agent reachable from off the machine
* Cover the above with unit and integration tests, and document it in the extension reference and the 3.39.0 migration guide