### PR TITLE
Backport #9066 and #9072 to 3.27.x

### DIFF
--- a/docs/modules/ROOT/pages/migration-guide/3.27.6.adoc
+++ b/docs/modules/ROOT/pages/migration-guide/3.27.6.adoc
@@ -1,6 +1,6 @@
-= Camel Quarkus 3.40.0 Migration Guide
+= Camel Quarkus 3.27.6 Migration Guide
 
-The following guide outlines how to adapt your code to changes that were made in Camel Quarkus 3.40.0.
+The following guide outlines how to adapt your code to changes that were made in Camel Quarkus 3.27.6.
 
 == LDAP extension changes
 

--- a/docs/modules/ROOT/pages/migration-guide/3.40.0.adoc
+++ b/docs/modules/ROOT/pages/migration-guide/3.40.0.adoc
@@ -1,0 +1,20 @@
+= Camel Quarkus 3.40.0 Migration Guide
+
+The following guide outlines how to adapt your code to changes that were made in Camel Quarkus 3.40.0.
+
+== LDAP extension changes
+
+=== security-authentication is no longer defaulted to none
+
+`quarkus.camel.ldap.dir-contexts."name".security-authentication` previously defaulted to `none`, which was put into the JNDI environment for every directory context whether or not it had been configured. Its documentation has always said that the behaviour is determined by the service provider when the property is unspecified, and it is now the only option in that configuration group without a default, matching `initial-context-factory`, `provider-url`, `security-protocol` and `socket-factory`.
+
+The property is now only placed into the JNDI environment when it is configured, so the service provider decides otherwise.
+
+This matters where credentials are supplied through `additional-options`, which is the only way to pass them. Previously `none` was already in the environment, and supplying only a principal and credentials left the bind anonymous with the credentials ignored. They now take effect.
+
+To keep the previous behaviour for a context that relied on the default, set it explicitly.
+
+[source,properties]
+----
+quarkus.camel.ldap.dir-contexts."my-context".security-authentication=none
+----

--- a/docs/modules/ROOT/pages/migration-guide/3.40.0.adoc
+++ b/docs/modules/ROOT/pages/migration-guide/3.40.0.adoc
@@ -18,3 +18,18 @@ To keep the previous behaviour for a context that relied on the default, set it 
 ----
 quarkus.camel.ldap.dir-contexts."my-context".security-authentication=none
 ----
+
+== JTA extension changes
+
+=== Rollback and resume failures are no longer swallowed
+
+`TransactionalJtaTransactionPolicy`, the base class of all six `PROPAGATION_*` policies, logged a warning and carried on when `rollback()`, `setRollbackOnly()` or `resume()` failed. A route that handled the original exception could therefore continue as though the transaction had been marked for rollback when it had not, and work after a failed resume ran outside the transaction the policy was expected to restore.
+
+These failures are now raised:
+
+* A failure to roll back, or to mark an outer transaction for rollback, is attached to the exception that made the rollback necessary as a suppressed exception. That exception still propagates unchanged, so the failure is visible without hiding its cause.
+* A failure to resume a suspended transaction, in `PROPAGATION_REQUIRES_NEW` and `PROPAGATION_NOT_SUPPORTED`, is attached to the in-flight failure in the same way, or raised on its own when the body succeeded.
+
+An application that inspected only the top-level exception sees no difference. One that handles exceptions and continues may now see a failure it previously never learned about. Check `Throwable.getSuppressed()` when diagnosing.
+
+No method signatures changed. `resumeTransaction(Transaction)` is unchanged and now wraps a resume failure in a `RuntimeCamelException`; a new `resumeTransaction(Transaction, Throwable)` overload is what the policies use so that a resume failure cannot replace a failure already on its way out.

--- a/docs/modules/ROOT/pages/migration-guide/index.adoc
+++ b/docs/modules/ROOT/pages/migration-guide/index.adoc
@@ -4,6 +4,7 @@ We do frequent releases, a release almost every month, and even though we strive
 
 Listed here are guides on how to migrate between major versions and anything of significance to watch for when upgrading from minor versions.
 
+* xref:migration-guide/3.27.6.adoc[Camel Quarkus 3.27.5 to Camel Quarkus 3.27.6 migration guide]
 * xref:migration-guide/3.27.0.adoc[Camel Quarkus 3.26.x to Camel Quarkus 3.27.0 migration guide]
 * xref:migration-guide/3.26.0.adoc[Camel Quarkus 3.25.x to Camel Quarkus 3.26.0 migration guide]
 * xref:migration-guide/3.23.0.adoc[Camel Quarkus 3.22.x to Camel Quarkus 3.23.0 migration guide]

--- a/docs/modules/ROOT/pages/reference/extensions/ldap.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/ldap.adoc
@@ -136,7 +136,7 @@ Its value is one of the following strings:
 If this property is unspecified,
 the behaviour is determined by the service provider.
 | `string`
-| `none`
+| 
 
 a| [[quarkus-camel-ldap-dir-contexts-dir-contexts-socket-factory]]`link:#quarkus-camel-ldap-dir-contexts-dir-contexts-socket-factory[quarkus.camel.ldap.dir-contexts."dir-contexts".socket-factory]`
 

--- a/extensions/jta/deployment/src/test/java/org/apache/camel/quarkus/component/jta/JtaTransactionFailurePropagationTest.java
+++ b/extensions/jta/deployment/src/test/java/org/apache/camel/quarkus/component/jta/JtaTransactionFailurePropagationTest.java
@@ -18,7 +18,7 @@ package org.apache.camel.quarkus.component.jta;
 
 import java.util.Arrays;
 
-import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.test.QuarkusUnitTest;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import jakarta.transaction.Status;
@@ -45,7 +45,7 @@ import static org.mockito.Mockito.when;
 public class JtaTransactionFailurePropagationTest {
 
     @RegisterExtension
-    static final QuarkusExtensionTest CONFIG = new QuarkusExtensionTest()
+    static final QuarkusUnitTest CONFIG = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(MockTransactionManagerProducer.class, MockTransaction.class));
 

--- a/extensions/jta/deployment/src/test/java/org/apache/camel/quarkus/component/jta/JtaTransactionFailurePropagationTest.java
+++ b/extensions/jta/deployment/src/test/java/org/apache/camel/quarkus/component/jta/JtaTransactionFailurePropagationTest.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.quarkus.component.jta;
+
+import java.util.Arrays;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.transaction.Status;
+import jakarta.transaction.SystemException;
+import jakarta.transaction.Transaction;
+import jakarta.transaction.TransactionManager;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+/**
+ * A transaction whose rollback, rollback marking or resumption fails must not let that failure disappear, and must not
+ * let it replace the exception that made the rollback necessary.
+ */
+public class JtaTransactionFailurePropagationTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest CONFIG = new QuarkusExtensionTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(MockTransactionManagerProducer.class, MockTransaction.class));
+
+    @Inject
+    TransactionManager transactionManager;
+
+    @Inject
+    @Named("PROPAGATION_REQUIRED")
+    RequiredJtaTransactionPolicy requiredPolicy;
+
+    @Inject
+    @Named("PROPAGATION_REQUIRES_NEW")
+    RequiresNewJtaTransactionPolicy requiresNewPolicy;
+
+    @AfterEach
+    public void afterEach() {
+        reset(transactionManager);
+    }
+
+    @Test
+    public void failedRollbackMarkingIsReportedAndKeepsTheOriginalCause() throws Exception {
+        // Participating in an outer transaction, so the policy marks it rather than rolling it back
+        when(transactionManager.getStatus()).thenReturn(Status.STATUS_ACTIVE);
+        doThrow(new SystemException("mark failed")).when(transactionManager).setRollbackOnly();
+
+        Exception routeFailure = new Exception("route failed");
+        Throwable thrown = assertThrows(Throwable.class, () -> requiredPolicy.run(() -> {
+            throw routeFailure;
+        }));
+
+        // The original failure still surfaces
+        assertEquals(routeFailure, thrown);
+        // and the marking failure rides along rather than vanishing into a log line
+        assertTrue(Arrays.stream(thrown.getSuppressed())
+                .anyMatch(s -> s.getMessage().contains("Unable to mark the transaction for rollback")),
+                "expected the failed setRollbackOnly to be attached, got "
+                        + Arrays.toString(thrown.getSuppressed()));
+    }
+
+    @Test
+    public void failedRollbackIsReportedAndKeepsTheOriginalCause() throws Exception {
+        when(transactionManager.getStatus()).thenReturn(Status.STATUS_NO_TRANSACTION);
+        doThrow(new SystemException("rollback failed")).when(transactionManager).rollback();
+
+        Exception routeFailure = new Exception("route failed");
+        Throwable thrown = assertThrows(Throwable.class, () -> requiredPolicy.run(() -> {
+            throw routeFailure;
+        }));
+
+        assertEquals(routeFailure, thrown);
+        assertTrue(Arrays.stream(thrown.getSuppressed())
+                .anyMatch(s -> s.getMessage().contains("Unable to rollback transaction")),
+                "expected the failed rollback to be attached, got " + Arrays.toString(thrown.getSuppressed()));
+    }
+
+    @Test
+    public void failedResumeIsReportedWhenTheBodySucceeded() throws Exception {
+        Transaction suspended = new MockTransaction();
+        when(transactionManager.getStatus()).thenReturn(Status.STATUS_NO_TRANSACTION);
+        when(transactionManager.suspend()).thenReturn(suspended);
+        doThrow(new SystemException("resume failed")).when(transactionManager).resume(suspended);
+
+        // Nothing else is in flight, so the resume failure is the failure
+        Throwable thrown = assertThrows(Throwable.class, () -> requiresNewPolicy.run(() -> {
+        }));
+
+        assertTrue(thrown.getMessage().contains("Unable to resume transaction"),
+                "expected the resume failure to surface, got " + thrown);
+    }
+
+    @Test
+    public void failedResumeDoesNotReplaceTheBodyFailure() throws Exception {
+        Transaction suspended = new MockTransaction();
+        when(transactionManager.getStatus()).thenReturn(Status.STATUS_NO_TRANSACTION);
+        when(transactionManager.suspend()).thenReturn(suspended);
+        doThrow(new SystemException("resume failed")).when(transactionManager).resume(suspended);
+
+        Exception routeFailure = new Exception("route failed");
+        Throwable thrown = assertThrows(Throwable.class, () -> requiresNewPolicy.run(() -> {
+            throw routeFailure;
+        }));
+
+        // The body's failure wins; the resume failure is attached to it
+        assertEquals(routeFailure, thrown);
+        assertTrue(Arrays.stream(thrown.getSuppressed())
+                .anyMatch(s -> s.getMessage().contains("Unable to resume transaction")),
+                "expected the failed resume to be attached, got " + Arrays.toString(thrown.getSuppressed()));
+    }
+}

--- a/extensions/jta/runtime/src/main/java/org/apache/camel/quarkus/component/jta/NotSupportedJtaTransactionPolicy.java
+++ b/extensions/jta/runtime/src/main/java/org/apache/camel/quarkus/component/jta/NotSupportedJtaTransactionPolicy.java
@@ -25,11 +25,16 @@ public final class NotSupportedJtaTransactionPolicy extends TransactionalJtaTran
     @Override
     public void run(final Runnable runnable) throws Throwable {
         Transaction suspendedTransaction = null;
+        Throwable primary = null;
         try {
             suspendedTransaction = suspendTransaction();
             runnable.run();
+        } catch (Throwable e) {
+            primary = e;
+            throw e;
         } finally {
-            resumeTransaction(suspendedTransaction);
+            // Passing the failure already on its way out keeps a resume failure from replacing it
+            resumeTransaction(suspendedTransaction, primary);
         }
     }
 }

--- a/extensions/jta/runtime/src/main/java/org/apache/camel/quarkus/component/jta/RequiresNewJtaTransactionPolicy.java
+++ b/extensions/jta/runtime/src/main/java/org/apache/camel/quarkus/component/jta/RequiresNewJtaTransactionPolicy.java
@@ -25,11 +25,16 @@ public final class RequiresNewJtaTransactionPolicy extends TransactionalJtaTrans
     @Override
     public void run(final Runnable runnable) throws Throwable {
         Transaction suspendedTransaction = null;
+        Throwable primary = null;
         try {
             suspendedTransaction = suspendTransaction();
             runWithTransaction(runnable, true);
+        } catch (Throwable e) {
+            primary = e;
+            throw e;
         } finally {
-            resumeTransaction(suspendedTransaction);
+            // Passing the failure already on its way out keeps a resume failure from replacing it
+            resumeTransaction(suspendedTransaction, primary);
         }
     }
 }

--- a/extensions/jta/runtime/src/main/java/org/apache/camel/quarkus/component/jta/TransactionalJtaTransactionPolicy.java
+++ b/extensions/jta/runtime/src/main/java/org/apache/camel/quarkus/component/jta/TransactionalJtaTransactionPolicy.java
@@ -25,16 +25,13 @@ import jakarta.transaction.SystemException;
 import jakarta.transaction.Transaction;
 import jakarta.transaction.TransactionManager;
 import org.apache.camel.CamelException;
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.jta.JtaTransactionPolicy;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Helper methods for transaction handling
  */
 public abstract class TransactionalJtaTransactionPolicy extends JtaTransactionPolicy {
-
-    private static final Logger LOG = LoggerFactory.getLogger(TransactionalJtaTransactionPolicy.class);
 
     @Inject
     TransactionManager transactionManager;
@@ -46,7 +43,7 @@ public abstract class TransactionalJtaTransactionPolicy extends JtaTransactionPo
         try {
             runnable.run();
         } catch (Throwable e) {
-            rollback(isNew);
+            rollbackSuppressing(e, isNew);
             throw e;
         }
         if (isNew) {
@@ -64,11 +61,18 @@ public abstract class TransactionalJtaTransactionPolicy extends JtaTransactionPo
         } catch (HeuristicMixedException | HeuristicRollbackException | RollbackException | SystemException e) {
             throw new CamelException("Unable to commit transaction", e);
         } catch (Exception | Error e) {
-            rollback(true);
+            rollbackSuppressing(e, true);
             throw e;
         }
     }
 
+    /**
+     * Rolls the transaction back, or marks it for rollback when it belongs to an outer policy.
+     *
+     * A failure here is raised rather than logged and discarded. Callers that already have an exception on its way
+     * out attach this one to it through {@link #rollbackSuppressing(Throwable, boolean)}, so the original cause is
+     * never replaced.
+     */
     final protected void rollback(boolean isNew) throws Exception {
         try {
             if (isNew) {
@@ -77,7 +81,20 @@ public abstract class TransactionalJtaTransactionPolicy extends JtaTransactionPo
                 transactionManager.setRollbackOnly();
             }
         } catch (Throwable e) {
-            LOG.warn("Could not rollback transaction!", e);
+            throw new CamelException(
+                    isNew ? "Unable to rollback transaction" : "Unable to mark the transaction for rollback", e);
+        }
+    }
+
+    /**
+     * Rolls back while an exception is already on its way out, attaching a rollback failure to it as a suppressed
+     * exception. Replacing the original would hide why the rollback was needed in the first place.
+     */
+    private void rollbackSuppressing(Throwable primary, boolean isNew) {
+        try {
+            rollback(isNew);
+        } catch (Throwable rollbackFailure) {
+            primary.addSuppressed(rollbackFailure);
         }
     }
 
@@ -85,7 +102,25 @@ public abstract class TransactionalJtaTransactionPolicy extends JtaTransactionPo
         return transactionManager.suspend();
     }
 
+    /**
+     * Resumes the suspended transaction, raising a failure rather than logging and discarding it, so that work after
+     * this point does not silently continue outside the transaction the caller expects to be restored.
+     */
     final protected void resumeTransaction(final Transaction suspendedTransaction) {
+        try {
+            resumeTransaction(suspendedTransaction, null);
+        } catch (Exception e) {
+            throw RuntimeCamelException.wrapRuntimeCamelException(e);
+        }
+    }
+
+    /**
+     * Resumes the suspended transaction while {@code primary} may already be on its way out, which is the case in the
+     * `finally` block of a policy that suspends. A resume failure is attached to {@code primary} when there is one and
+     * raised on its own otherwise, so it is neither lost nor allowed to replace the original failure.
+     */
+    final protected void resumeTransaction(final Transaction suspendedTransaction, final Throwable primary)
+            throws Exception {
         if (suspendedTransaction == null) {
             return;
         }
@@ -93,7 +128,12 @@ public abstract class TransactionalJtaTransactionPolicy extends JtaTransactionPo
         try {
             transactionManager.resume(suspendedTransaction);
         } catch (Throwable e) {
-            LOG.warn("Could not resume transaction!", e);
+            CamelException failure = new CamelException("Unable to resume transaction", e);
+            if (primary != null) {
+                primary.addSuppressed(failure);
+            } else {
+                throw failure;
+            }
         }
     }
 

--- a/extensions/ldap/runtime/src/main/java/org/apache/camel/quarkus/component/ldap/CamelLdapConfig.java
+++ b/extensions/ldap/runtime/src/main/java/org/apache/camel/quarkus/component/ldap/CamelLdapConfig.java
@@ -23,7 +23,6 @@ import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
-import io.smallrye.config.WithDefault;
 
 @ConfigRoot(phase = ConfigPhase.RUN_TIME)
 @ConfigMapping(prefix = "quarkus.camel.ldap")
@@ -64,8 +63,7 @@ public interface CamelLdapConfig {
          * If this property is unspecified,
          * the behaviour is determined by the service provider.
          */
-        @WithDefault("none")
-        String securityAuthentication();
+        Optional<String> securityAuthentication();
 
         /**
          * The custom socket factory to use. The value of the property should be the fully qualified class name

--- a/extensions/ldap/runtime/src/main/java/org/apache/camel/quarkus/component/ldap/CamelLdapRecorder.java
+++ b/extensions/ldap/runtime/src/main/java/org/apache/camel/quarkus/component/ldap/CamelLdapRecorder.java
@@ -42,7 +42,7 @@ public class CamelLdapRecorder {
                     Hashtable<String, Object> env = new Hashtable<>();
                     dirConfig.initialContextFactory().ifPresent(v -> env.put(Context.INITIAL_CONTEXT_FACTORY, v));
                     dirConfig.providerUrl().ifPresent(v -> env.put(Context.PROVIDER_URL, v));
-                    env.put(Context.SECURITY_AUTHENTICATION, dirConfig.securityAuthentication());
+                    dirConfig.securityAuthentication().ifPresent(v -> env.put(Context.SECURITY_AUTHENTICATION, v));
                     dirConfig.securityProtocol().ifPresent(v -> env.put(Context.SECURITY_PROTOCOL, v));
                     dirConfig.socketFactory().ifPresent(v -> env.put("java.naming.ldap.factory.socket", v));
 

--- a/integration-tests/ldap/src/main/java/org/apache/camel/quarkus/component/ldap/it/LdapResource.java
+++ b/integration-tests/ldap/src/main/java/org/apache/camel/quarkus/component/ldap/it/LdapResource.java
@@ -18,6 +18,7 @@ package org.apache.camel.quarkus.component.ldap.it;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
 
@@ -51,6 +52,22 @@ public class LdapResource {
     public Response search(@PathParam("direct") String directName,
             @QueryParam("ldapQuery") String ldapQuery) throws Exception {
         return Response.ok(searchByUid(directName, ldapQuery)).build();
+    }
+
+    /**
+     * Reports a single entry of the JNDI environment bound for the named dir context, so that a test can assert
+     * which properties the extension actually put there. Answers {@code <absent>} when the key was not set.
+     */
+    @Path("/dirContextEnv/{name}/{key}")
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public Response dirContextEnv(@PathParam("name") String name, @PathParam("key") String key) {
+        Hashtable<?, ?> env = camelContext.getRegistry().lookupByNameAndType(name, Hashtable.class);
+        if (env == null) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+        Object value = env.get(key);
+        return Response.ok(value == null ? "<absent>" : value.toString()).build();
     }
 
     @Path("/safeSearch")

--- a/integration-tests/ldap/src/test/java/org/apache/camel/quarkus/component/ldap/it/LdapTest.java
+++ b/integration-tests/ldap/src/test/java/org/apache/camel/quarkus/component/ldap/it/LdapTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @TestCertificates(certificates = {
@@ -46,6 +47,27 @@ class LdapTest {
      *
      * @throws Exception
      */
+    /**
+     * security-authentication must only reach the JNDI environment when it was configured, so that credentials
+     * passed through additional-options are not silently overridden by a default.
+     */
+    @Test
+    public void securityAuthenticationOnlySetWhenConfigured() {
+        String key = "java.naming.security.authentication";
+
+        // httpserver sets it explicitly
+        RestAssured.get("/ldap/dirContextEnv/httpserver/" + key)
+                .then()
+                .statusCode(200)
+                .body(is("none"));
+
+        // sslserver does not, so the service provider decides rather than the extension
+        RestAssured.get("/ldap/dirContextEnv/sslserver/" + key)
+                .then()
+                .statusCode(200)
+                .body(is("<absent>"));
+    }
+
     @ParameterizedTest
     @ValueSource(strings = { "http", "ssl", "originalConfig", "additionalOptions" })
     public void ldapSearchTest(String direct) throws Exception {


### PR DESCRIPTION
Backports two fixes from `main` to the `3.27.x` LTS line. Both defects are present on this branch.

| Original | Fix |
|---|---|
| #9066 (issue #9054) | LDAP `security-authentication` is only put into the JNDI environment when configured, so credentials supplied through `additional-options` are no longer silently ignored on an anonymous bind |
| #9072 (issue #9056) | JTA rollback and resume failures are raised instead of logged and discarded, attached via `addSuppressed` so they never replace the exception that made the rollback necessary |

Both cherry-picks were taken with `-x`, so each commit records the `main` SHA it came from.

**One adaptation commit on top**, covering two things a cherry-pick cannot know:

1. The changes carry a `3.40.0` migration guide, which belongs to `main` rather than this release line. Replaced with a `3.27.6` guide holding the same two notes, with `migration-guide/index.adoc` pointing at that instead. This follows the `3.20.2.adoc` precedent — a patch level guide added only on its maintenance branch for a behaviour change backported into it.

2. **`QuarkusExtensionTest` does not exist in Quarkus 3.27.x.** This line uses `quarkus-junit5-internal`, which ships only `QuarkusDevModeTest`, `QuarkusProdModeTest` and `QuarkusUnitTest`, so the new test uses `QuarkusUnitTest` here, as its six sibling JTA tests already do. The swap to the non-deprecated class on `main` came from #9075, which is not part of this backport. Worth noting because the cherry-pick applies cleanly and only fails at compile time.

**Verification on this branch**

- `extensions/jta/deployment` — 18 tests, 0 failures (the 4 new cases plus the 6 existing policy test classes)
- `integration-tests/ldap` — 6 tests, 0 failures
- `./mvnw clean validate -pl docs` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018YmgydQvapQHWoJfotF8tK