### PR TITLE
Use a floating tag for the Google Cloud emulators test container image

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -253,7 +253,7 @@
         <fhir.container.image>${fhir.container.image.base}:v8.10.0-3</fhir.container.image>
         <fhir-dstu.container.image>${fhir.container.image.base}:v4.2.0</fhir-dstu.container.image>
         <floci.container.image>mirror.gcr.io/floci/floci:1.6.0</floci.container.image>
-        <google-cloud-sdk.container.image>gcr.io/google.com/cloudsdktool/cloud-sdk:551.0.0-emulators</google-cloud-sdk.container.image>
+        <google-cloud-sdk.container.image>gcr.io/google.com/cloudsdktool/google-cloud-cli:emulators</google-cloud-sdk.container.image>
         <google-storage.container.image>mirror.gcr.io/fsouza/fake-gcs-server:1.52.3</google-storage.container.image>
         <greenmail.container.image>mirror.gcr.io/greenmail/standalone:2.1.8</greenmail.container.image>
         <hashicorp-vault.container.image>mirror.gcr.io/hashicorp/vault:2.0.3</hashicorp-vault.container.image>


### PR DESCRIPTION
Relates to failing google-pubsub tests from #9086. 

Google [enforces](https://github.com/GoogleCloudPlatform/cloud-sdk-docker/blob/master/README.md#package-retention-policy) a 365 day retention policy on the Google Cloud CLI Docker image repositories, so pinned version tags are deleted after a year.

Thus I think we should use a floating container image tag like the Camel core and Quarkus Google Cloud services is doing.