### PR TITLE
Fixes #9057. Document what exposing the dev console in prod mode means

### DIFF
--- a/docs/modules/ROOT/pages/reference/extensions/console.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/console.adoc
@@ -85,6 +85,15 @@ quarkus.camel.console.exposure-mode=ALL
 
 See the configuration overview below for further details about `exposure-mode`.
 
+IMPORTANT: The console authenticates nobody. Anyone who can reach it can read what the consoles expose, which includes route and endpoint configuration, in-flight and recent exchange data, JVM and environment details, and the application's own configuration values. Confine it to a trusted network, or put authentication in front of it, before enabling `ALL` in prod.
+
+The route is registered as a Quarkus non-application endpoint. Those are served on the *main* HTTP port under `/q/` unless a separate management interface is enabled, so by default the console shares the socket that serves application traffic rather than sitting on a port you can firewall separately. To move it to its own port, enable the management interface.
+
+[source,properties]
+----
+quarkus.management.enabled=true
+----
+
 
 [id="extensions-console-additional-camel-quarkus-configuration"]
 == Additional Camel Quarkus configuration

--- a/extensions-jvm/console/runtime/src/main/doc/usage.adoc
+++ b/extensions-jvm/console/runtime/src/main/doc/usage.adoc
@@ -38,3 +38,12 @@ quarkus.camel.console.exposure-mode=ALL
 ----
 
 See the configuration overview below for further details about `exposure-mode`.
+
+IMPORTANT: The console authenticates nobody. Anyone who can reach it can read what the consoles expose, which includes route and endpoint configuration, in-flight and recent exchange data, JVM and environment details, and the application's own configuration values. Confine it to a trusted network, or put authentication in front of it, before enabling `ALL` in prod.
+
+The route is registered as a Quarkus non-application endpoint. Those are served on the *main* HTTP port under `/q/` unless a separate management interface is enabled, so by default the console shares the socket that serves application traffic rather than sitting on a port you can firewall separately. To move it to its own port, enable the management interface.
+
+[source,properties]
+----
+quarkus.management.enabled=true
+----


### PR DESCRIPTION
Fixes #9057.

`ConsoleProcessor.canExposeManagementEndpoint` returns true for `exposure-mode=ALL` regardless of launch mode. That is intentional — it is the documented way to expose the console in prod, and the default is `DEV_TEST` — but `usage.adoc` explained how to turn it on without saying what it exposes.

This adds two things to the existing "Exposing the developer console in prod mode" section:

- The console authenticates nobody, and what the consoles actually disclose — route and endpoint configuration, in-flight and recent exchange data, JVM and environment details, and the application's own configuration values.
- The route is registered via `nonApplicationRootPathBuildItem...management()`. Quarkus non-application endpoints are served on the **main** HTTP port under `/q/` unless `quarkus.management.enabled=true`, so by default the console shares the socket serving application traffic rather than sitting on a port that can be firewalled separately. That is the part most likely to surprise an operator who assumed `/q/` meant a management port.

**Documentation only — no behaviour change.** The gate is untouched; `exposure-mode=ALL` remains an explicit operator opt-in, which is out of scope as a vulnerability under the Camel security model.

I did not add a second acknowledgement property as the issue floated. `exposure-mode=ALL` is already an explicit opt-in, and a second flag to confirm the first buys little for the friction it adds.

Every property referenced in the new text was checked against the generated reference page — the console extension has exactly three options (`enabled`, `path`, `exposure-mode`), and `quarkus.management.enabled` is a stock Quarkus one.

`./mvnw clean validate -pl docs` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)