### PR TITLE
Skip external DTDs and parameter entities in XSLT input documents

### DIFF
--- a/docs/modules/ROOT/pages/migration-guide/3.40.0.adoc
+++ b/docs/modules/ROOT/pages/migration-guide/3.40.0.adoc
@@ -135,7 +135,7 @@ This affects more than the `xslt:` endpoints. The extension registers its factor
 
 === External entities in input documents are no longer resolved
 
-Documents being transformed are now parsed with an `XMLReader` that does not resolve external general entities, so a `SYSTEM` entity in a `DOCTYPE` declaration no longer expands into the transformation result.
+Documents being transformed are now parsed with an `XMLReader` that does not resolve external entities or load external DTDs, so a `SYSTEM` entity in a `DOCTYPE` declaration no longer expands into the transformation result, and an external DTD or parameter entity is skipped.
 
 Most routes see no change, because camel-xslt already converts `String`, `byte[]` and `InputStream` bodies through Camel's own hardened parser before the transformer sees them. The change matters where the body reaches the transformer already shaped as a `Source`, for example after `convertBodyTo(Source.class)` or from a component that produces one, and for code calling the factory directly.
 

--- a/docs/modules/ROOT/pages/reference/extensions/xslt.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/xslt.adoc
@@ -100,9 +100,9 @@ have to be compiled ahead of time to work in native mode. Xalan-J 2.7.x predates
 and its secure-processing feature restricts extension functions without implying the external access
 restrictions the JDK applies under the same feature. The extension applies those restrictions itself:
 
-* Documents being transformed are parsed with an `XMLReader` that does not resolve external general entities, so
-a `SYSTEM` entity in a `DOCTYPE` declaration does not expand into the result. A `SAXSource` carrying an
-`XMLReader` the caller configured is used as it is.
+* Documents being transformed are parsed with an `XMLReader` that does not resolve external entities or load
+external DTDs, so a `SYSTEM` entity in a `DOCTYPE` declaration does not expand into the result, and an external
+DTD or parameter entity is skipped. A `SAXSource` carrying an `XMLReader` the caller configured is used as it is.
 * Resources fetched at transform time by the `document()` function are denied unless a
 `javax.xml.transform.URIResolver` resolves them. This applies to every entry point that hands out something to
 transform with, so a `TransformerHandler` or an `XMLFilter` is restricted just as a `Transformer` is. The

--- a/extensions-support/xalan/deployment/src/test/java/org/apache/camel/quarkus/support/xalan/deployment/XalanTransformerFactoryExternalAccessTest.java
+++ b/extensions-support/xalan/deployment/src/test/java/org/apache/camel/quarkus/support/xalan/deployment/XalanTransformerFactoryExternalAccessTest.java
@@ -69,6 +69,7 @@ class XalanTransformerFactoryExternalAccessTest {
 
     private static String secretUri;
     private static String secretXmlUri;
+    private static String secretDtdUri;
     private static String includedUri;
 
     @BeforeAll
@@ -83,6 +84,12 @@ class XalanTransformerFactoryExternalAccessTest {
         Files.writeString(secretXml, "<s>" + SECRET + "</s>");
         secretXmlUri = secretXml.toUri().toString();
 
+        // An attribute default rather than an entity, so that the document stays well formed whether or not the
+        // DTD is read, and reading it shows up in the result
+        final Path secretDtd = tempDir.resolve("secret.dtd");
+        Files.writeString(secretDtd, "<!ATTLIST data leak CDATA '" + SECRET + "'>");
+        secretDtdUri = secretDtd.toUri().toString();
+
         final Path included = tempDir.resolve("included.xsl");
         Files.writeString(included, INCLUDED_XSL);
         includedUri = included.toUri().toString();
@@ -92,6 +99,12 @@ class XalanTransformerFactoryExternalAccessTest {
     private static final String COPY_DATA_XSL = "<xsl:stylesheet version='1.0'"
             + " xmlns:xsl='http://www.w3.org/1999/XSL/Transform'><xsl:output method='text'/>"
             + "<xsl:template match='/'><xsl:value-of select='//data'/></xsl:template></xsl:stylesheet>";
+
+    /** Copies {@code //data} and its {@code leak} attribute, which only a DTD that was read can default */
+    private static final String COPY_DATA_AND_DEFAULTED_ATTRIBUTE_XSL = "<xsl:stylesheet version='1.0'"
+            + " xmlns:xsl='http://www.w3.org/1999/XSL/Transform'><xsl:output method='text'/>"
+            + "<xsl:template match='/'><xsl:value-of select='//data'/><xsl:value-of select='//data/@leak'/>"
+            + "</xsl:template></xsl:stylesheet>";
 
     private static String externalEntityDocument() {
         return "<?xml version='1.0'?><!DOCTYPE r [<!ENTITY xxe SYSTEM '" + secretUri + "'>]>"
@@ -232,6 +245,29 @@ class XalanTransformerFactoryExternalAccessTest {
                 new StreamSource(document.toUri().toString()));
 
         assertFalse(result.contains(SECRET), "The external entity was resolved into the transformation result");
+    }
+
+    /**
+     * An external DTD is skipped rather than fetched. Refusing it would leave the protection to the JDK's
+     * {@code accessExternalDTD}, which a system property can lift and which a third-party parser on the
+     * classpath does not apply at all.
+     */
+    @Test
+    void externalDtdInSourceShapedInputIsNotLoaded() throws Exception {
+        final String result = transform(new XalanTransformerFactory(), COPY_DATA_AND_DEFAULTED_ATTRIBUTE_XSL,
+                new StreamSource(new StringReader("<?xml version='1.0'?><!DOCTYPE r SYSTEM '" + secretDtdUri + "'>"
+                        + "<r><data>HELLO</data></r>")));
+
+        assertEquals("HELLO", result.trim());
+    }
+
+    @Test
+    void externalParameterEntityInSourceShapedInputIsNotLoaded() throws Exception {
+        final String result = transform(new XalanTransformerFactory(), COPY_DATA_AND_DEFAULTED_ATTRIBUTE_XSL,
+                new StreamSource(new StringReader("<?xml version='1.0'?><!DOCTYPE r [<!ENTITY % p SYSTEM '"
+                        + secretDtdUri + "'> %p;]><r><data>HELLO</data></r>")));
+
+        assertEquals("HELLO", result.trim());
     }
 
     /** Loading a document by system id has to keep working, entities aside */

--- a/extensions-support/xalan/runtime/src/main/java/org/apache/camel/quarkus/support/xalan/XalanTransformerFactory.java
+++ b/extensions-support/xalan/runtime/src/main/java/org/apache/camel/quarkus/support/xalan/XalanTransformerFactory.java
@@ -63,8 +63,8 @@ import org.slf4j.LoggerFactory;
  * be lost silently. This factory therefore applies the deny-by-default part itself:
  * <ul>
  * <li>input documents passed to {@link Transformer#transform(Source, javax.xml.transform.Result)} are
- * parsed with an {@link XMLReader} that does not resolve external general entities, which is what upstream
- * Camel's {@code XmlConverter} does for the bodies it converts to a {@link SAXSource} itself,</li>
+ * parsed with an {@link XMLReader} that does not resolve external entities or load external DTDs, which is
+ * what upstream Camel's {@code XmlConverter} does for the bodies it converts to a {@link SAXSource} itself,</li>
  * <li>resources fetched at transform time by the {@code document()} function are denied unless the
  * application's own {@link URIResolver} resolves them, on every entry point that hands out something to
  * transform with - {@link Transformer}, {@link Templates}, {@link TransformerHandler} and
@@ -81,6 +81,8 @@ public final class XalanTransformerFactory extends SAXTransformerFactory {
     private static final Logger LOGGER = LoggerFactory.getLogger(XalanTransformerFactory.class);
 
     private static final String EXTERNAL_GENERAL_ENTITIES = "http://xml.org/sax/features/external-general-entities";
+    private static final String EXTERNAL_PARAMETER_ENTITIES = "http://xml.org/sax/features/external-parameter-entities";
+    private static final String LOAD_EXTERNAL_DTD = "http://apache.org/xml/features/nonvalidating/load-external-dtd";
 
     private final SAXTransformerFactory delegate;
 
@@ -276,9 +278,12 @@ public final class XalanTransformerFactory extends SAXTransformerFactory {
     private static XMLReader createSecureXmlReader() throws TransformerException {
         final SAXParserFactory factory = SAXParserFactory.newInstance();
         factory.setNamespaceAware(true);
-        setFeature(factory, javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING, true);
         setFeature(factory, EXTERNAL_GENERAL_ENTITIES, false);
+        setFeature(factory, EXTERNAL_PARAMETER_ENTITIES, false);
+        setFeature(factory, LOAD_EXTERNAL_DTD, false);
         try {
+            // Every JAXP implementation must support secure processing, so a failure is not swallowed
+            factory.setFeature(javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING, true);
             return factory.newSAXParser().getXMLReader();
         } catch (ParserConfigurationException | SAXException e) {
             throw new TransformerException("Could not create a secure XMLReader for the input document", e);

--- a/extensions/xslt/runtime/src/main/doc/configuration.adoc
+++ b/extensions/xslt/runtime/src/main/doc/configuration.adoc
@@ -48,9 +48,9 @@ have to be compiled ahead of time to work in native mode. Xalan-J 2.7.x predates
 and its secure-processing feature restricts extension functions without implying the external access
 restrictions the JDK applies under the same feature. The extension applies those restrictions itself:
 
-* Documents being transformed are parsed with an `XMLReader` that does not resolve external general entities, so
-a `SYSTEM` entity in a `DOCTYPE` declaration does not expand into the result. A `SAXSource` carrying an
-`XMLReader` the caller configured is used as it is.
+* Documents being transformed are parsed with an `XMLReader` that does not resolve external entities or load
+external DTDs, so a `SYSTEM` entity in a `DOCTYPE` declaration does not expand into the result, and an external
+DTD or parameter entity is skipped. A `SAXSource` carrying an `XMLReader` the caller configured is used as it is.
 * Resources fetched at transform time by the `document()` function are denied unless a
 `javax.xml.transform.URIResolver` resolves them. This applies to every entry point that hands out something to
 transform with, so a `TransformerHandler` or an `XMLFilter` is restricted just as a `Transformer` is. The


### PR DESCRIPTION
Follow up to #9116.