### PR TITLE
Fixes #9052. Do not enable the CLI connector in prod mode by default

### DIFF
--- a/docs/modules/ROOT/pages/migration-guide/3.40.0.adoc
+++ b/docs/modules/ROOT/pages/migration-guide/3.40.0.adoc
@@ -18,3 +18,20 @@ To keep the previous behaviour for a context that relied on the default, set it 
 ----
 quarkus.camel.ldap.dir-contexts."my-context".security-authentication=none
 ----
+
+== CLI connector extension changes
+
+=== The connector is no longer active in prod mode by default
+
+`quarkus.camel.cli.enabled` defaults to `true` and had no launch mode condition, so the Camel CLI connector's action file IPC was active in production builds as well as in dev and test.
+
+A `quarkus.camel.cli.exposure-mode` option is added, following the same shape as `quarkus.camel.console.exposure-mode`. It defaults to `dev-test`, which enables the connector only in dev and test modes. Dev and test behaviour is unchanged.
+
+To keep the connector active in prod mode, ask for it explicitly.
+
+[source,properties]
+----
+quarkus.camel.cli.exposure-mode=all
+----
+
+`none` never enables the connector, and `quarkus.camel.cli.enabled=false` still turns it off in every mode.

--- a/docs/modules/ROOT/pages/reference/extensions/cli-connector.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/cli-connector.adoc
@@ -53,6 +53,14 @@ a|icon:lock[title=Fixed at build time] [[quarkus-camel-cli-enabled]]`link:#quark
 Sets whether to enable Camel CLI Connector support.
 | `boolean`
 | `true`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-cli-exposure-mode]]`link:#quarkus-camel-cli-exposure-mode[quarkus.camel.cli.exposure-mode]`
+
+The modes in which the Camel CLI connector is available. The default `dev-test` enables the connector only in
+dev and test modes. A value of `all` enables it in dev, test and prod modes. Setting the value to `none` never
+enables it.
+| `all`, `dev-test`, `none`
+| `dev-test`
 |===
 
 [.configuration-legend]

--- a/extensions-jvm/cli-connector/deployment/src/main/java/org/apache/camel/quarkus/component/cli/connector/deployment/CliConnectorProcessor.java
+++ b/extensions-jvm/cli-connector/deployment/src/main/java/org/apache/camel/quarkus/component/cli/connector/deployment/CliConnectorProcessor.java
@@ -25,7 +25,9 @@ import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.pkg.steps.NativeOrNativeSourcesBuild;
+import io.quarkus.runtime.LaunchMode;
 import org.apache.camel.quarkus.component.cli.connector.CamelCliConnectorConfig;
+import org.apache.camel.quarkus.component.cli.connector.CamelCliConnectorConfig.ExposureMode;
 import org.apache.camel.quarkus.component.cli.connector.CamelCliConnectorRecorder;
 import org.apache.camel.quarkus.core.JvmOnlyRecorder;
 import org.apache.camel.quarkus.core.deployment.spi.CamelBeanBuildItem;
@@ -63,9 +65,17 @@ class CliConnectorProcessor {
 
     static class CliConnectorEnabled implements BooleanSupplier {
         CamelCliConnectorConfig config;
+        LaunchMode launchMode;
 
         public boolean getAsBoolean() {
-            return config.enabled();
+            if (!config.enabled()) {
+                return false;
+            }
+            // The connector's action file IPC authenticates nobody, so it is a dev and test facility unless the
+            // deployer asks for it in prod
+            ExposureMode exposureMode = config.exposureMode();
+            return exposureMode == ExposureMode.ALL
+                    || (exposureMode == ExposureMode.DEV_TEST && launchMode.isDevOrTest());
         }
     }
 }

--- a/extensions-jvm/cli-connector/deployment/src/test/java/org/apache/camel/quarkus/component/cli/connector/deployment/CliConnectorEnabledSupplierTest.java
+++ b/extensions-jvm/cli-connector/deployment/src/test/java/org/apache/camel/quarkus/component/cli/connector/deployment/CliConnectorEnabledSupplierTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.cli.connector.deployment;
+
+import io.quarkus.runtime.LaunchMode;
+import org.apache.camel.quarkus.component.cli.connector.CamelCliConnectorConfig;
+import org.apache.camel.quarkus.component.cli.connector.CamelCliConnectorConfig.ExposureMode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Covers the launch mode dimension of the gate, which {@code QuarkusUnitTest} cannot reach because it always runs in
+ * test mode.
+ */
+public class CliConnectorEnabledSupplierTest {
+
+    @Test
+    public void devTestModeEnabledInDevAndTest() {
+        assertTrue(enabled(true, ExposureMode.DEV_TEST, LaunchMode.DEVELOPMENT));
+        assertTrue(enabled(true, ExposureMode.DEV_TEST, LaunchMode.TEST));
+    }
+
+    @Test
+    public void devTestModeNotEnabledInProd() {
+        assertFalse(enabled(true, ExposureMode.DEV_TEST, LaunchMode.NORMAL));
+    }
+
+    @Test
+    public void allModeEnabledEverywhere() {
+        assertTrue(enabled(true, ExposureMode.ALL, LaunchMode.NORMAL));
+        assertTrue(enabled(true, ExposureMode.ALL, LaunchMode.DEVELOPMENT));
+        assertTrue(enabled(true, ExposureMode.ALL, LaunchMode.TEST));
+    }
+
+    @Test
+    public void noneModeNeverEnabled() {
+        assertFalse(enabled(true, ExposureMode.NONE, LaunchMode.DEVELOPMENT));
+        assertFalse(enabled(true, ExposureMode.NONE, LaunchMode.NORMAL));
+    }
+
+    @Test
+    public void disabledWinsOverEveryExposureMode() {
+        for (ExposureMode mode : ExposureMode.values()) {
+            assertFalse(enabled(false, mode, LaunchMode.DEVELOPMENT));
+            assertFalse(enabled(false, mode, LaunchMode.NORMAL));
+        }
+    }
+
+    private static boolean enabled(boolean enabled, ExposureMode exposureMode, LaunchMode launchMode) {
+        CliConnectorProcessor.CliConnectorEnabled supplier = new CliConnectorProcessor.CliConnectorEnabled();
+        supplier.config = new CamelCliConnectorConfig() {
+            @Override
+            public boolean enabled() {
+                return enabled;
+            }
+
+            @Override
+            public ExposureMode exposureMode() {
+                return exposureMode;
+            }
+        };
+        supplier.launchMode = launchMode;
+        return supplier.getAsBoolean();
+    }
+}

--- a/extensions-jvm/cli-connector/runtime/src/main/java/org/apache/camel/quarkus/component/cli/connector/CamelCliConnectorConfig.java
+++ b/extensions-jvm/cli-connector/runtime/src/main/java/org/apache/camel/quarkus/component/cli/connector/CamelCliConnectorConfig.java
@@ -31,4 +31,20 @@ public interface CamelCliConnectorConfig {
      */
     @WithDefault("true")
     boolean enabled();
+
+    /**
+     * The modes in which the Camel CLI connector is available. The default `dev-test` enables the connector only in
+     * dev and test modes. A value of `all` enables it in dev, test and prod modes. Setting the value to `none` never
+     * enables it.
+     *
+     * @asciidoclet
+     */
+    @WithDefault("DEV_TEST")
+    ExposureMode exposureMode();
+
+    enum ExposureMode {
+        ALL,
+        DEV_TEST,
+        NONE,
+    }
 }


### PR DESCRIPTION
Fixes #9052.

`CamelCliConnectorConfig.enabled()` carries `@WithDefault("true")` and `CliConnectorProcessor` applied no launch mode condition — the only gate was that flag — so the connector's action file IPC was active in production builds. `CamelCliConnectorRecorder` then calls `factory.setEnabled(true)` unconditionally.

**Change**

Adds `quarkus.camel.cli.exposure-mode`, following the same shape as `quarkus.camel.console.exposure-mode` (the issue suggested gating it like the console extension):

| Value | Effect |
|---|---|
| `dev-test` (default) | dev and test modes only |
| `all` | dev, test and prod |
| `none` | never |

`quarkus.camel.cli.enabled=false` still turns it off in every mode. Dev and test behaviour is unchanged, so this only affects prod builds, and a deployer opts back in with `quarkus.camel.cli.exposure-mode=all`. Migration guide entry added.

**Tests**

`CliConnectorEnabledSupplierTest` exercises the gate directly across launch modes — `QuarkusUnitTest` always runs in test mode, so it cannot cover the prod case. Against the previous gate, `devTestModeNotEnabledInProd` and `noneModeNeverEnabled` both fail with `expected: <false> but was: <true>`; both pass with this change.

The existing `CliConnectorEnabledTest` (no config override, expects the factory present) and `CliConnectorDisabledTest` still pass — 7/7 green. `@QuarkusTest`-based `CliConnectorTest` is unaffected, since that is test mode.

`./mvnw clean validate -pl docs` passes.

> Note: this adds `docs/modules/ROOT/pages/migration-guide/3.40.0.adoc`, as does #9066. Whichever merges second will need a trivial conflict resolution in that file and in `migration-guide/index.adoc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)