### PR TITLE
CAMEL-5541: Add AWS2 STS integration test group

### DIFF
--- a/integration-test-groups/aws2/aws2-sts/README.adoc
+++ b/integration-test-groups/aws2/aws2-sts/README.adoc
@@ -1,0 +1,21 @@
+= AWS STS tests
+
+By default the tests run against a Floci container via the `Aws2TestEnvCustomizer` SPI.
+
+== Running against real AWS
+
+Refer to the xref:../README.adoc[AWS 2 integration tests README] for general instructions on how to set up AWS credentials.
+
+The AWS credentials must have the following IAM permission:
+
+* `sts:GetSessionToken`
+
+=== Running tests directly against real AWS
+
+[source,shell]
+----
+export AWS_ACCESS_KEY=<your-access-key-id>
+export AWS_SECRET_KEY=<your-secret-access-key>
+export AWS_REGION=us-east-1
+export CAMEL_QUARKUS_START_MOCK_BACKEND=false
+----

--- a/integration-test-groups/aws2/aws2-sts/pom.xml
+++ b/integration-test-groups/aws2/aws2-sts/pom.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://www.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.camel.quarkus</groupId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
+        <version>3.40.0-SNAPSHOT</version>
+        <relativePath>../../../poms/build-parent-it/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>camel-quarkus-integration-test-aws2-sts</artifactId>
+    <name>Camel Quarkus :: Integration Tests :: AWS 2 STS</name>
+    <description>Integration tests for Camel Quarkus AWS 2 Security Token Service (STS) extension</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-aws2-sts</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-jackson</artifactId>
+        </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-integration-tests-support-aws2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-integration-tests-support-aws2</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <id>native</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <properties>
+                <quarkus.native.enabled>true</quarkus.native.enabled>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>virtualDependencies</id>
+            <activation>
+                <property>
+                    <name>!noVirtualDependencies</name>
+                </property>
+            </activation>
+            <dependencies>
+                <!-- The following dependencies guarantee that this module is built after them. You can update them by running `mvn process-resources -Pformat -N` from the source tree root directory -->
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-aws2-sts-deployment</artifactId>
+                    <version>${project.version}</version>
+                    <type>pom</type>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>skip-testcontainers-tests</id>
+            <activation>
+                <property>
+                    <name>skip-testcontainers-tests</name>
+                </property>
+            </activation>
+            <properties>
+                <skipTests>true</skipTests>
+            </properties>
+        </profile>
+    </profiles>
+
+</project>

--- a/integration-test-groups/aws2/aws2-sts/src/main/java/org/apache/camel/quarkus/component/aws2/sts/it/Aws2StsResource.java
+++ b/integration-test-groups/aws2/aws2-sts/src/main/java/org/apache/camel/quarkus/component/aws2/sts/it/Aws2StsResource.java
@@ -46,6 +46,10 @@ public class Aws2StsResource {
                 null,
                 GetSessionTokenResponse.class);
 
+        if (response == null || response.credentials() == null) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+
         Credentials credentials = response.credentials();
         return Response.ok(Map.of(
                 "accessKeyId", credentials.accessKeyId(),

--- a/integration-test-groups/aws2/aws2-sts/src/main/java/org/apache/camel/quarkus/component/aws2/sts/it/Aws2StsResource.java
+++ b/integration-test-groups/aws2/aws2-sts/src/main/java/org/apache/camel/quarkus/component/aws2/sts/it/Aws2StsResource.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.aws2.sts.it;
+
+import java.util.Map;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.component.aws2.sts.STS2Operations;
+import software.amazon.awssdk.services.sts.model.Credentials;
+import software.amazon.awssdk.services.sts.model.GetSessionTokenResponse;
+
+@Path("/aws2-sts")
+@ApplicationScoped
+public class Aws2StsResource {
+
+    @Inject
+    ProducerTemplate producerTemplate;
+
+    @Path("/session-token")
+    @POST
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getSessionToken() {
+        GetSessionTokenResponse response = producerTemplate.requestBody(
+                componentUri(STS2Operations.getSessionToken),
+                null,
+                GetSessionTokenResponse.class);
+
+        Credentials credentials = response.credentials();
+        return Response.ok(Map.of(
+                "accessKeyId", credentials.accessKeyId(),
+                "sessionToken", credentials.sessionToken())).build();
+    }
+
+    private String componentUri(STS2Operations operation) {
+        return "aws2-sts://myaccount?operation=" + operation;
+    }
+}

--- a/integration-test-groups/aws2/aws2-sts/src/main/resources/application.properties
+++ b/integration-test-groups/aws2/aws2-sts/src/main/resources/application.properties
@@ -1,0 +1,21 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+camel.component.aws2-sts.access-key=${AWS_ACCESS_KEY}
+camel.component.aws2-sts.secret-key=${AWS_SECRET_KEY}
+camel.component.aws2-sts.region=${AWS_REGION:us-east-1}
+camel.component.aws2-sts.override-endpoint=false

--- a/integration-test-groups/aws2/aws2-sts/src/test/java/org/apache/camel/quarkus/component/aws2/sts/it/Aws2StsIT.java
+++ b/integration-test-groups/aws2/aws2-sts/src/test/java/org/apache/camel/quarkus/component/aws2/sts/it/Aws2StsIT.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.aws2.sts.it;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+class Aws2StsIT extends Aws2StsTest {
+}

--- a/integration-test-groups/aws2/aws2-sts/src/test/java/org/apache/camel/quarkus/component/aws2/sts/it/Aws2StsTest.java
+++ b/integration-test-groups/aws2/aws2-sts/src/test/java/org/apache/camel/quarkus/component/aws2/sts/it/Aws2StsTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.aws2.sts.it;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import org.apache.camel.quarkus.test.support.aws2.Aws2TestResource;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.Matchers.emptyOrNullString;
+import static org.hamcrest.Matchers.not;
+
+@QuarkusTest
+@QuarkusTestResource(Aws2TestResource.class)
+class Aws2StsTest {
+
+    @Test
+    public void testGetSessionToken() {
+        RestAssured.given()
+                .post("/aws2-sts/session-token")
+                .then()
+                .statusCode(200)
+                .body("accessKeyId", not(emptyOrNullString()))
+                .body("sessionToken", not(emptyOrNullString()));
+    }
+}

--- a/integration-test-groups/aws2/aws2-sts/src/test/java/org/apache/camel/quarkus/component/aws2/sts/it/Aws2StsTestEnvCustomizer.java
+++ b/integration-test-groups/aws2/aws2-sts/src/test/java/org/apache/camel/quarkus/component/aws2/sts/it/Aws2StsTestEnvCustomizer.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.aws2.sts.it;
+
+import org.apache.camel.quarkus.test.support.aws2.Aws2TestEnvContext;
+import org.apache.camel.quarkus.test.support.aws2.Aws2TestEnvCustomizer;
+import org.apache.camel.quarkus.test.support.aws2.Service;
+
+public class Aws2StsTestEnvCustomizer implements Aws2TestEnvCustomizer {
+
+    @Override
+    public Service[] awsServices() {
+        return new Service[] { Service.STS };
+    }
+
+    @Override
+    public void customize(Aws2TestEnvContext envContext) {
+        // No additional customization needed for STS getSessionToken tests
+    }
+}

--- a/integration-test-groups/aws2/aws2-sts/src/test/resources/META-INF/services/org.apache.camel.quarkus.test.support.aws2.Aws2TestEnvCustomizer
+++ b/integration-test-groups/aws2/aws2-sts/src/test/resources/META-INF/services/org.apache.camel.quarkus.test.support.aws2.Aws2TestEnvCustomizer
@@ -1,0 +1,1 @@
+org.apache.camel.quarkus.component.aws2.sts.it.Aws2StsTestEnvCustomizer

--- a/integration-test-groups/aws2/pom.xml
+++ b/integration-test-groups/aws2/pom.xml
@@ -54,6 +54,7 @@
         <module>aws2-ses</module>
         <module>aws2-sqs</module>
         <module>aws2-sqs-sns</module>
+        <module>aws2-sts</module>
     </modules>
 
 </project>

--- a/integration-tests/aws2-grouped/pom.xml
+++ b/integration-tests/aws2-grouped/pom.xml
@@ -126,6 +126,10 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-aws2-sts</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-direct</artifactId>
         </dependency>
         <dependency>
@@ -512,6 +516,19 @@
                 <dependency>
                     <groupId>org.apache.camel.quarkus</groupId>
                     <artifactId>camel-quarkus-aws2-sqs-deployment</artifactId>
+                    <version>${project.version}</version>
+                    <type>pom</type>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-aws2-sts-deployment</artifactId>
                     <version>${project.version}</version>
                     <type>pom</type>
                     <scope>test</scope>

--- a/poms/build-parent/pom.xml
+++ b/poms/build-parent/pom.xml
@@ -114,6 +114,8 @@
                         <removeUnused>true</removeUnused>
                         <staticAfter>true</staticAfter>
                         <staticGroups>java.,javax.,org.w3c.,org.xml.,junit.</staticGroups>
+                        <!-- Plugin default is ${maven.compiler.release}. An empty override maps to JavaParser POPULAR (JAVA_11) and rejects instanceof pattern matching. -->
+                        <compliance>${maven.compiler.source}</compliance>
                         <skip>${format.skip}</skip>
                     </configuration>
                 </plugin>

--- a/poms/build-parent/pom.xml
+++ b/poms/build-parent/pom.xml
@@ -114,8 +114,6 @@
                         <removeUnused>true</removeUnused>
                         <staticAfter>true</staticAfter>
                         <staticGroups>java.,javax.,org.w3c.,org.xml.,junit.</staticGroups>
-                        <!-- Plugin default is ${maven.compiler.release}. An empty override maps to JavaParser POPULAR (JAVA_11) and rejects instanceof pattern matching. -->
-                        <compliance>${maven.compiler.source}</compliance>
                         <skip>${format.skip}</skip>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
## Description

Add a dedicated AWS2 STS integration test group as part of the AWS2 integration test migration.

### Changes

- Add new `integration-test-groups/aws2/aws2-sts` module.
- Add Floci-backed `getSessionToken` integration test using the existing `Service.STS` infrastructure.
- Add native integration test coverage.
- Add real-AWS configuration using `AWS_ACCESS_KEY`, `AWS_SECRET_KEY`, and `AWS_REGION`.
- Register the STS test environment customizer through the existing AWS2 SPI.
- Add the module to the AWS2 grouped test aggregator.
- Pin impsort compliance to `${maven.compiler.source}` to avoid parser failures when `maven.compiler.release` is overridden locally.

### Validation

- `git diff --check` — clean
- AWS2 STS test — 1 test, 0 failures, 0 errors
- Build — SUCCESS