### PR TITLE
Fixes #9104. Allow serialization-enabled to veto extension serialization registrations

### DIFF
--- a/docs/modules/ROOT/pages/migration-guide/3.40.0.adoc
+++ b/docs/modules/ROOT/pages/migration-guide/3.40.0.adoc
@@ -33,3 +33,19 @@ These failures are now raised:
 An application that inspected only the top-level exception sees no difference. One that handles exceptions and continues may now see a failure it previously never learned about. Check `Throwable.getSuppressed()` when diagnosing.
 
 No method signatures changed. `resumeTransaction(Transaction)` is unchanged and now wraps a resume failure in a `RuntimeCamelException`; a new `resumeTransaction(Transaction, Throwable)` overload is what the policies use so that a resume failure cannot replace a failure already on its way out.
+
+== Core extension changes
+
+=== serialization-enabled can now veto extension serialization registrations
+
+`quarkus.camel.native.reflection.serialization-enabled` previously defaulted to `false`, but a `false` value carried no meaning of its own. Extensions that require Java serialization to work, such as `camel-quarkus-jms`, `camel-quarkus-jolt`, `camel-quarkus-management`, `camel-quarkus-netty`, `camel-quarkus-sjms`, `camel-quarkus-sjms2` and `camel-quarkus-sql`, registered the base set of classes for serialization on being present on the classpath, and there was no way to prevent it.
+
+The option is now unset by default and has three states:
+
+* When it is not set, classes are registered for serialization only if an extension on the classpath requires it. This matches the previous behaviour.
+* When it is `true`, the base set of classes is always registered. This is unchanged.
+* When it is `false`, nothing is registered for serialization, even if extensions on the classpath require it. This is new.
+
+Setting the option to `false` therefore now bounds what the native image is able to deserialize, at the cost of breaking any component that depends on Java serialization. A build that requests the veto while extensions ask for serialization logs a warning.
+
+Applications that set the option to `false` while relying on one of the extensions above must remove the setting to keep working. Applications that set it to `true`, or that never set it, are unaffected.

--- a/docs/modules/ROOT/pages/reference/extensions/activemq.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/activemq.adoc
@@ -57,7 +57,7 @@ you must ensure that the `camel-quarkus-xml-jaxp` extension is present on the cl
 === Native mode support for jakarta.jms.ObjectMessage
 
 When sending JMS message payloads as `jakarta.jms.ObjectMessage`, you must annotate the relevant classes to be registered for serialization with `@RegisterForReflection(serialization = true)`.
-Note that this extension automatically sets `quarkus.camel.native.reflection.serialization-enabled = true` for you. Refer to the xref:user-guide/native-mode.adoc#serialization[native mode user guide] for more information.
+Note that this extension automatically enables native serialization support for you. Refer to the xref:user-guide/native-mode.adoc#serialization[native mode user guide] for more information.
 
 
 [id="extensions-activemq-camel-quarkus-limitations"]

--- a/docs/modules/ROOT/pages/reference/extensions/activemq6.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/activemq6.adoc
@@ -56,7 +56,7 @@ you must ensure that the `camel-quarkus-xml-jaxp` extension is present on the cl
 === Native mode support for jakarta.jms.ObjectMessage
 
 When sending JMS message payloads as `jakarta.jms.ObjectMessage`, you must annotate the relevant classes to be registered for serialization with `@RegisterForReflection(serialization = true)`.
-Note that this extension automatically sets `quarkus.camel.native.reflection.serialization-enabled = true` for you. Refer to the xref:user-guide/native-mode.adoc#serialization[native mode user guide] for more information.
+Note that this extension automatically enables native serialization support for you. Refer to the xref:user-guide/native-mode.adoc#serialization[native mode user guide] for more information.
 
 
 [id="extensions-activemq6-camel-quarkus-limitations"]

--- a/docs/modules/ROOT/pages/reference/extensions/amqp.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/amqp.adoc
@@ -61,7 +61,7 @@ you must ensure that the `camel-quarkus-xml-jaxp` extension is present on the cl
 === Native mode support for jakarta.jms.ObjectMessage
 
 When sending JMS message payloads as `jakarta.jms.ObjectMessage`, you must annotate the relevant classes to be registered for serialization with `@RegisterForReflection(serialization = true)`.
-Note that this extension automatically sets `quarkus.camel.native.reflection.serialization-enabled = true` for you. Refer to the xref:user-guide/native-mode.adoc#serialization[native mode user guide] for more information.
+Note that this extension automatically enables native serialization support for you. Refer to the xref:user-guide/native-mode.adoc#serialization[native mode user guide] for more information.
 
 [id="extensions-amqp-usage-connection-pooling"]
 === Connection Pooling

--- a/docs/modules/ROOT/pages/reference/extensions/core.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/core.adoc
@@ -315,13 +315,21 @@ where `my-dep` is a label of your choice to tell Quarkus that `org.my-group` and
 
 a|icon:lock[title=Fixed at build time] [[quarkus-camel-native-reflection-serialization-enabled]]`link:#quarkus-camel-native-reflection-serialization-enabled[quarkus.camel.native.reflection.serialization-enabled]`
 
-If `true`, basic classes are registered for serialization; otherwise basic classes won't be registered automatically
-for serialization in native mode. The list of classes automatically registered for serialization can be found in
+Controls whether classes are registered for serialization in native mode. The base set of classes registered can be
+found in
 link:https://github.com/apache/camel-quarkus/blob/main/extensions-core/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/CamelSerializationProcessor.java[CamelSerializationProcessor.BASE_SERIALIZATION_CLASSES].
-Setting this to `false` helps to reduce the size of the native image. In JVM mode, there is no real benefit of
-setting this flag to `true` except for making the behavior consistent with native mode.
+
+When this option is not set, classes are registered for serialization only if an extension on the classpath requires
+it.
+
+Setting this option to `true` always registers the base set of classes for serialization. Setting it to `false`
+prevents any registration, even when extensions on the classpath require it. Note that this can cause components
+relying on Java serialization to fail at runtime.
+
+Disabling serialization helps to reduce the size of the native image. In JVM mode, this option has no effect other
+than making the behavior consistent with native mode.
 | `boolean`
-| `false`
+| 
 
 a|icon:lock[title=Fixed at build time] [[quarkus-camel-expression-on-build-time-analysis-failure]]`link:#quarkus-camel-expression-on-build-time-analysis-failure[quarkus.camel.expression.on-build-time-analysis-failure]`
 

--- a/docs/modules/ROOT/pages/reference/extensions/jms.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/jms.adoc
@@ -57,7 +57,7 @@ you must ensure that the `camel-quarkus-xml-jaxp` extension is present on the cl
 === Native mode support for jakarta.jms.ObjectMessage
 
 When sending JMS message payloads as `jakarta.jms.ObjectMessage`, you must annotate the relevant classes to be registered for serialization with `@RegisterForReflection(serialization = true)`.
-Note that this extension automatically sets `quarkus.camel.native.reflection.serialization-enabled = true` for you. Refer to the xref:user-guide/native-mode.adoc#serialization[native mode user guide] for more information.
+Note that this extension automatically enables native serialization support for you. Refer to the xref:user-guide/native-mode.adoc#serialization[native mode user guide] for more information.
 
 [id="extensions-jms-usage-support-for-connection-pooling-and-x-open-xa-distributed-transactions"]
 === Support for Connection pooling and X/Open XA distributed transactions

--- a/docs/modules/ROOT/pages/reference/extensions/sjms.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/sjms.adoc
@@ -57,7 +57,7 @@ you must ensure that the `camel-quarkus-xml-jaxp` extension is present on the cl
 === Native mode support for jakarta.jms.ObjectMessage
 
 When sending JMS message payloads as `jakarta.jms.ObjectMessage`, you must annotate the relevant classes to be registered for serialization with `@RegisterForReflection(serialization = true)`.
-Note that this extension automatically sets `quarkus.camel.native.reflection.serialization-enabled = true` for you. Refer to the xref:user-guide/native-mode.adoc#serialization[native mode user guide] for more information.
+Note that this extension automatically enables native serialization support for you. Refer to the xref:user-guide/native-mode.adoc#serialization[native mode user guide] for more information.
 
 
 [id="extensions-sjms-transferexception-option-in-native-mode"]

--- a/docs/modules/ROOT/pages/reference/extensions/sjms2.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/sjms2.adoc
@@ -57,7 +57,7 @@ you must ensure that the `camel-quarkus-xml-jaxp` extension is present on the cl
 === Native mode support for jakarta.jms.ObjectMessage
 
 When sending JMS message payloads as `jakarta.jms.ObjectMessage`, you must annotate the relevant classes to be registered for serialization with `@RegisterForReflection(serialization = true)`.
-Note that this extension automatically sets `quarkus.camel.native.reflection.serialization-enabled = true` for you. Refer to the xref:user-guide/native-mode.adoc#serialization[native mode user guide] for more information.
+Note that this extension automatically enables native serialization support for you. Refer to the xref:user-guide/native-mode.adoc#serialization[native mode user guide] for more information.
 
 
 [id="extensions-sjms2-transferexception-option-in-native-mode"]

--- a/docs/modules/ROOT/pages/reference/extensions/sql.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/sql.adoc
@@ -84,7 +84,7 @@ quarkus.native.resources.includes = queries.sql, sql/*.sql
 [id="extensions-sql-configuration-sql-aggregation-repository-in-native-mode"]
 === SQL aggregation repository in native mode
 
-In order to use SQL aggregation repositories like `JdbcAggregationRepository` in native mode, you must xref:extensions/core.adoc#quarkus-camel-native-reflection-serialization-enabled[enable native serialization support].
+SQL aggregation repositories like `JdbcAggregationRepository` require native serialization support, which this extension enables for you. Refer to the xref:user-guide/native-mode.adoc#serialization[native mode user guide] for more information.
 
 In addition, if your exchange bodies are custom types, they must be registered for serialization by annotating their class declaration with `@RegisterForReflection(serialization = true)`.
 

--- a/docs/modules/ROOT/pages/user-guide/native-mode.adoc
+++ b/docs/modules/ROOT/pages/user-guide/native-mode.adoc
@@ -129,6 +129,24 @@ quarkus.index-dependency.commons-lang3.artifact-id = commons-lang3
 [[serialization]]
 == Registering classes for serialization
 
-If serialization support is requested via `quarkus.camel.native.reflection.serialization-enabled`, the classes listed in https://github.com/apache/camel-quarkus/blob/main/extensions-core/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/CamelSerializationProcessor.java[CamelSerializationProcessor.BASE_SERIALIZATION_CLASSES] are automatically registered for serialization.
+Some extensions require Java serialization support in order to work. For example, `camel-quarkus-netty` installs a codec
+based on Java serialization by default, `camel-quarkus-management` needs it for JMX, and `camel-quarkus-jms` needs it to
+handle `ObjectMessage` payloads or routes configured with `transferExchange=true`. Such extensions automatically register the
+classes listed in https://github.com/apache/camel-quarkus/blob/main/extensions-core/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/CamelSerializationProcessor.java[CamelSerializationProcessor.BASE_SERIALIZATION_CLASSES]
+for serialization.
+
+The `quarkus.camel.native.reflection.serialization-enabled` option controls this behavior:
+
+* When the option is not set, classes are registered for serialization only if an extension on the classpath requires it.
+This is the default.
+* When set to `true`, the base set of classes is always registered for serialization. This is needed for functionality that
+relies on serialization but is not tied to an extension that enables it automatically, such as the Cassandra and Infinispan
+aggregation repositories.
+* When set to `false`, nothing is registered for serialization, even if extensions on the classpath require it. This bounds
+what the native image is able to deserialize, at the cost of breaking any component that depends on Java serialization.
+
+Note that this option governs only the base set of classes and any additional classes that extensions register alongside
+it. Classes registered individually with `@io.quarkus.runtime.annotations.RegisterForReflection(serialization = true)` are
+not affected.
 
 Users can register more classes using `@io.quarkus.runtime.annotations.RegisterForReflection(serialization = true)`.

--- a/extensions-core/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/CamelSerializationProcessor.java
+++ b/extensions-core/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/CamelSerializationProcessor.java
@@ -25,6 +25,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.ConcurrentSkipListSet;
 
@@ -71,23 +72,33 @@ public class CamelSerializationProcessor {
     };
 
     @BuildStep
-    void produceSerializationBuildItem(CamelConfig config, BuildProducer<CamelSerializationBuildItem> serializationBuildItems) {
-        final CamelConfig.ReflectionConfig reflectionConfig = config.native_().reflection();
-        if (reflectionConfig.serializationEnabled()) {
-            LOGGER.debug(
-                    "Registration of basic types for serialization is enabled via quarkus.camel.native.reflection.serialization-enabled");
-            serializationBuildItems.produce(new CamelSerializationBuildItem());
-        }
-    }
-
-    @BuildStep
-    void baseSerializationClasses(List<CamelSerializationBuildItem> serializationRequests,
+    void baseSerializationClasses(CamelConfig config, List<CamelSerializationBuildItem> serializationRequests,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClasses) {
 
-        if (!serializationRequests.isEmpty()) {
-            //required for serialization of BigInteger
-            reflectiveClasses.produce(ReflectiveClassBuildItem.builder(byte[].class).build());
-            reflectiveClasses.produce(ReflectiveClassBuildItem.serializationClass(BASE_SERIALIZATION_CLASSES));
+        Optional<Boolean> serializationEnabled = config.native_().reflection().serializationEnabled();
+        if (serializationEnabled.isPresent() && !serializationEnabled.get()) {
+            if (!serializationRequests.isEmpty()) {
+                LOGGER.warn(
+                        "Serialization registration requested by extensions on the classpath was vetoed by quarkus.camel.native.reflection.serialization-enabled=false. Components relying on Java serialization may fail at runtime.");
+            }
+            return;
+        }
+
+        if (serializationEnabled.isEmpty() && serializationRequests.isEmpty()) {
+            return;
+        }
+
+        //required for serialization of BigInteger
+        reflectiveClasses.produce(ReflectiveClassBuildItem.builder(byte[].class).build());
+        reflectiveClasses.produce(ReflectiveClassBuildItem.serializationClass(BASE_SERIALIZATION_CLASSES));
+
+        String[] additionalClasses = serializationRequests.stream()
+                .map(CamelSerializationBuildItem::getClassNames)
+                .flatMap(List::stream)
+                .distinct()
+                .toArray(String[]::new);
+        if (additionalClasses.length > 0) {
+            reflectiveClasses.produce(ReflectiveClassBuildItem.serializationClass(additionalClasses));
         }
     }
 }

--- a/extensions-core/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/spi/CamelSerializationBuildItem.java
+++ b/extensions-core/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/spi/CamelSerializationBuildItem.java
@@ -16,12 +16,37 @@
  */
 package org.apache.camel.quarkus.core.deployment.spi;
 
+import java.util.List;
+
 import io.quarkus.builder.item.MultiBuildItem;
 
 /**
- * Signal that basic classes listed in
- * {@code org.apache.camel.quarkus.core.deployment.CamelSerializationProcessor.baseSerializationClasses()}
- * should be registered for serialization.
+ * Signal that the basic classes listed in
+ * {@code org.apache.camel.quarkus.core.deployment.CamelSerializationProcessor.BASE_SERIALIZATION_CLASSES}, together
+ * with any
+ * additional classes passed to this build item, should be registered for serialization.
+ * <p>
+ * Registrations requested via this build item can be vetoed by the user with
+ * {@code quarkus.camel.native.reflection.serialization-enabled=false}. Extensions that need the base set of classes
+ * must
+ * therefore route their serialization registrations through this build item, instead of producing
+ * {@code ReflectiveClassBuildItem.serializationClass(..)} directly.
  */
 public final class CamelSerializationBuildItem extends MultiBuildItem {
+    private final List<String> classNames;
+
+    public CamelSerializationBuildItem() {
+        this.classNames = List.of();
+    }
+
+    public CamelSerializationBuildItem(String... classNames) {
+        this.classNames = List.of(classNames);
+    }
+
+    /**
+     * Additional classes to register for serialization, on top of the base set.
+     */
+    public List<String> getClassNames() {
+        return classNames;
+    }
 }

--- a/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/CamelConfig.java
+++ b/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/CamelConfig.java
@@ -288,16 +288,23 @@ public interface CamelConfig {
         public Optional<List<String>> includePatterns();
 
         /**
-         * If `true`, basic classes are registered for serialization; otherwise basic classes won't be registered automatically
-         * for serialization in native mode. The list of classes automatically registered for serialization can be found in
+         * Controls whether classes are registered for serialization in native mode. The base set of classes registered can be
+         * found in
          * link:https://github.com/apache/camel-quarkus/blob/main/extensions-core/core/deployment/src/main/java/org/apache/camel/quarkus/core/deployment/CamelSerializationProcessor.java[CamelSerializationProcessor.BASE_SERIALIZATION_CLASSES].
-         * Setting this to `false` helps to reduce the size of the native image. In JVM mode, there is no real benefit of
-         * setting this flag to `true` except for making the behavior consistent with native mode.
+         *
+         * When this option is not set, classes are registered for serialization only if an extension on the classpath requires
+         * it.
+         *
+         * Setting this option to `true` always registers the base set of classes for serialization. Setting it to `false`
+         * prevents any registration, even when extensions on the classpath require it. Note that this can cause components
+         * relying on Java serialization to fail at runtime.
+         *
+         * Disabling serialization helps to reduce the size of the native image. In JVM mode, this option has no effect other
+         * than making the behavior consistent with native mode.
          *
          * @asciidoclet
          */
-        @WithDefault("false")
-        boolean serializationEnabled();
+        Optional<Boolean> serializationEnabled();
     }
 
     interface RuntimeCatalogConfig {

--- a/extensions/activemq/runtime/src/main/doc/usage.adoc
+++ b/extensions/activemq/runtime/src/main/doc/usage.adoc
@@ -6,4 +6,4 @@ you must ensure that the `camel-quarkus-xml-jaxp` extension is present on the cl
 === Native mode support for jakarta.jms.ObjectMessage
 
 When sending JMS message payloads as `jakarta.jms.ObjectMessage`, you must annotate the relevant classes to be registered for serialization with `@RegisterForReflection(serialization = true)`.
-Note that this extension automatically sets `quarkus.camel.native.reflection.serialization-enabled = true` for you. Refer to the xref:user-guide/native-mode.adoc#serialization[native mode user guide] for more information.
+Note that this extension automatically enables native serialization support for you. Refer to the xref:user-guide/native-mode.adoc#serialization[native mode user guide] for more information.

--- a/extensions/activemq6/runtime/src/main/doc/usage.adoc
+++ b/extensions/activemq6/runtime/src/main/doc/usage.adoc
@@ -6,4 +6,4 @@ you must ensure that the `camel-quarkus-xml-jaxp` extension is present on the cl
 === Native mode support for jakarta.jms.ObjectMessage
 
 When sending JMS message payloads as `jakarta.jms.ObjectMessage`, you must annotate the relevant classes to be registered for serialization with `@RegisterForReflection(serialization = true)`.
-Note that this extension automatically sets `quarkus.camel.native.reflection.serialization-enabled = true` for you. Refer to the xref:user-guide/native-mode.adoc#serialization[native mode user guide] for more information.
+Note that this extension automatically enables native serialization support for you. Refer to the xref:user-guide/native-mode.adoc#serialization[native mode user guide] for more information.

--- a/extensions/amqp/runtime/src/main/doc/usage.adoc
+++ b/extensions/amqp/runtime/src/main/doc/usage.adoc
@@ -10,7 +10,7 @@ you must ensure that the `camel-quarkus-xml-jaxp` extension is present on the cl
 === Native mode support for jakarta.jms.ObjectMessage
 
 When sending JMS message payloads as `jakarta.jms.ObjectMessage`, you must annotate the relevant classes to be registered for serialization with `@RegisterForReflection(serialization = true)`.
-Note that this extension automatically sets `quarkus.camel.native.reflection.serialization-enabled = true` for you. Refer to the xref:user-guide/native-mode.adoc#serialization[native mode user guide] for more information.
+Note that this extension automatically enables native serialization support for you. Refer to the xref:user-guide/native-mode.adoc#serialization[native mode user guide] for more information.
 
 === Connection Pooling
 

--- a/extensions/jms/runtime/src/main/doc/usage.adoc
+++ b/extensions/jms/runtime/src/main/doc/usage.adoc
@@ -6,7 +6,7 @@ you must ensure that the `camel-quarkus-xml-jaxp` extension is present on the cl
 === Native mode support for jakarta.jms.ObjectMessage
 
 When sending JMS message payloads as `jakarta.jms.ObjectMessage`, you must annotate the relevant classes to be registered for serialization with `@RegisterForReflection(serialization = true)`.
-Note that this extension automatically sets `quarkus.camel.native.reflection.serialization-enabled = true` for you. Refer to the xref:user-guide/native-mode.adoc#serialization[native mode user guide] for more information.
+Note that this extension automatically enables native serialization support for you. Refer to the xref:user-guide/native-mode.adoc#serialization[native mode user guide] for more information.
 
 === Support for Connection pooling and X/Open XA distributed transactions
 

--- a/extensions/management/deployment/src/main/java/org/apache/camel/quarkus/component/management/deployment/ManagementProcessor.java
+++ b/extensions/management/deployment/src/main/java/org/apache/camel/quarkus/component/management/deployment/ManagementProcessor.java
@@ -143,11 +143,8 @@ class ManagementProcessor {
                 ReflectiveClassBuildItem.builder(managedBeanClasses.toArray(String[]::new))
                         .fields().methods().build());
 
-        // Various javax.management classes require serialization
-        reflectiveClass.produce(ReflectiveClassBuildItem.builder(SERIALIZATION_CLASSES).serialization().build());
-
-        // Add serialization support for some core JDK & Camel classes
-        camelSerialization.produce(new CamelSerializationBuildItem());
+        // Add serialization support for some core JDK & Camel classes, plus the javax.management classes that JMX requires
+        camelSerialization.produce(new CamelSerializationBuildItem(SERIALIZATION_CLASSES));
     }
 
     @Record(ExecutionTime.RUNTIME_INIT)

--- a/extensions/sjms/runtime/src/main/doc/usage.adoc
+++ b/extensions/sjms/runtime/src/main/doc/usage.adoc
@@ -6,4 +6,4 @@ you must ensure that the `camel-quarkus-xml-jaxp` extension is present on the cl
 === Native mode support for jakarta.jms.ObjectMessage
 
 When sending JMS message payloads as `jakarta.jms.ObjectMessage`, you must annotate the relevant classes to be registered for serialization with `@RegisterForReflection(serialization = true)`.
-Note that this extension automatically sets `quarkus.camel.native.reflection.serialization-enabled = true` for you. Refer to the xref:user-guide/native-mode.adoc#serialization[native mode user guide] for more information.
+Note that this extension automatically enables native serialization support for you. Refer to the xref:user-guide/native-mode.adoc#serialization[native mode user guide] for more information.

--- a/extensions/sjms2/runtime/src/main/doc/usage.adoc
+++ b/extensions/sjms2/runtime/src/main/doc/usage.adoc
@@ -6,4 +6,4 @@ you must ensure that the `camel-quarkus-xml-jaxp` extension is present on the cl
 === Native mode support for jakarta.jms.ObjectMessage
 
 When sending JMS message payloads as `jakarta.jms.ObjectMessage`, you must annotate the relevant classes to be registered for serialization with `@RegisterForReflection(serialization = true)`.
-Note that this extension automatically sets `quarkus.camel.native.reflection.serialization-enabled = true` for you. Refer to the xref:user-guide/native-mode.adoc#serialization[native mode user guide] for more information.
+Note that this extension automatically enables native serialization support for you. Refer to the xref:user-guide/native-mode.adoc#serialization[native mode user guide] for more information.

--- a/extensions/sql/deployment/src/main/java/org/apache/camel/quarkus/component/sql/deployment/SqlProcessor.java
+++ b/extensions/sql/deployment/src/main/java/org/apache/camel/quarkus/component/sql/deployment/SqlProcessor.java
@@ -17,7 +17,6 @@
 package org.apache.camel.quarkus.component.sql.deployment;
 
 import java.sql.Types;
-import java.util.LinkedHashMap;
 
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -44,6 +43,5 @@ class SqlProcessor {
     void registerForReflection(BuildProducer<ReflectiveClassBuildItem> reflectiveClass) {
         reflectiveClass.produce(
                 ReflectiveClassBuildItem.builder(Types.class, DefaultExchangeHolder.class).fields().build());
-        reflectiveClass.produce(ReflectiveClassBuildItem.serializationClass(LinkedHashMap.class.getName()));
     }
 }

--- a/extensions/sql/runtime/src/main/doc/configuration.adoc
+++ b/extensions/sql/runtime/src/main/doc/configuration.adoc
@@ -29,6 +29,6 @@ quarkus.native.resources.includes = queries.sql, sql/*.sql
 
 === SQL aggregation repository in native mode
 
-In order to use SQL aggregation repositories like `JdbcAggregationRepository` in native mode, you must xref:extensions/core.adoc#quarkus-camel-native-reflection-serialization-enabled[enable native serialization support].
+SQL aggregation repositories like `JdbcAggregationRepository` require native serialization support, which this extension enables for you. Refer to the xref:user-guide/native-mode.adoc#serialization[native mode user guide] for more information.
 
 In addition, if your exchange bodies are custom types, they must be registered for serialization by annotating their class declaration with `@RegisterForReflection(serialization = true)`.


### PR DESCRIPTION
Fixes #9104

`quarkus.camel.native.reflection.serialization-enabled` changes from `boolean` to `Optional<Boolean>`:

- **unset** (the new default) — classes are registered for serialization only if an extension on the classpath requires it. This is the existing behaviour.
- **`true`** — the base set is always registered. Unchanged.
- **`false`** — nothing is registered, even when extensions require it, and the build logs a warning.

Applications that set the option to `true`, or never set it, are unaffected. Only an explicit `false` changes meaning.

`CamelSerializationBuildItem` now carries additional class names, so extensions can route all of their serialization registrations through it rather than producing `ReflectiveClassBuildItem.serializationClass(..)` directly, making the option a single point of control. `ManagementProcessor` is moved over accordingly, with no change to what it registers. `SqlProcessor` drops a `LinkedHashMap` registration that is already part of the base set.

Documentation is updated to match, including a 3.40.0 migration guide entry, and the `extensions/sql` note that incorrectly told users they must enable serialization themselves.

Verified with native builds of `integration-tests/management` in both states: with the veto applied the warning is logged and the build succeeds, and with the option unset `ManagementIT` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
