### PR TITLE
Document Twitter native locale requirements #2564

### DIFF
--- a/docs/modules/ROOT/pages/reference/extensions/twitter.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/twitter.adoc
@@ -63,6 +63,7 @@ quarkus.default-locale=en-US
 
 See also xref:user-guide/native-mode.adoc#locale[Locale in native mode].
 
+
 [id="extensions-twitter-ssl-in-native-mode"]
 == SSL in native mode
 

--- a/docs/modules/ROOT/pages/reference/extensions/twitter.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/twitter.adoc
@@ -47,17 +47,10 @@ ifeval::[{doc-show-user-guide-link} == true]
 Check the xref:user-guide/index.adoc[User guide] for more information about writing Camel Quarkus applications.
 endif::[]
 
-[id="extensions-twitter-ssl-in-native-mode"]
-== SSL in native mode
-
-This extension auto-enables SSL support in native mode. Hence you do not need to add
-`quarkus.ssl.native=true` to your `application.properties` yourself. See also
-https://quarkus.io/guides/native-and-ssl[Quarkus SSL guide].
-
 [id="extensions-twitter-camel-quarkus-limitations"]
 == Camel Quarkus limitations
 
-The Twitter Java client parses timestamps with `Locale.ENGLISH` and expects timezone UTC.
+The Twitter Java client parses timestamps with `Locale.US`.
 In native mode, GraalVM includes only the build machine locale by default. A non-English locale
 (for example French) then fails to parse Twitter API responses.
 
@@ -68,19 +61,11 @@ Set the default locale to `en-US` in `application.properties`:
 quarkus.default-locale=en-US
 ----
 
-You can also pin language and country on the native image:
-
-[source,properties]
-----
-quarkus.native.user-language=en
-quarkus.native.user-country=US
-----
-
-Pin the timezone to UTC for the native build:
-
-[source,properties]
-----
-quarkus.native.additional-build-args=-J-Duser.timezone=UTC
-----
-
 See also xref:user-guide/native-mode.adoc#locale[Locale in native mode].
+
+[id="extensions-twitter-ssl-in-native-mode"]
+== SSL in native mode
+
+This extension auto-enables SSL support in native mode. Hence you do not need to add
+`quarkus.ssl.native=true` to your `application.properties` yourself. See also
+https://quarkus.io/guides/native-and-ssl[Quarkus SSL guide].

--- a/docs/modules/ROOT/pages/reference/extensions/twitter.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/twitter.adoc
@@ -53,3 +53,34 @@ endif::[]
 This extension auto-enables SSL support in native mode. Hence you do not need to add
 `quarkus.ssl.native=true` to your `application.properties` yourself. See also
 https://quarkus.io/guides/native-and-ssl[Quarkus SSL guide].
+
+[id="extensions-twitter-camel-quarkus-limitations"]
+== Camel Quarkus limitations
+
+The Twitter Java client parses timestamps with `Locale.ENGLISH` and expects timezone UTC.
+In native mode, GraalVM includes only the build machine locale by default. A non-English locale
+(for example French) then fails to parse Twitter API responses.
+
+Set the default locale to `en-US` in `application.properties`:
+
+[source,properties]
+----
+quarkus.default-locale=en-US
+----
+
+You can also pin language and country on the native image:
+
+[source,properties]
+----
+quarkus.native.user-language=en
+quarkus.native.user-country=US
+----
+
+Pin the timezone to UTC for the native build:
+
+[source,properties]
+----
+quarkus.native.additional-build-args=-J-Duser.timezone=UTC
+----
+
+See also xref:user-guide/native-mode.adoc#locale[Locale in native mode].

--- a/extensions/twitter/runtime/src/main/doc/limitations.adoc
+++ b/extensions/twitter/runtime/src/main/doc/limitations.adoc
@@ -1,0 +1,27 @@
+The Twitter Java client parses timestamps with `Locale.ENGLISH` and expects timezone UTC.
+In native mode, GraalVM includes only the build machine locale by default. A non-English locale
+(for example French) then fails to parse Twitter API responses.
+
+Set the default locale to `en-US` in `application.properties`:
+
+[source,properties]
+----
+quarkus.default-locale=en-US
+----
+
+You can also pin language and country on the native image:
+
+[source,properties]
+----
+quarkus.native.user-language=en
+quarkus.native.user-country=US
+----
+
+Pin the timezone to UTC for the native build:
+
+[source,properties]
+----
+quarkus.native.additional-build-args=-J-Duser.timezone=UTC
+----
+
+See also xref:user-guide/native-mode.adoc#locale[Locale in native mode].

--- a/extensions/twitter/runtime/src/main/doc/limitations.adoc
+++ b/extensions/twitter/runtime/src/main/doc/limitations.adoc
@@ -1,4 +1,4 @@
-The Twitter Java client parses timestamps with `Locale.ENGLISH` and expects timezone UTC.
+The Twitter Java client parses timestamps with `Locale.US`.
 In native mode, GraalVM includes only the build machine locale by default. A non-English locale
 (for example French) then fails to parse Twitter API responses.
 
@@ -7,21 +7,6 @@ Set the default locale to `en-US` in `application.properties`:
 [source,properties]
 ----
 quarkus.default-locale=en-US
-----
-
-You can also pin language and country on the native image:
-
-[source,properties]
-----
-quarkus.native.user-language=en
-quarkus.native.user-country=US
-----
-
-Pin the timezone to UTC for the native build:
-
-[source,properties]
-----
-quarkus.native.additional-build-args=-J-Duser.timezone=UTC
 ----
 
 See also xref:user-guide/native-mode.adoc#locale[Locale in native mode].

--- a/integration-tests/twitter/README.adoc
+++ b/integration-tests/twitter/README.adoc
@@ -17,3 +17,6 @@ export TWITTER_USER_NAME=my-twitter-username
 ----
 
 
+
+Native tests need `Locale.ENGLISH` and timezone UTC, otherwise Twitter API date parsing fails.
+The test `application.properties` already sets `quarkus.default-locale=en-US` and UTC for the native image.

--- a/integration-tests/twitter/README.adoc
+++ b/integration-tests/twitter/README.adoc
@@ -18,5 +18,5 @@ export TWITTER_USER_NAME=my-twitter-username
 
 
 
-Native tests need `Locale.ENGLISH` and timezone UTC, otherwise Twitter API date parsing fails.
-The test `application.properties` already sets `quarkus.default-locale=en-US` and UTC for the native image.
+Native tests need `Locale.US`, otherwise Twitter API date parsing fails.
+The test `application.properties` already sets `quarkus.default-locale=en-US`.

--- a/integration-tests/twitter/src/main/resources/application.properties
+++ b/integration-tests/twitter/src/main/resources/application.properties
@@ -43,3 +43,11 @@ camel.component.twitter-directmessage.consumerKey={{env:TWITTER_CONSUMER_KEY}}
 camel.component.twitter-directmessage.consumerSecret={{env:TWITTER_CONSUMER_SECRET}}
 camel.component.twitter-directmessage.accessToken={{env:TWITTER_ACCESS_TOKEN}}
 camel.component.twitter-directmessage.accessTokenSecret={{env:TWITTER_ACCESS_TOKEN_SECRET}}
+
+#
+# Native image: Twitter4J parses dates with Locale.ENGLISH and timezone UTC
+#
+quarkus.default-locale=en-US
+quarkus.native.user-language=en
+quarkus.native.user-country=US
+quarkus.native.additional-build-args=-J-Duser.timezone=UTC

--- a/integration-tests/twitter/src/main/resources/application.properties
+++ b/integration-tests/twitter/src/main/resources/application.properties
@@ -45,9 +45,6 @@ camel.component.twitter-directmessage.accessToken={{env:TWITTER_ACCESS_TOKEN}}
 camel.component.twitter-directmessage.accessTokenSecret={{env:TWITTER_ACCESS_TOKEN_SECRET}}
 
 #
-# Native image: Twitter4J parses dates with Locale.ENGLISH and timezone UTC
+# Native image: Twitter4J parses dates with Locale.US
 #
 quarkus.default-locale=en-US
-quarkus.native.user-language=en
-quarkus.native.user-country=US
-quarkus.native.additional-build-args=-J-Duser.timezone=UTC


### PR DESCRIPTION
Fixes #2564

Twitter4J parses API dates with Locale.US. Native images only embed the build-machine locale, so a French locale fails to parse the responses.

I documented `quarkus.default-locale=en-US` on the Twitter extension page, and set the same property on the Twitter integration tests.
