### PR TITLE
Fixes #9059. Declare least-privilege permissions on the cron workflows

### DIFF
--- a/.github/workflows/camel-master-cron.yaml
+++ b/.github/workflows/camel-master-cron.yaml
@@ -30,8 +30,14 @@ env:
   ISSUE_ID: 2927
   DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
+permissions:
+  contents: read
+
 jobs:
   initial-mvn-install:
+    permissions:
+      contents: read
+      issues: write
     if: github.repository == 'apache/camel-quarkus'
     runs-on: ubuntu-latest
     outputs:
@@ -138,6 +144,9 @@ jobs:
           ./mvnw ${CQ_MAVEN_ARGS} verify -N -Pbuild-notification -Dstatus=${{ job.status }} -DissueId=${{ env.ISSUE_ID }} -Dtoken=${{ secrets.GITHUB_TOKEN }} -DbuildId=$(cat ~/build-data/build-id.txt) -Drepo=${GITHUB_REPOSITORY} -Dbranch=camel-main -Dbranch-commit=$(cat ~/build-data/main-sha.txt)
 
   native-tests:
+    permissions:
+      contents: read
+      issues: write
     name: Native Tests - ${{matrix.category}}
     needs: initial-mvn-install
     runs-on: ubuntu-latest
@@ -220,6 +229,9 @@ jobs:
           ./mvnw ${CQ_MAVEN_ARGS} verify -N -Pbuild-notification -Dstatus=${{ job.status }} -DissueId=${{ env.ISSUE_ID }} -Dtoken=${{ secrets.GITHUB_TOKEN }} -DbuildId=$(cat ~/build-data/build-id.txt) -Drepo=${GITHUB_REPOSITORY} -Dbranch=camel-main -Dbranch-commit=$(cat ~/build-data/main-sha.txt)
 
   functional-extension-tests:
+    permissions:
+      contents: read
+      issues: write
     runs-on: ubuntu-latest
     needs: initial-mvn-install
     env:
@@ -311,6 +323,9 @@ jobs:
           ./mvnw ${CQ_MAVEN_ARGS} verify -N -Pbuild-notification -Dstatus=${{ job.status }} -DissueId=${{ env.ISSUE_ID }} -Dtoken=${{ secrets.GITHUB_TOKEN }} -DbuildId=$(cat ~/build-data/build-id.txt) -Drepo=${GITHUB_REPOSITORY} -Dbranch=camel-main -Dbranch-commit=$(cat ~/build-data/main-sha.txt)
 
   integration-tests-jvm:
+    permissions:
+      contents: read
+      issues: write
     runs-on: ubuntu-latest
     needs: initial-mvn-install
     env:
@@ -355,6 +370,9 @@ jobs:
           ./mvnw ${CQ_MAVEN_ARGS} verify -N -Pbuild-notification -Dstatus=${{ job.status }} -DissueId=${{ env.ISSUE_ID }} -Dtoken=${{ secrets.GITHUB_TOKEN }} -DbuildId=$(cat ~/build-data/build-id.txt) -Drepo=${GITHUB_REPOSITORY} -Dbranch=camel-main -Dbranch-commit=$(cat ~/build-data/main-sha.txt)
 
   integration-tests-alternative-platform:
+    permissions:
+      contents: read
+      issues: write
     runs-on: ${{ matrix.os }}
     needs: initial-mvn-install
     strategy:
@@ -405,6 +423,9 @@ jobs:
           ./mvnw ${CQ_MAVEN_ARGS} verify -N -Pbuild-notification -Dstatus=${{ job.status }} -DissueId=${{ env.ISSUE_ID }} -Dtoken=${{ secrets.GITHUB_TOKEN }} -DbuildId=$(cat ~/build-data/build-id.txt) -Drepo=${GITHUB_REPOSITORY} -Dbranch=camel-main -Dbranch-commit=$(cat ~/build-data/main-sha.txt)
 
   examples-tests:
+    permissions:
+      contents: read
+      issues: write
     name: Examples Tests - ${{matrix.name}}
     needs: initial-mvn-install
     runs-on: ubuntu-latest
@@ -487,6 +508,9 @@ jobs:
           ./mvnw ${CQ_MAVEN_ARGS} verify -N -Pbuild-notification -Dstatus=${{ job.status }} -DissueId=${{ env.ISSUE_ID }} -Dtoken=${{ secrets.GITHUB_TOKEN }} -DbuildId=$(cat ~/build-data/build-id.txt) -Drepo=${GITHUB_REPOSITORY} -Dbranch=camel-main -Dbranch-commit=$(cat ~/build-data/main-sha.txt)
 
   handle-build-status:
+    permissions:
+      contents: write
+      issues: write
     needs: native-tests
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/quarkus-master-cron.yaml
+++ b/.github/workflows/quarkus-master-cron.yaml
@@ -30,8 +30,14 @@ env:
   ISSUE_ID: 2926
   DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
+permissions:
+  contents: read
+
 jobs:
   initial-mvn-install:
+    permissions:
+      contents: read
+      issues: write
     if: github.repository == 'apache/camel-quarkus'
     runs-on: ubuntu-latest
     outputs:
@@ -140,6 +146,9 @@ jobs:
           ./mvnw ${CQ_MAVEN_ARGS} verify -N -Pbuild-notification -Dstatus=${{ job.status }} -DissueId=${{ env.ISSUE_ID }} -Dtoken=${{ secrets.GITHUB_TOKEN }} -DbuildId=$(cat ~/build-data/build-id.txt) -Drepo=${GITHUB_REPOSITORY} -Dbranch=quarkus-main -Dbranch-commit=$(cat ~/build-data/main-sha.txt)
 
   native-tests:
+    permissions:
+      contents: read
+      issues: write
     name: Native Tests - ${{matrix.category}}
     needs: initial-mvn-install
     runs-on: ubuntu-latest
@@ -222,6 +231,9 @@ jobs:
           ./mvnw ${CQ_MAVEN_ARGS} verify -N -Pbuild-notification -Dstatus=${{ job.status }} -DissueId=${{ env.ISSUE_ID }} -Dtoken=${{ secrets.GITHUB_TOKEN }} -DbuildId=$(cat ~/build-data/build-id.txt) -Drepo=${GITHUB_REPOSITORY} -Dbranch=quarkus-main -Dbranch-commit=$(cat ~/build-data/main-sha.txt)
 
   functional-extension-tests:
+    permissions:
+      contents: read
+      issues: write
     runs-on: ubuntu-latest
     needs: initial-mvn-install
     env:
@@ -313,6 +325,9 @@ jobs:
           ./mvnw ${CQ_MAVEN_ARGS} verify -N -Pbuild-notification -Dstatus=${{ job.status }} -DissueId=${{ env.ISSUE_ID }} -Dtoken=${{ secrets.GITHUB_TOKEN }} -DbuildId=$(cat ~/build-data/build-id.txt) -Drepo=${GITHUB_REPOSITORY} -Dbranch=quarkus-main -Dbranch-commit=$(cat ~/build-data/main-sha.txt)
 
   integration-tests-jvm:
+    permissions:
+      contents: read
+      issues: write
     runs-on: ubuntu-latest
     needs: initial-mvn-install
     env:
@@ -357,6 +372,9 @@ jobs:
           ./mvnw ${CQ_MAVEN_ARGS} verify -N -Pbuild-notification -Dstatus=${{ job.status }} -DissueId=${{ env.ISSUE_ID }} -Dtoken=${{ secrets.GITHUB_TOKEN }} -DbuildId=$(cat ~/build-data/build-id.txt) -Drepo=${GITHUB_REPOSITORY} -Dbranch=quarkus-main -Dbranch-commit=$(cat ~/build-data/main-sha.txt)
 
   integration-tests-alternative-platform:
+    permissions:
+      contents: read
+      issues: write
     runs-on: ${{ matrix.os }}
     needs: initial-mvn-install
     strategy:
@@ -407,6 +425,9 @@ jobs:
           ./mvnw ${CQ_MAVEN_ARGS} verify -N -Pbuild-notification -Dstatus=${{ job.status }} -DissueId=${{ env.ISSUE_ID }} -Dtoken=${{ secrets.GITHUB_TOKEN }} -DbuildId=$(cat ~/build-data/build-id.txt) -Drepo=${GITHUB_REPOSITORY} -Dbranch=quarkus-main -Dbranch-commit=$(cat ~/build-data/main-sha.txt)
 
   examples-tests:
+    permissions:
+      contents: read
+      issues: write
     name: Examples Tests - ${{matrix.name}}
     needs: initial-mvn-install
     runs-on: ubuntu-latest
@@ -489,6 +510,9 @@ jobs:
           ./mvnw ${CQ_MAVEN_ARGS} verify -N -Pbuild-notification -Dstatus=${{ job.status }} -DissueId=${{ env.ISSUE_ID }} -Dtoken=${{ secrets.GITHUB_TOKEN }} -DbuildId=$(cat ~/build-data/build-id.txt) -Drepo=${GITHUB_REPOSITORY} -Dbranch=quarkus-main -Dbranch-commit=$(cat ~/build-data/main-sha.txt)
 
   handle-build-status:
+    permissions:
+      contents: write
+      issues: write
     needs: native-tests
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Fixes #9059.

`camel-master-cron.yaml` and `quarkus-master-cron.yaml` were the only two workflows in `.github/workflows/` without a `permissions:` block, so their jobs ran with the repository default token scope while building code cloned from another repository.

This adds a top-level `permissions: contents: read` and scopes each job to what it actually needs:

- Every job runs the build-notification step, and `tooling/scripts/report-build-status.groovy` calls `issue.reopen()`, `issue.comment()` and `issue.close()` on the tracking issue — so each job carries `issues: write`.
- `handle-build-status` additionally runs `git push --force-with-lease origin <branch>`, so it carries `contents: write`.

The change is purely additive (48 lines, no existing lines touched) and follows the pattern already used in `jdk25-build.yaml` and the other workflows that declare permissions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)