### PR TITLE
Fix #2398: Add AWS2 EKS integration test

### DIFF
--- a/integration-test-groups/aws2/aws2-eks/README.adoc
+++ b/integration-test-groups/aws2/aws2-eks/README.adoc
@@ -1,0 +1,37 @@
+= AWS EKS tests
+
+By default, the integration tests run against a Floci container.
+
+== Running against real AWS
+
+Refer to the xref:../README.adoc[AWS 2 integration tests README] for general instructions on how to set up AWS credentials.
+
+The AWS credentials must have the following IAM permissions:
+
+* `eks:ListClusters`
+* `eks:DescribeCluster`
+* `eks:CreateCluster`
+* `eks:DeleteCluster`
+* `iam:PassRole`
+
+== Prerequisites for real AWS environment
+
+The following environment variables are required when running against a real AWS account. They are not needed for the default Floci run, which uses mock-friendly values.
+
+`AWS_EKS_ROLE_ARN`::
+Must point to an EKS cluster IAM role in the caller's AWS account. The role must have `AmazonEKSClusterPolicy` attached, and a trust relationship that allows the EKS service (`eks.amazonaws.com`) to assume it. The caller needs `iam:PassRole` for this specific role.
+
+`AWS_EKS_SUBNETS`::
+Must contain at least two suitable subnet IDs, in different Availability Zones.
+
+=== Running tests directly against real AWS
+
+[source,shell]
+----
+export AWS_ACCESS_KEY=<your-access-key-id>
+export AWS_SECRET_KEY=<your-secret-access-key>
+export AWS_REGION=us-east-1
+export CAMEL_QUARKUS_START_MOCK_BACKEND=false
+export AWS_EKS_ROLE_ARN=arn:aws:iam::<account-id>:role/<eks-cluster-role>
+export AWS_EKS_SUBNETS=<subnet-id-1>,<subnet-id-2>
+----

--- a/integration-test-groups/aws2/aws2-eks/pom.xml
+++ b/integration-test-groups/aws2/aws2-eks/pom.xml
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://www.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.camel.quarkus</groupId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
+        <version>3.40.0-SNAPSHOT</version>
+        <relativePath>../../../poms/build-parent-it/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>camel-quarkus-integration-test-aws2-eks</artifactId>
+    <name>Camel Quarkus :: Integration Tests :: AWS 2 EKS</name>
+    <description>Integration tests for Camel Quarkus AWS 2 EKS extension</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-aws2-eks</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>eks</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-integration-tests-support-aws2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-integration-tests-support-aws2</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <id>native</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <properties>
+                <quarkus.native.enabled>true</quarkus.native.enabled>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>virtualDependencies</id>
+            <activation>
+                <property>
+                    <name>!noVirtualDependencies</name>
+                </property>
+            </activation>
+            <dependencies>
+                <!-- The following dependencies guarantee that this module is built after them. You can update them by running `mvn process-resources -Pformat -N` from the source tree root directory -->
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-aws2-eks-deployment</artifactId>
+                    <version>${project.version}</version>
+                    <type>pom</type>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>skip-testcontainers-tests</id>
+            <activation>
+                <property>
+                    <name>skip-testcontainers-tests</name>
+                </property>
+            </activation>
+            <properties>
+                <skipTests>true</skipTests>
+            </properties>
+        </profile>
+    </profiles>
+
+</project>

--- a/integration-test-groups/aws2/aws2-eks/src/main/java/org/apache/camel/quarkus/component/aws2/eks/it/Aws2EksResource.java
+++ b/integration-test-groups/aws2/aws2-eks/src/main/java/org/apache/camel/quarkus/component/aws2/eks/it/Aws2EksResource.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.aws2.eks.it;
+
+import java.util.List;
+import java.util.Map;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.component.aws2.eks.EKS2Constants;
+import org.apache.camel.component.aws2.eks.EKS2Operations;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import software.amazon.awssdk.services.eks.model.Cluster;
+import software.amazon.awssdk.services.eks.model.CreateClusterResponse;
+import software.amazon.awssdk.services.eks.model.DeleteClusterResponse;
+import software.amazon.awssdk.services.eks.model.DescribeClusterResponse;
+import software.amazon.awssdk.services.eks.model.ListClustersResponse;
+import software.amazon.awssdk.services.eks.model.VpcConfigRequest;
+
+@Path("/aws2-eks")
+@ApplicationScoped
+public class Aws2EksResource {
+
+    @Inject
+    ProducerTemplate producerTemplate;
+
+    @ConfigProperty(name = "aws.eks.role.arn")
+    String roleArn;
+
+    @ConfigProperty(name = "aws.eks.subnets")
+    List<String> subnets;
+
+    @Path("/clusters")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response listClusters(@QueryParam("maxResults") Integer maxResults) {
+        Map<String, Object> headers = maxResults != null
+                ? Map.of(EKS2Constants.MAX_RESULTS, maxResults)
+                : Map.of();
+
+        ListClustersResponse response = producerTemplate.requestBodyAndHeaders(
+                componentUri(EKS2Operations.listClusters),
+                null,
+                headers,
+                ListClustersResponse.class);
+
+        return Response.ok(response.clusters()).build();
+    }
+
+    @Path("/clusters/{clusterName}")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response describeCluster(@PathParam("clusterName") String clusterName) {
+        DescribeClusterResponse response = producerTemplate.requestBodyAndHeader(
+                componentUri(EKS2Operations.describeCluster),
+                null,
+                EKS2Constants.CLUSTER_NAME,
+                clusterName,
+                DescribeClusterResponse.class);
+
+        if (response.cluster() == null) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+
+        Cluster cluster = response.cluster();
+        Map<String, String> result = Map.of(
+                "clusterName", cluster.name(),
+                "clusterArn", cluster.arn(),
+                "clusterStatus", cluster.statusAsString());
+        return Response.ok(result).build();
+    }
+
+    @Path("/clusters")
+    @POST
+    @Produces(MediaType.TEXT_PLAIN)
+    public Response createCluster(@QueryParam("clusterName") String clusterName) {
+        Map<String, Object> headers = Map.of(
+                EKS2Constants.CLUSTER_NAME, clusterName,
+                EKS2Constants.ROLE_ARN, roleArn,
+                EKS2Constants.VPC_CONFIG, VpcConfigRequest.builder().subnetIds(subnets).build());
+
+        CreateClusterResponse response = producerTemplate.requestBodyAndHeaders(
+                componentUri(EKS2Operations.createCluster),
+                null,
+                headers,
+                CreateClusterResponse.class);
+
+        return Response.ok(response.cluster().arn()).build();
+    }
+
+    @Path("/clusters/{clusterName}")
+    @DELETE
+    @Produces(MediaType.TEXT_PLAIN)
+    public Response deleteCluster(@PathParam("clusterName") String clusterName) {
+        DeleteClusterResponse response = producerTemplate.requestBodyAndHeader(
+                componentUri(EKS2Operations.deleteCluster),
+                null,
+                EKS2Constants.CLUSTER_NAME,
+                clusterName,
+                DeleteClusterResponse.class);
+
+        return Response.ok(response.cluster().arn()).build();
+    }
+
+    private String componentUri(EKS2Operations operation) {
+        return "aws2-eks://test?operation=" + operation;
+    }
+}

--- a/integration-test-groups/aws2/aws2-eks/src/main/resources/application.properties
+++ b/integration-test-groups/aws2/aws2-eks/src/main/resources/application.properties
@@ -1,0 +1,24 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+camel.component.aws2-eks.access-key=${AWS_ACCESS_KEY}
+camel.component.aws2-eks.secret-key=${AWS_SECRET_KEY}
+camel.component.aws2-eks.region=${AWS_REGION:us-east-1}
+camel.component.aws2-eks.override-endpoint=false
+
+aws.eks.role.arn=${AWS_EKS_ROLE_ARN:arn:aws:iam::123456789012:role/cq-eks-test-role}
+aws.eks.subnets=${AWS_EKS_SUBNETS:subnet-1,subnet-2}

--- a/integration-test-groups/aws2/aws2-eks/src/test/java/org/apache/camel/quarkus/component/aws2/eks/it/Aws2EksIT.java
+++ b/integration-test-groups/aws2/aws2-eks/src/test/java/org/apache/camel/quarkus/component/aws2/eks/it/Aws2EksIT.java
@@ -14,40 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.quarkus.test.support.aws2;
+package org.apache.camel.quarkus.component.aws2.eks.it;
 
-public enum Service {
-    API_GATEWAY("apigateway"),
-    EC2("ec2"),
-    EKS("eks"),
-    KINESIS("kinesis"),
-    DYNAMODB("dynamodb"),
-    DYNAMODB_STREAMS("dynamodbstreams"),
-    S3("s3"),
-    FIREHOSE("firehose"),
-    LAMBDA("lambda"),
-    SNS("sns"),
-    SQS("sqs"),
-    REDSHIFT("redshift"),
-    SES("ses"),
-    ROUTE53("route53"),
-    CLOUDFORMATION("cloudformation"),
-    CLOUDWATCH("cloudwatch"),
-    SSM("ssm"),
-    SECRETSMANAGER("secretsmanager"),
-    STEPFUNCTIONS("stepfunctions"),
-    CLOUDWATCHLOGS("logs"),
-    STS("sts"),
-    IAM("iam"),
-    KMS("kms");
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-    private final String serviceName;
-
-    Service(String serviceName) {
-        this.serviceName = serviceName;
-    }
-
-    public String getName() {
-        return serviceName;
-    }
+@QuarkusIntegrationTest
+class Aws2EksIT extends Aws2EksTest {
 }

--- a/integration-test-groups/aws2/aws2-eks/src/test/java/org/apache/camel/quarkus/component/aws2/eks/it/Aws2EksTest.java
+++ b/integration-test-groups/aws2/aws2-eks/src/test/java/org/apache/camel/quarkus/component/aws2/eks/it/Aws2EksTest.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.aws2.eks.it;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import org.apache.camel.quarkus.test.support.aws2.Aws2TestResource;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.notNullValue;
+
+@QuarkusTest
+@QuarkusTestResource(Aws2TestResource.class)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class Aws2EksTest {
+
+    static final String CLUSTER_NAME = "cq-test-cluster";
+
+    static String clusterArn;
+
+    @Test
+    @Order(1)
+    public void testCreateCluster() {
+        clusterArn = RestAssured.given()
+                .queryParam("clusterName", CLUSTER_NAME)
+                .post("/aws2-eks/clusters")
+                .then()
+                .statusCode(200)
+                .body(notNullValue())
+                .extract().body().asString();
+
+        // Wait for the cluster to become ACTIVE before running further tests
+        Awaitility.await()
+                .atMost(30, TimeUnit.MINUTES)
+                .pollDelay(0, TimeUnit.SECONDS)
+                .pollInterval(1, TimeUnit.MINUTES)
+                .until(() -> "ACTIVE".equals(clusterStatus(CLUSTER_NAME)));
+    }
+
+    @Test
+    @Order(2)
+    public void testClusterOperations() {
+        // List all clusters (EKS returns cluster names, not ARNs)
+        RestAssured.given()
+                .get("/aws2-eks/clusters")
+                .then()
+                .statusCode(200)
+                .body("$", hasItem(CLUSTER_NAME));
+
+        // List clusters with max results: assert limit behavior only (order is not guaranteed)
+        RestAssured.given()
+                .queryParam("maxResults", 10)
+                .get("/aws2-eks/clusters")
+                .then()
+                .statusCode(200)
+                .body("$", hasSize(lessThanOrEqualTo(10)));
+
+        // Describe cluster
+        RestAssured.given()
+                .get("/aws2-eks/clusters/" + CLUSTER_NAME)
+                .then()
+                .statusCode(200)
+                .body("clusterName", is(CLUSTER_NAME))
+                .body("clusterArn", is(clusterArn))
+                .body("clusterStatus", is("ACTIVE"));
+    }
+
+    @Test
+    @Order(3)
+    public void testDeleteCluster() {
+        RestAssured.given()
+                .delete("/aws2-eks/clusters/" + CLUSTER_NAME)
+                .then()
+                .statusCode(200)
+                .body(is(clusterArn));
+    }
+
+    @Test
+    @Order(4)
+    public void cleanUpVerification() {
+        // Wait until the cluster is no longer listed as deletion is asynchronous in AWS
+        Awaitility.await()
+                .atMost(30, TimeUnit.MINUTES)
+                .pollDelay(0, TimeUnit.SECONDS)
+                .pollInterval(1, TimeUnit.MINUTES)
+                .until(() -> {
+                    List<?> clusters = RestAssured.given()
+                            .get("/aws2-eks/clusters")
+                            .then()
+                            .statusCode(200)
+                            .extract().jsonPath().getList("$");
+                    return !clusters.contains(CLUSTER_NAME);
+                });
+    }
+
+    private static String clusterStatus(String clusterName) {
+        return RestAssured.given()
+                .get("/aws2-eks/clusters/" + clusterName)
+                .then()
+                .statusCode(200)
+                .extract().jsonPath().getString("clusterStatus");
+    }
+}

--- a/integration-test-groups/aws2/aws2-eks/src/test/java/org/apache/camel/quarkus/component/aws2/eks/it/Aws2EksTestEnvCustomizer.java
+++ b/integration-test-groups/aws2/aws2-eks/src/test/java/org/apache/camel/quarkus/component/aws2/eks/it/Aws2EksTestEnvCustomizer.java
@@ -14,40 +14,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.quarkus.test.support.aws2;
+package org.apache.camel.quarkus.component.aws2.eks.it;
 
-public enum Service {
-    API_GATEWAY("apigateway"),
-    EC2("ec2"),
-    EKS("eks"),
-    KINESIS("kinesis"),
-    DYNAMODB("dynamodb"),
-    DYNAMODB_STREAMS("dynamodbstreams"),
-    S3("s3"),
-    FIREHOSE("firehose"),
-    LAMBDA("lambda"),
-    SNS("sns"),
-    SQS("sqs"),
-    REDSHIFT("redshift"),
-    SES("ses"),
-    ROUTE53("route53"),
-    CLOUDFORMATION("cloudformation"),
-    CLOUDWATCH("cloudwatch"),
-    SSM("ssm"),
-    SECRETSMANAGER("secretsmanager"),
-    STEPFUNCTIONS("stepfunctions"),
-    CLOUDWATCHLOGS("logs"),
-    STS("sts"),
-    IAM("iam"),
-    KMS("kms");
+import org.apache.camel.quarkus.test.support.aws2.Aws2TestEnvContext;
+import org.apache.camel.quarkus.test.support.aws2.Aws2TestEnvCustomizer;
+import org.apache.camel.quarkus.test.support.aws2.Service;
 
-    private final String serviceName;
+public class Aws2EksTestEnvCustomizer implements Aws2TestEnvCustomizer {
 
-    Service(String serviceName) {
-        this.serviceName = serviceName;
+    @Override
+    public Service[] awsServices() {
+        return new Service[] { Service.EKS };
     }
 
-    public String getName() {
-        return serviceName;
+    @Override
+    public void customize(Aws2TestEnvContext envContext) {
     }
 }

--- a/integration-test-groups/aws2/aws2-eks/src/test/resources/META-INF/services/org.apache.camel.quarkus.test.support.aws2.Aws2TestEnvCustomizer
+++ b/integration-test-groups/aws2/aws2-eks/src/test/resources/META-INF/services/org.apache.camel.quarkus.test.support.aws2.Aws2TestEnvCustomizer
@@ -1,0 +1,1 @@
+org.apache.camel.quarkus.component.aws2.eks.it.Aws2EksTestEnvCustomizer

--- a/integration-test-groups/aws2/pom.xml
+++ b/integration-test-groups/aws2/pom.xml
@@ -43,6 +43,7 @@
         <module>aws2-ddb</module>
         <module>aws2-ec2</module>
         <module>aws2-ecs</module>
+        <module>aws2-eks</module>
         <module>aws2-iam</module>
         <module>aws2-kinesis</module>
         <module>aws2-kms</module>

--- a/integration-tests-support/aws2/src/test/java/org/apache/camel/quarkus/test/support/aws2/Aws2TestResource.java
+++ b/integration-tests-support/aws2/src/test/java/org/apache/camel/quarkus/test/support/aws2/Aws2TestResource.java
@@ -79,6 +79,11 @@ public final class Aws2TestResource implements QuarkusTestResourceLifecycleManag
                     .flatMap(Stream::of)
                     .anyMatch(s -> s == Service.LAMBDA);
 
+            boolean needsEksMock = customizers.stream()
+                    .map(Aws2TestEnvCustomizer::awsServices)
+                    .flatMap(Stream::of)
+                    .anyMatch(s -> s == Service.EKS);
+
             DockerImageName imageName = DockerImageName
                     .parse(ConfigProvider.getConfig().getValue("floci.container.image", String.class));
 
@@ -88,6 +93,11 @@ public final class Aws2TestResource implements QuarkusTestResourceLifecycleManag
                     .withEnv("AWS_ACCESS_KEY_ID", "testAccessKeyId") //has to be longer then `test`, to work on FIPS systems
                     .withEnv("AWS_SECRET_ACCESS_KEY", "testSecretKeyId")
                     .withLogConsumer(new Slf4jLogConsumer(LOG));
+
+            if (needsEksMock) {
+                // Camel EKS tests cover the control-plane API only; avoid starting a k3s cluster per CreateCluster
+                floci.withEnv("FLOCI_SERVICES_EKS_MOCK", "true");
+            }
 
             if (needsDockerSocket) {
                 Path dockerSocket = Path.of("/var/run/docker.sock");

--- a/integration-tests/aws2-grouped/pom.xml
+++ b/integration-tests/aws2-grouped/pom.xml
@@ -82,6 +82,10 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-aws2-eks</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-aws2-iam</artifactId>
         </dependency>
         <dependency>
@@ -151,6 +155,16 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>ecs</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>eks</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>
@@ -355,6 +369,19 @@
                 <dependency>
                     <groupId>org.apache.camel.quarkus</groupId>
                     <artifactId>camel-quarkus-aws2-ecs-deployment</artifactId>
+                    <version>${project.version}</version>
+                    <type>pom</type>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-aws2-eks-deployment</artifactId>
                     <version>${project.version}</version>
                     <type>pom</type>
                     <scope>test</scope>


### PR DESCRIPTION
## Description

Adds an AWS2 EKS integration test covering the `camel-aws2-eks` component.

The test:
- Adds a dedicated `aws2-eks` integration test module.
- Covers EKS cluster create, describe, list, and delete operations.
- Uses WireMock mappings to mock AWS EKS API responses.
- Registers the module in the AWS2 integration test group.

Fixes #2398

## Testing

- `mvnw -pl integration-test-groups/aws2/aws2-eks process-resources -Pformat`
- `git diff --check`

Formatting completed successfully with no changes required.