### PR TITLE
Fixes #9051. Resolve camel.debug.enabled instead of testing for key presence

### DIFF
--- a/extensions-core/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/CamelDebugProcessor.java
+++ b/extensions-core/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/CamelDebugProcessor.java
@@ -21,6 +21,7 @@ import java.util.function.BooleanSupplier;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.builditem.AllowJNDIBuildItem;
+import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 
 /**
@@ -38,11 +39,18 @@ public class CamelDebugProcessor {
     static final class CamelDebugEnabled implements BooleanSupplier {
         @Override
         public boolean getAsBoolean() {
-            // Resolve the value rather than testing whether any camel.debug.* key is present, so that
-            // pinning debugging off with camel.debug.enabled=false does not still allow JNDI
-            return ConfigProvider.getConfig()
-                    .getOptionalValue("camel.debug.enabled", boolean.class)
-                    .orElse(false);
+            return isDebugEnabled(ConfigProvider.getConfig());
+        }
+
+        /**
+         * Resolves the value rather than testing whether any {@code camel.debug.*} key is present, so that pinning
+         * debugging off with {@code camel.debug.enabled=false} does not still allow JNDI.
+         *
+         * Takes the {@link Config} so that it can be exercised without touching the configuration registered for the
+         * class loader, which is shared with every other test in the JVM.
+         */
+        static boolean isDebugEnabled(Config config) {
+            return config.getOptionalValue("camel.debug.enabled", boolean.class).orElse(false);
         }
     }
 }

--- a/extensions-core/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/CamelDebugProcessor.java
+++ b/extensions-core/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/CamelDebugProcessor.java
@@ -17,7 +17,6 @@
 package org.apache.camel.quarkus.core.deployment;
 
 import java.util.function.BooleanSupplier;
-import java.util.stream.StreamSupport;
 
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.BuildSteps;
@@ -29,18 +28,21 @@ import org.eclipse.microprofile.config.ConfigProvider;
  * having the capability to enable debugging features that live in the Camel core such as the
  * DebuggerJmxConnectorService
  */
-@BuildSteps(onlyIf = CamelDebugProcessor.CamelDebugConfigurationPresent.class)
+@BuildSteps(onlyIf = CamelDebugProcessor.CamelDebugEnabled.class)
 public class CamelDebugProcessor {
     @BuildStep
     AllowJNDIBuildItem allowJNDI() {
         return new AllowJNDIBuildItem();
     }
 
-    static final class CamelDebugConfigurationPresent implements BooleanSupplier {
+    static final class CamelDebugEnabled implements BooleanSupplier {
         @Override
         public boolean getAsBoolean() {
-            return StreamSupport.stream(ConfigProvider.getConfig().getPropertyNames().spliterator(), false)
-                    .anyMatch(key -> key.startsWith("camel.debug"));
+            // Resolve the value rather than testing whether any camel.debug.* key is present, so that
+            // pinning debugging off with camel.debug.enabled=false does not still allow JNDI
+            return ConfigProvider.getConfig()
+                    .getOptionalValue("camel.debug.enabled", boolean.class)
+                    .orElse(false);
         }
     }
 }

--- a/extensions-core/core/deployment/src/test/java/org/apache/camel/quarkus/core/deployment/CamelDebugEnabledTest.java
+++ b/extensions-core/core/deployment/src/test/java/org/apache/camel/quarkus/core/deployment/CamelDebugEnabledTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.core.deployment;
+
+import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class CamelDebugEnabledTest {
+
+    private static final String CAMEL_DEBUG_ENABLED = "camel.debug.enabled";
+    private static final String CAMEL_DEBUG_OTHER = "camel.debug.logging-level";
+
+    @AfterEach
+    public void clearProperties() {
+        System.clearProperty(CAMEL_DEBUG_ENABLED);
+        System.clearProperty(CAMEL_DEBUG_OTHER);
+        releaseConfig();
+    }
+
+    @Test
+    public void notEnabledWhenUnconfigured() {
+        assertFalse(camelDebugEnabled());
+    }
+
+    @Test
+    public void enabledWhenTrue() {
+        setProperty(CAMEL_DEBUG_ENABLED, "true");
+        assertTrue(camelDebugEnabled());
+    }
+
+    @Test
+    public void notEnabledWhenExplicitlyFalse() {
+        setProperty(CAMEL_DEBUG_ENABLED, "false");
+        assertFalse(camelDebugEnabled());
+    }
+
+    @Test
+    public void notEnabledByAnUnrelatedCamelDebugProperty() {
+        // A camel.debug.* key being present says nothing about whether debugging is on
+        setProperty(CAMEL_DEBUG_OTHER, "INFO");
+        assertFalse(camelDebugEnabled());
+    }
+
+    @Test
+    public void notEnabledWhenFalseAlongsideAnotherCamelDebugProperty() {
+        setProperty(CAMEL_DEBUG_ENABLED, "false");
+        setProperty(CAMEL_DEBUG_OTHER, "INFO");
+        assertFalse(camelDebugEnabled());
+    }
+
+    private static boolean camelDebugEnabled() {
+        return new CamelDebugProcessor.CamelDebugEnabled().getAsBoolean();
+    }
+
+    private static void setProperty(String key, String value) {
+        System.setProperty(key, value);
+        // The config is cached per classloader, so drop it to pick the new value up
+        releaseConfig();
+    }
+
+    private static void releaseConfig() {
+        ConfigProviderResolver resolver = ConfigProviderResolver.instance();
+        resolver.releaseConfig(resolver.getConfig());
+    }
+}

--- a/extensions-core/core/deployment/src/test/java/org/apache/camel/quarkus/core/deployment/CamelDebugEnabledTest.java
+++ b/extensions-core/core/deployment/src/test/java/org/apache/camel/quarkus/core/deployment/CamelDebugEnabledTest.java
@@ -16,68 +16,55 @@
  */
 package org.apache.camel.quarkus.core.deployment;
 
-import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
-import org.junit.jupiter.api.AfterEach;
+import java.util.Map;
+
+import io.smallrye.config.PropertiesConfigSource;
+import io.smallrye.config.SmallRyeConfigBuilder;
+import org.eclipse.microprofile.config.Config;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+/**
+ * Each case builds its own {@link Config} rather than registering one for the class loader, so that nothing here
+ * disturbs the configuration the rest of the tests in this JVM rely on.
+ */
 public class CamelDebugEnabledTest {
 
     private static final String CAMEL_DEBUG_ENABLED = "camel.debug.enabled";
     private static final String CAMEL_DEBUG_OTHER = "camel.debug.logging-level";
 
-    @AfterEach
-    public void clearProperties() {
-        System.clearProperty(CAMEL_DEBUG_ENABLED);
-        System.clearProperty(CAMEL_DEBUG_OTHER);
-        releaseConfig();
-    }
-
     @Test
     public void notEnabledWhenUnconfigured() {
-        assertFalse(camelDebugEnabled());
+        assertFalse(isDebugEnabled(Map.of()));
     }
 
     @Test
     public void enabledWhenTrue() {
-        setProperty(CAMEL_DEBUG_ENABLED, "true");
-        assertTrue(camelDebugEnabled());
+        assertTrue(isDebugEnabled(Map.of(CAMEL_DEBUG_ENABLED, "true")));
     }
 
     @Test
     public void notEnabledWhenExplicitlyFalse() {
-        setProperty(CAMEL_DEBUG_ENABLED, "false");
-        assertFalse(camelDebugEnabled());
+        assertFalse(isDebugEnabled(Map.of(CAMEL_DEBUG_ENABLED, "false")));
     }
 
     @Test
     public void notEnabledByAnUnrelatedCamelDebugProperty() {
         // A camel.debug.* key being present says nothing about whether debugging is on
-        setProperty(CAMEL_DEBUG_OTHER, "INFO");
-        assertFalse(camelDebugEnabled());
+        assertFalse(isDebugEnabled(Map.of(CAMEL_DEBUG_OTHER, "INFO")));
     }
 
     @Test
     public void notEnabledWhenFalseAlongsideAnotherCamelDebugProperty() {
-        setProperty(CAMEL_DEBUG_ENABLED, "false");
-        setProperty(CAMEL_DEBUG_OTHER, "INFO");
-        assertFalse(camelDebugEnabled());
+        assertFalse(isDebugEnabled(Map.of(CAMEL_DEBUG_ENABLED, "false", CAMEL_DEBUG_OTHER, "INFO")));
     }
 
-    private static boolean camelDebugEnabled() {
-        return new CamelDebugProcessor.CamelDebugEnabled().getAsBoolean();
-    }
-
-    private static void setProperty(String key, String value) {
-        System.setProperty(key, value);
-        // The config is cached per classloader, so drop it to pick the new value up
-        releaseConfig();
-    }
-
-    private static void releaseConfig() {
-        ConfigProviderResolver resolver = ConfigProviderResolver.instance();
-        resolver.releaseConfig(resolver.getConfig());
+    private static boolean isDebugEnabled(Map<String, String> properties) {
+        Config config = new SmallRyeConfigBuilder()
+                .withSources(new PropertiesConfigSource(properties, "CamelDebugEnabledTest", 100))
+                .build();
+        return CamelDebugProcessor.CamelDebugEnabled.isDebugEnabled(config);
     }
 }


### PR DESCRIPTION
Fixes #9051.

`CamelDebugProcessor.CamelDebugConfigurationPresent` decided whether the class's build steps ran by scanning for *any* property name starting with `camel.debug`:

```java
return StreamSupport.stream(ConfigProvider.getConfig().getPropertyNames().spliterator(), false)
        .anyMatch(key -> key.startsWith("camel.debug"));
```

Because that tests presence rather than value, `camel.debug.enabled=false` still matched and still produced `AllowJNDIBuildItem`. So did any unrelated `camel.debug.*` key. The supplier now resolves the boolean, and is renamed `CamelDebugEnabled` to match what it actually tests.

The value lookup lives in a package-private `isDebugEnabled(Config)`; `getAsBoolean()` passes `ConfigProvider.getConfig()` into it. That keeps runtime behaviour identical while letting the test supply its own `Config` without touching the one registered for the class loader.

**Scope — `DebugProcessor` is deliberately unchanged.**

The issue also raised `DebugProcessor.DebugEnabled` reading the bare `camel.debug.enabled` property through `ConfigProvider`. That read is intentional and must stay: it is the camel-main way to enable debugging, it has a dedicated test (`DebugEnabledFromCamelMainTest`), and `integration-tests/main` and `integration-tests/management` both rely on it. `ManagementProcessor` reads the same property. Removing it would break all of those.

**Tests**

`CamelDebugEnabledTest` covers the supplier directly. Each case builds its own `SmallRyeConfig`, so nothing here disturbs the configuration the rest of the JVM shares.

| Case | Expected |
|---|---|
| unconfigured | not enabled |
| `camel.debug.enabled=true` | enabled |
| `camel.debug.enabled=false` | not enabled |
| unrelated `camel.debug.*` key only | not enabled |
| `camel.debug.enabled=false` + another `camel.debug.*` key | not enabled |

Verified as a real regression test: 3 of the 5 fail against the previous presence-scan implementation with `expected: <false> but was: <true>`; all 5 pass with this change.

The full `camel-quarkus-core-deployment` suite passes — 78 tests, 0 failures, 0 errors — as does `./mvnw clean install -DskipTests` from the repository root, with no regenerated artifacts left uncommitted.

> An earlier revision of this PR drove the test through system properties and released the class loader's config after each case. That broke `CamelDevModeProfileTest` and `CamelDevModeSingletonBeanTest` with `SRCFG00015: No configuration is available for this class loader`, since surefire shares a JVM. The current revision holds no global state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)