### PR TITLE
Fixes #9054. Only set LDAP security-authentication when it is configured

### DIFF
--- a/docs/modules/ROOT/pages/migration-guide/3.40.0.adoc
+++ b/docs/modules/ROOT/pages/migration-guide/3.40.0.adoc
@@ -1,0 +1,20 @@
+= Camel Quarkus 3.40.0 Migration Guide
+
+The following guide outlines how to adapt your code to changes that were made in Camel Quarkus 3.40.0.
+
+== LDAP extension changes
+
+=== security-authentication is no longer defaulted to none
+
+`quarkus.camel.ldap.dir-contexts."name".security-authentication` previously defaulted to `none`, which was put into the JNDI environment for every directory context whether or not it had been configured. Its documentation has always said that the behaviour is determined by the service provider when the property is unspecified, and it is now the only option in that configuration group without a default, matching `initial-context-factory`, `provider-url`, `security-protocol` and `socket-factory`.
+
+The property is now only placed into the JNDI environment when it is configured, so the service provider decides otherwise.
+
+This matters where credentials are supplied through `additional-options`, which is the only way to pass them. Previously `none` was already in the environment, and supplying only a principal and credentials left the bind anonymous with the credentials ignored. They now take effect.
+
+To keep the previous behaviour for a context that relied on the default, set it explicitly.
+
+[source,properties]
+----
+quarkus.camel.ldap.dir-contexts."my-context".security-authentication=none
+----

--- a/docs/modules/ROOT/pages/migration-guide/index.adoc
+++ b/docs/modules/ROOT/pages/migration-guide/index.adoc
@@ -4,6 +4,7 @@ We do frequent releases, a release almost every month, and even though we strive
 
 Listed here are guides on how to migrate between major versions and anything of significance to watch for when upgrading from minor versions.
 
+* xref:migration-guide/3.40.0.adoc[Camel Quarkus 3.39.x to Camel Quarkus 3.40.0 migration guide]
 * xref:migration-guide/3.39.0.adoc[Camel Quarkus 3.38.x to Camel Quarkus 3.39.0 migration guide]
 * xref:migration-guide/3.38.0.adoc[Camel Quarkus 3.36.x to Camel Quarkus 3.38.0 migration guide]
 * xref:migration-guide/3.36.0.adoc[Camel Quarkus 3.35.x to Camel Quarkus 3.36.0 migration guide]

--- a/docs/modules/ROOT/pages/reference/extensions/ldap.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/ldap.adoc
@@ -136,7 +136,7 @@ Its value is one of the following strings:
 If this property is unspecified,
 the behaviour is determined by the service provider.
 | `string`
-| `none`
+| 
 
 a| [[quarkus-camel-ldap-dir-contexts-dir-contexts-socket-factory]]`link:#quarkus-camel-ldap-dir-contexts-dir-contexts-socket-factory[quarkus.camel.ldap.dir-contexts."dir-contexts".socket-factory]`
 

--- a/extensions/ldap/runtime/src/main/java/org/apache/camel/quarkus/component/ldap/CamelLdapConfig.java
+++ b/extensions/ldap/runtime/src/main/java/org/apache/camel/quarkus/component/ldap/CamelLdapConfig.java
@@ -23,7 +23,6 @@ import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
-import io.smallrye.config.WithDefault;
 
 @ConfigRoot(phase = ConfigPhase.RUN_TIME)
 @ConfigMapping(prefix = "quarkus.camel.ldap")
@@ -64,8 +63,7 @@ public interface CamelLdapConfig {
          * If this property is unspecified,
          * the behaviour is determined by the service provider.
          */
-        @WithDefault("none")
-        String securityAuthentication();
+        Optional<String> securityAuthentication();
 
         /**
          * The custom socket factory to use. The value of the property should be the fully qualified class name

--- a/extensions/ldap/runtime/src/main/java/org/apache/camel/quarkus/component/ldap/CamelLdapRecorder.java
+++ b/extensions/ldap/runtime/src/main/java/org/apache/camel/quarkus/component/ldap/CamelLdapRecorder.java
@@ -42,7 +42,7 @@ public class CamelLdapRecorder {
                     Hashtable<String, Object> env = new Hashtable<>();
                     dirConfig.initialContextFactory().ifPresent(v -> env.put(Context.INITIAL_CONTEXT_FACTORY, v));
                     dirConfig.providerUrl().ifPresent(v -> env.put(Context.PROVIDER_URL, v));
-                    env.put(Context.SECURITY_AUTHENTICATION, dirConfig.securityAuthentication());
+                    dirConfig.securityAuthentication().ifPresent(v -> env.put(Context.SECURITY_AUTHENTICATION, v));
                     dirConfig.securityProtocol().ifPresent(v -> env.put(Context.SECURITY_PROTOCOL, v));
                     dirConfig.socketFactory().ifPresent(v -> env.put("java.naming.ldap.factory.socket", v));
 

--- a/integration-tests/ldap/src/main/java/org/apache/camel/quarkus/component/ldap/it/LdapResource.java
+++ b/integration-tests/ldap/src/main/java/org/apache/camel/quarkus/component/ldap/it/LdapResource.java
@@ -18,6 +18,7 @@ package org.apache.camel.quarkus.component.ldap.it;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
 
@@ -51,6 +52,22 @@ public class LdapResource {
     public Response search(@PathParam("direct") String directName,
             @QueryParam("ldapQuery") String ldapQuery) throws Exception {
         return Response.ok(searchByUid(directName, ldapQuery)).build();
+    }
+
+    /**
+     * Reports a single entry of the JNDI environment bound for the named dir context, so that a test can assert
+     * which properties the extension actually put there. Answers {@code <absent>} when the key was not set.
+     */
+    @Path("/dirContextEnv/{name}/{key}")
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public Response dirContextEnv(@PathParam("name") String name, @PathParam("key") String key) {
+        Hashtable<?, ?> env = camelContext.getRegistry().lookupByNameAndType(name, Hashtable.class);
+        if (env == null) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+        Object value = env.get(key);
+        return Response.ok(value == null ? "<absent>" : value.toString()).build();
     }
 
     @Path("/safeSearch")

--- a/integration-tests/ldap/src/test/java/org/apache/camel/quarkus/component/ldap/it/LdapTest.java
+++ b/integration-tests/ldap/src/test/java/org/apache/camel/quarkus/component/ldap/it/LdapTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @TestCertificates(certificates = {
@@ -46,6 +47,27 @@ class LdapTest {
      *
      * @throws Exception
      */
+    /**
+     * security-authentication must only reach the JNDI environment when it was configured, so that credentials
+     * passed through additional-options are not silently overridden by a default.
+     */
+    @Test
+    public void securityAuthenticationOnlySetWhenConfigured() {
+        String key = "java.naming.security.authentication";
+
+        // httpserver sets it explicitly
+        RestAssured.get("/ldap/dirContextEnv/httpserver/" + key)
+                .then()
+                .statusCode(200)
+                .body(is("none"));
+
+        // sslserver does not, so the service provider decides rather than the extension
+        RestAssured.get("/ldap/dirContextEnv/sslserver/" + key)
+                .then()
+                .statusCode(200)
+                .body(is("<absent>"));
+    }
+
     @ParameterizedTest
     @ValueSource(strings = { "http", "ssl", "originalConfig", "additionalOptions" })
     public void ldapSearchTest(String direct) throws Exception {


### PR DESCRIPTION
Fixes #9054.

`CamelLdapConfig.LdapDirContextConfig.securityAuthentication()` carried `@WithDefault("none")` while its own javadoc says:

> If this property is unspecified, the behaviour is determined by the service provider.

It was also the only option in that group with a default — `initial-context-factory`, `provider-url`, `security-protocol` and `socket-factory` are all `Optional<String>`.

`CamelLdapRecorder` put the value into the JNDI environment unconditionally. `additionalOptions` is merged afterwards, so an operator who sets `java.naming.security.authentication` explicitly was fine — but one who supplied only a principal and credentials through `additional-options` (the only way to pass them) got `none` and an anonymous bind, with the credentials silently ignored.

**Change**

- `securityAuthentication()` becomes `Optional<String>`, matching its javadoc and its sibling options.
- The recorder sets it only when configured, using the same `ifPresent` style as the lines around it.
- Generated reference docs updated (the default column is now empty).
- Migration guide entry added for 3.40.0, since a context that relied on the default now lets the provider decide.

**Tests**

`LdapTest.securityAuthenticationOnlySetWhenConfigured` asserts the property reaches the JNDI environment only for a context that configures it — `httpserver` sets it explicitly and still reports `none`; `sslserver` does not and now reports absent. A small `/ldap/dirContextEnv/{name}/{key}` endpoint exposes the bound environment for the assertion.

Verified as a real regression test: with the previous `@WithDefault("none")` restored and the runtime module rebuilt, this case fails; with the change it passes. All 6 `LdapTest` cases are green, including the `ssl` and `additionalOptions` parameterised runs that previously relied on the removed default.

`./mvnw clean validate -pl docs` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)