### PR TITLE
 Fixes #8864. Add langchain4j-embeddings-ql4j integration test module

### DIFF
--- a/integration-tests/langchain4j-embeddings-ql4j/pom.xml
+++ b/integration-tests/langchain4j-embeddings-ql4j/pom.xml
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.camel.quarkus</groupId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
+        <version>3.40.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>camel-quarkus-integration-test-langchain4j-embeddings-ql4j</artifactId>
+    <name>Camel Quarkus :: Integration Tests :: LangChain4j Embeddings QL4J</name>
+    <description>Integration tests for Camel Quarkus LangChain4j Embeddings extension with Quarkus LangChain4j on the classpath</description>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.quarkiverse.langchain4j</groupId>
+                <artifactId>quarkus-langchain4j-bom</artifactId>
+                <version>${quarkiverse-langchain4j.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-direct</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-langchain4j-embeddings</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.langchain4j</groupId>
+            <artifactId>quarkus-langchain4j-ollama</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-jackson</artifactId>
+        </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-integration-wiremock-support</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <id>native</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <properties>
+                <quarkus.native.enabled>true</quarkus.native.enabled>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>virtualDependencies</id>
+            <activation>
+                <property>
+                    <name>!noVirtualDependencies</name>
+                </property>
+            </activation>
+            <dependencies>
+                <!-- The following dependencies guarantee that this module is built after them. You can update them by running `mvn process-resources -Pformat -N` from the source tree root directory -->
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-direct-deployment</artifactId>
+                    <version>${project.version}</version>
+                    <type>pom</type>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-langchain4j-embeddings-deployment</artifactId>
+                    <version>${project.version}</version>
+                    <type>pom</type>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+</project>

--- a/integration-tests/langchain4j-embeddings-ql4j/src/main/java/org/apache/camel/quarkus/component/langchain4j/embeddings/ql4j/it/Langchain4jEmbeddingsQl4jResource.java
+++ b/integration-tests/langchain4j-embeddings-ql4j/src/main/java/org/apache/camel/quarkus/component/langchain4j/embeddings/ql4j/it/Langchain4jEmbeddingsQl4jResource.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.langchain4j.embeddings.ql4j.it;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import dev.langchain4j.data.embedding.Embedding;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.component.langchain4j.embeddings.LangChain4jEmbeddingsHeaders;
+
+@Path("/langchain4j-embeddings")
+@ApplicationScoped
+public class Langchain4jEmbeddingsQl4jResource {
+    @Inject
+    ProducerTemplate producerTemplate;
+
+    @Path("/create")
+    @POST
+    @Consumes(MediaType.TEXT_PLAIN)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response createEmbedding(String text) throws Exception {
+        Exchange result = producerTemplate.request("direct:start", e -> e.getMessage().setBody(text));
+        Message message = result.getMessage();
+
+        Embedding embedding = message.getHeader(LangChain4jEmbeddingsHeaders.VECTOR, Embedding.class);
+        Integer inputTokenLength = message.getHeader(LangChain4jEmbeddingsHeaders.INPUT_TOKEN_COUNT, Integer.class);
+
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("vectorLength", embedding.vector().length);
+        if (inputTokenLength != null) {
+            body.put("inputTokenLength", inputTokenLength);
+        }
+        return Response.ok().entity(body).build();
+    }
+}

--- a/integration-tests/langchain4j-embeddings-ql4j/src/main/java/org/apache/camel/quarkus/component/langchain4j/embeddings/ql4j/it/Langchain4jEmbeddingsQl4jRoutes.java
+++ b/integration-tests/langchain4j-embeddings-ql4j/src/main/java/org/apache/camel/quarkus/component/langchain4j/embeddings/ql4j/it/Langchain4jEmbeddingsQl4jRoutes.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.langchain4j.embeddings.ql4j.it;
+
+import org.apache.camel.builder.RouteBuilder;
+
+public class Langchain4jEmbeddingsQl4jRoutes extends RouteBuilder {
+    @Override
+    public void configure() throws Exception {
+        from("direct:start")
+                .to("langchain4j-embeddings:create-from-text");
+    }
+}

--- a/integration-tests/langchain4j-embeddings-ql4j/src/main/resources/application.properties
+++ b/integration-tests/langchain4j-embeddings-ql4j/src/main/resources/application.properties
@@ -1,0 +1,22 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+quarkus.devservices.enabled=false
+quarkus.langchain4j.devservices.enabled=false
+quarkus.langchain4j.ollama.base-url=http://localhost:11434
+quarkus.langchain4j.ollama.embedding-model.model-id=nomic-embed-text
+quarkus.langchain4j.embedding-model.provider=ollama

--- a/integration-tests/langchain4j-embeddings-ql4j/src/test/java/org/apache/camel/quarkus/component/langchain4j/embeddings/ql4j/it/Langchain4jEmbeddingsQl4jIT.java
+++ b/integration-tests/langchain4j-embeddings-ql4j/src/test/java/org/apache/camel/quarkus/component/langchain4j/embeddings/ql4j/it/Langchain4jEmbeddingsQl4jIT.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.langchain4j.embeddings.ql4j.it;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+class Langchain4jEmbeddingsQl4jIT extends Langchain4jEmbeddingsQl4jTest {
+}

--- a/integration-tests/langchain4j-embeddings-ql4j/src/test/java/org/apache/camel/quarkus/component/langchain4j/embeddings/ql4j/it/Langchain4jEmbeddingsQl4jTest.java
+++ b/integration-tests/langchain4j-embeddings-ql4j/src/test/java/org/apache/camel/quarkus/component/langchain4j/embeddings/ql4j/it/Langchain4jEmbeddingsQl4jTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.langchain4j.embeddings.ql4j.it;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+@QuarkusTestResource(Langchain4jEmbeddingsQl4jTestResource.class)
+@QuarkusTest
+class Langchain4jEmbeddingsQl4jTest {
+
+    @Test
+    void createTextEmbeddings() {
+        RestAssured.given()
+                .body("Hello World")
+                .post("/langchain4j-embeddings/create")
+                .then()
+                .statusCode(200)
+                // WireMock stub returns a 5-element vector
+                .body("vectorLength", is(5))
+                // Token count not available from Quarkus LangChain4j embedding model
+                .body("$", not(hasKey("inputTokenLength")));
+    }
+
+    @Test
+    void createTextEmbeddingsMultiWord() {
+        RestAssured.given()
+                .body("The quick brown fox jumps over the lazy dog")
+                .post("/langchain4j-embeddings/create")
+                .then()
+                .statusCode(200)
+                // WireMock stub returns a 5-element vector
+                .body("vectorLength", is(5))
+                .body("$", not(hasKey("inputTokenLength")));
+    }
+}

--- a/integration-tests/langchain4j-embeddings-ql4j/src/test/java/org/apache/camel/quarkus/component/langchain4j/embeddings/ql4j/it/Langchain4jEmbeddingsQl4jTestResource.java
+++ b/integration-tests/langchain4j-embeddings-ql4j/src/test/java/org/apache/camel/quarkus/component/langchain4j/embeddings/ql4j/it/Langchain4jEmbeddingsQl4jTestResource.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.langchain4j.embeddings.ql4j.it;
+
+import java.util.Map;
+
+import org.apache.camel.quarkus.test.wiremock.WireMockTestResourceLifecycleManager;
+
+public class Langchain4jEmbeddingsQl4jTestResource extends WireMockTestResourceLifecycleManager {
+    private static final String OLLAMA_ENV_URL = "LANGCHAIN4J_OLLAMA_BASE_URL";
+
+    @Override
+    public Map<String, String> start() {
+        Map<String, String> properties = super.start();
+        String wiremockUrl = properties.get("wiremock.url");
+        String url = wiremockUrl != null ? wiremockUrl : getRecordTargetBaseUrl();
+        properties.put("quarkus.langchain4j.ollama.base-url", url);
+        return properties;
+    }
+
+    @Override
+    protected String getRecordTargetBaseUrl() {
+        return System.getenv(OLLAMA_ENV_URL);
+    }
+
+    @Override
+    protected boolean isMockingEnabled() {
+        return !envVarsPresent(OLLAMA_ENV_URL);
+    }
+
+    @Override
+    protected String getStubsSubdirectory() {
+        return "embeddings";
+    }
+}

--- a/integration-tests/langchain4j-embeddings-ql4j/src/test/resources/mappings/embeddings/api_embed-hello-world.json
+++ b/integration-tests/langchain4j-embeddings-ql4j/src/test/resources/mappings/embeddings/api_embed-hello-world.json
@@ -1,0 +1,22 @@
+{
+  "id" : "a1b2c3d4-e5f6-7890-abcd-ef1234567801",
+  "name" : "api_embed",
+  "request" : {
+    "url" : "/api/embed",
+    "method" : "POST",
+    "bodyPatterns" : [ {
+      "equalToJson" : "{\"model\":\"nomic-embed-text\",\"input\":\"Hello World\"}",
+      "ignoreArrayOrder" : true,
+      "ignoreExtraElements" : true
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\"model\":\"nomic-embed-text\",\"embeddings\":[[0.123,0.456,0.789,0.234,0.567]],\"prompt_eval_count\":2}",
+    "headers" : {
+      "Content-Type" : "application/json; charset=utf-8"
+    }
+  },
+  "uuid" : "a1b2c3d4-e5f6-7890-abcd-ef1234567801",
+  "persistent" : true
+}

--- a/integration-tests/langchain4j-embeddings-ql4j/src/test/resources/mappings/embeddings/api_embed-quick-brown-fox.json
+++ b/integration-tests/langchain4j-embeddings-ql4j/src/test/resources/mappings/embeddings/api_embed-quick-brown-fox.json
@@ -1,0 +1,22 @@
+{
+  "id" : "a1b2c3d4-e5f6-7890-abcd-ef1234567802",
+  "name" : "api_embed",
+  "request" : {
+    "url" : "/api/embed",
+    "method" : "POST",
+    "bodyPatterns" : [ {
+      "equalToJson" : "{\"model\":\"nomic-embed-text\",\"input\":\"The quick brown fox jumps over the lazy dog\"}",
+      "ignoreArrayOrder" : true,
+      "ignoreExtraElements" : true
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\"model\":\"nomic-embed-text\",\"embeddings\":[[0.321,0.654,0.987,0.432,0.765]],\"prompt_eval_count\":10}",
+    "headers" : {
+      "Content-Type" : "application/json; charset=utf-8"
+    }
+  },
+  "uuid" : "a1b2c3d4-e5f6-7890-abcd-ef1234567802",
+  "persistent" : true
+}

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -165,6 +165,7 @@
         <module>langchain4j-agent-ql4j</module>
         <module>langchain4j-chat</module>
         <module>langchain4j-embeddings</module>
+        <module>langchain4j-embeddings-ql4j</module>
         <module>langchain4j-embeddingstore</module>
         <module>langchain4j-ingest</module>
         <module>langchain4j-rag-bridge-ql4j</module>

--- a/tooling/scripts/test-categories.yaml
+++ b/tooling/scripts/test-categories.yaml
@@ -142,6 +142,7 @@ group-07:
   - jslt
   - ldap
   - langchain4j-embeddings
+  - langchain4j-embeddings-ql4j
   - langchain4j-ingest
   - langchain4j-rag-bridge-ql4j
   - lumberjack


### PR DESCRIPTION
  Fixes #8864. Add langchain4j-embeddings-ql4j integration test module
 ## Summary
 
Add integration-tests/langchain4j-embeddings-ql4j/ module to verify that camel-quarkus-langchain4j-embeddings works correctly when Quarkus LangChain4j is on the classpath.

  - Uses quarkus-langchain4j-ollama with a QL4J-managed EmbeddingModel (no self-defined bean)
  - Ollama API mocked via WireMock test resource
  - Token count headers asserted as absent due to a quarkus-langchain4j limitation (EmbeddingResponse DTO does not deserialize prompt_eval_count)
  - Registered in test-categories.yaml group-07 alongside the existing langchain4j-embeddings tests

