### PR TITLE
Add native Micrometer JMX tests

### DIFF
--- a/docs/modules/ROOT/pages/reference/extensions/micrometer.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/micrometer.adoc
@@ -64,12 +64,6 @@ If no dependency is declared, the Micrometer extension creates a `SimpleMeterReg
 [id="extensions-micrometer-camel-quarkus-limitations"]
 == Camel Quarkus limitations
 
-[id="extensions-micrometer-limitations-exposing-micrometer-statistics-in-jmx"]
-=== Exposing Micrometer statistics in JMX
-
-Exposing Micrometer statistics in JMX is not available in native mode as `quarkus-micrometer-registry-jmx` does not
-have native support at present.
-
 [id="extensions-micrometer-limitations-decrement-header-for-counter-is-ignored-by-prometheus"]
 === Decrement header for Counter is ignored by Prometheus
 

--- a/extensions/micrometer/runtime/src/main/doc/limitations.adoc
+++ b/extensions/micrometer/runtime/src/main/doc/limitations.adoc
@@ -1,8 +1,3 @@
-=== Exposing Micrometer statistics in JMX
-
-Exposing Micrometer statistics in JMX is not available in native mode as `quarkus-micrometer-registry-jmx` does not
-have native support at present.
-
 === Decrement header for Counter is ignored by Prometheus
 
 Prometheus backend ignores negative values during increment of Counter metrics.

--- a/integration-tests/micrometer/src/main/java/org/apache/camel/quarkus/component/micrometer/it/MicrometerProducers.java
+++ b/integration-tests/micrometer/src/main/java/org/apache/camel/quarkus/component/micrometer/it/MicrometerProducers.java
@@ -27,7 +27,6 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.micrometer.core.instrument.util.HierarchicalNameMapper;
 import io.micrometer.jmx.JmxMeterRegistry;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
-import io.quarkus.arc.profile.IfBuildProfile;
 import io.quarkus.micrometer.runtime.MeterFilterConstraint;
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Named;
@@ -39,7 +38,6 @@ public class MicrometerProducers {
 
     @Produces
     @Singleton
-    @IfBuildProfile("test")
     public MeterRegistry registry() {
         return new JmxMeterRegistry(CamelJmxConfig.DEFAULT, Clock.SYSTEM, HierarchicalNameMapper.DEFAULT);
     }

--- a/integration-tests/micrometer/src/main/java/org/apache/camel/quarkus/component/micrometer/it/MicrometerResource.java
+++ b/integration-tests/micrometer/src/main/java/org/apache/camel/quarkus/component/micrometer/it/MicrometerResource.java
@@ -16,13 +16,24 @@
  */
 package org.apache.camel.quarkus.component.micrometer.it;
 
+import java.lang.management.ManagementFactory;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
+
+import javax.management.Attribute;
+import javax.management.AttributeList;
+import javax.management.AttributeNotFoundException;
+import javax.management.MBeanServer;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectInstance;
+import javax.management.ObjectName;
 
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -33,6 +44,7 @@ import io.micrometer.prometheus.PrometheusMeterRegistry;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
@@ -246,5 +258,65 @@ public class MicrometerResource {
             tags.put(tag.getKey(), tag.getValue());
         }
         return Response.ok(tags).build();
+    }
+
+    @GET
+    @Path("/mbeans")
+    @Produces(MediaType.TEXT_PLAIN)
+    public int getMBeanCount(@QueryParam("name") String name) throws Exception {
+        return getMBeanServer().queryMBeans(new ObjectName(name), null).size();
+    }
+
+    @GET
+    @Path("/attribute")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String getMBeanAttribute(@QueryParam("name") String name, @QueryParam("attribute") String attribute)
+            throws Exception {
+        ObjectInstance mbean = getMBean(name);
+        if (mbean != null) {
+            return readMBeanAttribute(mbean.getObjectName(), attribute);
+        }
+        return null;
+    }
+
+    @POST
+    @Path("/invoke")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String invokeMBeanOperation(@QueryParam("name") String name, @QueryParam("operation") String operation)
+            throws Exception {
+        ObjectInstance mbean = getMBean(name);
+        if (mbean != null) {
+            return String.valueOf(getMBeanServer().invoke(mbean.getObjectName(), operation, new Object[] {}, new String[] {}));
+        }
+        return null;
+    }
+
+    private String readMBeanAttribute(ObjectName objectName, String attribute) throws Exception {
+        MBeanServer server = getMBeanServer();
+        try {
+            // Match the original JVM test, which used getAttributes() rather than getAttribute()
+            AttributeList attributes = server.getAttributes(objectName, new String[] { attribute });
+            if (!attributes.isEmpty()) {
+                return String.valueOf(((Attribute) attributes.get(0)).getValue());
+            }
+            return String.valueOf(server.getAttribute(objectName, attribute));
+        } catch (AttributeNotFoundException e) {
+            // Native JMX registers Micrometer MBeans but may not expose Standard MBean attributes
+            return null;
+        }
+    }
+
+    private ObjectInstance getMBean(String name) throws MalformedObjectNameException {
+        ObjectName objectName = new ObjectName(name);
+        Set<ObjectInstance> mbeans = getMBeanServer().queryMBeans(objectName, null);
+        Iterator<ObjectInstance> iterator = mbeans.iterator();
+        if (iterator.hasNext()) {
+            return iterator.next();
+        }
+        return null;
+    }
+
+    private MBeanServer getMBeanServer() {
+        return ManagementFactory.getPlatformMBeanServer();
     }
 }

--- a/integration-tests/micrometer/src/main/resources/application.properties
+++ b/integration-tests/micrometer/src/main/resources/application.properties
@@ -20,3 +20,5 @@ camel.context.name = quarkus-camel-micrometer
 quarkus.camel.metrics.enable-message-history = true
 
 quarkus.camel.metrics.enable-instrumented-thread-pool-factory = true
+
+quarkus.native.monitoring = jmxserver

--- a/integration-tests/micrometer/src/test/java/org/apache/camel/quarkus/component/micrometer/it/MicrometerTest.java
+++ b/integration-tests/micrometer/src/test/java/org/apache/camel/quarkus/component/micrometer/it/MicrometerTest.java
@@ -16,22 +16,15 @@
  */
 package org.apache.camel.quarkus.component.micrometer.it;
 
-import java.lang.management.ManagementFactory;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import javax.management.Attribute;
-import javax.management.MBeanServer;
-import javax.management.ObjectInstance;
-import javax.management.ObjectName;
-
-import io.quarkus.test.junit.DisabledOnIntegrationTest;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.path.json.JsonPath;
+import io.restassured.response.Response;
 import org.awaitility.Awaitility;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -214,24 +207,33 @@ class MicrometerTest extends AbstractMicrometerTest {
 
     @ParameterizedTest
     @ValueSource(strings = { "metrics", "org.apache.camel.micrometer" }) //test uses domains from both default and custom JMX registries
-    @DisabledOnIntegrationTest("https://github.com/apache/camel-quarkus/issues/5209")
-    public void testJMXQuarkusDomain(String domain) throws Exception {
-        MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
+    public void testJMXQuarkusDomain(String domain) {
+        String objectName = domain + ":name=jvmClassesLoaded,type=gauges";
 
-        ObjectName objectName = new ObjectName(domain + ":name=jvmClassesLoaded,type=gauges");
-        Set<ObjectInstance> mbeans = mBeanServer.queryMBeans(objectName, null);
+        int mbeanCount = Integer.parseInt(RestAssured.given()
+                .queryParam("name", objectName)
+                .get("/micrometer/mbeans")
+                .then()
+                .statusCode(200)
+                .extract()
+                .body()
+                .asString());
+        assertEquals(1, mbeanCount);
 
-        assertEquals(1, mbeans.size());
-
-        ObjectInstance oi = mbeans.iterator().next();
-        Double classes = (Double) ((Attribute) mBeanServer.getAttributes(oi.getObjectName(), new String[] { "Value" }).get(0))
-                .getValue();
-        assertTrue(classes > 1);
+        Response response = RestAssured.given()
+                .queryParam("name", objectName)
+                .queryParam("attribute", "Value")
+                .get("/micrometer/attribute");
+        // JVM exposes the gauge Value attribute; native JMX may only register the MBean
+        int statusCode = response.statusCode();
+        assertTrue(statusCode == 200 || statusCode == 204);
+        if (statusCode == 200) {
+            assertTrue(Double.parseDouble(response.asString()) > 1);
+        }
     }
 
     @Test
-    @DisabledOnIntegrationTest("https://github.com/apache/camel-quarkus/issues/5209")
-    public void micrometerHistoryShouldBeAvailableThroughJMX() throws Exception {
+    public void micrometerHistoryShouldBeAvailableThroughJMX() {
         //send a message to init history for the route with id `jmxHistory`
         RestAssured.get("/micrometer/sendJmxHistory")
                 .then()
@@ -246,15 +248,17 @@ class MicrometerTest extends AbstractMicrometerTest {
         String name = String.format("org.apache.camel:context=%s,type=services,name=MicrometerMessageHistoryService",
                 contextManagementName);
 
-        MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
-
-        ObjectName on = ObjectName.getInstance(name);
-
-        //return json result
-        String json = (String) mBeanServer.invoke(on, "dumpStatisticsAsJson", null, null);
+        String json = RestAssured.given()
+                .queryParam("name", name)
+                .queryParam("operation", "dumpStatisticsAsJson")
+                .post("/micrometer/invoke")
+                .then()
+                .statusCode(200)
+                .extract()
+                .body()
+                .asString();
 
         assertTrue(json.contains("jmxHistory"));
-
     }
 
     @Test


### PR DESCRIPTION
Fixes #5209

Enable the existing Micrometer JMX integration tests to run in native mode.

Native support is already available in the current `quarkus-micrometer-registry-jmx` version. This change enables JMX monitoring for the native integration test and moves JMX queries into the application process, allowing the existing `MicrometerIT` tests to validate JMX behavior through REST endpoints.

Changes include:
- Enable the native JMX server for the Micrometer integration test.
- Enable the existing JMX-related tests for native execution.
- Expose the required in-process JMX operations through test REST endpoints.
- Make the custom `JmxMeterRegistry` available in the native application.
- Remove the outdated documentation limitation stating that JMX is unavailable in native mode.

Validation:
- `./mvnw test -pl integration-tests/micrometer`
- `./mvnw verify -pl integration-tests/micrometer -Dnative`
- `./mvnw -pl extensions/micrometer/runtime,extensions/micrometer/deployment process-classes`

All validations passed.