### PR TITLE
Fixes #9060. Pin the Maven wrapper distribution and jar by SHA-256

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -15,4 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.16/apache-maven-3.9.16-bin.zip
+distributionSha256Sum=5af3b743dd8b876b5c45da33b676251e5f1687712644abb4ee519ca56e1d89ce
 wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar
+wrapperSha256Sum=4e2fbf6554bc8a4702cdfdd3bef464f423393d784ddbb037216320ce55d5e4e1


### PR DESCRIPTION
Fixes #9060.

`.mvn/wrapper/maven-wrapper.properties` declared `distributionUrl` and `wrapperUrl` but neither of the checksum properties the wrapper supports, so whatever those URLs returned was accepted.

**How the checksums were derived.** Maven Central publishes no `.sha256` for either artifact, so each was downloaded and verified against what *is* published before its SHA-256 was computed:

| Artifact | Verified against | Result |
|---|---|---|
| `apache-maven-3.9.16-bin.zip` | published `.sha512` | match |
| `maven-wrapper-3.3.4.jar` | published `.sha1` | match |

As a side check, the `maven-wrapper.jar` committed in `.mvn/wrapper/` is byte-identical to the published 3.3.4 jar.

**Verification**

- Clean download with `MAVEN_USER_HOME` pointed at an empty directory succeeds, so the pin does not break a cold build.
- Substituting a deliberately wrong `distributionSha256Sum` fails the build with `Failed to validate Maven distribution SHA-256`, confirming the properties are actually enforced rather than silently ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)