### PR TITLE
Fix Aws2SqsTest sqsJmsLikeSelector caused by SQS 60s purge cooldown

### DIFF
--- a/integration-test-groups/aws2/aws2-sqs/src/test/java/org/apache/camel/quarkus/component/aws2/sqs/it/Aws2SqsTest.java
+++ b/integration-test-groups/aws2/aws2-sqs/src/test/java/org/apache/camel/quarkus/component/aws2/sqs/it/Aws2SqsTest.java
@@ -92,6 +92,13 @@ class Aws2SqsTest extends BaseAWs2TestSupport {
     void purgeQueueAndWait() {
         String qName = getPredefinedQueueName();
         purgeQueue(qName);
+
+        String selectorQueueName = ConfigProvider.getConfig()
+                .getOptionalValue("aws-sqs.selector-name", String.class).orElse(null);
+        if (selectorQueueName != null) {
+            purgeQueue(selectorQueueName);
+        }
+
         // purge takes up to 60 seconds
         // all messages delivered within those 60 seconds might get deleted
         try {
@@ -324,7 +331,6 @@ class Aws2SqsTest extends BaseAWs2TestSupport {
 
         // clean previously collected messages
         RestAssured.delete("/aws2-sqs/selector/messages").then().statusCode(200);
-        purgeQueue(selectorQueueName);
 
         final String selectedMsg = "selected-" + UUID.randomUUID().toString().replace("-", "");
         final String rejectedMsg = "rejected-" + UUID.randomUUID().toString().replace("-", "");
@@ -359,9 +365,6 @@ class Aws2SqsTest extends BaseAWs2TestSupport {
                 .then().statusCode(200).extract().body().as(List.class);
         Assertions.assertTrue(collected.contains(selectedMsg), "Selected message should have been collected");
         Assertions.assertFalse(collected.contains(rejectedMsg), "Rejected message should not have been collected");
-
-        // purge rejected messages remaining in queue
-        purgeQueue(selectorQueueName);
     }
 
     @Override


### PR DESCRIPTION
Move selector queue purge into @AfterEach purgeQueueAndWait() so all queues are purged at the same time and covered by the 60-second sleep. Remove the two purgeQueue calls from sqsJmsLikeSelector() that could trigger PurgeQueueInProgressException on real AWS SQS.