### PR TITLE
Release doc: how to solve GPG signing failure caused by a stale lock 

### DIFF
--- a/docs/modules/ROOT/pages/contributor-guide/release-guide.adoc
+++ b/docs/modules/ROOT/pages/contributor-guide/release-guide.adoc
@@ -522,3 +522,19 @@ git config --global credential.helper store
 ssh-add -l
 mvn help:evaluate -Dexpression=env.SSH_AUTH_SOCK -q -DforceStdout
 ----
+
+=== GPG signing failure caused by a stale lock file
+If GPG signing fails during the release with output such as:
+----
+[INFO] [INFO] Signer 'gpg' is signing 4 files with key default
+[INFO] gpg: Note: database_open 134217901 waiting for lock (held by 5376) ...
+[INFO] gpg: keydb_search failed: Connection timed out
+[INFO] gpg: no default secret key: Connection timed out
+[INFO] gpg: signing failed: Connection timed out
+----
+the cause may be a stale lock file in the GnuPG keybox database. The lock
+references the process ID that created it (`held by 5376`). If no such process
+is running, remove the lock file:
+----
+sudo rm ~/.gnupg/public-keys.d/pubring.db.lock
+----


### PR DESCRIPTION
Adds a troubleshooting entry to the release guide covering a GPG signing failure during release execution
```
[INFO] [INFO] Signer 'gpg' is signing 4 files with key default
[INFO] gpg: Note: database_open 134217901 waiting for lock (held by 5376) ...
[INFO] gpg: Note: database_open 134217901 waiting for lock (held by 5376) ...
[INFO] gpg: Note: database_open 134217901 waiting for lock (held by 5376) ...
[INFO] gpg: Note: database_open 134217901 waiting for lock (held by 5376) ...
[INFO] gpg: Note: database_open 134217901 waiting for lock (held by 5376) ...
[INFO] gpg: keydb_search failed: Connection timed out
[INFO] gpg: no default secret key: Connection timed out
[INFO] gpg: signing failed: Connection timed out
```

<!-- Uncomment and fill this section if your PR is not trivial
[ ] An issue should be filed for the change unless this is a trivial change (fixing a typo or similar). One issue should ideally be fixed by not more than one commit and the other way round, each commit should fix just one issue, without pulling in other changes.
[ ] Each commit in the pull request should have a meaningful and properly spelled subject line and body. Copying the title of the associated issue is typically enough. Please include the issue number in the commit message prefixed by #.
[ ] The pull request description should explain what the pull request does, how, and why. If the info is available in the associated issue or some other external document, a link is enough.
[ ] Phrases like Fix #<issueNumber> or Fixes #<issueNumber> will auto-close the named issue upon merging the pull request. Using them is typically a good idea.
[ ] Please run mvn process-resources -Pformat (and amend the changes if necessary) before sending the pull request.
[ ] Contributor guide is your good friend: https://camel.apache.org/camel-quarkus/latest/contributor-guide.html
-->