### PR TITLE
Fixes #9058. Serve only the diagram consoles from the diagram route

### DIFF
--- a/extensions-jvm/diagram/runtime/src/main/java/org/apache/camel/quarkus/component/diagram/CamelDiagramRecorder.java
+++ b/extensions-jvm/diagram/runtime/src/main/java/org/apache/camel/quarkus/component/diagram/CamelDiagramRecorder.java
@@ -18,6 +18,7 @@ package org.apache.camel.quarkus.component.diagram;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Consumer;
 
 import io.quarkus.runtime.RuntimeValue;
@@ -49,6 +50,13 @@ public class CamelDiagramRecorder {
     }
 
     static final class CamelDiagramHandler implements Handler<RoutingContext> {
+        /**
+         * The consoles this route exists to serve. The id is resolved against the registry, which holds every
+         * registered console, so without this an unrelated console could be rendered through the diagram route.
+         */
+        private static final Set<String> DIAGRAM_CONSOLE_IDS = Set.of("route-diagram", "route-structure",
+                "route-topology");
+
         private final DevConsoleRegistry devConsoleRegistry;
 
         CamelDiagramHandler(DevConsoleRegistry devConsoleRegistry) {
@@ -63,7 +71,7 @@ public class CamelDiagramRecorder {
             }
 
             String id = ctx.pathParam("id");
-            if (id == null || id.isEmpty()) {
+            if (id == null || !DIAGRAM_CONSOLE_IDS.contains(id)) {
                 ctx.response().setStatusCode(404).end();
                 return;
             }

--- a/integration-tests-jvm/diagram/src/test/java/org/apache/camel/quarkus/component/diagram/it/DiagramTest.java
+++ b/integration-tests-jvm/diagram/src/test/java/org/apache/camel/quarkus/component/diagram/it/DiagramTest.java
@@ -23,6 +23,8 @@ import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.emptyString;
@@ -80,6 +82,16 @@ class DiagramTest {
     @Test
     void nonExistentConsole() {
         RestAssured.get("/q/camel/diagram/nonexistent")
+                .then()
+                .statusCode(404);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "context", "jvm", "health", "java-security" })
+    void nonDiagramConsoleIsNotReachable(String consoleId) {
+        // These consoles are registered and were previously rendered by this route, which exists only to serve
+        // the diagram consoles
+        RestAssured.get("/q/camel/diagram/" + consoleId)
                 .then()
                 .statusCode(404);
     }


### PR DESCRIPTION
Fixes #9058.

`CamelDiagramHandler` resolved the `:id` path parameter against the entire `DevConsoleRegistry`:

```java
DevConsole console = devConsoleRegistry.stream()
        .filter(c -> c.getId().equals(id))
        .findFirst()
        .orElse(null);
```

so the route registered for diagrams rendered whatever console happened to be registered. `camel-quarkus-diagram` depends on `camel-quarkus-console`, so this is not hypothetical. Probing the integration test application against the current code, every one of these answered `200` on `/q/camel/diagram/{id}`:

`bean`, `consumer`, `context`, `endpoint`, `gc`, `health`, `java-security`, `jvm`, `log`

This restricts selection to `route-diagram`, `route-structure` and `route-topology` — the three the Dev UI and the tests actually use — matching the allowlist `CamelCoreDevUIService` already applies to the Dev UI JSON-RPC bridge.

This is **dev mode only**: `DiagramProcessor` is `@BuildSteps(onlyIf = IsDevelopment.class)`.

**Scope**

The issue also suggested allowlisting the query options and HTML-encoding the output. Neither is included:

- **HTML encoding would break the feature.** `DiagramTest.routeDiagramHtml` asserts the response contains `<html`; with `format=html` the diagram console legitimately emits markup, so encoding it would render escaped tags as visible text.
- **An options allowlist cannot be written safely from here.** The `camel-route-diagram.js` and `camel-topology-diagram.js` components ship from Camel core rather than this repository, so the set of parameters they send cannot be enumerated, and guessing risks breaking the Dev UI.

**Tests**

`DiagramTest.nonDiagramConsoleIsNotReachable` is parameterised over `context`, `jvm`, `health` and `java-security`. All four fail against the previous behaviour (they returned `200`) and pass with this change. The four existing cases are unchanged and still pass — 8/8 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)