### PR TITLE
 Fixes #8864. Add langchain4j-embeddings-ql4j integration test module

### DIFF
--- a/integration-tests/langchain4j-embeddings-ql4j/pom.xml
+++ b/integration-tests/langchain4j-embeddings-ql4j/pom.xml
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.camel.quarkus</groupId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
+        <version>3.39.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>camel-quarkus-integration-test-langchain4j-embeddings-ql4j</artifactId>
+    <name>Camel Quarkus :: Integration Tests :: LangChain4j Embeddings QL4J</name>
+    <description>Integration tests for Camel Quarkus LangChain4j Embeddings extension with Quarkus LangChain4j on the classpath</description>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.quarkiverse.langchain4j</groupId>
+                <artifactId>quarkus-langchain4j-bom</artifactId>
+                <version>${quarkiverse-langchain4j.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-direct</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-langchain4j-embeddings</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.langchain4j</groupId>
+            <artifactId>quarkus-langchain4j-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-embeddings-all-minilm-l6-v2</artifactId>
+        </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <id>native</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <properties>
+                <quarkus.native.enabled>true</quarkus.native.enabled>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>virtualDependencies</id>
+            <activation>
+                <property>
+                    <name>!noVirtualDependencies</name>
+                </property>
+            </activation>
+            <dependencies>
+                <!-- The following dependencies guarantee that this module is built after them. You can update them by running `mvn process-resources -Pformat -N` from the source tree root directory -->
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-direct-deployment</artifactId>
+                    <version>${project.version}</version>
+                    <type>pom</type>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-langchain4j-embeddings-deployment</artifactId>
+                    <version>${project.version}</version>
+                    <type>pom</type>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+</project>

--- a/integration-tests/langchain4j-embeddings-ql4j/src/main/java/org/apache/camel/quarkus/component/langchain4j/embeddings/ql4j/it/Langchain4jEmbeddingsQl4jProducers.java
+++ b/integration-tests/langchain4j-embeddings-ql4j/src/main/java/org/apache/camel/quarkus/component/langchain4j/embeddings/ql4j/it/Langchain4jEmbeddingsQl4jProducers.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.langchain4j.embeddings.ql4j.it;
+
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.embedding.onnx.allminilml6v2.AllMiniLmL6V2EmbeddingModel;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
+
+@ApplicationScoped
+public class Langchain4jEmbeddingsQl4jProducers {
+
+    @Produces
+    @Singleton
+    EmbeddingModel embeddingModel() {
+        return new AllMiniLmL6V2EmbeddingModel();
+    }
+}

--- a/integration-tests/langchain4j-embeddings-ql4j/src/main/java/org/apache/camel/quarkus/component/langchain4j/embeddings/ql4j/it/Langchain4jEmbeddingsQl4jResource.java
+++ b/integration-tests/langchain4j-embeddings-ql4j/src/main/java/org/apache/camel/quarkus/component/langchain4j/embeddings/ql4j/it/Langchain4jEmbeddingsQl4jResource.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.langchain4j.embeddings.ql4j.it;
+
+import java.util.Map;
+import java.util.Objects;
+
+import dev.langchain4j.data.embedding.Embedding;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.apache.camel.CamelExecutionException;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.component.langchain4j.embeddings.LangChain4jEmbeddingsHeaders;
+import org.apache.camel.support.LRUCacheFactory;
+
+@Path("/langchain4j-embeddings")
+@ApplicationScoped
+public class Langchain4jEmbeddingsQl4jResource {
+    @Inject
+    ProducerTemplate producerTemplate;
+
+    @Path("/create")
+    @POST
+    @Consumes(MediaType.TEXT_PLAIN)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response createEmbedding(String text) {
+        try {
+            Exchange result = producerTemplate.request("direct:start", e -> e.getMessage().setBody(text));
+
+            if (result.getException() != null) {
+                Exception ex = result.getException();
+                return Response.status(Response.Status.BAD_REQUEST)
+                        .entity(Map.of("error",
+                                Objects.toString(ex.getMessage(), ex.getClass().getSimpleName())))
+                        .build();
+            }
+
+            Message message = result.getMessage();
+
+            Embedding embedding = message.getHeader(LangChain4jEmbeddingsHeaders.VECTOR, Embedding.class);
+            Integer inputTokenLength = message.getHeader(LangChain4jEmbeddingsHeaders.INPUT_TOKEN_COUNT, Integer.class);
+
+            return Response.ok()
+                    .entity(Map.of(
+                            "vectorLength", embedding.vector().length,
+                            "inputTokenLength", inputTokenLength))
+                    .build();
+        } catch (CamelExecutionException e) {
+            Throwable cause = e.getCause() != null ? e.getCause() : e;
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity(Map.of("error",
+                            Objects.toString(cause.getMessage(), cause.getClass().getSimpleName())))
+                    .build();
+        } finally {
+            LRUCacheFactory.setLRUCacheFactory(null);
+        }
+    }
+}

--- a/integration-tests/langchain4j-embeddings-ql4j/src/main/java/org/apache/camel/quarkus/component/langchain4j/embeddings/ql4j/it/Langchain4jEmbeddingsQl4jRoutes.java
+++ b/integration-tests/langchain4j-embeddings-ql4j/src/main/java/org/apache/camel/quarkus/component/langchain4j/embeddings/ql4j/it/Langchain4jEmbeddingsQl4jRoutes.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.langchain4j.embeddings.ql4j.it;
+
+import org.apache.camel.builder.RouteBuilder;
+
+public class Langchain4jEmbeddingsQl4jRoutes extends RouteBuilder {
+    @Override
+    public void configure() throws Exception {
+        from("direct:start")
+                .to("langchain4j-embeddings:create-from-text");
+    }
+}

--- a/integration-tests/langchain4j-embeddings-ql4j/src/main/resources/application.properties
+++ b/integration-tests/langchain4j-embeddings-ql4j/src/main/resources/application.properties
@@ -1,0 +1,19 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+quarkus.devservices.enabled=false
+quarkus.langchain4j.devservices.enabled=false

--- a/integration-tests/langchain4j-embeddings-ql4j/src/test/java/org/apache/camel/quarkus/component/langchain4j/embeddings/ql4j/it/Langchain4jEmbeddingsQl4jIT.java
+++ b/integration-tests/langchain4j-embeddings-ql4j/src/test/java/org/apache/camel/quarkus/component/langchain4j/embeddings/ql4j/it/Langchain4jEmbeddingsQl4jIT.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.langchain4j.embeddings.ql4j.it;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+class Langchain4jEmbeddingsQl4jIT extends Langchain4jEmbeddingsQl4jTest {
+}

--- a/integration-tests/langchain4j-embeddings-ql4j/src/test/java/org/apache/camel/quarkus/component/langchain4j/embeddings/ql4j/it/Langchain4jEmbeddingsQl4jTest.java
+++ b/integration-tests/langchain4j-embeddings-ql4j/src/test/java/org/apache/camel/quarkus/component/langchain4j/embeddings/ql4j/it/Langchain4jEmbeddingsQl4jTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.langchain4j.embeddings.ql4j.it;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+@QuarkusTest
+class Langchain4jEmbeddingsQl4jTest {
+
+    @Test
+    void createTextEmbeddings() {
+        RestAssured.given()
+                .body("Hello World")
+                .post("/langchain4j-embeddings/create")
+                .then()
+                .statusCode(200)
+                .body(
+                        "vectorLength", is(384),
+                        "inputTokenLength", is(2));
+    }
+
+    @Test
+    void createTextEmbeddingsMultiWord() {
+        RestAssured.given()
+                .body("The quick brown fox jumps over the lazy dog")
+                .post("/langchain4j-embeddings/create")
+                .then()
+                .statusCode(200)
+                .body(
+                        "vectorLength", is(384),
+                        "inputTokenLength", greaterThan(2));
+    }
+
+    @Test
+    void createTextEmbeddingsEmptyString() {
+        RestAssured.given()
+                .body("")
+                .post("/langchain4j-embeddings/create")
+                .then()
+                .statusCode(400)
+                .body("error", notNullValue());
+    }
+
+    @Test
+    void createTextEmbeddingsNoBody() {
+        RestAssured.given()
+                .contentType(ContentType.TEXT)
+                .post("/langchain4j-embeddings/create")
+                .then()
+                .statusCode(400)
+                .body("error", notNullValue());
+    }
+}

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -165,6 +165,7 @@
         <module>langchain4j-agent-ql4j</module>
         <module>langchain4j-chat</module>
         <module>langchain4j-embeddings</module>
+        <module>langchain4j-embeddings-ql4j</module>
         <module>langchain4j-embeddingstore</module>
         <module>langchain4j-rag-bridge-ql4j</module>
         <module>langchain4j-tokenizer</module>

--- a/tooling/scripts/test-categories.yaml
+++ b/tooling/scripts/test-categories.yaml
@@ -142,6 +142,7 @@ group-07:
   - jslt
   - ldap
   - langchain4j-embeddings
+  - langchain4j-embeddings-ql4j
   - langchain4j-rag-bridge-ql4j
   - lumberjack
   - ognl


### PR DESCRIPTION
 Fixes #8864. Add langchain4j-embeddings-ql4j integration test module
  ## Summary
  - Add `integration-tests/langchain4j-embeddings-ql4j/` module to verify that `camel-quarkus-langchain4j-embeddings` works correctly when Quarkus LangChain4j is on the classpath
  - Uses `quarkus-langchain4j-core` (lightweight, no model provider overhead) with in-process `AllMiniLmL6V2EmbeddingModel`
  - Registered in `test-categories.yaml` group-07 alongside the existing `langchain4j-embeddings` tests
  
  ## Test scenarios
  | Test | Input | Asserts |
  |------|-------|---------|
  | `createTextEmbeddings` | "Hello World" | vectorLength == 384, inputTokenLength == 2 |
  | `createTextEmbeddingsMultiWord` | "The quick brown fox..." | vectorLength == 384, inputTokenLength > 2 |
  | `createTextEmbeddingsEmptyString` | "" | 400 with error |
  | `createTextEmbeddingsNoBody` | no body | 400 with error |
