### PR TITLE
Serve only what the Dev UI diagram page needs from the diagram route

### DIFF
--- a/extensions-jvm/diagram/runtime/src/main/java/org/apache/camel/quarkus/component/diagram/CamelDiagramRecorder.java
+++ b/extensions-jvm/diagram/runtime/src/main/java/org/apache/camel/quarkus/component/diagram/CamelDiagramRecorder.java
@@ -18,18 +18,21 @@ package org.apache.camel.quarkus.component.diagram;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
 
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
 import io.vertx.ext.web.Route;
 import io.vertx.ext.web.RoutingContext;
 import org.apache.camel.CamelContext;
 import org.apache.camel.console.DevConsole;
 import org.apache.camel.console.DevConsoleRegistry;
 import org.apache.camel.util.json.Jsoner;
+import org.jboss.logging.Logger;
 
 @Recorder
 public class CamelDiagramRecorder {
@@ -38,7 +41,8 @@ public class CamelDiagramRecorder {
         return new Consumer<Route>() {
             @Override
             public void accept(Route route) {
-                // No content type restriction — handler negotiates based on Accept header
+                // The handler negotiates and answers 406 itself. Restricting the route here makes a request for
+                // another type fall through to a 404 instead
             }
         };
     }
@@ -50,12 +54,27 @@ public class CamelDiagramRecorder {
     }
 
     static final class CamelDiagramHandler implements Handler<RoutingContext> {
+        private static final Logger LOG = Logger.getLogger(CamelDiagramHandler.class);
+
+        private static final Predicate<String> BOOLEAN_VALUE = value -> "true".equals(value) || "false".equals(value);
+        /** Route ids, endpoint URIs and source locations, optionally with wildcards. */
+        private static final Predicate<String> FILTER_VALUE = Pattern.compile("[A-Za-z0-9_.,:/@*?% -]{1,100}")
+                .asMatchPredicate();
+
         /**
-         * The consoles this route exists to serve. The id is resolved against the registry, which holds every
-         * registered console, so without this an unrelated console could be rendered through the diagram route.
+         * The consoles the Dev UI diagram page reads, and the options its web components send to them. The id is
+         * resolved against the registry, which holds every registered console, so without this an unrelated console
+         * could be rendered through the diagram route. Options are copied from the query string straight into
+         * {@link DevConsole#call(DevConsole.MediaType, Map)}, so anything absent from these rules is dropped, as
+         * {@code CamelCoreDevUIService.sanitizeOptions} does for the Dev UI bridge.
          */
-        private static final Set<String> DIAGRAM_CONSOLE_IDS = Set.of("route-diagram", "route-structure",
-                "route-topology");
+        private static final Map<String, Map<String, Predicate<String>>> DIAGRAM_CONSOLES = Map.of(
+                "route-structure", Map.of(
+                        "filter", FILTER_VALUE,
+                        "metric", BOOLEAN_VALUE),
+                "route-topology", Map.of(
+                        "external", BOOLEAN_VALUE,
+                        "metric", BOOLEAN_VALUE));
 
         private final DevConsoleRegistry devConsoleRegistry;
 
@@ -71,7 +90,7 @@ public class CamelDiagramRecorder {
             }
 
             String id = ctx.pathParam("id");
-            if (id == null || !DIAGRAM_CONSOLE_IDS.contains(id)) {
+            if (id == null || !DIAGRAM_CONSOLES.containsKey(id)) {
                 ctx.response().setStatusCode(404).end();
                 return;
             }
@@ -86,36 +105,47 @@ public class CamelDiagramRecorder {
                 return;
             }
 
-            Map<String, Object> options = new HashMap<>();
-            ctx.queryParams().forEach(entry -> options.put(entry.getKey(), entry.getValue()));
-
+            // The Dev UI web components render the diagrams from JSON, so JSON is all this route serves. Console text
+            // output is markup for a browser to run, so anything else asked for, a top level browser navigation
+            // included, is not acceptable here.
             String accept = ctx.request().getHeader("Accept");
             boolean wantsJson = accept != null && accept.contains("application/json");
-            String format = ctx.queryParams().get("format");
-            boolean wantsHtml = "html".equals(format);
-
-            if (wantsJson && console.supportMediaType(DevConsole.MediaType.JSON)) {
-                Object result = console.call(DevConsole.MediaType.JSON, options);
-                if (result != null) {
-                    ctx.response()
-                            .putHeader("Content-Type", "application/json")
-                            .end(Jsoner.serialize(result));
-                } else {
-                    ctx.response().setStatusCode(204).end();
-                }
-            } else if (console.supportMediaType(DevConsole.MediaType.TEXT)) {
-                Object result = console.call(DevConsole.MediaType.TEXT, options);
-                if (result != null) {
-                    String contentType = wantsHtml ? "text/html" : "text/plain";
-                    ctx.response()
-                            .putHeader("Content-Type", contentType)
-                            .end(result.toString());
-                } else {
-                    ctx.response().setStatusCode(204).end();
-                }
-            } else {
+            if (!wantsJson || !console.supportMediaType(DevConsole.MediaType.JSON)) {
                 ctx.response().setStatusCode(406).end();
+                return;
             }
+
+            Object result = console.call(DevConsole.MediaType.JSON, sanitizeOptions(id, ctx.queryParams()));
+            if (result != null) {
+                ctx.response()
+                        .putHeader("Content-Type", "application/json")
+                        .putHeader("X-Content-Type-Options", "nosniff")
+                        .end(Jsoner.serialize(result));
+            } else {
+                ctx.response().setStatusCode(204).end();
+            }
+        }
+
+        /**
+         * Copies the query parameters allowed for the given console into the options passed to
+         * {@link DevConsole#call(DevConsole.MediaType, Map)}. Unknown keys and values failing their rule are dropped.
+         */
+        private static Map<String, Object> sanitizeOptions(String id, MultiMap queryParams) {
+            Map<String, Predicate<String>> rules = DIAGRAM_CONSOLES.get(id);
+            Map<String, Object> options = new HashMap<>();
+            queryParams.forEach(entry -> {
+                String key = entry.getKey();
+                String value = entry.getValue();
+                Predicate<String> rule = rules.get(key);
+                if (rule == null) {
+                    LOG.debugf("Stripped disallowed option key '%s' for console '%s'", key, id);
+                } else if (value == null || !rule.test(value)) {
+                    LOG.debugf("Stripped option '%s' for console '%s' — value '%s' is not allowed", key, id, value);
+                } else {
+                    options.put(key, value);
+                }
+            });
+            return options;
         }
     }
 }

--- a/integration-tests-jvm/diagram/src/test/java/org/apache/camel/quarkus/component/diagram/it/DiagramTest.java
+++ b/integration-tests-jvm/diagram/src/test/java/org/apache/camel/quarkus/component/diagram/it/DiagramTest.java
@@ -19,7 +19,6 @@ package org.apache.camel.quarkus.component.diagram.it;
 import io.quarkus.test.QuarkusDevModeTest;
 import io.restassured.RestAssured;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -35,23 +34,7 @@ class DiagramTest {
     @RegisterExtension
     static final QuarkusDevModeTest TEST = new QuarkusDevModeTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addClass(DiagramRoutes.class)
-                    .addAsResource(new StringAsset("quarkus.camel.console.enabled=true\n"), "application.properties"));
-
-    @Test
-    void routeDiagramHtml() {
-        RestAssured.given()
-                .accept("text/html")
-                .queryParam("format", "html")
-                .queryParam("mode", "route")
-                .when()
-                .get("/q/camel/diagram/route-diagram")
-                .then()
-                .statusCode(200)
-                .contentType("text/html")
-                .body(containsString("<html"),
-                        containsString("camel-route-diagram"));
-    }
+                    .addClass(DiagramRoutes.class));
 
     @Test
     void routeStructureJson() {
@@ -62,6 +45,7 @@ class DiagramTest {
                 .then()
                 .statusCode(200)
                 .contentType("application/json")
+                .header("X-Content-Type-Options", "nosniff")
                 .body(containsString("routes"),
                         containsString("diagram-test-route"));
     }
@@ -75,8 +59,74 @@ class DiagramTest {
                 .then()
                 .statusCode(200)
                 .contentType("application/json")
+                .header("X-Content-Type-Options", "nosniff")
                 .body(containsString("nodes"),
                         not(emptyString()));
+    }
+
+    @Test
+    void allowedConsoleOptionsAreForwarded() {
+        // The Dev UI web components pass filter & metric to route-structure, and external & metric to route-topology
+        RestAssured.given()
+                .accept("application/json")
+                .queryParam("filter", "diagram-test-route")
+                .queryParam("metric", "true")
+                .when()
+                .get("/q/camel/diagram/route-structure")
+                .then()
+                .statusCode(200)
+                .body(containsString("diagram-test-route"));
+
+        RestAssured.given()
+                .accept("application/json")
+                .queryParam("filter", "no-such-route")
+                .when()
+                .get("/q/camel/diagram/route-structure")
+                .then()
+                .statusCode(200)
+                .body(not(containsString("diagram-test-route")));
+
+        RestAssured.given()
+                .accept("application/json")
+                .queryParam("external", "true")
+                .queryParam("metric", "true")
+                .when()
+                .get("/q/camel/diagram/route-topology")
+                .then()
+                .statusCode(200)
+                .body(containsString("nodes"));
+    }
+
+    @Test
+    void disallowedConsoleOptionsAreStripped() {
+        // The filter is applied when it reaches the console, so the route being listed shows that it did not
+        RestAssured.given()
+                .accept("application/json")
+                .queryParam("filter", "<script>alert(1)</script>")
+                .queryParam("limit", "1")
+                .when()
+                .get("/q/camel/diagram/route-structure")
+                .then()
+                .statusCode(200)
+                .body(containsString("diagram-test-route"),
+                        not(containsString("<script")));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "text/html",
+            // What a browser sends when the URL is opened as a top level navigation
+            "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+            "*/*" })
+    void onlyJsonIsAcceptable(String accept) {
+        // Console text output is markup meant for a browser to run, and this route serves JSON only
+        RestAssured.given()
+                .accept(accept)
+                .when()
+                .get("/q/camel/diagram/route-structure")
+                .then()
+                .statusCode(406)
+                .body(emptyString());
     }
 
     @Test
@@ -87,10 +137,10 @@ class DiagramTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = { "context", "jvm", "health", "java-security" })
+    @ValueSource(strings = { "route-diagram", "context", "jvm", "health", "java-security" })
     void nonDiagramConsoleIsNotReachable(String consoleId) {
-        // These consoles are registered and were previously rendered by this route, which exists only to serve
-        // the diagram consoles
+        // These consoles are registered and were previously rendered by this route, which exists to serve the two
+        // consoles the Dev UI diagram page reads
         RestAssured.get("/q/camel/diagram/" + consoleId)
                 .then()
                 .statusCode(404);


### PR DESCRIPTION
The route served console TEXT output as text/html when format=html was passed, and copied every query parameter straight into DevConsole.call().

The route exists for the Dev UI diagram page, which reads route-structure and route-topology as JSON and renders the diagrams itself. So serve JSON only, with nosniff, and answer 406 when the request asks for anything else, a top level browser navigation included. route-diagram is dropped, as its text output is an HTML page for a browser to run and nothing calls it. Query parameters are filtered through a per console allowlist of the options the Dev UI web components send, as CamelCoreDevUIService.sanitizeOptions does for the Dev UI bridge.

The Camel TUI reads these consoles over the CLI connector rather than this route, so it is unaffected.
