### PR TITLE
chore: document the backport targets in the project rules

### DIFF
--- a/.oss-ai-helper-rules/project-guidelines.md
+++ b/.oss-ai-helper-rules/project-guidelines.md
@@ -12,6 +12,19 @@ This rule file contains branching, commit, PR, and task-finding conventions for 
 - **CI-issue branch:** `ci-issue/<short-slug>`
 - **Commit format (ci-issue):** `ci: <brief description>`
 - **PR creation:** always
+- **Backport targets:** `main`, `3.39.x` (current release line), `3.33.x` (LTS), `3.27.x` (LTS). Camel Quarkus follows the **Quarkus LTS cadence**, so each line pairs with a Quarkus version (3.33.x ↔ Quarkus 3.33.x, 3.27.x ↔ Quarkus 3.27.x). `3.20.x` and `3.15.x` are older LTS lines that are no longer routinely maintained — do not open backport PRs against them without checking first. **A branch existing in `git branch -r` is not evidence that it is supported**: every `3.N.x` branch ever released is still present. Confirm against this list, or sort by real activity rather than by name:
+
+  ```sh
+  # %cd (committer date), not %ad: a cherry-picked backport keeps the original
+  # author date, so %ad makes an actively maintained line look stale.
+  for b in $(git branch -r | grep -oE 'origin/3\.[0-9]+\.x' | sort -u); do
+    printf "%-16s %s\n" "${b#origin/}" "$(git log -1 --format='%cd %s' --date=short "$b")"
+  done | sort -k2 -r
+  ```
+
+- **Backport method:** cherry-pick, preserving the original author and commit message. The backport lands as a new SHA on the target branch.
+- **Backport applicability check:** confirm the *defect* exists on the target, not just the file — extensions differ between lines (for example `extensions-jvm/diagram` does not exist on `3.33.x` or `3.27.x`). Use `git show origin/<branch>:<path>`.
+- **Backport migration-guide policy:** `docs/modules/ROOT/pages/migration-guide/<version>.adoc` is per release line. A change carrying a migration note on `main` must not backport that file; write an equivalent note for the target line's own version and add it to `migration-guide/index.adoc` on that branch.
 - **Find-task source:** GitHub labels
 - **Find-task beginner label:** `good first issue`
 - **Find-task experienced label:** `help wanted`


### PR DESCRIPTION
`.oss-ai-helper-rules/project-guidelines.md` covers branch naming, commit formats and task-finding, but says nothing about which release lines a fix should be backported to. The equivalent rules for `apache/camel` name their backport branches explicitly; this brings Camel Quarkus into line.

**What it records**

- **Targets:** `main`, `3.39.x` (current release line), `3.33.x` and `3.27.x` (LTS). `3.20.x` and `3.15.x` are older LTS lines that are no longer routinely maintained.
- **Method:** cherry-pick, preserving the original author and message — matching how `Fix #9010` reached `3.33.x`.
- **Applicability:** confirm the *defect* exists on the target rather than just the file, since extensions differ between lines (`extensions-jvm/diagram`, for instance, does not exist on `3.33.x` or `3.27.x`).
- **Migration guides:** `migration-guide/<version>.adoc` is per release line, so a change carrying a note on `main` must not backport that file — the target line needs its own note.

**Why it is worth writing down**

Every `3.N.x` branch ever released is still present in `git branch -r`, so the listing tells you nothing about which lines are supported. I got this wrong reading it: sorting those branch names lexically suggested the newest maintained line was `3.22.x`, last touched in April 2025, when `3.33.x` and `3.27.x` had both received commits days earlier.

The snippet in the new section sorts by **committer** date rather than author date. That distinction matters here specifically: a cherry-picked backport keeps the original author date, so `%ad` ranks `3.38.x` (2026-07-23) above `3.33.x`, which looks like `3.33.x` is the staler line. By `%cd` the LTS lines correctly sort above it, both at 2026-08-19.

Documentation only — no build or code impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)