### PR TITLE
Use ubuntu-slim runners for lightweight GitHub Actions workflows

### DIFF
--- a/.github/workflows/assign-issue-milestone.yaml
+++ b/.github/workflows/assign-issue-milestone.yaml
@@ -32,7 +32,7 @@ permissions:
 jobs:
   assign-issue-milestone:
     if: github.repository == 'apache/camel-quarkus'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Assign Closed Issues To Latest Milestone
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/assign-wontfix-issue-milestone.yaml
+++ b/.github/workflows/assign-wontfix-issue-milestone.yaml
@@ -30,7 +30,7 @@ jobs:
     if: github.repository == 'apache/camel-quarkus' &&
         github.event_name == 'issues' &&
         github.event.issue.milestone.number != 4 && (contains(github.event.issue.labels.*.name, 'wontfix') || github.event.issue.state_reason == 'not_planned')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     concurrency:
       group: assign-wont-fix-issue-milestone-${{ github.event.issue.number }}
       cancel-in-progress: true

--- a/.github/workflows/label-issue.yaml
+++ b/.github/workflows/label-issue.yaml
@@ -38,7 +38,7 @@ jobs:
          !contains(github.event.issue.labels.*.name, 'autolabel/ignore') &&
          !contains(github.event.issue.labels.*.name, 'build/camel-main') &&
          !contains(github.event.issue.labels.*.name, 'build/quarkus-main')"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Checkout Code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/pr-doc-validation.yml
+++ b/.github/workflows/pr-doc-validation.yml
@@ -36,8 +36,11 @@ permissions:
 jobs:
   check-doc:
     if: github.repository == 'apache/camel-quarkus'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
+      # ubuntu-slim does not provide yarn, so install the same version that ubuntu-latest does
+      - name: Install yarn
+        run: npm install -g yarn@1.22.22
       - name: Checkout camel-quarkus repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/synchronize-dependabot-branch.yaml
+++ b/.github/workflows/synchronize-dependabot-branch.yaml
@@ -27,7 +27,7 @@ on:
 
 jobs:
   update:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       # Read the changeset artifact produced by the unprivileged CI run
       actions: read
@@ -64,7 +64,7 @@ jobs:
               });
 
               const fs = require('fs');
-              fs.writeFileSync('/home/runner/work/dependabot-pr.zip', Buffer.from(download.data));
+              fs.writeFileSync(`${process.env.RUNNER_TEMP}/dependabot-pr.zip`, Buffer.from(download.data));
               return true;
             }
 
@@ -75,26 +75,28 @@ jobs:
         env:
           HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
-          if [[ -f /home/runner/work/dependabot-pr.zip ]]; then
-            mkdir -p /home/runner/work/dependabot-pr
-            unzip -o /home/runner/work/dependabot-pr.zip -d /home/runner/work/dependabot-pr
+          PR_ZIP="${RUNNER_TEMP:?}/dependabot-pr.zip"
+          PR_DIR="${RUNNER_TEMP:?}/dependabot-pr"
+          if [[ -f "${PR_ZIP}" ]]; then
+            mkdir -p "${PR_DIR}"
+            unzip -o "${PR_ZIP}" -d "${PR_DIR}"
 
-            PR_HEAD_SHA=$(cat /home/runner/work/dependabot-pr/PR_HEAD_SHA)
+            PR_HEAD_SHA=$(cat "${PR_DIR}/PR_HEAD_SHA")
             if [[ ! "${PR_HEAD_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
               exit 1
             fi
 
-            PR_NUMBER=$(cat /home/runner/work/dependabot-pr/PR_NUMBER)
+            PR_NUMBER=$(cat "${PR_DIR}/PR_NUMBER")
             if [[ ! "${PR_NUMBER}" =~ ^[0-9]+$ ]]; then
               exit 1
             fi
 
-            PR_AUTHOR=$(cat /home/runner/work/dependabot-pr/PR_AUTHOR)
+            PR_AUTHOR=$(cat "${PR_DIR}/PR_AUTHOR")
             if [[ "${PR_AUTHOR}" != "dependabot[bot]" ]]; then
               exit 1
             fi
 
-            BRANCH_REF=$(cat /home/runner/work/dependabot-pr/BRANCH_REF)
+            BRANCH_REF=$(cat "${PR_DIR}/BRANCH_REF")
             if [[ ! "${BRANCH_REF}" =~ ^dependabot/[A-Za-z0-9._/-]+$ ]]; then
               exit 1
             fi
@@ -125,7 +127,7 @@ jobs:
           git config --local user.email "49699333+dependabot[bot]@users.noreply.github.com"
           git config --local user.name "dependabot[bot]"
 
-          CHANGES_PATH=/home/runner/work/dependabot-pr/changes.patch
+          CHANGES_PATH="${RUNNER_TEMP:?}/dependabot-pr/changes.patch"
           if [[ -f "${CHANGES_PATH}" ]]; then
             COMMIT_MESSAGE="Auto generated changes for dependabot commit $(git log -1 --pretty=%H)"
 
@@ -167,7 +169,7 @@ jobs:
 
   rerun-pr-workflow:
     needs: update
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: needs.update.outputs.pr-updated == 'true'
     permissions:
       actions: write


### PR DESCRIPTION
Similar to apache/camel@b117561 ([Use ubuntu-slim for small GitHub Actions](https://github.com/apache/camel/commit/b11756115741463dcf4ae0ea7b8e3675b3daa1ff)).

Runner availability for Apache projects is often exhausted, so this switches some short-lived workflows to the 1 vCPU `ubuntu-slim` runner. `ubuntu-slim` jobs are limited to 15 minutes of execution time, and each job here completes well within that.

| Workflow | Typical run time | Max run time | Change |
|---|---|---|---|
| `label-issue.yaml` | ~15s | 19s | Runner only |
| `assign-issue-milestone.yaml` | ~4s | 6s | Runner only |
| `assign-wontfix-issue-milestone.yaml` | ~5s | 7s | Runner only |
| `pr-doc-validation.yml` | ~80s | 93s | Runner, plus a yarn install step |
| `synchronize-dependabot-branch.yaml` (`update` job) | ~24s | 44s | Runner, plus `RUNNER_TEMP` paths |
| `synchronize-dependabot-branch.yaml` (`rerun-pr-workflow` job) | ~4s | 6s | Runner only |

Run times are job execution times on `ubuntu-latest` (excluding time spent queued for a runner), taken from recent successful runs.

### Notes

- `ubuntu-slim` does not provide yarn, so `pr-doc-validation.yml` installs Yarn 1.22.22, the same version that `ubuntu-latest` provides.
- `synchronize-dependabot-branch.yaml` previously hard coded `/home/runner/work` paths. It now uses the `RUNNER_TEMP` environment variable, and fails if it is not set.

### Testing

Because `synchronize-dependabot-branch.yaml` has `contents: write` and processes an artifact from an unprivileged PR run, the old and new versions of its steps were tested against crafted artifact zips (path traversal, absolute paths & symlinks) on Ubuntu 24.04 with the same `unzip` version as `ubuntu-slim`. Both behaved identically and nothing was written outside of the extraction directory. [zizmor](https://docs.zizmor.sh/) reports the same findings before and after the change.

`pr-doc-validation.yml` only runs for `.adoc` changes. The label, milestone and dependabot workflows only run after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
