### PR TITLE
Fixes #9048. Accept DB2 and MS SQL Server test container licenses via container-env

### DIFF
--- a/integration-test-groups/jdbc/db2/pom.xml
+++ b/integration-test-groups/jdbc/db2/pom.xml
@@ -106,15 +106,6 @@
         </dependency>
     </dependencies>
 
-    <build>
-        <testResources>
-            <testResource>
-                <directory>src/test/resources</directory>
-                <filtering>true</filtering>
-            </testResource>
-        </testResources>
-    </build>
-
     <profiles>
         <profile>
             <id>native</id>

--- a/integration-test-groups/jdbc/db2/src/main/resources/application.properties
+++ b/integration-test-groups/jdbc/db2/src/main/resources/application.properties
@@ -20,6 +20,10 @@
 #
 quarkus.datasource.db2.db-kind=db2
 quarkus.datasource.db2.jdbc.max-size=8
+# Accept the DB2 license via the container environment instead of a container-license-acceptance.txt file,
+# because the file is not reliably visible on the classpath when the tests are executed from the published
+# test-jar, e.g. in the Quarkus Platform. See https://github.com/apache/camel-quarkus/issues/9048
+quarkus.datasource.db2.devservices.container-env."LICENSE"=accept
 # To not use anonymous volumes, which have problem on RHEL9 and Podman
 # See https://github.com/quarkusio/quarkus/issues/31253#issuecomment-3131458759
 quarkus.datasource.db2.devservices.container-env."PERSISTENT_HOME"=false

--- a/integration-test-groups/jdbc/db2/src/test/resources/container-license-acceptance.txt
+++ b/integration-test-groups/jdbc/db2/src/test/resources/container-license-acceptance.txt
@@ -1,1 +1,0 @@
-${db2.container.image}

--- a/integration-test-groups/jdbc/mssql/pom.xml
+++ b/integration-test-groups/jdbc/mssql/pom.xml
@@ -106,15 +106,6 @@
         </dependency>
     </dependencies>
 
-    <build>
-        <testResources>
-            <testResource>
-                <directory>src/test/resources</directory>
-                <filtering>true</filtering>
-            </testResource>
-        </testResources>
-    </build>
-
     <profiles>
         <profile>
             <id>native</id>

--- a/integration-test-groups/jdbc/mssql/src/main/resources/application.properties
+++ b/integration-test-groups/jdbc/mssql/src/main/resources/application.properties
@@ -21,5 +21,9 @@
 
 quarkus.datasource.mssql.db-kind=mssql
 quarkus.datasource.mssql.jdbc.max-size=8
+# Accept the MS SQL Server EULA via the container environment instead of a container-license-acceptance.txt file,
+# because the file is not reliably visible on the classpath when the tests are executed from the published
+# test-jar, e.g. in the Quarkus Platform. See https://github.com/apache/camel-quarkus/issues/9048
+quarkus.datasource.mssql.devservices.container-env."ACCEPT_EULA"=Y
 
 quarkus.native.resources.includes=postgresql.sql,mysql.sql,mariadb.sql,oracle.sql,h2.sql,db2.sql,inserts.sql,mssql.sql,droptables.sql

--- a/integration-test-groups/jdbc/mssql/src/test/resources/container-license-acceptance.txt
+++ b/integration-test-groups/jdbc/mssql/src/test/resources/container-license-acceptance.txt
@@ -1,1 +1,0 @@
-${sql-server.container.image}

--- a/integration-tests/jdbc-grouped/pom.xml
+++ b/integration-tests/jdbc-grouped/pom.xml
@@ -132,12 +132,6 @@
     </dependencies>
 
     <build>
-        <testResources>
-            <testResource>
-                <directory>src/test/resources</directory>
-                <filtering>true</filtering>
-            </testResource>
-        </testResources>
         <plugins>
             <plugin>
                 <groupId>org.codehaus.gmavenplus</groupId>
@@ -156,7 +150,7 @@
                             <properties>
                                 <group-tests.source.dir>${maven.multiModuleProjectDirectory}/integration-test-groups/jdbc</group-tests.source.dir>
                                 <group-tests.dest.module.dir>${project.basedir}</group-tests.dest.module.dir>
-                                <group-tests.concat.rel.paths>src/main/resources/application.properties,src/test/resources/container-license-acceptance.txt</group-tests.concat.rel.paths>
+                                <group-tests.concat.rel.paths>src/main/resources/application.properties</group-tests.concat.rel.paths>
                             </properties>
                         </configuration>
                     </execution>


### PR DESCRIPTION
fixes https://github.com/apache/camel-quarkus/issues/9048

In the Quarkus Platform CI, where the tests run from the published test-jar, the DB2 dev service fails with `The image icr.io/db2_community/db2:12.1.5.0 requires you to accept a license agreement`, even though the test-jar contains a correct `container-license-acceptance.txt` — the reason why the classpath lookup fails there could not be identified. The licenses are therefore accepted via properties instead: `quarkus.datasource.db2.devservices.container-env."LICENSE"=accept` and `quarkus.datasource.mssql.devservices.container-env."ACCEPT_EULA"=Y`, which makes Testcontainers skip the file lookup entirely. The license files and related build config are removed.

Verified with a platform-style reproducer (test-jar execution, license file filtered out): https://github.com/JiriOndrusek/cq-9048-reproducer — it fails with the exact platform error without this fix and passes with it. Oracle needs no change; the excluded tests can be re-enabled in quarkus-platform once a release with this fix is consumed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)